### PR TITLE
KIT: Button Group

### DIFF
--- a/app/pb_kits/playbook/packs/examples.js
+++ b/app/pb_kits/playbook/packs/examples.js
@@ -47,3 +47,6 @@ WebpackerReact.setup (Icon);
 
 import * as DashboardValue from "pb_dashboard_value/docs";
 WebpackerReact.setup (DashboardValue);
+
+import * as ButtonGroup from "pb_button_group/docs";
+WebpackerReact.setup (ButtonGroup);

--- a/app/pb_kits/playbook/packs/kits.js
+++ b/app/pb_kits/playbook/packs/kits.js
@@ -11,3 +11,4 @@ import "./pb_avatar.js";
 import "./pb_input.js";
 import "./pb_icon.js";
 import "./pb_dashboard_value.js";
+import "./pb_button_group.js";

--- a/app/pb_kits/playbook/packs/pb_button_group.js
+++ b/app/pb_kits/playbook/packs/pb_button_group.js
@@ -1,0 +1,4 @@
+import ButtonGroup from "pb_button_group/_button_group.jsx";
+
+import WebpackerReact from "webpacker-react";
+WebpackerReact.setup({ ButtonGroup });

--- a/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
+++ b/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
@@ -13,3 +13,4 @@
 @import '../../pb_line_graph/line_graph';
 @import '../../pb_icon/icon';
 @import '../../pb_dashboard_value/dashboard_value';
+@import '../../pb_button_group/button_group';

--- a/app/pb_kits/playbook/packs/site_styles/docs/_kit_doc.scss
+++ b/app/pb_kits/playbook/packs/site_styles/docs/_kit_doc.scss
@@ -8,6 +8,19 @@
   background: $white;
   overflow: hidden;
 
+  &-demo-row {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    margin: 50px 0;
+    flex-wrap: wrap;
+
+     & > div {
+      margin: 20px 0;
+    }
+  }
+
   .pb--close-toggle {
     position: absolute;
     right: 10px;

--- a/app/pb_kits/playbook/pb_button/_button_mixins.scss
+++ b/app/pb_kits/playbook/pb_button/_button_mixins.scss
@@ -76,7 +76,7 @@ $pb_button_border_width: 1px;
   @include pb_button($white, $primary_action, $primary_action);
 
   &:hover {
-    @include pb_button_hover(rgba($secondary_action, $opacity_3));
+    @include pb_button_hover(rgba($secondary_action, $opacity_1));
   }
 }
 

--- a/app/pb_kits/playbook/pb_button_group/_button_group.html.erb
+++ b/app/pb_kits/playbook/pb_button_group/_button_group.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname(object.kit_class)) do %>
+  <%= object.yield(context: self) %>
+<% end %>

--- a/app/pb_kits/playbook/pb_button_group/_button_group.jsx
+++ b/app/pb_kits/playbook/pb_button_group/_button_group.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from "prop-types";
+
+const propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.string
+};
+
+class ButtonGroup extends React.Component {
+  render() {
+    return (
+      <div className="pb_button_group">
+        <span>BUTTON GROUP CONTENT</span>
+      </div>
+    )
+  }
+}
+
+ButtonGroup.propTypes = propTypes;
+
+export default ButtonGroup;

--- a/app/pb_kits/playbook/pb_button_group/_button_group.scss
+++ b/app/pb_kits/playbook/pb_button_group/_button_group.scss
@@ -1,0 +1,73 @@
+[class^=pb_button_group]{
+  // Orientation =========
+  &[class*=_horizontal]  {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+
+    & > [class^=pb_button]  {
+      margin-right: $space-xs;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+  &[class*=_vertical]  {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+
+    & > [class^=pb_button]  {
+      display: block;
+      flex-grow: 1;
+      flex-shrink: 1;
+      flex-basis: auto;
+      width: 100%;
+      margin-bottom: $space-xs;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  // Connect =============
+  &[class*=_connect]  {
+    & > [class^=pb_button]  {
+      margin: 0;
+    }
+
+    &[class*=_horizontal] {
+      & > [class^=pb_button]  {
+        &:not(:last-child){
+          border-bottom-right-radius: 0;
+          border-top-right-radius: 0;
+          border-right-width: 0;
+        }
+        &:not(:first-child){
+          border-bottom-left-radius: 0;
+          border-top-left-radius: 0;
+          border-left-width: 0;
+        }
+      }
+    }
+
+    &[class*=_vertical] {
+      & > [class^=pb_button]  {
+        &:not(:last-child){
+          border-bottom-right-radius: 0;
+          border-bottom-left-radius: 0;
+          border-bottom-width: 0;
+        }
+        &:not(:first-child){
+          border-top-right-radius: 0;
+          border-top-left-radius: 0;
+          border-top-width: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/pb_kits/playbook/pb_button_group/button_group.rb
+++ b/app/pb_kits/playbook/pb_button_group/button_group.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbButtonGroup
+    class ButtonGroup < Playbook::PbKit::Base
+      PROPS = %i[configured_classname
+                 configured_connect
+                 configured_data
+                 configured_id
+                 configured_orientation
+                 block].freeze
+
+      def initialize(classname: default_configuration,
+                     connect: default_configuration,
+                     data: default_configuration,
+                     id: default_configuration,
+                     orientation: default_configuration,
+                     &block)
+        self.configured_classname = classname
+        self.configured_connect = connect
+        self.configured_data = data
+        self.configured_id = id
+        self.configured_orientation = orientation
+        self.block = block_given? ? block : nil
+      end
+
+      def orientation
+        orientation_options = %w[horizontal vertical]
+        one_of_value(configured_orientation, orientation_options, "horizontal")
+      end
+
+      def connect
+        true_value(configured_connect, "connect", nil)
+      end
+
+      def kit_class
+        kit_options = [
+          "pb_button_group",
+          connect,
+          orientation,
+        ]
+        kit_options.compact.join("_")
+      end
+
+      def yield(context:)
+        context.capture(&block)
+      end
+
+      def to_partial_path
+        "pb_button_group/button_group"
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_button_group/docs/_button_group_default.html.erb
+++ b/app/pb_kits/playbook/pb_button_group/docs/_button_group_default.html.erb
@@ -1,0 +1,11 @@
+<%= pb_rails("button_group", props: { orientation: "horizontal" }) do %>
+  <%= pb_rails("button", props: { text: "Button Primary" }) %>
+  <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+  <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+<% end %>
+
+<%= pb_rails("button_group", props: { orientation: "horizontal", connect: true }) do %>
+  <%= pb_rails("button", props: { text: "Button Primary" }) %>
+  <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+  <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+<% end %>

--- a/app/pb_kits/playbook/pb_button_group/docs/_button_group_default.jsx
+++ b/app/pb_kits/playbook/pb_button_group/docs/_button_group_default.jsx
@@ -1,0 +1,12 @@
+import React from "react"
+import ButtonGroup from "../_button_group.jsx"
+
+function ButtonGroupDefault() {
+  return (
+    <div>
+      <ButtonGroup />
+    </div>
+  )
+}
+
+export default ButtonGroupDefault;

--- a/app/pb_kits/playbook/pb_button_group/docs/_button_group_vertical.html.erb
+++ b/app/pb_kits/playbook/pb_button_group/docs/_button_group_vertical.html.erb
@@ -1,0 +1,16 @@
+<div class="pb--doc-demo-row">
+  <div>
+    <%= pb_rails("button_group", props: { orientation: "vertical" }) do %>
+      <%= pb_rails("button", props: { text: "Button Primary" }) %>
+      <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+      <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+    <% end %>
+  </div>
+  <div>
+    <%= pb_rails("button_group", props: { orientation: "vertical", connect: true }) do %>
+      <%= pb_rails("button", props: { text: "Button Primary" }) %>
+      <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+      <%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
+    <% end %>
+  </div>
+</div>

--- a/app/pb_kits/playbook/pb_button_group/docs/example.yml
+++ b/app/pb_kits/playbook/pb_button_group/docs/example.yml
@@ -1,0 +1,9 @@
+examples:
+
+  rails:
+  - button_group_default: Horizontal Button Group
+  - button_group_vertical: Vertical Button Group
+
+
+  react:
+  - button_group_default: Default

--- a/app/pb_kits/playbook/pb_button_group/docs/index.js
+++ b/app/pb_kits/playbook/pb_button_group/docs/index.js
@@ -1,0 +1,1 @@
+export {default as ButtonGroupDefault} from './_button_group_default.jsx';

--- a/config/data/menu.yml
+++ b/config/data/menu.yml
@@ -13,3 +13,4 @@ kits:
   - icon
   - table
   - dashboard_value
+  - button_group


### PR DESCRIPTION
# PbButtonGroup Kit

##### Props:
* orientation (one of: horizontal*, vertical)
* connect (boolean)
* &block

##### What is it?
Button group can be wrapped around PbButton Kits to make a button group with consistent spacing and styles. Available option to make connected groups.

![](https://d2y84jyh761mlc.cloudfront.net/items/0l0T0y1X3b450h2y0N0V/Image%202019-07-20%20at%208.14.12%20PM.png?X-CloudApp-Visitor-Id=3221729&v=7193ad50)

![](https://d2y84jyh761mlc.cloudfront.net/items/2N1u0w231E0e211Q183V/Image%202019-07-20%20at%208.14.39%20PM.png?X-CloudApp-Visitor-Id=3221729&v=780ec5b6)

![](https://d2y84jyh761mlc.cloudfront.net/items/0W0U201m241X1j412P2V/Image%202019-07-20%20at%208.15.19%20PM.png?X-CloudApp-Visitor-Id=3221729&v=3ead0dae)