### PR TITLE
Kits/stat

### DIFF
--- a/app/pb_kits/playbook/packs/examples.js
+++ b/app/pb_kits/playbook/packs/examples.js
@@ -44,3 +44,6 @@ WebpackerReact.setup (input);
 
 import * as Icon from "pb_icon/docs";
 WebpackerReact.setup (Icon);
+
+import * as DashboardValue from "pb_dashboard_value/docs";
+WebpackerReact.setup (DashboardValue);

--- a/app/pb_kits/playbook/packs/kits.js
+++ b/app/pb_kits/playbook/packs/kits.js
@@ -10,3 +10,4 @@ import "./pb_table.js";
 import "./pb_avatar.js";
 import "./pb_input.js";
 import "./pb_icon.js";
+import "./pb_dashboard_value.js";

--- a/app/pb_kits/playbook/packs/pb_dashboard_value.js
+++ b/app/pb_kits/playbook/packs/pb_dashboard_value.js
@@ -1,0 +1,4 @@
+import DashboardValue from "pb_dashboard_value/_dashboard_value.jsx";
+
+import WebpackerReact from "webpacker-react";
+WebpackerReact.setup({ DashboardValue });

--- a/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
+++ b/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
@@ -12,3 +12,4 @@
 @import '../../pb_input/input';
 @import '../../pb_line_graph/line_graph';
 @import '../../pb_icon/icon';
+@import '../../pb_dashboard_value/dashboard_value';

--- a/app/pb_kits/playbook/pb_body/_body.html.erb
+++ b/app/pb_kits/playbook/pb_body/_body.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag(object.tag,
   id: object.id,
   data: object.data,
-  class: object.classname("body#{object.color}#{object.dark}")) do %>
+  class: object.classname(object.kit_class)) do %>
 <%= object.yield(context: self) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_body/_body.scss
+++ b/app/pb_kits/playbook/pb_body/_body.scss
@@ -1,37 +1,17 @@
-@import "../tokens/colors";
-@import "../tokens/typography";
-@import "../tokens/line_height";
+@import "./body_mixins";
 
-.body {
+[class^=pb_body]{
+  @include pb_body;
 
-  $selectors: (
-    "&",
-    "&_light",
-    "&_lighter",
-    "&_dark",
-    "&_light_dark",
-    "&_lighter_dark",
-  );
-
-  @each $selector in $selectors {
-    #{$selector} {
-      margin: 0;
-      line-height: $lh_tight;
-      @if $selector == "&_dark" {
-        color: $text_dk_default;
-      } @else if $selector == "&_light" {
-        color: $text_lt_light;
-      } @else if $selector == "&_lighter" {
-        color: $text_lt_lighter;
-      } @else if $selector == "&_light_dark" {
-        color: $text_dk_light;
-      } @else if $selector == "&_lighter_dark" {
-        color: $text_dk_lighter;
-      } @else {
-        color: $text_lt_default;
-      }
-
+  @each $color_name, $color_value in $pb_body_colors {
+    &[class*=_#{$color_name}]  {
+      @include pb_body($color_value);
     }
   }
 
+  @each $status_name, $status_value in $pb_body_status {
+    &[class*=_#{$status_name}]  {
+      @include pb_body($status_value);
+    }
+  }
 }

--- a/app/pb_kits/playbook/pb_body/_body_mixins.scss
+++ b/app/pb_kits/playbook/pb_body/_body_mixins.scss
@@ -1,5 +1,4 @@
 @import "../tokens/colors";
-@import "../tokens/typography";
 @import "../tokens/line_height";
 
 $pb_body_colors: (

--- a/app/pb_kits/playbook/pb_body/_body_mixins.scss
+++ b/app/pb_kits/playbook/pb_body/_body_mixins.scss
@@ -1,0 +1,54 @@
+@import "../tokens/colors";
+@import "../tokens/typography";
+@import "../tokens/line_height";
+
+$pb_body_colors: (
+  default:        $text_lt_default,
+  light:          $text_lt_light,
+  lighter:        $text_lt_lighter,
+  dark:           $text_dk_default,
+  light_dark:     $text_dk_light,
+  lighter_dark:   $text_dk_lighter,
+);
+
+$pb_body_status: (
+  default:        $text_lt_default,
+  negative:       $error,
+  positive:       $success,
+);
+
+@mixin pb_body($color: $text_lt_default) {
+  margin: 0;
+  line-height: $lh_tight;
+  color: $color;
+}
+
+// Colors ======================
+@mixin pb_body_light {
+  @include pb_body($text_lt_light);
+}
+
+@mixin pb_body_lighter {
+  @include pb_body($text_lt_lighter);
+}
+
+@mixin pb_body_dark {
+  @include pb_body($text_dk_default);
+}
+
+@mixin pb_body_light_dark {
+  @include pb_body($text_dk_light);
+}
+
+@mixin pb_body_lighter_dark {
+  @include pb_body($text_dk_lighter);
+}
+
+// Statuses =====================
+@mixin pb_body_negative {
+  @include pb_body($error);
+}
+
+@mixin pb_body_positive {
+  @include pb_body($success);
+}

--- a/app/pb_kits/playbook/pb_body/body.rb
+++ b/app/pb_kits/playbook/pb_body/body.rb
@@ -7,6 +7,7 @@ module Playbook
           :configured_dark,
           :configured_data,
           :configured_id,
+          :configured_status,
           :configured_tag,
           :block].freeze
 
@@ -17,6 +18,7 @@ module Playbook
                    dark: default_configuration,
                    data: default_configuration,
                    id: default_configuration,
+                   status: default_configuration,
                    tag: default_configuration,
                    &block)
 
@@ -26,42 +28,53 @@ module Playbook
         self.configured_dark = dark
         self.configured_data = data
         self.configured_id = id
+        self.configured_status = status
         self.configured_tag = tag
         self.block = block_given? ? block : nil
       end
 
       def color
-        if configured_color == default_configuration
-          ""
-        else
-          "_#{configured_color}"
-        end
+        color_options = %w(default light lighter dark light_dark lighter_dark)
+        one_of_value(configured_color, color_options, "default")
+      end
+
+      def color_class
+        self.color != "default" ? self.color : nil
       end
 
       def dark
-        if configured_dark == default_configuration
-          ""
-        else
-          if (configured_dark == true)
-            "_dark"
-          end
-        end
+        is_true? configured_dark
+      end
+
+      def dark_class
+        true_value(configured_dark, "dark", nil)
+      end
+
+      def status
+        status_options = %w(default negative positive)
+        one_of_value(configured_status, status_options, "default")
+      end
+
+      def status_class
+        self.status != "default" ? self.status : nil
       end
 
       def tag
-        if configured_tag == default_configuration
-          "p"
-        else
-          configured_tag
-        end
+        default_value(configured_tag, "p")
       end
 
       def text
-        if configured_text == default_configuration
-          "This is some text"
-        else
-          configured_text
-        end
+        default_value(configured_text, "Body text")
+      end
+
+      def kit_class
+        body_options = [
+          "pb_body",
+          color_class,
+          dark_class,
+          status_class
+        ]
+        body_options.reject(&:nil?).join("_")
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_body/body.rb
+++ b/app/pb_kits/playbook/pb_body/body.rb
@@ -1,26 +1,25 @@
 module Playbook
   module PbBody
     class Body < Playbook::PbKit::Base
-      PROPS = [:configured_aria,
-        :configured_classname,
-        :configured_color,
-        :configured_dark,
-        :configured_data,
-        :configured_id,
-        :configured_status,
-        :configured_tag,
-        :block].freeze
-
+      PROPS = %i[configured_aria
+                 configured_classname
+                 configured_color
+                 configured_dark
+                 configured_data
+                 configured_id
+                 configured_status
+                 configured_tag
+                 block].freeze
 
       def initialize(aria: default_configuration,
-                   classname: default_configuration,
-                   color: default_configuration,
-                   dark: default_configuration,
-                   data: default_configuration,
-                   id: default_configuration,
-                   status: default_configuration,
-                   tag: default_configuration,
-                   &block)
+                     classname: default_configuration,
+                     color: default_configuration,
+                     dark: default_configuration,
+                     data: default_configuration,
+                     id: default_configuration,
+                     status: default_configuration,
+                     tag: default_configuration,
+                     &block)
 
         self.configured_aria = aria
         self.configured_classname = classname
@@ -34,12 +33,12 @@ module Playbook
       end
 
       def color
-        color_options = %w(default light lighter dark light_dark lighter_dark)
-        one_of_value(configured_color, color_options, "default")
+        color_options = %w[default light lighter dark light_dark lighter_dark]
+        one_of_value(configured_color, color_options, 'default')
       end
 
       def color_class
-        self.color != "default" ? self.color : nil
+        color != 'default' ? color : nil
       end
 
       def dark
@@ -47,24 +46,24 @@ module Playbook
       end
 
       def dark_class
-        true_value(configured_dark, "dark", nil)
+        true_value(configured_dark, 'dark', nil)
       end
 
       def status
-        status_options = %w(neutral negative positive)
-        one_of_value(configured_status, status_options, "neutral")
+        status_options = %w[neutral negative positive]
+        one_of_value(configured_status, status_options, 'neutral')
       end
 
       def status_class
-        self.status != "neutral" ? self.status : nil
+        status != 'neutral' ? status : nil
       end
 
       def tag
-        default_value(configured_tag, "p")
+        default_value(configured_tag, 'p')
       end
 
       def text
-        default_value(configured_text, "Body text")
+        default_value(configured_text, 'Body text')
       end
 
       def yield(context:)
@@ -73,19 +72,19 @@ module Playbook
 
       def kit_class
         body_options = [
-          "pb_body",
+          'pb_body',
           color_class,
           dark_class,
           status_class
         ]
-        body_options.compact.join("_")
+        body_options.compact.join('_')
       end
 
       def to_partial_path
-        "pb_body/body"
+        'pb_body/body'
       end
 
-    private
+      private
 
       DEFAULT = Object.new
       private_constant :DEFAULT

--- a/app/pb_kits/playbook/pb_body/body.rb
+++ b/app/pb_kits/playbook/pb_body/body.rb
@@ -51,12 +51,12 @@ module Playbook
       end
 
       def status
-        status_options = %w(default negative positive)
-        one_of_value(configured_status, status_options, "default")
+        status_options = %w(neutral negative positive)
+        one_of_value(configured_status, status_options, "neutral")
       end
 
       def status_class
-        self.status != "default" ? self.status : nil
+        self.status != "neutral" ? self.status : nil
       end
 
       def tag
@@ -65,6 +65,10 @@ module Playbook
 
       def text
         default_value(configured_text, "Body text")
+      end
+
+      def yield(context:)
+        context.capture(&block)
       end
 
       def kit_class
@@ -79,10 +83,6 @@ module Playbook
 
       def to_partial_path
         "pb_body/body"
-      end
-
-      def yield(context:)
-        context.capture(&block)
       end
 
     private

--- a/app/pb_kits/playbook/pb_body/body.rb
+++ b/app/pb_kits/playbook/pb_body/body.rb
@@ -78,7 +78,7 @@ module Playbook
           dark_class,
           status_class
         ]
-        body_options.reject(&:nil?).join("_")
+        body_options.compact.join("_")
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_body/body.rb
+++ b/app/pb_kits/playbook/pb_body/body.rb
@@ -2,14 +2,14 @@ module Playbook
   module PbBody
     class Body < Playbook::PbKit::Base
       PROPS = [:configured_aria,
-          :configured_classname,
-          :configured_color,
-          :configured_dark,
-          :configured_data,
-          :configured_id,
-          :configured_status,
-          :configured_tag,
-          :block].freeze
+        :configured_classname,
+        :configured_color,
+        :configured_dark,
+        :configured_data,
+        :configured_id,
+        :configured_status,
+        :configured_tag,
+        :block].freeze
 
 
       def initialize(aria: default_configuration,

--- a/app/pb_kits/playbook/pb_body/docs/_body_dark.html.erb
+++ b/app/pb_kits/playbook/pb_body/docs/_body_dark.html.erb
@@ -7,3 +7,13 @@ I am a body kit (Light)
 <%= pb_rails("body", props: { color: "lighter", dark: true }) do %>
   I am a body kit (Lighter)
 <% end %>
+
+<br><br>
+
+<%= pb_rails("body", props: { status: "negative", dark: true }) do %>
+  I am a body kit (Status: negative)
+<% end %>
+
+<%= pb_rails("body", props: { status: "positive", dark: true }) do %>
+  I am a body kit (Status: positive)
+<% end %>

--- a/app/pb_kits/playbook/pb_body/docs/_body_light.html.erb
+++ b/app/pb_kits/playbook/pb_body/docs/_body_light.html.erb
@@ -9,3 +9,13 @@
 <%= pb_rails("body", props: { color: "lighter" }) do %>
   I am a body kit (Lighter)
 <% end %>
+
+<br><br>
+
+<%= pb_rails("body", props: { status: "negative" }) do %>
+  I am a body kit (Status: negative)
+<% end %>
+
+<%= pb_rails("body", props: { status: "positive" }) do %>
+  I am a body kit (Status: positive)
+<% end %>

--- a/app/pb_kits/playbook/pb_button/_button_mixins.scss
+++ b/app/pb_kits/playbook/pb_button/_button_mixins.scss
@@ -6,7 +6,7 @@
 @import "../tokens/transition";
 @import "../tokens/typography";
 
-$pb_button-size: 40px;
+$pb_button_size: 40px;
 $pb_button_v_padding: 7px;
 $pb_button_h_padding: 34px;
 $pb_button_hover_darken: 4%;
@@ -23,7 +23,7 @@ $pb_button_border_width: 1px;
   border-color: transparent;
   border-style: solid;
   border-radius: $border_rad_light;
-  min-height: $pb_button-size;
+  min-height: $pb_button_size;
   line-height: 1.5;
   padding: $pb_button_v_padding $pb_button_h_padding;
   cursor: pointer;

--- a/app/pb_kits/playbook/pb_button/button.rb
+++ b/app/pb_kits/playbook/pb_button/button.rb
@@ -63,7 +63,11 @@ module Playbook
 
       def tag
         tag_options = %w(button a)
-        one_of_value(configured_tag, tag_options, "button")
+        if self.link.empty?
+          one_of_value(configured_tag, tag_options, "button")
+        else
+          "a"
+        end
       end
 
       def new_window

--- a/app/pb_kits/playbook/pb_button/docs/_button_link.html.erb
+++ b/app/pb_kits/playbook/pb_button/docs/_button_link.html.erb
@@ -1,3 +1,3 @@
 <%= pb_rails("button", props: { text: "A Tag Button", tag: "a", link: "http://google.com" }) %>
-<%= pb_rails("button", props: { text: "Open in new Window", tag: "a", new_window: true, link: "http://google.com" }) %>
-<%= pb_rails("button", props: { text: "A Tag Button Disabled", disabled: true, tag: "a", link: "http://google.com" }) %>
+<%= pb_rails("button", props: { text: "Open in new Window", new_window: true, link: "http://google.com" }) %>
+<%= pb_rails("button", props: { text: "A Tag Button Disabled", disabled: true, link: "http://google.com" }) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
@@ -1,0 +1,8 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname("pb_dashboard_value")) do %>
+  <%= object.stat_label %>
+  <%= object.stat_value %>
+  <%= object.stat_change %>
+<% end %>

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname("pb_dashboard_value")) do %>
+    class: object.classname(object.kit_class)) do %>
   <%= object.stat_label %>
   <%= object.stat_value %>
   <%= object.stat_change %>

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from "prop-types";
+
+const propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.string
+};
+
+class DashboardValue extends React.Component {
+  render() {
+    return (
+      <div className="pb_dashboard_value">
+        <span>DASHBOARD VALUE CONTENT</span>
+      </div>
+    )
+  }
+}
+
+DashboardValue.propTypes = propTypes;
+
+export default DashboardValue;

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.scss
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.scss
@@ -1,5 +1,10 @@
+@import "dashboard_value_mixins";
 @import "child_kits/stat_value";
 
 [class^=pb_dashboard_value]{
-  
+  @each $align_name, $align_value in $pb_dashboard_value_align {
+    &[class*=_#{$align_name}]  {
+      @include pb_dashboard_value($align_value);
+    }
+  }
 }

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.scss
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.scss
@@ -1,0 +1,5 @@
+@import "child_kits/stat_value";
+
+[class^=pb_dashboard_value]{
+  
+}

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value_mixins.scss
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value_mixins.scss
@@ -1,0 +1,12 @@
+$pb_dashboard_value_align: (
+  left:     flex-start,
+  center:   center,
+  right:    flex-end,
+);
+
+@mixin pb_dashboard_value($align: "flex-start") {
+  display: flex;
+  justify-content: flex-start;
+  align-items: $align;
+  flex-direction: column;
+}

--- a/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_change.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_change.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname(object.kit_class)) do %>
+  <%= object.display_value %>
+<% end %>

--- a/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_label.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_label.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname(object.kit_class)) do %>
+  <%= object.display_label %>
+<% end %>

--- a/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_value.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_value.html.erb
@@ -1,0 +1,10 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname(object.kit_class)) do %>
+  <div class="pb_stat_value_wrapper">
+    <%= object.display_value %>
+    &nbsp;
+    <%= object.display_unit %>
+  </div>
+<% end %>

--- a/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_value.scss
+++ b/app/pb_kits/playbook/pb_dashboard_value/child_kits/_stat_value.scss
@@ -1,0 +1,7 @@
+[class^=pb_stat_value]{
+  &[class*=_wrapper] {
+    display: flex;
+    justify-content: flex-start;
+    align-items: baseline;
+  }
+}

--- a/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -1,21 +1,21 @@
 module Playbook
   module PbDashboardValue
     class DashboardValue < Playbook::PbKit::Base
-      PROPS = [:configured_align,
-        :configured_classname,
-        :configured_data,
-        :configured_id,
-        :configured_stat_change,
-        :configured_stat_label,
-        :configured_stat_value].freeze
+      PROPS = %i[configured_align
+                 configured_classname
+                 configured_data
+                 configured_id
+                 configured_stat_change
+                 configured_stat_label
+                 configured_stat_value].freeze
 
       def initialize(align: default_configuration,
-        classname: default_configuration,
-        data: default_configuration,
-        id: default_configuration,
-        stat_change: default_configuration,
-        stat_label: default_configuration,
-        stat_value: default_configuration)
+                     classname: default_configuration,
+                     data: default_configuration,
+                     id: default_configuration,
+                     stat_change: default_configuration,
+                     stat_label: default_configuration,
+                     stat_value: default_configuration)
 
         self.configured_align = align
         self.configured_classname = classname
@@ -27,8 +27,8 @@ module Playbook
       end
 
       def align
-        align_options = %w(left center right)
-        one_of_value(configured_align, align_options, "left")
+        align_options = %w[left center right]
+        one_of_value(configured_align, align_options, 'left')
       end
 
       def stat_label
@@ -54,17 +54,17 @@ module Playbook
 
       def kit_class
         kit_options = [
-          "pb_dashboard_value",
+          'pb_dashboard_value',
           align
         ]
-        kit_options.join("_")
+        kit_options.join('_')
       end
 
       def to_partial_path
-        "pb_dashboard_value/dashboard_value"
+        'pb_dashboard_value/dashboard_value'
       end
 
-    private
+      private
 
       DEFAULT = Object.new
       private_constant :DEFAULT

--- a/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -1,25 +1,33 @@
 module Playbook
   module PbDashboardValue
     class DashboardValue < Playbook::PbKit::Base
-      PROPS = [:configured_classname,
+      PROPS = [:configured_align,
+          :configured_classname,
 					:configured_data,
 					:configured_id,
           :configured_stat_change,
           :configured_stat_label,
           :configured_stat_value].freeze
 
-      def initialize(classname: default_configuration,
+      def initialize(align: default_configuration,
+              classname: default_configuration,
 							data: default_configuration,
 							id: default_configuration,
               stat_change: default_configuration,
               stat_label: default_configuration,
               stat_value: default_configuration)
+        self.configured_align = align
         self.configured_classname = classname
 				self.configured_data = data
 				self.configured_id = id
 				self.configured_stat_change = stat_change
 				self.configured_stat_label = stat_label
 				self.configured_stat_value = stat_value
+      end
+
+      def align
+        align_options = %w(left center right)
+        one_of_value(configured_align, align_options, "left")
       end
 
       def stat_label
@@ -41,6 +49,14 @@ module Playbook
           pb_change = Playbook::PbDashboardValue::StatChange.new(configured_stat_change)
           ApplicationController.renderer.render(partial: pb_change, as: :object)
         end
+      end
+
+      def kit_class
+        kit_options = [
+          "pb_dashboard_value",
+          align
+        ]
+        kit_options.reject(&:nil?).join("_")
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -2,12 +2,12 @@ module Playbook
   module PbDashboardValue
     class DashboardValue < Playbook::PbKit::Base
       PROPS = [:configured_align,
-          :configured_classname,
-					:configured_data,
-					:configured_id,
-          :configured_stat_change,
-          :configured_stat_label,
-          :configured_stat_value].freeze
+        :configured_classname,
+        :configured_data,
+        :configured_id,
+        :configured_stat_change,
+        :configured_stat_label,
+        :configured_stat_value].freeze
 
       def initialize(align: default_configuration,
               classname: default_configuration,
@@ -56,7 +56,7 @@ module Playbook
           "pb_dashboard_value",
           align
         ]
-        kit_options.reject(&:nil?).join("_")
+        kit_options.join("_")
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -1,0 +1,60 @@
+module Playbook
+  module PbDashboardValue
+    class DashboardValue < Playbook::PbKit::Base
+      PROPS = [:configured_classname,
+					:configured_data,
+					:configured_id,
+          :configured_stat_change,
+          :configured_stat_label,
+          :configured_stat_value].freeze
+
+      def initialize(classname: default_configuration,
+							data: default_configuration,
+							id: default_configuration,
+              stat_change: default_configuration,
+              stat_label: default_configuration,
+              stat_value: default_configuration)
+        self.configured_classname = classname
+				self.configured_data = data
+				self.configured_id = id
+				self.configured_stat_change = stat_change
+				self.configured_stat_label = stat_label
+				self.configured_stat_value = stat_value
+      end
+
+      def stat_label
+        if is_set? configured_stat_label
+          pb_label = Playbook::PbDashboardValue::StatLabel.new(configured_stat_label)
+          ApplicationController.renderer.render(partial: pb_label, as: :object)
+        end
+      end
+
+      def stat_value
+        if is_set? configured_stat_value
+          pb_value = Playbook::PbDashboardValue::StatValue.new(configured_stat_value)
+          ApplicationController.renderer.render(partial: pb_value, as: :object)
+        end
+      end
+
+      def stat_change
+        if is_set? configured_stat_change
+          pb_change = Playbook::PbDashboardValue::StatChange.new(configured_stat_change)
+          ApplicationController.renderer.render(partial: pb_change, as: :object)
+        end
+      end
+
+      def to_partial_path
+        "pb_dashboard_value/dashboard_value"
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -10,19 +10,20 @@ module Playbook
         :configured_stat_value].freeze
 
       def initialize(align: default_configuration,
-              classname: default_configuration,
-							data: default_configuration,
-							id: default_configuration,
-              stat_change: default_configuration,
-              stat_label: default_configuration,
-              stat_value: default_configuration)
+        classname: default_configuration,
+        data: default_configuration,
+        id: default_configuration,
+        stat_change: default_configuration,
+        stat_label: default_configuration,
+        stat_value: default_configuration)
+
         self.configured_align = align
         self.configured_classname = classname
-				self.configured_data = data
-				self.configured_id = id
-				self.configured_stat_change = stat_change
-				self.configured_stat_label = stat_label
-				self.configured_stat_value = stat_value
+        self.configured_data = data
+        self.configured_id = id
+        self.configured_stat_change = stat_change
+        self.configured_stat_label = stat_label
+        self.configured_stat_value = stat_value
       end
 
       def align

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.html.erb
@@ -1,0 +1,23 @@
+<%= pb_rails("dashboard_value", props: {
+  stat_label: {label: "Top Title Value"},
+  stat_value: {value: "1,428", unit: "appts"},
+  stat_change: {change: "decrease", value: "26.1%"}
+}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  align: "center",
+  stat_label: {label: "Top Title Value"},
+  stat_value: {value: "1,428", unit: "appts"},
+  stat_change: {change: "decrease", value: "26.1%"}
+}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  align: "right",
+  stat_label: {label: "Top Title Value"},
+  stat_value: {value: "1,428", unit: "appts"},
+  stat_change: {change: "decrease", value: "26.1%"}
+}) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_change.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_change.html.erb
@@ -1,0 +1,15 @@
+<%= pb_rails("dashboard_value", props: {
+  stat_change: {change: "increase", value: "26.1%"}
+}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  stat_change: {change: "decrease", value: "26.1%"}
+}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  stat_change: {value: "26.1%"}
+}) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
@@ -1,11 +1,21 @@
-<%# Used within the single dashboard_value kit %>
 <%= pb_rails("dashboard_value", props: {
-  stat_label: {label: "Top Title Value"},
+  stat_label: {label: "Decreased Value"},
   stat_value: {value: "1,428", unit: "appts"},
   stat_change: {change: "decrease", value: "26.1%"}
 }) %>
 
-<%# Can be used separately in different kits %>
-<%= pb_rails("dash dashboard_value/stat_label", props: {label: "Top Title Value"}) %>
-<%= pb_rails("dash dashboard_value/stat_value", props: {value: "1,428", unit: "appts"}) %>
-<%= pb_rails("dash dashboard_value/stat_change", props: {change: "decrease", value: "26.1%"}) %>
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  stat_label: {label: "Increased Value"},
+  stat_value: {value: "938", unit: "homes"},
+  stat_change: {change: "increase", value: "26.1%"}
+}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  stat_label: {label: "Neutral Value"},
+  stat_value: {value: "261", unit: "windows"},
+  stat_change: {value: "26.1%"}
+}) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
@@ -1,11 +1,11 @@
-<%= pb_rails("dashboard_value/stat_label", props: {label: "Top Title Value"}) %>
-<%= pb_rails("dashboard_value/stat_value", props: {value: "1,428", unit: "appts"}) %>
-<%= pb_rails("dashboard_value/stat_change", props: {change: "decrease", value: "26.1%"}) %>
-
-<br><br>
-
+<%# Used within the single dashboard_value kit %>
 <%= pb_rails("dashboard_value", props: {
   stat_label: {label: "Top Title Value"},
   stat_value: {value: "1,428", unit: "appts"},
   stat_change: {change: "decrease", value: "26.1%"}
 }) %>
+
+<%# Can be used separately in different kits %>
+<%= pb_rails("dash dashboard_value/stat_label", props: {label: "Top Title Value"}) %>
+<%= pb_rails("dash dashboard_value/stat_value", props: {value: "1,428", unit: "appts"}) %>
+<%= pb_rails("dash dashboard_value/stat_change", props: {change: "decrease", value: "26.1%"}) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
@@ -1,0 +1,11 @@
+<%= pb_rails("dashboard_value/stat_label", props: {label: "Top Title Value"}) %>
+<%= pb_rails("dashboard_value/stat_value", props: {value: "1,428", unit: "appts"}) %>
+<%= pb_rails("dashboard_value/stat_change", props: {change: "decrease", value: "26.1%"}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  stat_label: {label: "Top Title Value"},
+  stat_value: {value: "1,428", unit: "appts"},
+  stat_change: {change: "decrease", value: "26.1%"}
+}) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.jsx
@@ -1,0 +1,12 @@
+import React from "react"
+import DashboardValue from "../_dashboard_value.jsx"
+
+function DashboardValueDefault() {
+  return (
+    <div>
+      <DashboardValue />
+    </div>
+  )
+}
+
+export default DashboardValueDefault;

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_label.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_label.html.erb
@@ -1,0 +1,19 @@
+<%= pb_rails("dashboard_value", props: {
+  stat_label: {label: "Top Title Value"},
+  stat_value: {value: "1,428", unit: "appts"},
+  stat_change: {change: "decrease", value: "26.1%"}
+}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  stat_label: {label: "Top Title Value"},
+  stat_value: {value: "1,428", unit: "appts"}
+}) %>
+
+<br><br>
+
+<%= pb_rails("dashboard_value", props: {
+  stat_label: {label: "Top Title Value"},
+  stat_change: {change: "decrease", value: "26.1%"}
+}) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/example.yml
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/example.yml
@@ -1,0 +1,10 @@
+examples:
+
+  rails:
+  - dashboard_value_default: Usage
+  - dashboard_value_change: Change
+  - dashboard_value_label: Label
+
+
+  react:
+  - dashboard_value_default: Default

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/example.yml
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/example.yml
@@ -1,9 +1,10 @@
 examples:
 
   rails:
-  - dashboard_value_default: Usage
+  - dashboard_value_default: Full Example
   - dashboard_value_change: Change
   - dashboard_value_label: Label
+  - dashboard_value_align: Align
 
 
   react:

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/index.js
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/index.js
@@ -1,0 +1,1 @@
+export {default as DashboardValueDefault} from './_dashboard_value_default.jsx';

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
@@ -2,20 +2,21 @@ module Playbook
   module PbDashboardValue
     class StatChange < Playbook::PbKit::Base
       PROPS = [:configured_change,
-          :configured_classname,
-					:configured_data,
-					:configured_id,
-          :configured_value].freeze
+        :configured_classname,
+        :configured_data,
+        :configured_id,
+        :configured_value].freeze
 
       def initialize(change: default_configuration,
-              classname: default_configuration,
-							data: default_configuration,
-							id: default_configuration,
-              value: default_configuration)
+        classname: default_configuration,
+        data: default_configuration,
+        id: default_configuration,
+        value: default_configuration)
+        
         self.configured_change = change
         self.configured_classname = classname
-				self.configured_data = data
-				self.configured_id = id
+        self.configured_data = data
+        self.configured_id = id
         self.configured_value = value
       end
 

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
@@ -72,7 +72,7 @@ module Playbook
           "pb_stat_change",
           status
         ]
-        stat_options.reject(&:nil?).join("_")
+        stat_options.join("_")
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
@@ -70,7 +70,7 @@ module Playbook
       def kit_class
         stat_options = [
           "pb_stat_change",
-          self.status
+          status
         ]
         stat_options.reject(&:nil?).join("_")
       end

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
@@ -1,18 +1,18 @@
 module Playbook
   module PbDashboardValue
     class StatChange < Playbook::PbKit::Base
-      PROPS = [:configured_change,
-        :configured_classname,
-        :configured_data,
-        :configured_id,
-        :configured_value].freeze
+      PROPS = %i[configured_change
+                 configured_classname
+                 configured_data
+                 configured_id
+                 configured_value].freeze
 
       def initialize(change: default_configuration,
-        classname: default_configuration,
-        data: default_configuration,
-        id: default_configuration,
-        value: default_configuration)
-        
+                     classname: default_configuration,
+                     data: default_configuration,
+                     id: default_configuration,
+                     value: default_configuration)
+
         self.configured_change = change
         self.configured_classname = classname
         self.configured_data = data
@@ -21,66 +21,64 @@ module Playbook
       end
 
       def change
-        change_options = %w(neutral increase decrease)
-        one_of_value(configured_change, change_options, "neutral")
+        change_options = %w[neutral increase decrease]
+        one_of_value(configured_change, change_options, 'neutral')
       end
 
       def status
-        case self.change
-        when "increase"
-          "positive"
-        when "decrease"
-          "negative"
+        case change
+        when 'increase'
+          'positive'
+        when 'decrease'
+          'negative'
         else
-          "neutral"
+          'neutral'
         end
       end
 
       def icon
-        case self.change
-        when "increase"
-          "arrow-up"
-        when "decrease"
-          "arrow-down"
-        else
-          nil
+        case change
+        when 'increase'
+          'arrow-up'
+        when 'decrease'
+          'arrow-down'
         end
       end
 
       def display_icon
-        if !self.icon.nil?
-          pb_icon = Playbook::PbIcon::Icon.new({icon: self.icon, fixed_width: true})
+        if !icon.nil?
+          pb_icon = Playbook::PbIcon::Icon.new(icon: icon, fixed_width: true)
           ApplicationController.renderer.render(partial: pb_icon, as: :object)
         else
-          String.new
+          ''
         end
       end
 
       def value
-        default_value(configured_value, String.new)
+        default_value(configured_value, '')
       end
 
       def display_value
-        pb_icon_element = Playbook::PbBody::Body.new(status: self.status) do |x|
-          self.display_icon +
-            self.value
+        pb_icon_element = Playbook::PbBody::Body.new(status: status) do |_x|
+          display_icon +
+            value
         end
         ApplicationController.renderer.render(partial: pb_icon_element, as: :object)
       end
 
       def kit_class
         stat_options = [
-          "pb_stat_change",
+          'pb_stat_change',
           status
         ]
-        stat_options.join("_")
+        stat_options.join('_')
       end
 
       def to_partial_path
-        "pb_dashboard_value/child_kits/stat_change"
+        'pb_dashboard_value/child_kits/stat_change'
       end
 
-    private
+      private
 
       DEFAULT = Object.new
       private_constant :DEFAULT

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_change.rb
@@ -1,0 +1,92 @@
+module Playbook
+  module PbDashboardValue
+    class StatChange < Playbook::PbKit::Base
+      PROPS = [:configured_change,
+          :configured_classname,
+					:configured_data,
+					:configured_id,
+          :configured_value].freeze
+
+      def initialize(change: default_configuration,
+              classname: default_configuration,
+							data: default_configuration,
+							id: default_configuration,
+              value: default_configuration)
+        self.configured_change = change
+        self.configured_classname = classname
+				self.configured_data = data
+				self.configured_id = id
+        self.configured_value = value
+      end
+
+      def change
+        change_options = %w(neutral increase decrease)
+        one_of_value(configured_change, change_options, "neutral")
+      end
+
+      def status
+        case self.change
+        when "increase"
+          "positive"
+        when "decrease"
+          "negative"
+        else
+          "neutral"
+        end
+      end
+
+      def icon
+        case self.change
+        when "increase"
+          "arrow-up"
+        when "decrease"
+          "arrow-down"
+        else
+          nil
+        end
+      end
+
+      def display_icon
+        if !self.icon.nil?
+          pb_icon = Playbook::PbIcon::Icon.new({icon: self.icon, fixed_width: true})
+          ApplicationController.renderer.render(partial: pb_icon, as: :object)
+        else
+          String.new
+        end
+      end
+
+      def value
+        default_value(configured_value, String.new)
+      end
+
+      def display_value
+        pb_icon_element = Playbook::PbBody::Body.new(status: self.status) do |x|
+          self.display_icon +
+            self.value
+        end
+        ApplicationController.renderer.render(partial: pb_icon_element, as: :object)
+      end
+
+      def kit_class
+        stat_options = [
+          "pb_stat_change",
+          self.status
+        ]
+        stat_options.reject(&:nil?).join("_")
+      end
+
+      def to_partial_path
+        "pb_dashboard_value/child_kits/stat_change"
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
@@ -1,15 +1,15 @@
 module Playbook
   module PbDashboardValue
     class StatLabel < Playbook::PbKit::Base
-      PROPS = [:configured_classname,
-        :configured_data,
-        :configured_id,
-        :configured_label].freeze
+      PROPS = %i[configured_classname
+                 configured_data
+                 configured_id
+                 configured_label].freeze
 
       def initialize(classname: default_configuration,
-        data: default_configuration,
-        id: default_configuration,
-        label: default_configuration)
+                     data: default_configuration,
+                     id: default_configuration,
+                     label: default_configuration)
 
         self.configured_classname = classname
         self.configured_data = data
@@ -22,23 +22,23 @@ module Playbook
       end
 
       def display_label
-        if !self.label.nil?
-          pb_label = Playbook::PbBody::Body.new(color: "light") do
-            self.label
+        unless label.nil?
+          pb_label = Playbook::PbBody::Body.new(color: 'light') do
+            label
           end
           ApplicationController.renderer.render(partial: pb_label, as: :object)
         end
       end
 
       def kit_class
-        "pb_stat_label"
+        'pb_stat_label'
       end
 
       def to_partial_path
-        "pb_dashboard_value/child_kits/stat_label"
+        'pb_dashboard_value/child_kits/stat_label'
       end
 
-    private
+      private
 
       DEFAULT = Object.new
       private_constant :DEFAULT

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
@@ -30,10 +30,7 @@ module Playbook
       end
 
       def kit_class
-        stat_options = [
-          "pb_stat_label"
-        ]
-        stat_options.reject(&:nil?).join("_")
+        "pb_stat_label"
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
@@ -2,17 +2,18 @@ module Playbook
   module PbDashboardValue
     class StatLabel < Playbook::PbKit::Base
       PROPS = [:configured_classname,
-					:configured_data,
-					:configured_id,
-          :configured_label].freeze
+        :configured_data,
+        :configured_id,
+        :configured_label].freeze
 
       def initialize(classname: default_configuration,
-							data: default_configuration,
-							id: default_configuration,
-              label: default_configuration)
+        data: default_configuration,
+        id: default_configuration,
+        label: default_configuration)
+
         self.configured_classname = classname
-				self.configured_data = data
-				self.configured_id = id
+        self.configured_data = data
+        self.configured_id = id
         self.configured_label = label
       end
 

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_label.rb
@@ -1,0 +1,53 @@
+module Playbook
+  module PbDashboardValue
+    class StatLabel < Playbook::PbKit::Base
+      PROPS = [:configured_classname,
+					:configured_data,
+					:configured_id,
+          :configured_label].freeze
+
+      def initialize(classname: default_configuration,
+							data: default_configuration,
+							id: default_configuration,
+              label: default_configuration)
+        self.configured_classname = classname
+				self.configured_data = data
+				self.configured_id = id
+        self.configured_label = label
+      end
+
+      def label
+        default_value(configured_label, nil)
+      end
+
+      def display_label
+        if !self.label.nil?
+          pb_label = Playbook::PbBody::Body.new(color: "light") do
+            self.label
+          end
+          ApplicationController.renderer.render(partial: pb_label, as: :object)
+        end
+      end
+
+      def kit_class
+        stat_options = [
+          "pb_stat_label"
+        ]
+        stat_options.reject(&:nil?).join("_")
+      end
+
+      def to_partial_path
+        "pb_dashboard_value/child_kits/stat_label"
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
@@ -40,10 +40,7 @@ module Playbook
       end
 
       def kit_class
-        stat_options = [
-          "pb_stat_value"
-        ]
-        stat_options.reject(&:nil?).join("_")
+        "pb_stat_value"
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
@@ -1,0 +1,63 @@
+module Playbook
+  module PbDashboardValue
+    class StatValue < Playbook::PbKit::Base
+      PROPS = [:configured_classname,
+					:configured_data,
+					:configured_id,
+          :configured_unit,
+          :configured_value].freeze
+
+      def initialize(classname: default_configuration,
+							data: default_configuration,
+							id: default_configuration,
+              unit: default_configuration,
+              value: default_configuration)
+        self.configured_classname = classname
+				self.configured_data = data
+				self.configured_id = id
+        self.configured_unit = unit
+        self.configured_value = value
+      end
+
+      def value
+        default_value(configured_value, 0)
+      end
+
+      def display_value
+        pb_title = Playbook::PbTitle::Title.new({size: 1, text: self.value})
+        ApplicationController.renderer.render(partial: pb_title, as: :object)
+      end
+
+      def unit
+        default_value(configured_unit, nil)
+      end
+
+      def display_unit
+        if !self.unit.nil?
+          pb_unit = Playbook::PbTitle::Title.new({size: 3, text: self.unit})
+          ApplicationController.renderer.render(partial: pb_unit, as: :object)
+        end
+      end
+
+      def kit_class
+        stat_options = [
+          "pb_stat_value"
+        ]
+        stat_options.reject(&:nil?).join("_")
+      end
+
+      def to_partial_path
+        "pb_dashboard_value/child_kits/stat_value"
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
@@ -2,19 +2,20 @@ module Playbook
   module PbDashboardValue
     class StatValue < Playbook::PbKit::Base
       PROPS = [:configured_classname,
-					:configured_data,
-					:configured_id,
-          :configured_unit,
-          :configured_value].freeze
+        :configured_data,
+        :configured_id,
+        :configured_unit,
+        :configured_value].freeze
 
       def initialize(classname: default_configuration,
-							data: default_configuration,
-							id: default_configuration,
-              unit: default_configuration,
-              value: default_configuration)
+        data: default_configuration,
+        id: default_configuration,
+        unit: default_configuration,
+        value: default_configuration)
+        
         self.configured_classname = classname
-				self.configured_data = data
-				self.configured_id = id
+        self.configured_data = data
+        self.configured_id = id
         self.configured_unit = unit
         self.configured_value = value
       end

--- a/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/stat_value.rb
@@ -1,18 +1,18 @@
 module Playbook
   module PbDashboardValue
     class StatValue < Playbook::PbKit::Base
-      PROPS = [:configured_classname,
-        :configured_data,
-        :configured_id,
-        :configured_unit,
-        :configured_value].freeze
+      PROPS = %i[configured_classname
+                 configured_data
+                 configured_id
+                 configured_unit
+                 configured_value].freeze
 
       def initialize(classname: default_configuration,
-        data: default_configuration,
-        id: default_configuration,
-        unit: default_configuration,
-        value: default_configuration)
-        
+                     data: default_configuration,
+                     id: default_configuration,
+                     unit: default_configuration,
+                     value: default_configuration)
+
         self.configured_classname = classname
         self.configured_data = data
         self.configured_id = id
@@ -25,7 +25,7 @@ module Playbook
       end
 
       def display_value
-        pb_title = Playbook::PbTitle::Title.new({size: 1, text: self.value})
+        pb_title = Playbook::PbTitle::Title.new(size: 1, text: value)
         ApplicationController.renderer.render(partial: pb_title, as: :object)
       end
 
@@ -34,21 +34,21 @@ module Playbook
       end
 
       def display_unit
-        if !self.unit.nil?
-          pb_unit = Playbook::PbTitle::Title.new({size: 3, text: self.unit})
+        unless unit.nil?
+          pb_unit = Playbook::PbTitle::Title.new(size: 3, text: unit)
           ApplicationController.renderer.render(partial: pb_unit, as: :object)
         end
       end
 
       def kit_class
-        "pb_stat_value"
+        'pb_stat_value'
       end
 
       def to_partial_path
-        "pb_dashboard_value/child_kits/stat_value"
+        'pb_dashboard_value/child_kits/stat_value'
       end
 
-    private
+      private
 
       DEFAULT = Object.new
       private_constant :DEFAULT

--- a/config/data/menu.yml
+++ b/config/data/menu.yml
@@ -12,3 +12,4 @@ kits:
   - line_graph
   - icon
   - table
+  - dashboard_value


### PR DESCRIPTION
**Kit**: Dashboard Value
**PR contains**: Rails version

## What is it 
Dashboard value is a reusable rails ui kit to be used to show stats within Nitro.

*IMPORTANT*: Dashboard Value is different than our more basic kits because we want to utilize existing kits to build it. Please look at my approach on how I did this in the PbDashboardValue and it’s child kits - such as PbDashboardValue::StatLabel classes and provide suggestions and feedback. Thank you!

![](https://d2y84jyh761mlc.cloudfront.net/items/343M191F013f1D0F233e/Image%202019-07-18%20at%208.42.49%20AM.png?X-CloudApp-Visitor-Id=3221729&v=96facfac)

![](https://d2y84jyh761mlc.cloudfront.net/items/2e1w0e0j1F2v1c2I1j28/Image%202019-07-18%20at%208.43.06%20AM.png?X-CloudApp-Visitor-Id=3221729&v=f6180221)

## Usage
Dashboard Value is made up of the `stat_label`, `stat_value` and `stat_change` child kits. 
Dashboard Value kit is made so that you can use it as a single kit, or the child kits can be used individually so we can use them within other kits.

![](https://d2y84jyh761mlc.cloudfront.net/items/2K15203Y1L1D3E441M2K/Image%202019-07-18%20at%209.55.34%20AM.png?X-CloudApp-Visitor-Id=3221729&v=c4384358)

## Examples
![](https://d2y84jyh761mlc.cloudfront.net/items/380A011A1M241f43293K/Image%202019-07-18%20at%208.51.54%20AM.png?X-CloudApp-Visitor-Id=3221729&v=85811ac6)

![](https://d2y84jyh761mlc.cloudfront.net/items/0O1G2R373b0l2f3Y1v3a/Image%202019-07-18%20at%208.52.44%20AM.png?X-CloudApp-Visitor-Id=3221729&v=dd292ed8)

---

![](https://d2y84jyh761mlc.cloudfront.net/items/1Q0h2d0c281t051h0238/Image%202019-07-18%20at%208.45.05%20AM.png?X-CloudApp-Visitor-Id=3221729&v=dc8c3409)

![](https://d2y84jyh761mlc.cloudfront.net/items/1O1z0q1l2536433T3J3m/Image%202019-07-18%20at%209.01.44%20AM.png?X-CloudApp-Visitor-Id=3221729&v=0c75814b)