### PR TITLE
Add required custom matcher

### DIFF
--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -122,6 +122,8 @@ RSpec.describe Playbook::Props do
       end
     end
 
+    it { is_expected.to define_string_prop(:required_prop).that_is_required }
+
     it "raises error when not given a value" do
       expect { subject.new({}) }.to raise_error(Playbook::Props::Error)
     end

--- a/spec/support/playbook/rspec.rb
+++ b/spec/support/playbook/rspec.rb
@@ -13,7 +13,13 @@ module Playbook
         @default = default
       end
 
+      chain :that_is_required do
+        @required = true
+      end
+
       match do |subject_class|
+        return false if @required && !subject_class.props[prop_key].required
+
         if @type_class && @default
           subject_class.props[prop_key].class == @type_class &&
             subject_class.props[prop_key].default == @default
@@ -31,12 +37,14 @@ module Playbook
         type_message = "of #{@type_class} type"
         default_message = "with default of #{@default}"
 
-        if @type_class && @default
+        if @type_class && @default && !@required
           [base_message, type_message, default_message].join(" ")
-        elsif @type_class && !@default
+        elsif @type_class && !@default && !@required
           [base_message, type_message].join(" ")
-        elsif !@type_class && @default
+        elsif !@type_class && @default && !@required
           [base_message, default_message].join(" ")
+        elsif @required
+          "expected #{prop_key} to be required"
         else
           base_message
         end
@@ -116,7 +124,13 @@ module Playbook
         @default = default
       end
 
+      chain :that_is_required do
+        @required = true
+      end
+
       match do |subject_class|
+        return false if @required && !subject_class.props[prop_key].required
+
         is_string = subject_class.props[prop_key]&.class == Props::String
 
         if @default
@@ -130,7 +144,13 @@ module Playbook
         base_message = "expected #{subject_class} to define :#{prop_key} string prop"
         default_message = "with default of #{@default}"
 
-        @default ? [base_message, default_message].join(" ") : base_message
+        if @default && !@required
+          [base_message, default_message].join(" ")
+        elsif @required
+          "expected #{prop_key} to be required"
+        else
+          base_message
+        end
       end
     end
 


### PR DESCRIPTION
When this matcher is used on a `string_prop` that is not required:

```
  1) Playbook::Props required props should define string prop :required_prop that is required
     Failure/Error: it { is_expected.to define_string_prop(:test_prop).that_is_required }
       expected test_prop to be required
     # ./spec/pb_kits/playbook/props_spec.rb:125:in `block (3 levels) in <top (required)>'
```

When this matcher is used on a `prop` that is not required:

```
  1) Playbook::Props required props should define string prop :required_prop that is required
     Failure/Error: it { is_expected.to define_prop(:test_prop).that_is_required }
       expected test_prop to be required
     # ./spec/pb_kits/playbook/props_spec.rb:125:in `block (3 levels) in <top (required)>'
```