### PR TITLE
Look for playbook partials outside of controller namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    playbook_ui (2.6.0)
+    playbook_ui (2.7.0)
       method_source (~> 0.9.2)
       rails (>= 5.1.6, < 6.0)
       redcarpet (= 3.4.0)

--- a/app/helpers/playbook/pb_kit_helper.rb
+++ b/app/helpers/playbook/pb_kit_helper.rb
@@ -12,13 +12,19 @@ module Playbook
       render_react(kit, props, options)
     end
 
-
   private
 
     def render_rails(kit, props, &block)
       props = defined?(props) && !props.nil? ? props : {}
       kit_class_obj = get_class_name(kit)
-      return render(partial: kit_class_obj.new(**props, &block), as: :object)
+      original_value = ActionView::Base.prefix_partial_path_with_controller_namespace
+
+      render(partial: kit_class_obj.new(**props, &block), as: :object)
+    rescue ActionView::MissingTemplate
+      ActionView::Base.prefix_partial_path_with_controller_namespace = false
+      render(partial: kit_class_obj.new(**props, &block), as: :object)
+    ensure
+      ActionView::Base.prefix_partial_path_with_controller_namespace = original_value
     end
 
     def render_react(kit, props, options)

--- a/lib/playbook/version.rb
+++ b/lib/playbook/version.rb
@@ -1,3 +1,3 @@
 module Playbook
-  VERSION = "2.6.0".freeze
+  VERSION = "2.7.0".freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Playbook",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",
   "scripts": {


### PR DESCRIPTION
While adding `playbook_ui` into Nitro, @markiearnold @jasperfurniss and I ran into an `ActionView::MissingTemplate` error. Here is the full message:

```
ActionView::MissingTemplate at /
Missing partial dev_docs/pb_caption/_caption with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :slim, :coffee, :prawn, :prawn_dsl]}. Searched in:
  * "/Users/garettarrowood/Power/nitro-web/components/ux_prototypes/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/user_profile/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/travel/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/talkbox_client/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/support/app/views"
  * "/Users/garettarrowood/Power/nitro-web/vendor/bundle/ruby/2.5.0/gems/saml_idp-0.6.0/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/sso/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/spaces/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/solar_roofing/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/scrum/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/sales/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/promos/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/product_rules/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/powerlife/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/power_glossary/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/nitro_survey/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/recruiting/app/views"
  * "/Users/garettarrowood/Power/nitro-web/vendor/bundle/ruby/2.5.0/gems/graphiql-rails-1.4.11/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/mobile_devices/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/mdm/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/marketing/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/inventory/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/human_resources/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/finance/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/expenses/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/employee_referrals/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/dev_docs/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/corporate_events/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/connect/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/charitable_giving/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/call_queues/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/contact_center/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/nitro_component_transition/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/nitro_notifications/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/apm/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/apm/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/allowances/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/adp/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/admin/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/accounting/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/speech_recognition/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/phone_metadata/app/views"
  * "/Users/garettarrowood/Power/nitro-web/vendor/bundle/ruby/2.5.0/gems/playbook_ui-2.6.0/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/nitro_theme/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/nitro_search/app/views"
  * "/Users/garettarrowood/Power/nitro-web/components/directory/app/views"
  * "/Users/garettarrowood/Power/nitro-web/vendor/bundle/ruby/2.5.0/gems/ckeditor-4.2.4/app/views"
  * "/Users/garettarrowood/Power/nitro-web/vendor/bundle/ruby/2.5.0/gems/apipie-rails-0.5.0/app/views"
  * "/Users/garettarrowood/Power/nitro-web/vendor/bundle/ruby/2.5.0/gems/playbook_ui-2.6.0/app/pb_kits/playbook"
```

You can see that the appended view_path is working correctly. `"/Users/garettarrowood/Power/nitro-web/vendor/bundle/ruby/2.5.0/gems/playbook_ui-2.6.0/app/pb_kits/playbook"` is getting checked for the `pb_caption` partial. However, Rails is looking within the controller namespace and not finding it.

We were able to get around this in nitro-web by adding this configuration as an initializer to the `dev_docs` component.

```ruby
Rails.application.config.action_view.prefix_partial_path_with_controller_namespace = false
```

However, this can't be done universally as it would disrupt all normal partial loading throughout Nitro. Documentation for ActionView configuration can be found [here](https://guides.rubyonrails.org/configuring.html#configuring-action-view).

I attempted to overwrite `local_prefixes`, as described in [this gist](https://gist.github.com/kevcha/458fcabcb271ab85c731), but was unable to get this approach working.  So instead, using an approach taken from [this article](https://traintodevelopment.wordpress.com/2018/11/19/remove-render-controller-prefix-on-rails/), I found this solution to work in Nitro. It has the added benefit of only looking for the non-controller namespaced view path when the playbook kit is used, and only after looking at all the normal places.

So - with this change - `playbook` partials are tested to load correctly in `nitro-web` without any additional config. And from testing locally, playbook still loads partials successfully as well.

* Note: Work to get styles loading in nitro-web is still in progress.