### PR TITLE
Enhance Date optional icon

### DIFF
--- a/app/pb_kits/playbook/pb_date/date.rb
+++ b/app/pb_kits/playbook/pb_date/date.rb
@@ -28,7 +28,14 @@ module Playbook
       end
 
       def display_value
-        size == "lg" ? display_value_lg : display_value_sm
+        case size
+        when "lg"
+          display_value_lg
+        when "sm"
+          display_value_sm
+        else
+          display_value_xs
+        end
       end
 
       def kit_class
@@ -67,7 +74,7 @@ module Playbook
       end
 
       def size
-        size_options = %w[lg sm]
+        size_options = %w[lg sm xs]
         one_of_value(configured_size, size_options, "sm")
       end
 
@@ -79,6 +86,13 @@ module Playbook
       def text
         content_tag(:span) do
           "#{day_of_week} &middot; #{month} #{day}".html_safe
+        end
+      end
+
+      def display_value_xs
+        if is_set? configured_timestamp
+          pb_value = Playbook::PbTitle::Title.new(size: 4, text: text)
+          ApplicationController.renderer.render(partial: pb_value, as: :object)
         end
       end
 

--- a/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
+++ b/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
@@ -8,3 +8,10 @@
 <%= pb_rails("date", props: {
   timestamp: "2012-08-02T15:49:29Z"
 }) %>
+
+<br>
+
+<%= pb_rails("date", props: {
+  timestamp: "2012-08-02T15:49:29Z",
+  size: "xs"
+}) %>


### PR DESCRIPTION
Allow for date to have optional icon.

Currently date has 2 sizes (lg, sm).  I added xs for the non-icon version. This is now consistent with the Time kit.

![](https://d2y84jyh761mlc.cloudfront.net/items/3L2a3l4637363o312y1J/Image%202019-09-20%20at%208.38.11%20AM.png?X-CloudApp-Visitor-Id=3221729)