### PR TITLE
modernize playbook distribution bar kit

### DIFF
--- a/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.html.erb
+++ b/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.html.erb
@@ -1,8 +1,8 @@
 <%= content_tag(:figure,
     id: object.id,
     data: object.data,
-    class: object.classname("pb_distribution_bar_#{object.size}")) do %>
-  <% object.values.each do |value| %>
-    <div class="pb_distribution_value" style="width:<%=value%>%"></div>
+    class: object.classname) do %>
+  <% object.widths_to_percentages.each do |percentage| %>
+    <div class="pb_distribution_width" style="width:<%= percentage %>%"></div>
   <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.jsx
+++ b/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.jsx
@@ -8,39 +8,37 @@ type DistributionBarProps = {
   data?: String,
   id?: String,
   size?: 'lg' | 'sm',
-  values?: Array<Number>,
+  widths?: Array<Number>,
 }
 
-const normalizeCharacters = (values) => {
-  return values.map( value => {
-    return parseInt(value.toString().replace(/[^0-9.]/gi, ''))
+const normalizeCharacters = (widths) => {
+  return widths.map(width => {
+    return parseInt(width.toString().replace(/[^0-9.]/gi, ''))
   })
 }
 
 const barValues = (normalizedValues) => {
   let arrSum = value => value.reduce((a,b) => (a + b), 0)
-  let valueSum = arrSum(normalizedValues)
+  let widthSum = arrSum(normalizedValues)
   return normalizedValues.map((value,i) => {
     return(
       <div
           key={i}
-          className={`pb_distribution_value`}
-          style={{width:`${value*100/valueSum}%`}}
+          className={`pb_distribution_width`}
+          style={{width:`${value*100/widthSum}%`}}
       />
     )
   })
 }
-
-
 
 const DistributionBar = ({
     className,
     data,
     id,
     size='lg',
-    values=[1]
+    widths=[1]
   }: DistributionBarProps) => {
-    const normalizedValues = normalizeCharacters(values)
+    const normalizedValues = normalizeCharacters(widths)
 
     return(
       <div className={`pb_distribution_bar_${size}`}>

--- a/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.scss
+++ b/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.scss
@@ -5,7 +5,7 @@
   $small_bar: 8px;
   $large_bar: 36px;
   display: flex;
-  .pb_distribution_value {
+  .pb_distribution_width {
     height: 100%;
     display: inline-block;
     @for $i from 1 through length($bar_colors) {

--- a/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.rb
+++ b/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.rb
@@ -2,54 +2,25 @@
 
 module Playbook
   module PbDistributionBar
-    class DistributionBar < Playbook::PbKit::Base
-      PROPS = %i[configured_classname
-                 configured_data
-                 configured_id
-                 configured_size
-                 configured_values].freeze
+    class DistributionBar
+      include Playbook::Props
 
-      def initialize(classname: default_configuration,
-                     data: default_configuration,
-                     id: default_configuration,
-                     size: default_configuration,
-                     values: default_configuration)
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_size = size
-        self.configured_values = values
+      partial "pb_distribution_bar/distribution_bar"
+
+      prop :size, type: Playbook::Props::Enum,
+                  values: %w[lg sm],
+                  default: "lg"
+      prop :widths, type: Playbook::Props::NumberArray,
+                    default: [1]
+
+      def classname
+        generate_classname("pb_distribution_bar", size)
       end
 
-      def size
-        size_options = %w[lg sm]
-        one_of_value(configured_size, size_options, "lg")
-      end
-
-      def values
-        default_value(values_to_percents, [1])
-      end
-
-      def to_partial_path
-        "pb_distribution_bar/distribution_bar"
-      end
-
-    private
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
-
-      def normalize_characters(value)
-        return value.to_s.gsub(/(\d\.\d)|[^a-zA-Z\d]/, '\\1').to_i
-      end
-
-      def values_to_percents
-        normalized_values = configured_values.map(&method(:normalize_characters))
-        normalized_values.map { |value| (value.to_f * 100 / normalized_values.sum ).round(2) }
+      def widths_to_percentages
+        widths.map do |width|
+          (width.to_f * 100 / widths.sum).round(2)
+        end
       end
     end
   end

--- a/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_default.html.erb
+++ b/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_default.html.erb
@@ -1,9 +1,9 @@
 <%= pb_rails("distribution_bar", props: {
-  values: [1,2,3,4,5,3,3,7]
+  widths: [1,2,3,4,5,3,3,7]
 }) %>
 
 <br><br>
 <%= pb_rails("distribution_bar", props: {
-  values: [1,2,3,4,5,3,3,7],
+  widths: [1,2,3,4,5,3,3,7],
   size: "sm"
 }) %>

--- a/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_default.jsx
+++ b/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_default.jsx
@@ -6,7 +6,7 @@ function DistributionBarDefault() {
     <React.Fragment>
       <div>
         <DistributionBar
-          values={[1,2,3,4,5,3,3,7]}
+          widths={[1,2,3,4,5,3,3,7]}
         />
       </div>
       <br/>
@@ -14,7 +14,7 @@ function DistributionBarDefault() {
       <div>
         <DistributionBar
           size='sm'
-          values={[1,2,3,4,5,3,3,7]}
+          widths={[1,2,3,4,5,3,3,7]}
         />
       </div>
     </React.Fragment>

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -5,6 +5,7 @@ require_relative "./props/base"
 require_relative "./props/boolean"
 require_relative "./props/enum"
 require_relative "./props/hash"
+require_relative "./props/number_array"
 require_relative "./props/string"
 
 module Playbook

--- a/app/pb_kits/playbook/props/number_array.rb
+++ b/app/pb_kits/playbook/props/number_array.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Playbook
+  module Props
+    class NumberArray < Playbook::Props::Base
+      def validate(value)
+        return false unless value.is_a?(Array)
+        return false if value.empty?
+
+        value.all?(Integer)
+      end
+    end
+  end
+end

--- a/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
+++ b/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
@@ -1,7 +1,7 @@
-# # frozen_string_literal: true
+# frozen_string_literal: true
 
-# require_relative "../../../../app/pb_kits/playbook/pb_distribution_bar/distribution_bar"
+require_relative "../../../../app/pb_kits/playbook/pb_distribution_bar/distribution_bar"
 
-# RSpec.describe Playbook::PbDistributionBar::DistributionBar do
-#   subject { Playbook::PbDistributionBar::DistributionBar }
-
+RSpec.describe Playbook::PbDistributionBar::DistributionBar do
+  subject { Playbook::PbDistributionBar::DistributionBar }
+end

--- a/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
+++ b/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
@@ -1,0 +1,7 @@
+# # frozen_string_literal: true
+
+# require_relative "../../../../app/pb_kits/playbook/pb_distribution_bar/distribution_bar"
+
+# RSpec.describe Playbook::PbDistributionBar::DistributionBar do
+#   subject { Playbook::PbDistributionBar::DistributionBar }
+

--- a/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
+++ b/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
@@ -4,4 +4,22 @@ require_relative "../../../../app/pb_kits/playbook/pb_distribution_bar/distribut
 
 RSpec.describe Playbook::PbDistributionBar::DistributionBar do
   subject { Playbook::PbDistributionBar::DistributionBar }
+
+  it { is_expected.to define_partial }
+
+  it { is_expected.to define_enum_prop(:size)
+                      .with_default("lg")
+                      .with_values("lg", "sm") }
+  it { is_expected.to define_prop(:widths)
+                      .of_type(Playbook::Props::NumberArray)
+                      .with_default([1]) }
+
+   describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      expect(subject.new({}).classname).to eq "pb_distribution_bar_lg"
+      expect(subject.new(size: "sm").classname).to eq "pb_distribution_bar_sm"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_distribution_bar_lg additional_class"
+    end
+  end
+
 end

--- a/spec/pb_kits/playbook/props/number_array_spec.rb
+++ b/spec/pb_kits/playbook/props/number_array_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Playbook::Props::NumberArray do
+  describe "#validate" do
+    it "returns true given a valid input" do
+      expect(Playbook::Props::NumberArray.new.validate([45, 67])).to eq true
+    end
+
+    it "returns false given an empty array" do
+      expect(Playbook::Props::NumberArray.new.validate([])).to eq false
+    end
+
+    it "returns false given anything something besides an array", :aggregate_failures do
+      expect(Playbook::Props::NumberArray.new.validate("true")).to eq false
+      expect(Playbook::Props::NumberArray.new.validate(:false)).to eq false
+      expect(Playbook::Props::NumberArray.new.validate(1)).to eq false
+      expect(Playbook::Props::NumberArray.new.validate({})).to eq false
+      expect(Playbook::Props::NumberArray.new.validate(6.5)).to eq false
+      expect(Playbook::Props::NumberArray.new.validate(nil)).to eq false
+    end
+
+    it "returns false given anything an array that does not contain integers", :aggregate_failures do
+      expect(Playbook::Props::NumberArray.new.validate([true])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([:false])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([{}])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([6.5])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([nil])).to eq false
+    end
+
+    it "returns false given anything an array that doesn't only contain integers", :aggregate_failures do
+      expect(Playbook::Props::NumberArray.new.validate([7, true])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([8, :false])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([{}, 9])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([1, 3, 5, 6.5])).to eq false
+      expect(Playbook::Props::NumberArray.new.validate([nil, 0, 65])).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Modernize the distribution bar kit and add spec file.
When trying to find what `values` represents dug deeper to see that it represents the `widths` which is a array of numbers. Also the distribution bar kit has not been used in Nitro anywhere, so we changed prop to a name that makes more sense. Also added the number array type.