### PR TITLE
[SPIKE][DO NOT MERGE THIS] Create dummy variables to be imported in nitro-web via JS imports

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,5 @@
+import colors from "./pb_kits/playbook/_colors"
+
+export {
+    colors
+}

--- a/app/pb_kits/playbook/_colors.scss
+++ b/app/pb_kits/playbook/_colors.scss
@@ -1,0 +1,5 @@
+$white-color: #fff;
+
+:export {
+    white: $white-color;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "playbook-ui",
   "version": "2.7.2",
   "description": "Nitro UI Styleguide + React component dev env",
-  "main": "components/index.js",
+  "main": "app/index.js",
   "scripts": {
     "storybook": "yarn run applicationcss && start-storybook -p 9001 -c .storybook -s ./public",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This is a spike on consuming sass variables from playbook in nitro-web via JS imports.

[This is the corresponding nitro-web PR](https://github.com/powerhome/nitro-web/pull/11841) consuming playbook as an NPM dep.

@jasperfurniss can you confirm that this is what you were trying to achieve on Fri? On Mon I can walk you through how these things are wired if needed, but basically, here's the TL;DR;

1. Playbook should expose every importable code (JS or SASS) [from the `app/index.js`](https://github.com/powerhome/playbook/blob/feature/sass-variable-exports/app/index.js#L4), which is the entry point of the NPM module -- see `package.json#main`.
2. Playbook is added as a [NPM dependency to `nitro-web/components/nitro_react`](https://github.com/powerhome/nitro-web/pull/11841/commits/23321f74044d4946bf5aa2084fa4ab7df6253102#diff-6e3281caf84ea043e1a737748409afbeR78) so that playbook becomes available to every component already using `nitro_react`.
3. `nitro_react` [exposes the relevant Playbook code](https://github.com/powerhome/nitro-web/pull/11841/commits/23321f74044d4946bf5aa2084fa4ab7df6253102#diff-a4f81bd58b0fa7766e290b9c1392c0faR117) so other components may import.
4. [Import Playbook specific stuff](https://github.com/powerhome/nitro-web/pull/11841/commits/23321f74044d4946bf5aa2084fa4ab7df6253102#diff-a19c87c8b83489f906c56dd4a0059f4cR15) from `nitro_react` in a Nitro Component.