### PR TITLE
BUG FIX: All table headers should be medium size

### DIFF
--- a/app/pb_kits/playbook/pb_table/styles/_structure.scss
+++ b/app/pb_kits/playbook/pb_table/styles/_structure.scss
@@ -8,7 +8,7 @@
       thead {
         tr {
           th {
-            padding: $value $cell-gutter;
+            padding: $cell-pad-md $cell-gutter;
 
             &:first-child {
               padding-left: $cell-pad-endcap;


### PR DESCRIPTION
Fix for [Issue #111](https://github.com/powerhome/playbook/issues/111)

For all table sizes, the table header should be medium.