### PR TITLE
Enhance Toggle to accept custom inputs

### DIFF
--- a/app/pb_kits/playbook/pb_toggle/_toggle.html.erb
+++ b/app/pb_kits/playbook/pb_toggle/_toggle.html.erb
@@ -6,7 +6,7 @@
     ) do %>
 
     <label class="pb_toggle_wrapper">
-      <input type="checkbox" <%= object.name %> <%= object.value %> <%= object.checked %> />
+      <%= object.yield(context: self) %>
       <div class="pb_toggle_control"></div>
     </label>
 <% end %>

--- a/app/pb_kits/playbook/pb_toggle/docs/_toggle_custom.html.erb
+++ b/app/pb_kits/playbook/pb_toggle/docs/_toggle_custom.html.erb
@@ -1,0 +1,3 @@
+<%= pb_rails("toggle", props: { size: "sm" }) do %>
+  <input class="my_custom_input" type="checkbox" name="custom_checkbox" value="ABC" />
+<% end %>

--- a/app/pb_kits/playbook/pb_toggle/docs/_toggle_custom_radio.html.erb
+++ b/app/pb_kits/playbook/pb_toggle/docs/_toggle_custom_radio.html.erb
@@ -1,0 +1,22 @@
+<%= pb_rails("title", props: { size: 4, text: "Select one option:" }) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "Male" }) %>
+<%= pb_rails("toggle", props: { size: "sm" }) do %>
+  <input type="radio" name="gender" value="male">
+<% end %>
+
+<br/>
+
+<%= pb_rails("caption", props: { text: "Female" }) %>
+<%= pb_rails("toggle", props: { size: "sm" }) do %>
+  <input type="radio" name="gender" value="female">
+<% end %>
+
+<br/>
+
+<%= pb_rails("caption", props: { text: "Other" }) %>
+<%= pb_rails("toggle", props: { size: "sm" }) do %>
+  <input type="radio" name="gender" value="other">
+<% end %>

--- a/app/pb_kits/playbook/pb_toggle/docs/_toggle_name.html.erb
+++ b/app/pb_kits/playbook/pb_toggle/docs/_toggle_name.html.erb
@@ -2,24 +2,20 @@
 
 <br>
 
-<label>
-  <%= pb_rails("caption", props: { text: "Car" }) %>
-  <%= pb_rails("toggle", props: {
-    size: "sm",
-    checked: false,
-    name: "vehicle",
-    value: "car"
-  }) %>
-</label>
+<%= pb_rails("caption", props: { text: "Car" }) %>
+<%= pb_rails("toggle", props: {
+  size: "sm",
+  checked: false,
+  name: "vehicle",
+  value: "car"
+}) %>
 
 <br>
 
-<label>
-  <%= pb_rails("caption", props: { text: "Bike" }) %>
-  <%= pb_rails("toggle", props: {
-    size: "sm",
-    checked: false,
-    name: "vehicle",
-    value: "bike"
-  }) %>
-</label>
+<%= pb_rails("caption", props: { text: "Bike" }) %>
+<%= pb_rails("toggle", props: {
+  size: "sm",
+  checked: false,
+  name: "vehicle",
+  value: "bike"
+}) %>

--- a/app/pb_kits/playbook/pb_toggle/docs/example.yml
+++ b/app/pb_kits/playbook/pb_toggle/docs/example.yml
@@ -4,6 +4,8 @@ examples:
   - toggle_default: Sizes
   - toggle_checked: Default State
   - toggle_name: Name and Value
+  - toggle_custom: Custom checkbox input
+  - toggle_custom_radio: Custom radio inputs
 
   react:
   - toggle_default: Default

--- a/app/pb_kits/playbook/pb_toggle/toggle.rb
+++ b/app/pb_kits/playbook/pb_toggle/toggle.rb
@@ -3,6 +3,9 @@
 module Playbook
   module PbToggle
     class Toggle < Playbook::PbKit::Base
+      include ActionView::Helpers::FormTagHelper
+      include ActionView::Context
+
       PROPS = %i[configured_aria
                  configured_classname
                  configured_checked
@@ -10,7 +13,8 @@ module Playbook
                  configured_id
                  configured_name
                  configured_size
-                 configured_value].freeze
+                 configured_value
+                 block].freeze
 
       def initialize(aria: default_configuration,
                      classname: default_configuration,
@@ -19,7 +23,8 @@ module Playbook
                      id: default_configuration,
                      name: default_configuration,
                      size: default_configuration,
-                     value: default_configuration)
+                     value: default_configuration,
+                     &block)
         self.configured_aria = aria
         self.configured_classname = classname
         self.configured_checked = checked
@@ -28,14 +33,15 @@ module Playbook
         self.configured_name = name
         self.configured_size = size
         self.configured_value = value
+        self.block = block_given? ? block : nil
       end
 
       def checked
-        true_value(configured_checked, "checked='true'", "")
+        is_true? configured_checked
       end
 
       def name
-        "name=\"#{configured_name}\"" if is_set? configured_name
+        configured_name if is_set? configured_name
       end
 
       def size
@@ -44,7 +50,15 @@ module Playbook
       end
 
       def value
-        "value=\"#{configured_value}\"" if is_set? configured_value
+        configured_value if is_set? configured_value
+      end
+
+      def input
+        check_box_tag(name, value, checked)
+      end
+
+      def yield(context:)
+        !block.nil? ? context.capture(&block) : input
       end
 
       def kit_class


### PR DESCRIPTION
Allow Toggle to accept custom inputs through the block syntax

**Custom checkbox**
```erb
<%= pb_rails("toggle", props: { size: "sm" }) do %>
  <input class="my_custom_input" type="checkbox" name="custom_checkbox" value="ABC" />
<% end %>
```

**Custom radio**
```erb
<%= pb_rails("toggle", props: { size: "sm" }) do %>
  <input type="radio" name="gender" value="male">
<% end %>
```

---

Or allow for default functionality of a checkbox input, but just passing in `name`, `value` and `checked`

```erb
<%= pb_rails("toggle", props: {
  size: "sm",
  checked: false,
  name: "vehicle",
  value: "car"
}) %>
```

---

## Demos

### Custom checkbox
![](https://d2y84jyh761mlc.cloudfront.net/items/2E0u2N1x0347122M1e3B/Screen%20Recording%202019-09-19%20at%2007.17%20PM.gif?X-CloudApp-Visitor-Id=3221729&v=f7e20290)

### Custom radio
![](https://d2y84jyh761mlc.cloudfront.net/items/3C2l471l0T1X0Z003223/Screen%20Recording%202019-09-19%20at%2007.17%20PM.gif?X-CloudApp-Visitor-Id=3221729)