### PR TITLE
Bug: Title Count spacing

### DIFF
--- a/app/pb_kits/playbook/pb_title_count/_title_count.scss
+++ b/app/pb_kits/playbook/pb_title_count/_title_count.scss
@@ -6,8 +6,8 @@
   justify-content: flex-start;
   align-items: baseline;
 
-  & > [class^=pb_title_kit] {
-    margin-right: $space-xs;
+  & > .pb_title_count_text {
+    padding-right: $space-xs;
   }
 
   &[class*=_center] {

--- a/app/pb_kits/playbook/pb_title_count/title_count.rb
+++ b/app/pb_kits/playbook/pb_title_count/title_count.rb
@@ -43,7 +43,7 @@ module Playbook
 
       def title
         if is_set? configured_title
-          pb_title = Playbook::PbTitle::Title.new(size: title_size, text: configured_title)
+          pb_title = Playbook::PbTitle::Title.new(size: title_size, text: configured_title, classname: "pb_title_count_text")
           ApplicationController.renderer.render(partial: pb_title, as: :object)
         end
       end


### PR DESCRIPTION
Changes:
* Adds missing space between title and count

## Before 
![](https://d2y84jyh761mlc.cloudfront.net/items/0v202p2B193K2m1f3F2L/Image%202019-09-19%20at%209.32.18%20AM.png?X-CloudApp-Visitor-Id=3221729)

## After 
![](https://d2y84jyh761mlc.cloudfront.net/items/1j0w0W0S1d2N3V3l3S0K/Image%202019-09-19%20at%209.32.06%20AM.png?X-CloudApp-Visitor-Id=3221729)

Resolves Issue #242 