### PR TITLE
Create vendor.js for exporting 

### DIFF
--- a/app/pb_kits/playbook/packs/application.js
+++ b/app/pb_kits/playbook/packs/application.js
@@ -1,10 +1,8 @@
 import "../../../../fonts/fontawesome.js"
 import "../../../../fonts/regular.js"
-import pbChart from "../plugins/pb_chart_plugin.js"
 import "./main.scss"
 import "./kits.js"
-
-window.pbChart = pbChart
+import "../vendor.js"
 
 // Move to separate file
 $(document).on("click", "[data-toggle]", function(e) {

--- a/app/pb_kits/playbook/packs/pb_image.js
+++ b/app/pb_kits/playbook/packs/pb_image.js
@@ -1,6 +1,5 @@
 import Image from "pb_image/_image.jsx";
 import WebpackerReact from "webpacker-react";
-import "lazysizes";
 
 
 WebpackerReact.setup({ Image });

--- a/app/pb_kits/playbook/pb_dashboard/pbChartsLightTheme.js
+++ b/app/pb_kits/playbook/pb_dashboard/pbChartsLightTheme.js
@@ -1,6 +1,8 @@
 import colors from '../tokens/_colors.scss';
 import typography from '../tokens/_typography.scss';
 
+import Highcharts from 'highcharts'
+
 const highchartsTheme = {
   colors: [
     colors.data_1,

--- a/app/pb_kits/playbook/plugins/pb_chart_plugin.js
+++ b/app/pb_kits/playbook/plugins/pb_chart_plugin.js
@@ -1,3 +1,5 @@
+import Highcharts from 'highcharts'
+
 import { highchartsTheme } from '../pb_dashboard/pbChartsLightTheme.js'
 
 class pbChart {

--- a/app/pb_kits/playbook/vendor.js
+++ b/app/pb_kits/playbook/vendor.js
@@ -1,0 +1,6 @@
+// Charts
+import pbChart from "./plugins/pb_chart_plugin"
+window.pbChart = pbChart
+
+// Lazy image loading
+import "lazysizes"

--- a/app/views/layouts/playbook/application.html.slim
+++ b/app/views/layouts/playbook/application.html.slim
@@ -16,7 +16,6 @@ html
           = yield
 
   = javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"
-  = javascript_include_tag "https://code.highcharts.com/highcharts.js"
   = javascript_pack_tag 'application'
   = javascript_pack_tag 'examples'
 = yield :pb_js

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-flowtype": "2.35.1",
     "flow-bin": "0.54.1",
     "flow-runtime": "0.14.0",
+    "highcharts": "^7.2.0",
     "lazysizes": "^4.1.6",
     "lodash": "4.17.15",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3913,6 +3913,11 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
 
+highcharts@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.2.0.tgz#d6bd00240767cfab67210ead47c6cd015384e74d"
+  integrity sha512-jOlMzj3oRuqNBoJg+rqHZI9vnlLHipwVfceJr00gAreXu8268UwahEh7yBGI/m1wa6Uc/XoBMIuzMpXUFMvFdg==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
This adds `vendor.js` which is to be consumed the same way in PB as in PG and Nitro. 

Lib tree in vendor:

- lazysizes
- pb_chart_plugin.js
  - Highcharts