### PR TITLE
PbDateTime Class

### DIFF
--- a/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
+++ b/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
@@ -1,17 +1,17 @@
 <%= pb_rails("date", props: {
-  timestamp: "2012-08-02T15:49:29Z",
+  date: Date.today,
   size: "lg"
 }) %>
 
 <br>
 
 <%= pb_rails("date", props: {
-  timestamp: "2012-08-02T15:49:29Z"
+  date: DateTime.now
 }) %>
 
 <br>
 
 <%= pb_rails("date", props: {
-  timestamp: "2012-08-02T15:49:29Z",
+  date: "2012-08-02T15:49:29Z",
   size: "xs"
 }) %>

--- a/app/pb_kits/playbook/pb_kit/pb_date_time.rb
+++ b/app/pb_kits/playbook/pb_kit/pb_date_time.rb
@@ -1,0 +1,56 @@
+module Playbook
+  module PbKit
+    class PbDateTime
+      def initialize(value, zone)
+        @value = self.convert_to_timestamp_and_zone(value, zone)
+      end
+
+      def convert_to_timestamp_and_zone(value, zone = nil)
+        zone ||= "America/New_York"
+        converted_time = value.is_a?(String) ? DateTime.parse(value) : value
+        converted_time.in_time_zone(zone)
+      end
+
+      def convert_to_timestamp
+        @value = @value.is_a?(String) ? DateTime.parse(@value) : @value
+      end
+
+      def convert_to_timezone(zone)
+        zone ||= "America/New_York"
+        @value = @value.in_time_zone(zone)
+      end
+
+      def to_day_of_week
+        @value.strftime("%a")
+      end
+
+      def to_month
+        @value.strftime("%^b")
+      end
+
+      def to_day
+        @value.strftime("%e")
+      end
+
+      def to_hour
+        @value.strftime("%l")
+      end
+
+      def to_minutes
+        @value.strftime("%M")
+      end
+
+      def to_meridian
+        @value.strftime("%P")[0, 1]
+      end
+
+      def to_timezone
+        @value.strftime("%Z")
+      end
+
+      def to_iso
+        @value.iso8601
+      end
+    end
+  end
+end

--- a/app/pb_kits/playbook/pb_time/docs/_time_default.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_default.html.erb
@@ -1,18 +1,18 @@
 <%= pb_rails("time", props: {
-  timestamp: "2012-08-02T15:49:29Z",
+  time: Time.now,
   size: "lg"
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  timestamp: "2012-08-02T15:49:29Z",
+  time: DateTime.now,
   size: "sm"
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  timestamp: "2012-08-02T15:49:29Z",
+  time: "2012-08-02T15:49:29Z",
   size: "xs"
 }) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_timestamp.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timestamp.html.erb
@@ -1,16 +1,16 @@
 <%= pb_rails("time", props: {
-  timestamp: "2012-08-02T15:49:29Z"
+  time: "2012-08-02T15:49:29Z"
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  timestamp: DateTime.now
+  time: DateTime.now
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  timestamp: DateTime.now,
+  time: DateTime.now,
   timezone: "America/Chicago"
 }) %>


### PR DESCRIPTION
Changes include:
* Extract all date related methods to its own class PbDateTime
* Update both Date and Time kits to use PbDateTime class
* Update Date Kit to accept prop `date` instead of `timestamp` (Both are available, but date is documented)
* Update Time Kit to accept prop `time` instead of `timestamp` (Both are available, but time is documented)

---

## PbDateTime Class Usage:
`timezone` arg is optional.  It allows the stored date or time passed in to be converted and displayed to a different timezone.  Timezone defaults to Eastern (America/New_York)

```ruby
# timezone is optional

date = Playbook::PbKit::PbDateTime.new(date, timezone)
date.to_day_of_week  # thu
date.to_day  # 2
```

```ruby
# timezone is optional

time = Playbook::PbKit::PbDateTime.new(time, timezone)
time.to_hour  # 11
time.to_meridian  # p
time.to_timeszone  # edt
```