### PR TITLE
Consistent name for Playbook library in npm & rubygems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Playbook",
+  "name": "playbook-ui",
   "version": "2.7.1",
   "description": "Nitro UI Styleguide + React component dev env",
   "main": "components/index.js",


### PR DESCRIPTION
Storybook is named `nitro_sg` as a Ruby gem, and `nitro-sg` as a npm package.
Playbook is named `playbook_ui` as a Ruby gem, and this change will make it `playbook-ui` as a npm package.

No version raise is necessary. The first release as a npm package will match its version as a Ruby gem.