### PR TITLE
Label Value update and Icon Body Title kit

### DIFF
--- a/app/pb_kits/playbook/packs/examples.js
+++ b/app/pb_kits/playbook/packs/examples.js
@@ -134,3 +134,6 @@ WebpackerReact.setup (IconBodyTitle);
 
 import * as InventoryLocation from "pb_inventory_location/docs";
 WebpackerReact.setup (InventoryLocation);
+
+import * as Installer from "pb_installer/docs";
+WebpackerReact.setup (Installer);

--- a/app/pb_kits/playbook/packs/examples.js
+++ b/app/pb_kits/playbook/packs/examples.js
@@ -137,3 +137,6 @@ WebpackerReact.setup (InventoryLocation);
 
 import * as Installer from "pb_installer/docs";
 WebpackerReact.setup (Installer);
+
+import * as Project from "pb_project/docs";
+WebpackerReact.setup (Project);

--- a/app/pb_kits/playbook/packs/examples.js
+++ b/app/pb_kits/playbook/packs/examples.js
@@ -128,3 +128,9 @@ WebpackerReact.setup (SectionSeparator);
 
 import * as Currency from "pb_currency/docs";
 WebpackerReact.setup (Currency);
+
+import * as IconBodyTitle from "pb_icon_body_title/docs";
+WebpackerReact.setup (IconBodyTitle);
+
+import * as InventoryLocation from "pb_inventory_location/docs";
+WebpackerReact.setup (InventoryLocation);

--- a/app/pb_kits/playbook/packs/kits.js
+++ b/app/pb_kits/playbook/packs/kits.js
@@ -40,3 +40,4 @@ import "./pb_section_separator.js";
 import "./pb_currency.js";
 import "./pb_icon_body_title.js";
 import "./pb_inventory_location.js";
+import "./pb_installer.js";

--- a/app/pb_kits/playbook/packs/kits.js
+++ b/app/pb_kits/playbook/packs/kits.js
@@ -38,3 +38,5 @@ import "./pb_stat_value.js";
 import "./pb_stat_change.js";
 import "./pb_section_separator.js";
 import "./pb_currency.js";
+import "./pb_icon_body_title.js";
+import "./pb_inventory_location.js";

--- a/app/pb_kits/playbook/packs/kits.js
+++ b/app/pb_kits/playbook/packs/kits.js
@@ -41,3 +41,4 @@ import "./pb_currency.js";
 import "./pb_icon_body_title.js";
 import "./pb_inventory_location.js";
 import "./pb_installer.js";
+import "./pb_project.js";

--- a/app/pb_kits/playbook/packs/pb_icon_body_title.js
+++ b/app/pb_kits/playbook/packs/pb_icon_body_title.js
@@ -1,0 +1,4 @@
+import IconBodyTitle from "pb_icon_body_title/_icon_body_title.jsx";
+
+import WebpackerReact from "webpacker-react";
+WebpackerReact.setup({ IconBodyTitle });

--- a/app/pb_kits/playbook/packs/pb_installer.js
+++ b/app/pb_kits/playbook/packs/pb_installer.js
@@ -1,0 +1,4 @@
+import Installer from "pb_installer/_installer.jsx";
+
+import WebpackerReact from "webpacker-react";
+WebpackerReact.setup({ Installer });

--- a/app/pb_kits/playbook/packs/pb_inventory_location.js
+++ b/app/pb_kits/playbook/packs/pb_inventory_location.js
@@ -1,0 +1,4 @@
+import InventoryLocation from "pb_inventory_location/_inventory_location.jsx";
+
+import WebpackerReact from "webpacker-react";
+WebpackerReact.setup({ InventoryLocation });

--- a/app/pb_kits/playbook/packs/pb_project.js
+++ b/app/pb_kits/playbook/packs/pb_project.js
@@ -1,0 +1,4 @@
+import Project from "pb_project/_project.jsx";
+
+import WebpackerReact from "webpacker-react";
+WebpackerReact.setup({ Project });

--- a/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
+++ b/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
@@ -42,3 +42,4 @@
 @import '../../pb_icon_body_title/icon_body_title';
 @import '../../pb_inventory_location/inventory_location';
 @import '../../pb_installer/installer';
+@import '../../pb_project/project';

--- a/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
+++ b/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
@@ -39,3 +39,5 @@
 @import '../../pb_stat_change/stat_change';
 @import '../../pb_section_separator/section_separator';
 @import '../../pb_currency/currency';
+@import '../../pb_icon_body_title/icon_body_title';
+@import '../../pb_inventory_location/inventory_location';

--- a/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
+++ b/app/pb_kits/playbook/packs/site_styles/_kit_style_index.scss
@@ -41,3 +41,4 @@
 @import '../../pb_currency/currency';
 @import '../../pb_icon_body_title/icon_body_title';
 @import '../../pb_inventory_location/inventory_location';
+@import '../../pb_installer/installer';

--- a/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.html.erb
+++ b/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.html.erb
@@ -1,0 +1,8 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.kit_class) do %>
+  <%= object.icon %>
+  <%= object.body %>
+  <%= object.title %>
+<% end %>

--- a/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.html.erb
+++ b/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.html.erb
@@ -2,7 +2,6 @@
     id: object.id,
     data: object.data,
     class: object.kit_class) do %>
-  <%= object.icon %>
   <%= object.body %>
   <%= object.title %>
 <% end %>

--- a/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.jsx
+++ b/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.jsx
@@ -21,10 +21,10 @@ const IconBodyTitle = ({ body, className, data, icon, id, title, link }: IconBod
   const titleContent = !!link ? (<a href={link}>{title}</a>) : title 
   return (
     <div className={classnames(`pb_icon_body_title_kit_${icon}`, className)} id={id} data={data}>
-      <Icon icon={icon} className="pb_icon_body_title_kit_icon" />
-      <If condition={!!body}>
-        <Body color="light" text={body} className="pb_icon_body_title_kit_body"></Body>
-      </If>
+      <Body color="light" className="pb_icon_body_title_kit_body">
+        <Icon icon={icon} className="pb_icon_body_title_kit_icon" />
+        {body}
+      </Body>
       <Title text={titleContent} tag="h4" size={4} className="pb_icon_body_title_kit_title" />
     </div>
   )

--- a/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.jsx
+++ b/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.jsx
@@ -1,0 +1,32 @@
+/* @flow */
+/*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
+
+import React from 'react'
+import Title from "../pb_title/_title.jsx";
+import Body from "../pb_body/_body.jsx";
+import Icon from "../pb_icon/_icon.jsx";
+
+type IconBodyTitleProps = {
+  body?: String,
+  className?: String,
+  data?: String,
+  icon?: String,
+  id?: String,
+  title?: String,
+  link?: String,
+}
+
+const IconBodyTitle = ({ body, className, data, icon, id, title, link }: IconBodyTitleProps) => {
+  const titleContent = !!link ? (<a href={link}>{title}</a>) : title 
+  return (
+    <div className={className || `pb_icon_body_title_kit_${icon}`} id={id} data={data}>
+      <Icon icon={icon} className="pb_icon_body_title_kit_icon" />
+      <If condition={!!body}>
+        <Body color="light" text={body} className="pb_icon_body_title_kit_body"></Body>
+      </If>
+      <Title text={titleContent} tag="h4" size={4} className="pb_icon_body_title_kit_title" />
+    </div>
+  )
+}
+
+export default IconBodyTitle

--- a/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.jsx
+++ b/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.jsx
@@ -2,13 +2,14 @@
 /*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
 
 import React from 'react'
-import Title from "../pb_title/_title.jsx";
-import Body from "../pb_body/_body.jsx";
-import Icon from "../pb_icon/_icon.jsx";
+import Title from "../pb_title/_title.jsx"
+import Body from "../pb_body/_body.jsx"
+import Icon from "../pb_icon/_icon.jsx"
+import classnames from 'classnames'
 
 type IconBodyTitleProps = {
   body?: String,
-  className?: String,
+  className?: String | Array<String>,
   data?: String,
   icon?: String,
   id?: String,
@@ -19,7 +20,7 @@ type IconBodyTitleProps = {
 const IconBodyTitle = ({ body, className, data, icon, id, title, link }: IconBodyTitleProps) => {
   const titleContent = !!link ? (<a href={link}>{title}</a>) : title 
   return (
-    <div className={className || `pb_icon_body_title_kit_${icon}`} id={id} data={data}>
+    <div className={classnames(`pb_icon_body_title_kit_${icon}`, className)} id={id} data={data}>
       <Icon icon={icon} className="pb_icon_body_title_kit_icon" />
       <If condition={!!body}>
         <Body color="light" text={body} className="pb_icon_body_title_kit_body"></Body>

--- a/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.scss
+++ b/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.scss
@@ -9,9 +9,6 @@
 
   .pb_icon_body_title_kit_title, .pb_icon_body_title_kit_body, .pb_icon_body_title_kit_icon {
     line-height: $lh_normal;
-  }
-
-  .pb_icon_body_title_kit_title, .pb_icon_body_title_kit_body {
-    margin-left: $space-xs;
+    margin-right: $space-xs;
   }
 }

--- a/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.scss
+++ b/app/pb_kits/playbook/pb_icon_body_title/_icon_body_title.scss
@@ -1,0 +1,17 @@
+@import "../tokens/spacing";
+@import "../tokens/line_height";
+
+[class^=pb_icon_body_title_kit] {
+  display: flex;
+  justify-content: flex-start;
+  align-items: baseline;
+  flex-direction: row;
+
+  .pb_icon_body_title_kit_title, .pb_icon_body_title_kit_body, .pb_icon_body_title_kit_icon {
+    line-height: $lh_normal;
+  }
+
+  .pb_icon_body_title_kit_title, .pb_icon_body_title_kit_body {
+    margin-left: $space-xs;
+  }
+}

--- a/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_default.html.erb
+++ b/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_default.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("icon_body_title", props: { icon: "user", body: "Nitro", title: "Digital Assistant", link: "#" }) %>

--- a/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_default.jsx
+++ b/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_default.jsx
@@ -4,7 +4,12 @@ import IconBodyTitle from "../_icon_body_title.jsx"
 function IconBodyTitleDefault() {
   return (
     <div>
-      <IconBodyTitle icon="user" title="Nitro" body="Virtual Assistant" link="#" />
+      <IconBodyTitle 
+        body="Virtual Assistant" 
+        icon="user" 
+        link="#"
+        title="Nitro" 
+      />
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_default.jsx
+++ b/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_default.jsx
@@ -1,0 +1,12 @@
+import React from "react"
+import IconBodyTitle from "../_icon_body_title.jsx"
+
+function IconBodyTitleDefault() {
+  return (
+    <div>
+      <IconBodyTitle icon="user" title="Nitro" body="Virtual Assistant" link="#" />
+    </div>
+  )
+}
+
+export default IconBodyTitleDefault;

--- a/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_no_link.html.erb
+++ b/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_no_link.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("icon_body_title", props: { icon: "user", body: "Nitro", title: "Digital Assistant" }) %>

--- a/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_no_link.jsx
+++ b/app/pb_kits/playbook/pb_icon_body_title/docs/_icon_body_title_no_link.jsx
@@ -1,0 +1,12 @@
+import React from "react"
+import IconBodyTitle from "../_icon_body_title.jsx"
+
+function IconBodyTitleNoLink() {
+  return (
+    <div>
+      <IconBodyTitle icon="user" title="Nitro" body="Virtual Assistant" />
+    </div>
+  )
+}
+
+export default IconBodyTitleNoLink;

--- a/app/pb_kits/playbook/pb_icon_body_title/docs/example.yml
+++ b/app/pb_kits/playbook/pb_icon_body_title/docs/example.yml
@@ -1,0 +1,11 @@
+examples:
+  
+  rails:
+  - icon_body_title_default: Default
+  - icon_body_title_no_link: No Link
+  
+  
+  react:
+  - icon_body_title_default: Default
+  - icon_body_title_no_link: No Link
+  

--- a/app/pb_kits/playbook/pb_icon_body_title/docs/index.js
+++ b/app/pb_kits/playbook/pb_icon_body_title/docs/index.js
@@ -1,0 +1,2 @@
+export {default as IconBodyTitleDefault} from './_icon_body_title_default.jsx';
+export {default as IconBodyTitleNoLink} from './_icon_body_title_no_link.jsx';

--- a/app/pb_kits/playbook/pb_icon_body_title/icon_body_title.rb
+++ b/app/pb_kits/playbook/pb_icon_body_title/icon_body_title.rb
@@ -20,7 +20,7 @@ module Playbook
                      icon: default_configuration,
                      id: default_configuration,
                      title: default_configuration,
-                     link: default_configuration)
+                     link: nil)
         self.configured_body = body
         self.configured_classname = classname
         self.configured_data = data
@@ -51,7 +51,7 @@ module Playbook
 
       def title
         if is_set? configured_title
-          title_text = if is_set?(configured_link)
+          title_text = if configured_link
             content_tag(:a, href: link) { configured_title } 
           else
             configured_title
@@ -62,7 +62,7 @@ module Playbook
       end
 
       def link
-        default_value(configured_link, "")
+        default_value(configured_link, nil)
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_icon_body_title/icon_body_title.rb
+++ b/app/pb_kits/playbook/pb_icon_body_title/icon_body_title.rb
@@ -14,7 +14,7 @@ module Playbook
                  configured_title
                  configured_link].freeze
 
-      def initialize(body: default_configuration,
+      def initialize(body: "",
                      classname: default_configuration,
                      data: default_configuration,
                      icon: default_configuration,
@@ -31,12 +31,10 @@ module Playbook
       end
 
       def body
-        if is_set? configured_body
-          pb_body = Playbook::PbBody::Body.new(color: "light", classname: "pb_icon_body_title_kit_body") do
-            configured_body
-          end
-          ApplicationController.renderer.render(partial: pb_body, as: :object)
+        pb_body = Playbook::PbBody::Body.new(color: "light", classname: "pb_icon_body_title_kit_body") do
+          icon + configured_body
         end
+        ApplicationController.renderer.render(partial: pb_body, as: :object)
       end
 
       def icon
@@ -52,17 +50,13 @@ module Playbook
       def title
         if is_set? configured_title
           title_text = if configured_link
-            content_tag(:a, href: link) { configured_title } 
+            content_tag(:a, href: configured_link) { configured_title } 
           else
             configured_title
           end
           pb_title = Playbook::PbTitle::Title.new(size: 4, tag: "h4", text: title_text, classname: "pb_icon_body_title_kit_title")
           ApplicationController.renderer.render(partial: pb_title, as: :object)
         end
-      end
-
-      def link
-        default_value(configured_link, nil)
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_icon_body_title/icon_body_title.rb
+++ b/app/pb_kits/playbook/pb_icon_body_title/icon_body_title.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbIconBodyTitle
+    class IconBodyTitle < Playbook::PbKit::Base
+      include ActionView::Helpers::TagHelper
+      include ActionView::Context
+
+      PROPS = %i[configured_body
+                 configured_classname
+                 configured_data
+                 configured_icon
+                 configured_id
+                 configured_title
+                 configured_link].freeze
+
+      def initialize(body: default_configuration,
+                     classname: default_configuration,
+                     data: default_configuration,
+                     icon: default_configuration,
+                     id: default_configuration,
+                     title: default_configuration,
+                     link: default_configuration)
+        self.configured_body = body
+        self.configured_classname = classname
+        self.configured_data = data
+        self.configured_icon = icon
+        self.configured_id = id
+        self.configured_title = title
+        self.configured_link = link
+      end
+
+      def body
+        if is_set? configured_body
+          pb_body = Playbook::PbBody::Body.new(color: "light", classname: "pb_icon_body_title_kit_body") do
+            configured_body
+          end
+          ApplicationController.renderer.render(partial: pb_body, as: :object)
+        end
+      end
+
+      def icon
+        if is_set? configured_icon
+          icon_props = { icon: configured_icon, fixed_width: true, classname: "pb_icon_body_title_kit_icon" }
+          pb_icon = Playbook::PbIcon::Icon.new(icon_props)
+          ApplicationController.renderer.render(partial: pb_icon, as: :object)
+        else
+          ""
+        end
+      end
+
+      def title
+        if is_set? configured_title
+          title_text = if is_set?(configured_link)
+            content_tag(:a, href: link) { configured_title } 
+          else
+            configured_title
+          end
+          pb_title = Playbook::PbTitle::Title.new(size: 4, tag: "h4", text: title_text, classname: "pb_icon_body_title_kit_title")
+          ApplicationController.renderer.render(partial: pb_title, as: :object)
+        end
+      end
+
+      def link
+        default_value(configured_link, "")
+      end
+
+      def to_partial_path
+        "pb_icon_body_title/icon_body_title"
+      end
+
+      def kit_class
+        kit_options = [
+          "pb_icon_body_title_kit",
+          configured_icon,
+        ]
+        kit_options.join("_")
+      end
+
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_installer/_installer.html.erb
+++ b/app/pb_kits/playbook/pb_installer/_installer.html.erb
@@ -1,0 +1,5 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname("pb_installer_kit")) { object.content }
+%>

--- a/app/pb_kits/playbook/pb_installer/_installer.jsx
+++ b/app/pb_kits/playbook/pb_installer/_installer.jsx
@@ -1,0 +1,30 @@
+/* @flow */
+/*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
+
+import React from 'react'
+import LabelValue from '../pb_label_value/_label_value.jsx'
+import IconBodyTitle from '../pb_icon_body_title/_icon_body_title.jsx'
+import classnames from 'classnames'
+
+type InstallerProps = {
+  className?: String,
+  data?: String,
+  id?: String,
+  link?: String,
+  name: String,
+  
+}
+
+const Installer = ({ className, data, id, link, name }: InstallerProps) => {
+  return (<div className={classnames("pb_installer_kit", className)} id={id} data={data}>
+    <LabelValue label="Installer">
+      <IconBodyTitle 
+        icon="truck" 
+        link={link}
+        title={name} 
+      />
+    </LabelValue>
+  </div>
+)}
+
+export default Installer

--- a/app/pb_kits/playbook/pb_installer/_installer.scss
+++ b/app/pb_kits/playbook/pb_installer/_installer.scss
@@ -1,0 +1,3 @@
+.pb_installer {
+
+}

--- a/app/pb_kits/playbook/pb_installer/docs/_installer_default.html.erb
+++ b/app/pb_kits/playbook/pb_installer/docs/_installer_default.html.erb
@@ -1,0 +1,3 @@
+<%= pb_rails("installer", props: { name: "JD Installations LLC"}) %>
+<br />
+<%= pb_rails("installer", props: { name: "JD Installations LLC", link: "#" }) %>

--- a/app/pb_kits/playbook/pb_installer/docs/_installer_default.jsx
+++ b/app/pb_kits/playbook/pb_installer/docs/_installer_default.jsx
@@ -1,0 +1,19 @@
+import React from "react"
+import Installer from "../_installer.jsx"
+
+function InstallerDefault() {
+  return (
+    <div>
+      <Installer
+        name="JD Installations LLC"
+      />
+      <br />
+      <Installer
+        name="JD Installations LLC"
+        link="#"
+      />
+    </div>
+  )
+}
+
+export default InstallerDefault;

--- a/app/pb_kits/playbook/pb_installer/docs/example.yml
+++ b/app/pb_kits/playbook/pb_installer/docs/example.yml
@@ -1,0 +1,9 @@
+examples:
+  
+  rails:
+  - installer_default: Default
+  
+  
+  react:
+  - installer_default: Default
+  

--- a/app/pb_kits/playbook/pb_installer/docs/index.js
+++ b/app/pb_kits/playbook/pb_installer/docs/index.js
@@ -1,0 +1,1 @@
+export {default as InstallerDefault} from './_installer_default.jsx';

--- a/app/pb_kits/playbook/pb_installer/installer.rb
+++ b/app/pb_kits/playbook/pb_installer/installer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbInstaller
+    class Installer < Playbook::PbKit::Base
+      PROPS = %i[configured_classname
+                 configured_data
+                 configured_id
+                 configured_link
+                 configured_name].freeze
+
+      def initialize(classname: default_configuration,
+                     data: default_configuration,
+                     id: default_configuration,
+                     link: nil,
+                     name: default_configuration)
+        self.configured_classname = classname
+        self.configured_data = data
+        self.configured_id = id
+        self.configured_link = link
+        self.configured_name = name
+      end
+
+      def to_partial_path
+        "pb_installer/installer"
+      end
+
+      def content
+        pb_label_value = Playbook::PbLabelValue::LabelValue.new(label: "Installer") do
+          icon_body_title = Playbook::PbIconBodyTitle::IconBodyTitle.new(icon: "truck", title: configured_name, link: configured_link)
+          ApplicationController.renderer.render(partial: icon_body_title, as: :object)
+        end
+        ApplicationController.renderer.render(partial: pb_label_value, as: :object)
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.html.erb
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname("pb_inventory_location")) do %>
-  <span>INVENTORY LOCATION CONTENT</span>
-<% end %>
+    class: object.classname("pb_inventory_location")) do 
+      object.content
+end %>

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.html.erb
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname("pb_inventory_location")) do 
+    class: object.classname("pb_inventory_location_kit")) do
       object.content
 end %>

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.html.erb
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname("pb_inventory_location")) do %>
+  <span>INVENTORY LOCATION CONTENT</span>
+<% end %>

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
@@ -2,16 +2,17 @@
 /*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
 
 import React from 'react'
-import LabelValue from '../pb_label_value/_label_value.jsx';
-import IconBodyTitle from '../pb_icon_body_title/_icon_body_title.jsx';
+import LabelValue from '../pb_label_value/_label_value.jsx'
+import IconBodyTitle from '../pb_icon_body_title/_icon_body_title.jsx'
+import classnames from 'classnames'
 
 type InventoryLocationProps = {
-  bin?: String,
-  className?: String,
+  bin: String,
+  className?: String | Array<String>,
   data?: String,
   id?: String,
   link?: String,
-  type?: 'rack' | 'cart' | 'zone',
+  type: 'rack' | 'cart' | 'zone',
 }
 
 const icons = {
@@ -21,7 +22,7 @@ const icons = {
 }
 
 const InventoryLocation = ({ bin, className, data,  id, link, type }: InventoryLocationProps) => {
-  return (<div className={className || "pb_inventory_location_kit"} id={id} data={data}>
+  return (<div className={classnames("pb_inventory_location_kit", className)} id={id} data={data}>
     <LabelValue label="Location">
       <IconBodyTitle icon={icons[type]} body={type} title={bin} link={link} />
     </LabelValue>

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
@@ -1,0 +1,32 @@
+/* @flow */
+/*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
+
+import React from 'react'
+import LabelValue from '../pb_label_value/_label_value';
+import IconBodyTitle from '../pb_icon_body_title/_icon_body_title';
+
+type InventoryLocationProps = {
+  bin?: String,
+  className?: String,
+  data?: String,
+  id?: String,
+  link?: String,
+  type?: 'rack' | 'cart' | 'zone',
+}
+
+const icons = {
+  rack: 'inventory',
+  cart: 'dolly-flatbed',
+  zone: 'flag-checkered'
+}
+
+const InventoryLocation = ({ bin, className, data,  id, link, type }: InventoryLocationProps) => {
+  return (<div className={className} id={id} data={data}>
+    <LabelValue label="Location">
+      <IconBodyTitle body={type} title={bin} link={link} />
+    </LabelValue>
+  </div>
+  )
+}
+
+export default InventoryLocation

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
@@ -2,8 +2,8 @@
 /*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
 
 import React from 'react'
-import LabelValue from '../pb_label_value/_label_value';
-import IconBodyTitle from '../pb_icon_body_title/_icon_body_title';
+import LabelValue from '../pb_label_value/_label_value.jsx';
+import IconBodyTitle from '../pb_icon_body_title/_icon_body_title.jsx';
 
 type InventoryLocationProps = {
   bin?: String,
@@ -23,7 +23,7 @@ const icons = {
 const InventoryLocation = ({ bin, className, data,  id, link, type }: InventoryLocationProps) => {
   return (<div className={className} id={id} data={data}>
     <LabelValue label="Location">
-      <IconBodyTitle body={type} title={bin} link={link} />
+      <IconBodyTitle icon={icons[type]} body={type} title={bin} link={link} />
     </LabelValue>
   </div>
   )

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.jsx
@@ -21,7 +21,7 @@ const icons = {
 }
 
 const InventoryLocation = ({ bin, className, data,  id, link, type }: InventoryLocationProps) => {
-  return (<div className={className} id={id} data={data}>
+  return (<div className={className || "pb_inventory_location_kit"} id={id} data={data}>
     <LabelValue label="Location">
       <IconBodyTitle icon={icons[type]} body={type} title={bin} link={link} />
     </LabelValue>

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.scss
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.scss
@@ -1,3 +1,3 @@
-.pb_inventory_location {
-
+[class^=pb_inventory_location_kit] {
+  text-transform: capitalize;
 }

--- a/app/pb_kits/playbook/pb_inventory_location/_inventory_location.scss
+++ b/app/pb_kits/playbook/pb_inventory_location/_inventory_location.scss
@@ -1,0 +1,3 @@
+.pb_inventory_location {
+
+}

--- a/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.html.erb
+++ b/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.html.erb
@@ -1,1 +1,5 @@
-<%= pb_rails("inventory_location") %>
+<%= pb_rails("inventory_location", props: { type: "rack", bin: "C-01-02", link: "#" }) %>
+<br />
+<%= pb_rails("inventory_location", props: { type: "cart", bin: "C-01", link: "#" }) %>
+<br />
+<%= pb_rails("inventory_location", props: { type: "zone", bin: "C" }) %>

--- a/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.html.erb
+++ b/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("inventory_location") %>

--- a/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.jsx
+++ b/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.jsx
@@ -1,0 +1,14 @@
+import React from "react"
+import InventoryLocation from "../_inventory_location.jsx"
+
+function InventoryLocationDefault() {
+  return (
+    <div>
+      <InventoryLocation type="cart" bin="01" link="#" />
+      <InventoryLocation type="rack" bin="C-01-01" link="#" />
+      <InventoryLocation type="zone" bin="C" />
+    </div>
+  )
+}
+
+export default InventoryLocationDefault;

--- a/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.jsx
+++ b/app/pb_kits/playbook/pb_inventory_location/docs/_inventory_location_default.jsx
@@ -5,7 +5,9 @@ function InventoryLocationDefault() {
   return (
     <div>
       <InventoryLocation type="cart" bin="01" link="#" />
+      <br />
       <InventoryLocation type="rack" bin="C-01-01" link="#" />
+      <br />
       <InventoryLocation type="zone" bin="C" />
     </div>
   )

--- a/app/pb_kits/playbook/pb_inventory_location/docs/example.yml
+++ b/app/pb_kits/playbook/pb_inventory_location/docs/example.yml
@@ -1,0 +1,9 @@
+examples:
+  
+  rails:
+  - inventory_location_default: Default
+  
+  
+  react:
+  - inventory_location_default: Default
+  

--- a/app/pb_kits/playbook/pb_inventory_location/docs/index.js
+++ b/app/pb_kits/playbook/pb_inventory_location/docs/index.js
@@ -1,0 +1,1 @@
+export {default as InventoryLocationDefault} from './_inventory_location_default.jsx';

--- a/app/pb_kits/playbook/pb_inventory_location/inventory_location.rb
+++ b/app/pb_kits/playbook/pb_inventory_location/inventory_location.rb
@@ -6,7 +6,6 @@ module Playbook
       PROPS = %i[configured_bin
                  configured_classname
                  configured_data
-                 configured_icon
                  configured_id
                  configured_link
                  configured_type].freeze
@@ -14,14 +13,12 @@ module Playbook
       def initialize(bin: default_configuration,
                      classname: default_configuration,
                      data: default_configuration,
-                     icon: default_configuration,
                      id: default_configuration,
-                     link: default_configuration,
+                     link: nil,
                      type: default_configuration)
         self.configured_bin = bin
         self.configured_classname = classname
         self.configured_data = data
-        self.configured_icon = icon
         self.configured_id = id
         self.configured_link = link
         self.configured_type = type
@@ -31,23 +28,36 @@ module Playbook
         default_value(configured_bin, "")
       end
 
+      def type
+        options = %w[cart rack zone]
+        one_of_value(configured_type, options, "rack")
+      end
+
       def icon
         default_value(configured_icon, "")
-      end
-
-      def link
-        default_value(configured_link, "")
-      end
-
-      def type
-        default_value(configured_type, "")
       end
 
       def to_partial_path
         "pb_inventory_location/inventory_location"
       end
 
+      def content
+        pb_label_value = Playbook::PbLabelValue::LabelValue.new(label: "Location") do
+          icon_body_title = Playbook::PbIconBodyTitle::IconBodyTitle.new(icon: icon_name, body: type, title: bin, link: configured_link)
+          ApplicationController.renderer.render(partial: icon_body_title, as: :object)
+        end
+        ApplicationController.renderer.render(partial: pb_label_value, as: :object)
+      end
+
     private
+
+      def icon_name
+        {
+          rack: "inventory",
+          cart: 'dolly-flatbed',
+          zone: 'flag-checkered',
+        }[type.to_sym]
+      end
 
       DEFAULT = Object.new
       private_constant :DEFAULT

--- a/app/pb_kits/playbook/pb_inventory_location/inventory_location.rb
+++ b/app/pb_kits/playbook/pb_inventory_location/inventory_location.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbInventoryLocation
+    class InventoryLocation < Playbook::PbKit::Base
+      PROPS = %i[configured_bin
+                 configured_classname
+                 configured_data
+                 configured_icon
+                 configured_id
+                 configured_link
+                 configured_type].freeze
+
+      def initialize(bin: default_configuration,
+                     classname: default_configuration,
+                     data: default_configuration,
+                     icon: default_configuration,
+                     id: default_configuration,
+                     link: default_configuration,
+                     type: default_configuration)
+        self.configured_bin = bin
+        self.configured_classname = classname
+        self.configured_data = data
+        self.configured_icon = icon
+        self.configured_id = id
+        self.configured_link = link
+        self.configured_type = type
+      end
+
+      def bin
+        default_value(configured_bin, "")
+      end
+
+      def icon
+        default_value(configured_icon, "")
+      end
+
+      def link
+        default_value(configured_link, "")
+      end
+
+      def type
+        default_value(configured_type, "")
+      end
+
+      def to_partial_path
+        "pb_inventory_location/inventory_location"
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
@@ -3,5 +3,5 @@
     data: object.data,
     class: object.classname(object.kit_class)) do %>
   <%= object.label %>
-  <%= object.value %>
+  <%= object.value || object.yield(context: self)%>
 <% end %>

--- a/app/pb_kits/playbook/pb_label_value/_label_value.jsx
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.jsx
@@ -1,21 +1,31 @@
+// @flow
 import React from 'react';
-import PropTypes from "prop-types";
+import Body from "../pb_body/_body.jsx";
+import Caption from "../pb_caption/_caption.jsx";
 
-const propTypes = {
-  className: PropTypes.string,
-  id: PropTypes.string
+type Props = {
+  className?: string,
+  id?: string,
+  label?: string,
+  value?: string,
+  children?: React.Node,
 };
 
-class LabelValue extends React.Component {
-  render() {
-    return (
-      <div className="pb_label_value">
-        <span>LABEL VALUE CONTENT</span>
-      </div>
-    )
-  }
+const LabelValue = ({id, className, label, value, children}: Props) => {
+  return (
+    <div className={className || "pb_label_value_kit"} id={id}>
+      <Caption text={label} />
+      <Choose>
+        <When condition={!!value}>
+          <Body text={value} />
+        </When>
+        <Otherwise>
+          {children}
+        </Otherwise>
+      </Choose>
+    </div>
+  )
 }
 
-LabelValue.propTypes = propTypes;
 
 export default LabelValue;

--- a/app/pb_kits/playbook/pb_label_value/docs/_label_value_block.html.erb
+++ b/app/pb_kits/playbook/pb_label_value/docs/_label_value_block.html.erb
@@ -1,0 +1,13 @@
+<%= pb_rails("label_value", props: {
+  label: "Role",
+}) do 
+  "Adminstrador, Moderator"
+end %>
+
+<br>
+
+<%= pb_rails("label_value", props: {
+  label: "Email",
+}) do
+  pb_rails("title", props: { text: "my-email@somedomain.com" })
+end %>

--- a/app/pb_kits/playbook/pb_label_value/docs/_label_value_custom.jsx
+++ b/app/pb_kits/playbook/pb_label_value/docs/_label_value_custom.jsx
@@ -1,0 +1,14 @@
+import React from "react"
+import LabelValue from "../_label_value.jsx"
+import Title from "../../pb_title/_title.jsx";
+
+function LabelValueCustom() {
+  return (
+    <LabelValue label="Role">
+      <Title text="Administrator" />
+      {`and Moderator`}
+    </LabelValue>
+  )
+}
+
+export default LabelValueCustom;

--- a/app/pb_kits/playbook/pb_label_value/docs/_label_value_default.jsx
+++ b/app/pb_kits/playbook/pb_label_value/docs/_label_value_default.jsx
@@ -3,7 +3,7 @@ import LabelValue from "../_label_value.jsx"
 
 function LabelValueDefault() {
   return (
-    <h1>{`Coming Soon...`}</h1>
+    <LabelValue label="Role" value="Moderator" />
   )
 }
 

--- a/app/pb_kits/playbook/pb_label_value/docs/example.yml
+++ b/app/pb_kits/playbook/pb_label_value/docs/example.yml
@@ -2,8 +2,10 @@ examples:
   
   rails:
   - label_value_default: Default
+  - label_value_block: Using Blocks
   
   
   react:
   - label_value_default: Default
+  - label_value_custom: Custom Content
   

--- a/app/pb_kits/playbook/pb_label_value/docs/index.js
+++ b/app/pb_kits/playbook/pb_label_value/docs/index.js
@@ -1,1 +1,2 @@
 export {default as LabelValueDefault} from './_label_value_default.jsx';
+export {default as LabelValueCustom} from './_label_value_custom.jsx';

--- a/app/pb_kits/playbook/pb_label_value/label_value.rb
+++ b/app/pb_kits/playbook/pb_label_value/label_value.rb
@@ -7,18 +7,21 @@ module Playbook
                  configured_data
                  configured_id
                  configured_label
-                 configured_value].freeze
+                 configured_value
+                 block].freeze
 
       def initialize(classname: default_configuration,
                      data: default_configuration,
                      id: default_configuration,
                      label: default_configuration,
-                     value: default_configuration)
+                     value: default_configuration,
+                     &block)
         self.configured_classname = classname
         self.configured_data = data
         self.configured_id = id
         self.configured_label = label
         self.configured_value = value
+        self.block = block_given? ? block : nil
       end
 
       def label
@@ -29,10 +32,12 @@ module Playbook
       end
 
       def value
-        pb_body = Playbook::PbBody::Body.new do
-          default_value(configured_value, "")
+        if is_set?(configured_value)
+          pb_body = Playbook::PbBody::Body.new do
+            configured_value
+          end
+          ApplicationController.renderer.render(partial: pb_body, as: :object)
         end
-        ApplicationController.renderer.render(partial: pb_body, as: :object)
       end
 
       def kit_class
@@ -41,6 +46,10 @@ module Playbook
 
       def to_partial_path
         "pb_label_value/label_value"
+      end
+
+      def yield(context:)
+        context.capture(&block)
       end
 
     private

--- a/app/pb_kits/playbook/pb_project/_project.html.erb
+++ b/app/pb_kits/playbook/pb_project/_project.html.erb
@@ -1,0 +1,4 @@
+<%= content_tag(:div,
+    id: object.id,
+    data: object.data,
+    class: object.classname("pb_project_kit")) { object.content } %>

--- a/app/pb_kits/playbook/pb_project/_project.jsx
+++ b/app/pb_kits/playbook/pb_project/_project.jsx
@@ -1,0 +1,37 @@
+/* @flow */
+/*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
+
+import React from 'react'
+import LabelValue from '../pb_label_value/_label_value.jsx'
+import IconBodyTitle from '../pb_icon_body_title/_icon_body_title.jsx'
+import classnames from 'classnames'
+
+type ProjectProps = {
+  className?: String,
+  data?: String,
+  date?: Date,
+  id?: String,
+  link?: String,
+  ownerName: String,
+  projectNumber: String,
+  
+}
+
+const Project = ({ className, data, date, id, link, ownerName, projectNumber }: ProjectProps) =>  {
+  let title = ownerName;
+  if(date != null) {
+    title += ` ${String.fromCharCode(183)} ${date}`
+  }
+  return (<div className={classnames("pb_home_kit", className)} id={id} data={data}>
+    <LabelValue label="Project">
+      <IconBodyTitle 
+        body={projectNumber}
+        icon="home" 
+        link={link}
+        title={title} 
+      />
+    </LabelValue>
+  </div>
+)}
+
+export default Project

--- a/app/pb_kits/playbook/pb_project/_project.scss
+++ b/app/pb_kits/playbook/pb_project/_project.scss
@@ -1,0 +1,3 @@
+.pb_project {
+
+}

--- a/app/pb_kits/playbook/pb_project/docs/_project_default.html.erb
+++ b/app/pb_kits/playbook/pb_project/docs/_project_default.html.erb
@@ -1,0 +1,7 @@
+<%= pb_rails("project", props: { project_number: "33-01015", owner_name: "Jefferson-Smith", date: Date.new }) %>
+<br />
+<%= pb_rails("project", props: { project_number: "33-01015", owner_name: "Jefferson-Smith", date: Date.new - 50, link: "#" }) %>
+<br />
+<%= pb_rails("project", props: { project_number: "33-01015", owner_name: "Jefferson-Smith", link: "#" }) %>
+<br />
+<%= pb_rails("project", props: { project_number: "33-01015", owner_name: "Jefferson-Smith" }) %>

--- a/app/pb_kits/playbook/pb_project/docs/_project_default.jsx
+++ b/app/pb_kits/playbook/pb_project/docs/_project_default.jsx
@@ -1,0 +1,18 @@
+import React from "react"
+import Project from "../_project.jsx"
+
+function ProjectDefault() {
+  return (
+    <div>
+      <Project projectNumber="33-01023" ownerName="Jefferson-Smith" link="#" date="11/18" />
+      <br />
+      <Project projectNumber="33-01023" ownerName="Jefferson-Smith" date="11/18" />
+      <br />
+      <Project projectNumber="33-01023" ownerName="Jefferson-Smith" />
+      <br />
+      <Project projectNumber="33-01023" ownerName="Jefferson-Smith" link="#" />
+    </div>
+  )
+}
+
+export default ProjectDefault;

--- a/app/pb_kits/playbook/pb_project/docs/example.yml
+++ b/app/pb_kits/playbook/pb_project/docs/example.yml
@@ -1,0 +1,9 @@
+examples:
+  
+  rails:
+  - project_default: Default
+  
+  
+  react:
+  - project_default: Default
+  

--- a/app/pb_kits/playbook/pb_project/docs/index.js
+++ b/app/pb_kits/playbook/pb_project/docs/index.js
@@ -1,0 +1,1 @@
+export {default as ProjectDefault} from './_project_default.jsx';

--- a/app/pb_kits/playbook/pb_project/project.rb
+++ b/app/pb_kits/playbook/pb_project/project.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbProject
+    class Project < Playbook::PbKit::Base
+      PROPS = %i[configured_classname
+                 configured_data
+                 configured_date
+                 configured_id
+                 configured_link
+                 configured_owner_name
+                 configured_project_number].freeze
+
+      def initialize(classname: default_configuration,
+                     data: default_configuration,
+                     date: nil,
+                     id: default_configuration,
+                     link: nil,
+                     owner_name: default_configuration,
+                     project_number: default_configuration)
+        self.configured_classname = classname
+        self.configured_data = data
+        self.configured_date = date
+        self.configured_id = id
+        self.configured_link = link
+        self.configured_owner_name = owner_name
+        self.configured_project_number = project_number
+      end
+
+      def title
+        title = owner_name
+        title += " &middot; #{formatted_date}" if configured_date
+        title.html_safe
+      end
+
+      def formatted_date
+        configured_date.respond_to?(:strftime) ? configured_date.strftime("%m/%d") : configured_date.to_s
+      end
+
+      def owner_name
+        default_value(configured_owner_name, "")
+      end
+
+      def project_number
+        default_value(configured_project_number, "")
+      end
+
+      def to_partial_path
+        "pb_project/project"
+      end
+
+      def content
+        pb_label_value = Playbook::PbLabelValue::LabelValue.new(label: "Project") do
+          icon_body_title = Playbook::PbIconBodyTitle::IconBodyTitle.new(icon: "home", body: project_number, title: title, link: configured_link)
+          ApplicationController.renderer.render(partial: icon_body_title, as: :object)
+        end
+        ApplicationController.renderer.render(partial: pb_label_value, as: :object)
+      end
+
+    private
+
+      DEFAULT = Object.new
+      private_constant :DEFAULT
+      def default_configuration
+        DEFAULT
+      end
+      attr_accessor(*PROPS)
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_title/_title.jsx
+++ b/app/pb_kits/playbook/pb_title/_title.jsx
@@ -9,7 +9,7 @@ type TitleProps = {
   dark?: Boolean,
   size?: 1 | 2 | 3 | 4,
   text?: String,
-  tag?: 'h1' | 'h2' | 'h3',
+  tag?: 'h1' | 'h2' | 'h3' | ' h4',
 }
 
 const tagCSS = ({

--- a/app/pb_kits/playbook/pb_title/_title.jsx
+++ b/app/pb_kits/playbook/pb_title/_title.jsx
@@ -9,7 +9,7 @@ type TitleProps = {
   dark?: Boolean,
   size?: 1 | 2 | 3 | 4,
   text?: String,
-  tag?: 'h1' | 'h2' | 'h3' | ' h4',
+  tag?: 'h1' | 'h2' | 'h3' | 'h4',
 }
 
 const tagCSS = ({

--- a/config/data/menu.yml
+++ b/config/data/menu.yml
@@ -42,3 +42,4 @@ kits:
   - icon_body_title
   - inventory_location
   - installer
+  - project

--- a/config/data/menu.yml
+++ b/config/data/menu.yml
@@ -41,3 +41,4 @@ kits:
   - currency
   - icon_body_title
   - inventory_location
+  - installer

--- a/config/data/menu.yml
+++ b/config/data/menu.yml
@@ -39,3 +39,5 @@ kits:
   - stat_change
   - section_separator
   - currency
+  - icon_body_title
+  - inventory_location


### PR DESCRIPTION
- Updates Label Value kit to support content passed as block in addition to parameters.

- Add `IconBodyTitle` kit

<img width="212" alt="Screenshot 2019-09-24 15 45 09" src="https://user-images.githubusercontent.com/931104/65544968-6df10d00-dee2-11e9-87d4-17c4b82aa353.png">

- Add `InventoryLocation` kit  (https://github.com/powerhome/playbook/issues/172)

<img width="223" alt="Screenshot 2019-09-24 15 44 22" src="https://user-images.githubusercontent.com/931104/65544984-76494800-dee2-11e9-98ba-a42b4c4654b9.png">

- Installer (https://github.com/powerhome/playbook/issues/173)

<img width="271" alt="Screenshot 2019-09-24 15 44 35" src="https://user-images.githubusercontent.com/931104/65545007-83663700-dee2-11e9-8461-87214972d421.png">

- Project (https://github.com/powerhome/playbook/issues/174)

<img width="313" alt="Screenshot 2019-09-24 15 44 01" src="https://user-images.githubusercontent.com/931104/65545052-98db6100-dee2-11e9-9bef-a75ffc39507e.png">

