### PR TITLE
Node-sass bugfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN bundle install --frozen
 
 ADD package.json yarn.lock /home/app/src/
 RUN yarn install
+RUN npm rebuild node-sass
 
 COPY ./startup.sh /
 RUN chmod +x /startup.sh


### PR DESCRIPTION
Fix from [this](https://github.com/sass/node-sass/issues/1918) issue.

Suggested running `npm rebuild node-sass` within DockerFile **after** `yarn install`.

The first attempted fix in Playbook was incorrectly running this before `yarn install`, which did not fix the problem.

---

## Open question:
Unknown if this should use the force option: `npm rebuild node-sass --force`