### PR TITLE
SPIKE: Dockerfile Optionally use `RAILS_ENV` ARG for Dev Env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN yarn install
 ADD --chown=app:app . /home/app/src
 RUN mkdir /etc/service/puma && ln -s /home/app/src/services/puma.sh /etc/service/puma/run
 
-RUN cd spec/dummy; RAILS_ENV=production SECRET_KEY_BASE=does_not_matter_here bin/rails assets:precompile
+RUN cd spec/dummy; RAILS_ENV=development SECRET_KEY_BASE=does_not_matter_here bin/rails assets:precompile --trace


### PR DESCRIPTION
TODO:

- Use Docker `ARG` variables to allow `make start_dev` command that will send `RAILS_ENV=development` which speeds up the development environment and matches it's intent with verbosity by also sending `--trace` flag. :1234: 