### PR TITLE
Eslint to Overcommit 

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -10,6 +10,16 @@ PreCommit:
     on_warn: fail
     problem_on_unmodified_line: ignore
     command: ['bundle', 'exec', 'rubocop']
+  EsLint:
+    enabled: true
+    on_warn: fail
+    required_executable: 'yarn'
+    problem_on_unmodified_line: ignore
+    command: ['yarn', 'lint', '--', '-f', 'compact']
+    include:
+      - '.eslintrc'
+      - 'app/pb_kits/playbook/**/*.js'
+      - 'app/pb_kits/playbook/**/*.jsx'
 
 CommitMsg:
   CapitalizedSubject:


### PR DESCRIPTION
Notes:

- Setup only to work with new commits
- Errors will trigger fail while warnings will not
- Based on `.eslintrc.json` rules from [Nitro](https://github.com/powerhome/nitro-web/blob/master/components/nitro_react/.eslintrc.json)

<img width="829" alt="Screen Shot 2019-08-26 at 4 30 26 PM" src="https://user-images.githubusercontent.com/2293844/63725024-da62e880-c81e-11e9-9070-2ff71b1c6cef.png">
