### PR TITLE
Bring webpacker gem dependency upto the version of the npm package

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       sassc-rails (= 1.3.0)
       slim-rails (= 3.2.0)
       sprockets-rails (= 2.3.3)
-      webpacker (= 4.0.2)
+      webpacker (= 4.0.7)
       webpacker-react (~> 0.3.2)
 
 GEM
@@ -206,7 +206,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webpacker (4.0.2)
+    webpacker (4.0.7)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)

--- a/playbook_ui.gemspec
+++ b/playbook_ui.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sassc-rails", "1.3.0"
   s.add_dependency "slim-rails", "3.2.0"
   s.add_dependency "sprockets-rails", "2.3.3"
-  s.add_dependency "webpacker", "4.0.2"
+  s.add_dependency "webpacker", "4.0.7"
   s.add_dependency "webpacker-react", "~> 0.3.2"
 
   s.add_development_dependency "better_errors"


### PR DESCRIPTION
Summary
-------

The Ruby Gem portion of playbook depends on webpacker version`4.0.2`,
but the JavaScript portion of Playbook depends on `4.0.7`. This causes
conflict when upgrading downstream consumers which depend on both the
Playbook Node package AND the ruby gem.

Affected versions: 2.8.1, 2.8.2

Referenes
---------

- https://github.com/powerhome/playbook/issues/107
- https://github.com/powerhome/playbook/blob/master/playbook_ui.gemspec#L25
- https://github.com/powerhome/playbook/blob/master/package.json#L48