### PR TITLE
Migrate Checkbox Kit

### DIFF
--- a/app/pb_kits/playbook/pb_caption/caption.rb
+++ b/app/pb_kits/playbook/pb_caption/caption.rb
@@ -15,14 +15,7 @@ module Playbook
       prop :text, default: "Caption"
 
       def classname
-        [
-          [
-            "pb_caption_kit",
-            large_class,
-            dark_class,
-          ].compact.join("_"),
-          prop(:classname),
-        ].compact.join(" ")
+        generate_classname("pb_caption_kit", large_class, dark_class)
       end
 
     private

--- a/app/pb_kits/playbook/pb_caption/caption.rb
+++ b/app/pb_kits/playbook/pb_caption/caption.rb
@@ -20,7 +20,7 @@ module Playbook
             dark_class,
           ].compact.join("_"),
           prop(:classname),
-        ].join(" ")
+        ].compact.join(" ")
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_caption/caption.rb
+++ b/app/pb_kits/playbook/pb_caption/caption.rb
@@ -5,6 +5,8 @@ module Playbook
     class Caption
       include Playbook::Props
 
+      partial "pb_caption/caption"
+
       prop :dark, type: Playbook::Props::Boolean, default: false
       prop :large, type: Playbook::Props::Boolean, default: false
       prop :tag, type: Playbook::Props::Enum,
@@ -21,10 +23,6 @@ module Playbook
           ].compact.join("_"),
           prop(:classname),
         ].compact.join(" ")
-      end
-
-      def to_partial_path
-        "pb_caption/caption"
       end
 
     private

--- a/app/pb_kits/playbook/pb_checkbox/_checkbox.html.erb
+++ b/app/pb_kits/playbook/pb_checkbox/_checkbox.html.erb
@@ -1,10 +1,7 @@
-<%= content_tag(:label, id: object.id, data: object.data, class: object.classname(object.kit_class)) do %>
-<input type="checkbox" value="<%=object.value%>" name="<%=object.name%>" <%=object.checked%>>
-<span class="pb_checkbox_checkmark">
-  <%= object.icon %>
-</span>
-<span class="pb_checkbox_label">
-  <%= object.text %>
-</span>
-
+<%= content_tag(:label, id: object.id,
+                        data: object.data,
+                        class: object.classname) do %>
+  <input type="checkbox" value="<%=object.value%>" name="<%=object.name%>" <%= object.checked_html %>>
+  <span class="pb_checkbox_checkmark"><%= object.icon_html %></span>
+  <span class="pb_checkbox_label"><%= object.text %></span>
 <% end %>

--- a/app/pb_kits/playbook/pb_checkbox/_checkbox.html.erb
+++ b/app/pb_kits/playbook/pb_checkbox/_checkbox.html.erb
@@ -2,6 +2,8 @@
                         data: object.data,
                         class: object.classname) do %>
   <input type="checkbox" value="<%=object.value%>" name="<%=object.name%>" <%= object.checked_html %>>
-  <span class="pb_checkbox_checkmark"><%= object.icon_html %></span>
+  <span class="pb_checkbox_checkmark">
+    <%= pb_rails("icon", props: { icon: "check", id: "check_icon", classname: "check_icon", fixed_width: true}) if object.icon %>
+  </span>
   <span class="pb_checkbox_label"><%= object.text %></span>
 <% end %>

--- a/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -10,9 +10,9 @@ module Playbook
       prop :dark, type: Playbook::Props::Boolean, default: false
       prop :checked, type: Playbook::Props::Boolean, default: false
       prop :icon, type: Playbook::Props::Boolean, default: false
-      prop :text, default: ""
-      prop :value, default: ""
-      prop :name, default: ""
+      prop :text
+      prop :value
+      prop :name
 
       def checked_html
         checked ? "checked='true'" : nil

--- a/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -5,16 +5,14 @@ module Playbook
     class Checkbox
       include Playbook::Props
 
+      partial "pb_checkbox/checkbox"
+
       prop :dark, type: Playbook::Props::Boolean, default: false
       prop :checked, type: Playbook::Props::Boolean, default: false
       prop :icon, type: Playbook::Props::Boolean, default: false
       prop :text, default: ""
       prop :value, default: ""
       prop :name, default: ""
-
-      def to_partial_path
-        "pb_checkbox/checkbox"
-      end
 
       def checked_html
         checked ? "checked='true'" : nil

--- a/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -6,10 +6,10 @@ module Playbook
       include Playbook::Props
 
       prop :dark, type: Playbook::Props::Boolean, default: false
+      prop :checked, type: Playbook::Props::Boolean, default: false
       prop :text, default: ""
       prop :value, default: ""
       prop :name, default: ""
-      prop :checked
       prop :icon
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -19,14 +19,7 @@ module Playbook
       end
 
       def classname
-        [
-          [
-            "pb_checkbox_kit",
-            dark_class,
-            checked_class,
-          ].compact.join("_"),
-          prop(:classname),
-        ].compact.join(" ")
+        generate_classname("pb_checkbox_kit", dark_class, checked_class)
       end
 
     private

--- a/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -7,20 +7,13 @@ module Playbook
 
       prop :dark, type: Playbook::Props::Boolean, default: false
       prop :checked, type: Playbook::Props::Boolean, default: false
+      prop :icon, type: Playbook::Props::Boolean, default: false
       prop :text, default: ""
       prop :value, default: ""
       prop :name, default: ""
-      prop :icon
 
       def to_partial_path
         "pb_checkbox/checkbox"
-      end
-
-      def icon_html
-        unless icon.nil?
-          pb_icon = Playbook::PbIcon::Icon.new(icon: "check", id: "check_icon", classname: "check_icon", fixed_width: true)
-          ApplicationController.renderer.render(partial: pb_icon, as: :object)
-        end
       end
 
       def checked_html

--- a/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -2,93 +2,51 @@
 
 module Playbook
   module PbCheckbox
-    class Checkbox < Playbook::PbKit::Base
-      PROPS = %i[configured_classname
-                 configured_data
-                 configured_id
-                 configured_dark
-                 configured_text
-                configured_value
-              configured_name
-              configured_checked
-              configured_icon
-            ].freeze
+    class Checkbox
+      include Playbook::Props
 
-      def initialize(classname: default_configuration,
-                     data: default_configuration,
-                     id: default_configuration,
-                     dark: default_configuration,
-                     text: default_configuration,
-                   value: default_configuration,
-                 name: default_configuration,
-                 checked: default_configuration,
-                 icon: default_configuration
-               )
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_dark = dark
-        self.configured_text = text
-        self.configured_value = value
-        self.configured_name = name
-        self.configured_checked = checked
-        self.configured_icon = icon
-
-      end
+      prop :dark, type: Playbook::Props::Boolean, default: false
+      prop :text, default: ""
+      prop :value, default: ""
+      prop :name, default: ""
+      prop :checked, default: nil
+      prop :icon, default: nil
 
       def to_partial_path
         "pb_checkbox/checkbox"
       end
 
-      def icon
-        if is_set? configured_icon
+      def icon_html
+        unless icon.nil?
           pb_icon = Playbook::PbIcon::Icon.new(icon: "check", id: "check_icon", classname: "check_icon", fixed_width: true)
           ApplicationController.renderer.render(partial: pb_icon, as: :object)
         end
       end
 
-      def text
-        default_value(configured_text, "")
+      def checked_html
+        checked ? "checked='true'" : nil
       end
 
-      def value
-        default_value(configured_value, "")
+      def classname
+        [
+          [
+            "pb_checkbox_kit",
+            dark_class,
+            checked_class,
+          ].compact.join("_"),
+          prop(:classname),
+        ].compact.join(" ")
       end
 
-      def name
-        default_value(configured_name, "")
-      end
-
-      def checked
-        true_value(configured_checked, "checked='true'",nil)
-      end
+    private
 
       def checked_class
         checked ? "on" : "off"
       end
 
-
       def dark_class
-        true_value(configured_dark, "dark", nil)
+        dark ? "dark" : nil
       end
-
-      def kit_class
-        caption_options = [
-          "pb_checkbox_kit",
-          dark_class,
-          checked_class
-        ]
-        caption_options.reject(&:nil?).join("_")
-      end
-
-    private
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -9,8 +9,8 @@ module Playbook
       prop :text, default: ""
       prop :value, default: ""
       prop :name, default: ""
-      prop :checked, default: nil
-      prop :icon, default: nil
+      prop :checked
+      prop :icon
 
       def to_partial_path
         "pb_checkbox/checkbox"

--- a/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_checked.html.erb
+++ b/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_checked.html.erb
@@ -2,6 +2,6 @@
   text: "Checked Checkbox",
   value: "checkbox-value",
   checked: true,
-  icon: "check",
+  icon: true,
   name: "checkbox-name"
 }) %>

--- a/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_checked.html.erb
+++ b/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_checked.html.erb
@@ -1,6 +1,7 @@
 <%= pb_rails("checkbox" , props: {
-  text: "Checkbox Label",
+  text: "Checked Checkbox",
   value: "checkbox-value",
+  checked: true,
   icon: "check",
   name: "checkbox-name"
 }) %>

--- a/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_dark.html.erb
+++ b/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_dark.html.erb
@@ -1,1 +1,5 @@
-<%= pb_rails("checkbox", props: {text:"Checkbox Label" , icon:"check", dark: true}) %>
+<%= pb_rails("checkbox", props: {
+  text: "Checkbox Label" ,
+  icon: "check",
+  dark: true
+}) %>

--- a/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_dark.html.erb
+++ b/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_dark.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("checkbox", props: {
   text: "Checkbox Label" ,
-  icon: "check",
+  icon: true,
   dark: true
 }) %>

--- a/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_default.html.erb
+++ b/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_default.html.erb
@@ -1,6 +1,6 @@
 <%= pb_rails("checkbox" , props: {
   text: "Checkbox Label",
   value: "checkbox-value",
-  icon: "check",
+  icon: true,
   name: "checkbox-name"
 }) %>

--- a/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_default.jsx
+++ b/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_default.jsx
@@ -5,7 +5,6 @@ function CheckboxDefault() {
   return (
     <div>
       <Checkbox
-
           label='Checkbox label'
           name='default name'
           value='default value'

--- a/app/pb_kits/playbook/pb_checkbox/docs/example.yml
+++ b/app/pb_kits/playbook/pb_checkbox/docs/example.yml
@@ -1,8 +1,8 @@
 examples:
-
   rails:
-  - checkbox_default: Default
-  - checkbox_dark: Dark
+    - checkbox_default: Default
+    - checkbox_checked: Load as checked
+    - checkbox_dark: Dark
 
   react:
   - checkbox_default: Default

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -25,7 +25,7 @@ module Playbook
     included do
       prop :id, default: nil
       prop :data, type: Playbook::Props::Hash, default: {}
-      prop :classname, default: ""
+      prop :classname, default: nil
       prop :aria, type: Playbook::Props::Hash, default: {}
     end
 

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -40,6 +40,10 @@ module Playbook
 
         define_method(name) { prop(name) }
       end
+
+      def partial(path)
+        define_method(:to_partial_path) { path }
+      end
     end
   end
 end

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -22,6 +22,13 @@ module Playbook
       self.class.props[name].value @values[name]
     end
 
+    def generate_classname(*name_parts)
+      [
+        name_parts.compact.join("_"),
+        prop(:classname),
+      ].compact.join(" ")
+    end
+
     included do
       prop :id
       prop :data, type: Playbook::Props::Hash, default: {}

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -23,9 +23,9 @@ module Playbook
     end
 
     included do
-      prop :id, default: nil
+      prop :id
       prop :data, type: Playbook::Props::Hash, default: {}
-      prop :classname, default: nil
+      prop :classname
       prop :aria, type: Playbook::Props::Hash, default: {}
     end
 

--- a/spec/pb_kits/playbook/kits/caption_spec.rb
+++ b/spec/pb_kits/playbook/kits/caption_spec.rb
@@ -7,10 +7,10 @@ module Playbook
     describe Caption do
       subject { Caption }
 
-      it { is_expected.to define_prop(:dark).of_type(Props::Boolean).with_default(false) }
-      it { is_expected.to define_prop(:large).of_type(Props::Boolean).with_default(false) }
-      it { is_expected.to define_prop(:tag).of_type(Props::Enum).with_default("div") }
-      it { is_expected.to define_prop(:text).of_type(Props::String).with_default("Caption") }
+      it { is_expected.to define_boolean_prop(:dark).with_default(false) }
+      it { is_expected.to define_boolean_prop(:large).with_default(false) }
+      it { is_expected.to define_enum_prop(:tag).with_default("div") }
+      it { is_expected.to define_string_prop(:text).with_default("Caption") }
 
       it { is_expected.to define_partial }
 

--- a/spec/pb_kits/playbook/kits/caption_spec.rb
+++ b/spec/pb_kits/playbook/kits/caption_spec.rb
@@ -12,6 +12,8 @@ module Playbook
       it { is_expected.to define_prop(:tag).of_type(Props::Enum).with_default("div") }
       it { is_expected.to define_prop(:text).of_type(Props::String).with_default("Caption") }
 
+      it { is_expected.to define_partial }
+
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do
           expect(Caption.new({}).classname).to eq "pb_caption_kit"

--- a/spec/pb_kits/playbook/kits/caption_spec.rb
+++ b/spec/pb_kits/playbook/kits/caption_spec.rb
@@ -14,10 +14,10 @@ module Playbook
 
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do
-          expect(Caption.new({}).classname).to eq "pb_caption_kit "
-          expect(Caption.new(dark: true).classname).to eq "pb_caption_kit_dark "
-          expect(Caption.new(large: true).classname).to eq "pb_caption_kit_lg "
-          expect(Caption.new(dark: true, large: true).classname).to eq "pb_caption_kit_lg_dark "
+          expect(Caption.new({}).classname).to eq "pb_caption_kit"
+          expect(Caption.new(dark: true).classname).to eq "pb_caption_kit_dark"
+          expect(Caption.new(large: true).classname).to eq "pb_caption_kit_lg"
+          expect(Caption.new(dark: true, large: true).classname).to eq "pb_caption_kit_lg_dark"
           expect(Caption.new(classname: "additional_class").classname).to eq "pb_caption_kit additional_class"
         end
       end

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -14,6 +14,8 @@ module Playbook
       it { is_expected.to define_prop(:checked).of_type(Props::Boolean).with_default(false) }
       it { is_expected.to define_prop(:icon).of_type(Props::Boolean).with_default(false) }
 
+      it { is_expected.to define_partial }
+
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do
           expect(Checkbox.new({}).classname).to eq "pb_checkbox_kit_off"

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -8,9 +8,9 @@ module Playbook
       subject { Checkbox }
 
       it { is_expected.to define_boolean_prop(:dark).with_default(false) }
-      it { is_expected.to define_prop(:text).with_default("") }
-      it { is_expected.to define_prop(:value).with_default("") }
-      it { is_expected.to define_prop(:name).with_default("") }
+      it { is_expected.to define_prop(:text) }
+      it { is_expected.to define_prop(:value) }
+      it { is_expected.to define_prop(:name) }
       it { is_expected.to define_boolean_prop(:checked).with_default(false) }
       it { is_expected.to define_boolean_prop(:icon).with_default(false) }
 

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -11,7 +11,7 @@ module Playbook
       it { is_expected.to define_prop(:text).with_default("") }
       it { is_expected.to define_prop(:value).with_default("") }
       it { is_expected.to define_prop(:name).with_default("") }
-      it { is_expected.to define_prop(:checked) }
+      it { is_expected.to define_prop(:checked).of_type(Props::Boolean).with_default(false) }
       it { is_expected.to define_prop(:icon) }
 
       describe "#classname" do

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -12,7 +12,7 @@ module Playbook
       it { is_expected.to define_prop(:value).with_default("") }
       it { is_expected.to define_prop(:name).with_default("") }
       it { is_expected.to define_prop(:checked).of_type(Props::Boolean).with_default(false) }
-      it { is_expected.to define_prop(:icon) }
+      it { is_expected.to define_prop(:icon).of_type(Props::Boolean).with_default(false) }
 
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -11,8 +11,8 @@ module Playbook
       it { is_expected.to define_prop(:text).with_default("") }
       it { is_expected.to define_prop(:value).with_default("") }
       it { is_expected.to define_prop(:name).with_default("") }
-      it { is_expected.to define_prop(:checked).with_default(nil) }
-      it { is_expected.to define_prop(:icon).with_default(nil) }
+      it { is_expected.to define_prop(:checked) }
+      it { is_expected.to define_prop(:icon) }
 
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_checkbox/checkbox"
+
+module Playbook
+  module PbCheckbox
+    describe Checkbox do
+      subject { Checkbox }
+
+      it { is_expected.to define_prop(:dark).of_type(Props::Boolean).with_default(false) }
+      it { is_expected.to define_prop(:text).with_default("") }
+      it { is_expected.to define_prop(:value).with_default("") }
+      it { is_expected.to define_prop(:name).with_default("") }
+      it { is_expected.to define_prop(:checked).with_default(nil) }
+      it { is_expected.to define_prop(:icon).with_default(nil) }
+
+      describe "#classname" do
+        it "returns namespaced class name", :aggregate_failures do
+          expect(Checkbox.new({}).classname).to eq "pb_checkbox_kit_off"
+          expect(Checkbox.new(dark: true).classname).to eq "pb_checkbox_kit_dark_off"
+          expect(Checkbox.new(checked: true).classname).to eq "pb_checkbox_kit_on"
+          expect(Checkbox.new(dark: true, checked: true).classname).to eq "pb_checkbox_kit_dark_on"
+          expect(Checkbox.new(classname: "additional_class").classname).to eq "pb_checkbox_kit_off additional_class"
+        end
+      end
+    end
+  end
+end

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -7,12 +7,12 @@ module Playbook
     describe Checkbox do
       subject { Checkbox }
 
-      it { is_expected.to define_prop(:dark).of_type(Props::Boolean).with_default(false) }
+      it { is_expected.to define_boolean_prop(:dark).with_default(false) }
       it { is_expected.to define_prop(:text).with_default("") }
       it { is_expected.to define_prop(:value).with_default("") }
       it { is_expected.to define_prop(:name).with_default("") }
-      it { is_expected.to define_prop(:checked).of_type(Props::Boolean).with_default(false) }
-      it { is_expected.to define_prop(:icon).of_type(Props::Boolean).with_default(false) }
+      it { is_expected.to define_boolean_prop(:checked).with_default(false) }
+      it { is_expected.to define_boolean_prop(:icon).with_default(false) }
 
       it { is_expected.to define_partial }
 

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -9,9 +9,9 @@ module Playbook
     describe "base props" do
       subject { BasePropsClass }
 
-      it { is_expected.to define_prop(:id).with_default(nil) }
+      it { is_expected.to define_prop(:id) }
       it { is_expected.to define_prop(:data).of_type(Props::Hash).with_default({}) }
-      it { is_expected.to define_prop(:classname).with_default(nil) }
+      it { is_expected.to define_prop(:classname) }
       it { is_expected.to define_prop(:aria).of_type(Props::Hash).with_default({}) }
 
       describe "can be overwritten with custom values" do
@@ -40,21 +40,23 @@ module Playbook
     class ExtendedPropsClass
       include Playbook::Props
 
-      prop :string_prop, default: "foo"
+      prop :string_prop, type: Playbook::Props::String, default: "foo"
       prop :boolean_prop, type: Playbook::Props::Boolean, default: true
       prop :hash_prop, type: Playbook::Props::Hash, default: { baz: :foo }
       prop :enum_prop, type: Playbook::Props::Enum,
                        values: %i[up down left right],
                        default: :right
+      prop :default_prop
     end
 
     describe "additional props" do
       subject { ExtendedPropsClass }
 
-      it { is_expected.to define_prop(:string_prop).with_default("foo") }
+      it { is_expected.to define_prop(:string_prop).of_type(Props::String).with_default("foo") }
       it { is_expected.to define_prop(:boolean_prop).of_type(Props::Boolean).with_default(true) }
       it { is_expected.to define_prop(:hash_prop).of_type(Props::Hash).with_default(baz: :foo) }
       it { is_expected.to define_prop(:enum_prop).of_type(Props::Enum).with_default(:right) }
+      it { is_expected.to define_prop(:default_prop).of_type(Props::String).with_default(nil) }
 
       describe "can be overwritten with custom values" do
         it "as string" do
@@ -82,10 +84,10 @@ module Playbook
     describe ".props" do
       it "returns collection of available properties", :aggregate_failures do
         expect(BasePropsClass.props).to include(:id, :data, :classname, :aria)
-        expect(BasePropsClass.props).to_not include(:string_prop, :boolean_prop, :hash_prop, :enum_prop)
+        expect(BasePropsClass.props).to_not include(:string_prop, :boolean_prop, :hash_prop, :enum_prop, :default_prop)
 
         expect(ExtendedPropsClass.props).to include(:id, :data, :classname, :aria)
-        expect(ExtendedPropsClass.props).to include(:string_prop, :boolean_prop, :hash_prop, :enum_prop)
+        expect(ExtendedPropsClass.props).to include(:string_prop, :boolean_prop, :hash_prop, :enum_prop, :default_prop)
       end
     end
   end

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -10,9 +10,9 @@ module Playbook
       subject { BasePropsClass }
 
       it { is_expected.to define_prop(:id) }
-      it { is_expected.to define_prop(:data).of_type(Props::Hash).with_default({}) }
+      it { is_expected.to define_hash_prop(:data).with_default({}) }
       it { is_expected.to define_prop(:classname) }
-      it { is_expected.to define_prop(:aria).of_type(Props::Hash).with_default({}) }
+      it { is_expected.to define_hash_prop(:aria).with_default({}) }
 
       describe "can be overwritten with custom values" do
         it "#id" do
@@ -52,11 +52,11 @@ module Playbook
     describe "additional props" do
       subject { ExtendedPropsClass }
 
-      it { is_expected.to define_prop(:string_prop).of_type(Props::String).with_default("foo") }
-      it { is_expected.to define_prop(:boolean_prop).of_type(Props::Boolean).with_default(true) }
-      it { is_expected.to define_prop(:hash_prop).of_type(Props::Hash).with_default(baz: :foo) }
-      it { is_expected.to define_prop(:enum_prop).of_type(Props::Enum).with_default(:right) }
-      it { is_expected.to define_prop(:default_prop).of_type(Props::String).with_default(nil) }
+      it { is_expected.to define_string_prop(:string_prop).with_default("foo") }
+      it { is_expected.to define_boolean_prop(:boolean_prop).with_default(true) }
+      it { is_expected.to define_hash_prop(:hash_prop).with_default(baz: :foo) }
+      it { is_expected.to define_enum_prop(:enum_prop).with_default(:right) }
+      it { is_expected.to define_string_prop(:default_prop).with_default(nil) }
 
       describe "can be overwritten with custom values" do
         it "as string" do

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -11,7 +11,7 @@ module Playbook
 
       it { is_expected.to define_prop(:id).with_default(nil) }
       it { is_expected.to define_prop(:data).of_type(Props::Hash).with_default({}) }
-      it { is_expected.to define_prop(:classname).with_default("") }
+      it { is_expected.to define_prop(:classname).with_default(nil) }
       it { is_expected.to define_prop(:aria).of_type(Props::Hash).with_default({}) }
 
       describe "can be overwritten with custom values" do

--- a/spec/support/playbook/rspec.rb
+++ b/spec/support/playbook/rspec.rb
@@ -42,5 +42,11 @@ module Playbook
         end
       end
     end
+
+    matcher :define_partial do
+      match do |subject_class|
+        subject_class.instance_methods.include?(:to_partial_path)
+      end
+    end
   end
 end

--- a/spec/support/playbook/rspec.rb
+++ b/spec/support/playbook/rspec.rb
@@ -43,6 +43,98 @@ module Playbook
       end
     end
 
+    matcher :define_enum_prop do |prop_key|
+      chain :with_default do |default|
+        @default = default
+      end
+
+      match do |subject_class|
+        is_enum = subject_class.props[prop_key]&.class == Props::Enum
+
+        if @default
+          is_enum && subject_class.props[prop_key].default == @default
+        else
+          is_enum
+        end
+      end
+
+      failure_message do |subject_class|
+        base_message = "expected #{subject_class} to define :#{prop_key} enum prop"
+        default_message = "with default of #{@default}"
+
+        @default ? [base_message, default_message].join(" ") : base_message
+      end
+    end
+
+    matcher :define_boolean_prop do |prop_key|
+      chain :with_default do |default|
+        @default = default
+      end
+
+      match do |subject_class|
+        is_boolean = subject_class.props[prop_key]&.class == Props::Boolean
+
+        if @default
+          is_boolean && subject_class.props[prop_key].default == @default
+        else
+          is_boolean
+        end
+      end
+
+      failure_message do |subject_class|
+        base_message = "expected #{subject_class} to define :#{prop_key} boolean prop"
+        default_message = "with default of #{@default}"
+
+        @default ? [base_message, default_message].join(" ") : base_message
+      end
+    end
+
+    matcher :define_string_prop do |prop_key|
+      chain :with_default do |default|
+        @default = default
+      end
+
+      match do |subject_class|
+        is_string = subject_class.props[prop_key]&.class == Props::String
+
+        if @default
+          is_string && subject_class.props[prop_key].default == @default
+        else
+          is_string
+        end
+      end
+
+      failure_message do |subject_class|
+        base_message = "expected #{subject_class} to define :#{prop_key} string prop"
+        default_message = "with default of #{@default}"
+
+        @default ? [base_message, default_message].join(" ") : base_message
+      end
+    end
+
+    matcher :define_hash_prop do |prop_key|
+      chain :with_default do |default|
+        @default = default
+      end
+
+      match do |subject_class|
+        is_hash = subject_class.props[prop_key]&.class == Props::Hash
+
+        if @default
+          is_hash && subject_class.props[prop_key].default == @default
+        else
+          is_hash
+        end
+      end
+
+      failure_message do |subject_class|
+        base_message = "expected #{subject_class} to define :#{prop_key} hash prop"
+        default_message = "with default of #{@default}"
+
+        @default ? [base_message, default_message].join(" ") : base_message
+      end
+    end
+
     matcher :define_partial do
       match do |subject_class|
         subject_class.instance_methods.include?(:to_partial_path)


### PR DESCRIPTION
1. Migrate Checkbox Kit to new format
1. Add a checked example to the docs.
1. Adjust base classname default (see change in test expectation in `caption_spec.rb`).
1. Add more custom matchers.
1. Add `partial` helper method.
1. Add `generate_classname` helper method.