### PR TITLE
[#158148287] Move playbook contianer image into quay.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ node('docker') {
   stage('Build') {
     def scmVars = checkout scm
     tag = "${env.BRANCH_NAME.replaceAll('/', '_')}-${scmVars.GIT_COMMIT}-${env.BUILD_ID}"
-    appImage = docker.build("docker-registry.powerhrg.com/tools/playbook:${tag}")
+    appImage = docker.build("quay.io/powerhome/playbook:${tag}")
   }
 
   stage('Test') {

--- a/charts/playbook/values.yaml
+++ b/charts/playbook/values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 2
 image:
-  repository: docker-registry.powerhrg.com/tools/playbook
+  repository: quay.io/powerhome/playbook
   tag: latest
   pullPolicy: IfNotPresent
   pullSecret: registry-user


### PR DESCRIPTION
Playbook is failing when pushing to to registry.
The plan is to move it's registry into quay.io till we get our internal registry stable.

Needs powerhome/APP#131 merged before we can merge this.