### PR TITLE
Allow Props#generate_classname to take a custom delimiter

### DIFF
--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -25,9 +25,9 @@ module Playbook
       self.class.props[name].value @values[name]
     end
 
-    def generate_classname(*name_parts)
+    def generate_classname(*name_parts, separator: "_")
       [
-        name_parts.compact.join("_"),
+        name_parts.compact.join(separator),
         prop(:classname),
       ].compact.join(" ")
     end

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -56,6 +56,30 @@ RSpec.describe Playbook::Props do
         expect(subject.props).to include(:id, :data, :classname, :aria)
       end
     end
+
+    describe "#generate_classname" do
+      it "with default separator" do
+        instance = subject.new(classname: "passed_classname")
+
+        expect(instance.generate_classname("separate", "with", "default")).to eq(
+          "separate_with_default passed_classname"
+        )
+      end
+
+      it "with custom separator" do
+        instance = subject.new(classname: "passed_classname")
+
+        expect(instance.generate_classname("separate", "with", "custom", separator: "X")).to eq(
+          "separateXwithXcustom passed_classname"
+        )
+
+        another_instance = subject.new(classname: "passed_classname")
+
+        expect(instance.generate_classname("separate", "with", "custom", separator: " ")).to eq(
+          "separate with custom passed_classname"
+        )
+      end
+    end
   end
 
   describe "additional props" do


### PR DESCRIPTION
Some kits do not connect each part of their unique classnames with an underscore (the default), and instead use whitespace. This addition allows `#generate_classname` to take a custom `separator`. It also adds some test support to this method which demonstrates its functionality.