### PR TITLE
Prevent common errors when running Playbook locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ADD Gemfile* *.gemspec /home/app/src/
 RUN bundle install --frozen
 
 ADD package.json yarn.lock /home/app/src/
+RUN yarn add --force node-sass
 RUN yarn install
 
 ADD --chown=app:app . /home/app/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build: .
     env_file:
       - '.env.docker'
-    command: bash -c "rm -rf /app/public/packs; ./bin/webpack-dev-server"
+    command: bash -c "rm -rf /app/public/packs; rm -rf /home/app/src/spec/dummy/tmp/pids/server.pid; ./bin/webpack-dev-server"
     volumes:
       - .:/home/app/src
     ports:


### PR DESCRIPTION
Prevent common errors when running Playbook locally

Addresses 2 common errors defined in [Common Errors & Solutions](https://github.com/powerhome/playbook/wiki/Common-Errors-&-Solutions)

* Already running server.pid
* Node-sass bindings