### PR TITLE
Migrate card kit

### DIFF
--- a/app/pb_kits/playbook/pb_card/_card.html.erb
+++ b/app/pb_kits/playbook/pb_card/_card.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname(object.kit_class),
+    class: object.classname,
     aria: object.aria) do %>
   <%= object.yield(context: self) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_card/_card.html.erb
+++ b/app/pb_kits/playbook/pb_card/_card.html.erb
@@ -3,5 +3,7 @@
     data: object.data,
     class: object.classname,
     aria: object.aria) do %>
-  <%= object.yield(context: self) %>
+  <% if object.block %>
+    <%= pb_rails("card/card_body", props: { padding: object.padding}) { capture(&object.block) } %>
+  <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_card/card.rb
+++ b/app/pb_kits/playbook/pb_card/card.rb
@@ -11,15 +11,6 @@ module Playbook
       prop :selected, type: Playbook::Props::Boolean, default: false
       prop :shadow, type: Playbook::Props::Enum, values: %w[none shallow default deep deeper deepest], default: "none"
 
-      def yield(context:)
-        unless block.nil?
-          pb_card_body = Playbook::PbCard::CardBody.new(padding: padding) do
-            context.capture(&block)
-          end
-          ApplicationController.renderer.render(partial: pb_card_body, as: :object)
-        end
-      end
-
       def classname
         generate_classname("pb_card_kit", selected_class, shadow_class)
       end

--- a/app/pb_kits/playbook/pb_card/card.rb
+++ b/app/pb_kits/playbook/pb_card/card.rb
@@ -7,9 +7,13 @@ module Playbook
 
       partial "pb_card/card"
 
-      prop :padding, type: Playbook::Props::Enum, values: %w[none xs sm md lg xl], default: "md"
       prop :selected, type: Playbook::Props::Boolean, default: false
-      prop :shadow, type: Playbook::Props::Enum, values: %w[none shallow default deep deeper deepest], default: "none"
+      prop :padding, type: Playbook::Props::Enum,
+                     values: %w[none xs sm md lg xl],
+                     default: "md"
+      prop :shadow, type: Playbook::Props::Enum,
+                    values: %w[none shallow default deep deeper deepest],
+                    default: "none"
 
       def classname
         generate_classname("pb_card_kit", selected_class, shadow_class)

--- a/app/pb_kits/playbook/pb_card/card.rb
+++ b/app/pb_kits/playbook/pb_card/card.rb
@@ -19,10 +19,6 @@ module Playbook
         generate_classname("pb_card_kit", selected_class, shadow_class)
       end
 
-      def to_partial_path
-        "pb_card/card"
-      end
-
     private
 
       def selected_class

--- a/app/pb_kits/playbook/pb_card/card_body.rb
+++ b/app/pb_kits/playbook/pb_card/card_body.rb
@@ -9,10 +9,6 @@ module Playbook
 
       prop :padding
 
-      def yield(context:)
-        context.capture(&block)
-      end
-
       def classname
         generate_classname("pb_card_body_kit", padding)
       end

--- a/app/pb_kits/playbook/pb_card/card_body.rb
+++ b/app/pb_kits/playbook/pb_card/card_body.rb
@@ -7,7 +7,9 @@ module Playbook
 
       partial "pb_card/child_kits/card_body"
 
-      prop :padding
+      prop :padding, type: Playbook::Props::Enum,
+                     values: %w[none xs sm md lg xl],
+                     default: "md"
 
       def classname
         generate_classname("pb_card_body_kit", padding)

--- a/app/pb_kits/playbook/pb_card/card_body.rb
+++ b/app/pb_kits/playbook/pb_card/card_body.rb
@@ -2,57 +2,20 @@
 
 module Playbook
   module PbCard
-    class CardBody < Playbook::PbKit::Base
-      PROPS = %i[configured_aria
-                 configured_classname
-                 configured_data
-                 configured_id
-                 configured_padding
-                 block].freeze
+    class CardBody
+      include Playbook::Props
 
-      def initialize(aria: default_configuration,
-                     classname: default_configuration,
-                     data: default_configuration,
-                     id: default_configuration,
-                     padding: default_configuration,
-                     &block)
-        self.configured_aria = aria
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_padding = padding
-        self.block = block_given? ? block : nil
-      end
+      partial "pb_card/child_kits/card_body"
 
-      def padding_class
-        padding_options = %w[none xs sm md lg xl]
-        one_of_value(configured_padding.to_s, padding_options, "md")
-      end
+      prop :padding
 
       def yield(context:)
         context.capture(&block)
       end
 
-      def kit_class
-        card_body_options = [
-          "pb_card_body_kit",
-          padding_class,
-        ]
-        card_body_options.join("_")
+      def classname
+        generate_classname("pb_card_body_kit", padding)
       end
-
-      def to_partial_path
-        "pb_card/child_kits/card_body"
-      end
-
-    private
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/app/pb_kits/playbook/pb_card/child_kits/_card_body.html.erb
+++ b/app/pb_kits/playbook/pb_card/child_kits/_card_body.html.erb
@@ -3,5 +3,5 @@
     data: object.data,
     class: object.classname,
     aria: object.aria) do %>
-  <%= object.yield(context: self) %>
+  <%= capture(&object.block) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_card/child_kits/_card_body.html.erb
+++ b/app/pb_kits/playbook/pb_card/child_kits/_card_body.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname(object.kit_class),
+    class: object.classname,
     aria: object.aria) do %>
   <%= object.yield(context: self) %>
 <% end %>

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -11,11 +11,14 @@ module Playbook
   module Props
     extend ActiveSupport::Concern
 
-    def initialize(prop_values)
+    attr_reader :block
+
+    def initialize(prop_values, &block)
       @values = prop_values
       self.class.props.each do |key, definition|
         definition.validate! @values[key]
       end
+      @block = block_given? ? block : nil
     end
 
     def prop(name)

--- a/app/pb_kits/playbook/props/enum.rb
+++ b/app/pb_kits/playbook/props/enum.rb
@@ -3,6 +3,8 @@
 module Playbook
   module Props
     class Enum < Playbook::Props::Base
+      attr_reader :values
+
       def initialize(values:, **options)
         super(**options)
         @values = values

--- a/spec/pb_kits/playbook/kits/caption_spec.rb
+++ b/spec/pb_kits/playbook/kits/caption_spec.rb
@@ -9,7 +9,12 @@ module Playbook
 
       it { is_expected.to define_boolean_prop(:dark).with_default(false) }
       it { is_expected.to define_boolean_prop(:large).with_default(false) }
-      it { is_expected.to define_enum_prop(:tag).with_default("div") }
+      it do
+        is_expected.to define_enum_prop(:tag)
+                       .with_default("div")
+                       .with_values("h1", "h2", "h3", "h4", "h5",
+                                    "h6", "p", "span", "div")
+      end
       it { is_expected.to define_string_prop(:text).with_default("Caption") }
 
       it { is_expected.to define_partial }

--- a/spec/pb_kits/playbook/kits/caption_spec.rb
+++ b/spec/pb_kits/playbook/kits/caption_spec.rb
@@ -7,6 +7,8 @@ module Playbook
     describe Caption do
       subject { Caption }
 
+      it { is_expected.to define_partial }
+
       it { is_expected.to define_boolean_prop(:dark).with_default(false) }
       it { is_expected.to define_boolean_prop(:large).with_default(false) }
       it do
@@ -16,8 +18,6 @@ module Playbook
                                     "h6", "p", "span", "div")
       end
       it { is_expected.to define_string_prop(:text).with_default("Caption") }
-
-      it { is_expected.to define_partial }
 
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do

--- a/spec/pb_kits/playbook/kits/card_body_spec.rb
+++ b/spec/pb_kits/playbook/kits/card_body_spec.rb
@@ -9,7 +9,11 @@ module Playbook
 
       it { is_expected.to define_partial }
 
-      it { is_expected.to define_enum_prop(:padding).with_default("md") }
+      it do
+        is_expected.to define_enum_prop(:padding)
+                       .with_default("md")
+                       .with_values("none", "xs", "sm", "md", "lg", "xl")
+      end
 
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do

--- a/spec/pb_kits/playbook/kits/card_body_spec.rb
+++ b/spec/pb_kits/playbook/kits/card_body_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_card/card_body"
+
+module Playbook
+  module PbCard
+    describe CardBody do
+      subject { CardBody }
+
+      it { is_expected.to define_partial }
+
+      it { is_expected.to define_enum_prop(:padding).with_default("md") }
+
+      describe "#classname" do
+        it "returns namespaced class name", :aggregate_failures do
+          expect(CardBody.new({}).classname).to eq "pb_card_body_kit_md"
+          expect(CardBody.new(padding: "none").classname).to eq "pb_card_body_kit_none"
+          expect(CardBody.new(classname: "additional_class").classname).to eq "pb_card_body_kit_md additional_class"
+        end
+      end
+    end
+  end
+end

--- a/spec/pb_kits/playbook/kits/card_spec.rb
+++ b/spec/pb_kits/playbook/kits/card_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_card/card"
+
+module Playbook
+  module PbCard
+    describe Card do
+      subject { Card }
+
+      it { is_expected.to define_partial }
+
+      it { is_expected.to define_boolean_prop(:selected).with_default(false) }
+      it { is_expected.to define_enum_prop(:padding).with_default("md") }
+      it { is_expected.to define_enum_prop(:shadow).with_default("none") }
+
+      describe "#classname" do
+        it "returns namespaced class name", :aggregate_failures do
+          expect(Card.new({}).classname).to eq "pb_card_kit_deselected"
+          expect(Card.new(selected: true).classname).to eq "pb_card_kit_selected"
+          expect(Card.new(shadow: "deeper").classname).to eq "pb_card_kit_deselected_shadow_deeper"
+          expect(Card.new(selected: true, shadow: "shallow").classname).to eq "pb_card_kit_selected_shadow_shallow"
+          expect(Card.new(classname: "additional_class").classname).to eq "pb_card_kit_deselected additional_class"
+        end
+      end
+    end
+  end
+end

--- a/spec/pb_kits/playbook/kits/card_spec.rb
+++ b/spec/pb_kits/playbook/kits/card_spec.rb
@@ -10,8 +10,17 @@ module Playbook
       it { is_expected.to define_partial }
 
       it { is_expected.to define_boolean_prop(:selected).with_default(false) }
-      it { is_expected.to define_enum_prop(:padding).with_default("md") }
-      it { is_expected.to define_enum_prop(:shadow).with_default("none") }
+      it do
+        is_expected.to define_enum_prop(:padding)
+                       .with_default("md")
+                       .with_values("none", "xs", "sm", "md", "lg", "xl")
+      end
+      it do
+        is_expected.to define_enum_prop(:shadow)
+                       .with_default("none")
+                       .with_values("none", "shallow", "default",
+                                    "deep", "deeper", "deepest")
+      end
 
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do

--- a/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -7,14 +7,14 @@ module Playbook
     describe Checkbox do
       subject { Checkbox }
 
+      it { is_expected.to define_partial }
+
       it { is_expected.to define_boolean_prop(:dark).with_default(false) }
       it { is_expected.to define_prop(:text) }
       it { is_expected.to define_prop(:value) }
       it { is_expected.to define_prop(:name) }
       it { is_expected.to define_boolean_prop(:checked).with_default(false) }
       it { is_expected.to define_boolean_prop(:icon).with_default(false) }
-
-      it { is_expected.to define_partial }
 
       describe "#classname" do
         it "returns namespaced class name", :aggregate_failures do

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -55,7 +55,11 @@ module Playbook
       it { is_expected.to define_string_prop(:string_prop).with_default("foo") }
       it { is_expected.to define_boolean_prop(:boolean_prop).with_default(true) }
       it { is_expected.to define_hash_prop(:hash_prop).with_default(baz: :foo) }
-      it { is_expected.to define_enum_prop(:enum_prop).with_default(:right) }
+      it do
+        is_expected.to define_enum_prop(:enum_prop)
+                       .with_default(:right)
+                       .with_values(:up, :down, :left, :right)
+      end
       it { is_expected.to define_string_prop(:default_prop).with_default(nil) }
 
       describe "can be overwritten with custom values" do


### PR DESCRIPTION
1. Migrate `card` kit and `card_body` subkit.
1. Extend base initialization of kit to capture a `block` if yielded one.
1. Add `#with_values` matcher for `Enum` prop assertions.


