### PR TITLE
Allow re-ordered data colors export

### DIFF
--- a/app/pb_kits/playbook/index.js
+++ b/app/pb_kits/playbook/index.js
@@ -49,7 +49,7 @@ import UserBadge from "./pb_user_badge/_user_badge.jsx"
 import VerticalNav from "./pb_vertical_nav/_vertical_nav.jsx"
 
 // Dashboard Settings
-import commonSettings from "./pb_dashboard/commonSettings"
+import { commonSettings, dataColors } from "./pb_dashboard/commonSettings"
 import lineGraphSettings from "./pb_line_graph/lineGraphSettings"
 import barGraphSettings from "./pb_bar_graph/barGraphSettings"
 import dashboardValueSettings from "./pb_dashboard_value/dashboardValueSettings"
@@ -62,17 +62,14 @@ export {
   Avatar,
   Badge,
   BarGraph,
-  barGraphSettings,
   Body,
   Button,
   Caption,
   Card,
   Checkbox,
-  commonSettings,
   Contact,
   Currency,
   DashboardValue,
-  dashboardValueSettings,
   DateRangeInline,
   DateYearStacked,
   DistributionBar,
@@ -88,13 +85,11 @@ export {
   LabelValue,
   Layout,
   LineGraph,
-  lineGraphSettings,
   List,
   ListItem,
   LoadingInline,
   Message,
   OnlineStatus,
-  pbChart,
   Person,
   PersonContact,
   Pill,
@@ -112,4 +107,10 @@ export {
   User,
   UserBadge,
   VerticalNav,
+  barGraphSettings,
+  commonSettings,
+  dashboardValueSettings,
+  dataColors,
+  lineGraphSettings,
+  pbChart,
 }

--- a/app/pb_kits/playbook/pb_bar_graph/barGraphSettings.js
+++ b/app/pb_kits/playbook/pb_bar_graph/barGraphSettings.js
@@ -5,26 +5,27 @@ const sizeColumns = function(highchart) {
   let column = highchart.plotOptions.column;
   let series = highchart.plotOptions.series;
 
-    series.borderWidth = 0
-    series.shadow = false
-    series.pointPadding = 0.3
-    series.groupPadding = 0.2
-}
+  column.borderRadius = 0;
+  column.pointPadding = 0.3;
+  column.groupPadding = 0.2;
 
-const colorDataLabels = (highchart) => {
-    let column = highchart.plotOptions.column
-    let series = highchart.plotOptions.series
+  series.borderWidth = 0;
+  series.shadow = false;
+  series.pointPadding = 0.3;
+  series.groupPadding = 0.2;
+};
 
-    series.dataLabels.color = colors.slate
-    series.dataLabels.style.fontFamily = typography.font_family_base;
-    series.dataLabels.style.fontSize = typography.font_small;
-    
-}
+const styleDataLabels = highchart => {
+  let series = highchart.plotOptions.series;
+
+  series.dataLabels.style.fontFamily = typography.font_family_base;
+  series.dataLabels.style.fontSize = typography.text_small;
+};
 
 const barGraphSettings = function(highchart) {
-  commonSettings(highchart)
-  sizeColumns(highchart)
-  colorDataLabels(highchart)
-}
+  commonSettings(highchart);
+  sizeColumns(highchart);
+  styleDataLabels(highchart);
+};
 
-export default barGraphSettings
+export default barGraphSettings;

--- a/app/pb_kits/playbook/pb_bar_graph/barGraphSettings.js
+++ b/app/pb_kits/playbook/pb_bar_graph/barGraphSettings.js
@@ -1,4 +1,4 @@
-import commonSettings from "../pb_dashboard/commonSettings.js"
+import { commonSettings } from "../pb_dashboard/commonSettings.js";
 import typography from "../tokens/_typography.scss";
 
 const sizeColumns = function(highchart) {

--- a/app/pb_kits/playbook/pb_bar_graph/barGraphSettings.js
+++ b/app/pb_kits/playbook/pb_bar_graph/barGraphSettings.js
@@ -1,31 +1,30 @@
-import commonSettings from "../pb_dashboard/commonSettings.js";
+import commonSettings from "../pb_dashboard/commonSettings.js"
 import typography from "../tokens/_typography.scss";
 
 const sizeColumns = function(highchart) {
   let column = highchart.plotOptions.column;
   let series = highchart.plotOptions.series;
 
-  column.borderRadius = 0;
-  column.pointPadding = 0.3;
-  column.groupPadding = 0.2;
+    series.borderWidth = 0
+    series.shadow = false
+    series.pointPadding = 0.3
+    series.groupPadding = 0.2
+}
 
-  series.borderWidth = 0;
-  series.shadow = false;
-  series.pointPadding = 0.3;
-  series.groupPadding = 0.2;
-};
+const colorDataLabels = (highchart) => {
+    let column = highchart.plotOptions.column
+    let series = highchart.plotOptions.series
 
-const styleDataLabels = highchart => {
-  let series = highchart.plotOptions.series;
-
-  series.dataLabels.style.fontFamily = typography.font_family_base;
-  series.dataLabels.style.fontSize = typography.text_small;
-};
+    series.dataLabels.color = colors.slate
+    series.dataLabels.style.fontFamily = typography.font_family_base;
+    series.dataLabels.style.fontSize = typography.font_small;
+    
+}
 
 const barGraphSettings = function(highchart) {
-  commonSettings(highchart);
-  sizeColumns(highchart);
-  styleDataLabels(highchart);
-};
+  commonSettings(highchart)
+  sizeColumns(highchart)
+  colorDataLabels(highchart)
+}
 
-export default barGraphSettings;
+export default barGraphSettings

--- a/app/pb_kits/playbook/pb_dashboard/commonSettings.js
+++ b/app/pb_kits/playbook/pb_dashboard/commonSettings.js
@@ -15,7 +15,6 @@ const applyCustomSeriesColors = function(highchart) {
   highchart.series.forEach(function(item, index) {
     const selected_color = data_colors[index];
     item.color = selected_color;
-
     item.data.forEach(function(data_item) {
       if(data_item.color){
         data_item.color = selected_color;

--- a/app/pb_kits/playbook/pb_dashboard/commonSettings.js
+++ b/app/pb_kits/playbook/pb_dashboard/commonSettings.js
@@ -1,19 +1,20 @@
 import colors from "../tokens/_colors.scss"
 import typography from "../tokens/_typography.scss";
 
-const applyCustomSeriesColors = function(highchart) {
-  const data_colors = [
-    colors.data_1,
-    colors.data_2,
-    colors.data_3,
-    colors.data_4,
-    colors.data_5,
-    colors.data_6,
-    colors.data_7
-  ];
+const dataColors = [
+  colors.data_1,
+  colors.data_2,
+  colors.data_3,
+  colors.data_4,
+  colors.data_5,
+  colors.data_6,
+  colors.data_7,
+  colors.data_8,
+]
 
+const applyCustomSeriesColors = function(highchart) {
   highchart.series.forEach(function(item, index) {
-    const selected_color = data_colors[index];
+    const selected_color = dataColors[index];
     item.color = selected_color;
     item.data.forEach(function(data_item) {
       if(data_item.color){
@@ -97,4 +98,7 @@ const commonSettings = function(highchart) {
   styleLegend(highchart);
 };
 
-export default commonSettings;
+export {
+  commonSettings,
+  dataColors,
+}

--- a/app/pb_kits/playbook/pb_line_graph/lineGraphSettings.js
+++ b/app/pb_kits/playbook/pb_line_graph/lineGraphSettings.js
@@ -1,4 +1,4 @@
-import commonSettings from "../pb_dashboard/commonSettings.js";
+import { commonSettings } from "../pb_dashboard/commonSettings.js";
 import typography from "../tokens/_typography.scss";
 
 const markerStyles = highchart => {


### PR DESCRIPTION
This adds `dataColors` as a main export in `index.js` for use in Nitro (and beyond). Currently affects any graph that uses data colors. Color order was changed per https://github.com/powerhome/playbook/pull/349