### PR TITLE
Modernize Pill Kit bug fix

### DIFF
--- a/app/pb_kits/playbook/pb_label_pill/label_pill.rb
+++ b/app/pb_kits/playbook/pb_label_pill/label_pill.rb
@@ -39,7 +39,7 @@ module Playbook
       end
 
       def variant
-        default_value(configured_variant, "")
+        default_value(configured_variant, "neutral")
       end
 
       def to_partial_path

--- a/app/pb_kits/playbook/pb_pill/_pill.html.erb
+++ b/app/pb_kits/playbook/pb_pill/_pill.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname(object.kit_class)) do %>
-  <%= object.display_text %>
+    class: object.classname) do %>
+  <%= pb_rails("title", props: { text: object.display_text, tag: "h4", size: 4, classname: "pb_pill_text" }) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_pill/_pill.html.erb
+++ b/app/pb_kits/playbook/pb_pill/_pill.html.erb
@@ -2,5 +2,5 @@
     id: object.id,
     data: object.data,
     class: object.classname) do %>
-  <%= pb_rails("title", props: { text: object.display_text, tag: "h4", size: 4, classname: "pb_pill_text" }) %>
+  <%= pb_rails("title", props: { text: object.display_text, size: 4, classname: "pb_pill_text" }) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_pill/pill.rb
+++ b/app/pb_kits/playbook/pb_pill/pill.rb
@@ -2,59 +2,23 @@
 
 module Playbook
   module PbPill
-    class Pill < Playbook::PbKit::Base
-      PROPS = %i[configured_classname
-                 configured_data
-                 configured_id
-                 configured_text
-                 configured_variant].freeze
+    class Pill
+      include Playbook::Props
 
-      def initialize(classname: default_configuration,
-                     data: default_configuration,
-                     id: default_configuration,
-                     text: default_configuration,
-                     variant: default_configuration)
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_text = text
-        self.configured_variant = variant
+      partial "pb_pill/pill"
+
+      prop :text
+      prop :variant, type: Playbook::Props::Enum,
+                     values: %w[success warning error info neutral],
+                     default: "neutral"
+
+      def classname
+        generate_classname("pb_pill_kit", variant)
       end
 
       def display_text
-        pb_text = Playbook::PbTitle::Title.new(size: 4, text: text, classname: "pb_pill_text")
-        ApplicationController.renderer.render(partial: pb_text, as: :object)
+        text.downcase
       end
-
-      def kit_class
-        kit_options = [
-          "pb_pill_kit",
-          variant,
-        ]
-        kit_options.join("_")
-      end
-
-      def to_partial_path
-        "pb_pill/pill"
-      end
-
-    private
-
-      def variant
-        variant_options = %w[success warning error info neutral]
-        one_of_value(configured_variant, variant_options, "neutral")
-      end
-
-      def text
-        default_value(configured_text.downcase, "")
-      end
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/spec/pb_kits/playbook/kits/pill_spec.rb
+++ b/spec/pb_kits/playbook/kits/pill_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_pill/pill"
+
+RSpec.describe Playbook::PbPill::Pill do
+  subject { Playbook::PbPill::Pill }
+
+  it { is_expected.to define_partial }
+  it { is_expected.to define_prop(:text) }
+  it { is_expected.to define_enum_prop(:variant)
+                      .with_default("neutral")
+                      .with_values("neutral", "success", "warning", "error", "info") }
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      expect(subject.new({}).classname).to eq "pb_pill_kit_neutral"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_pill_kit_neutral additional_class"
+    end
+  end
+end
+


### PR DESCRIPTION
The Label Pill kit was using the pill kit in it and it was being passed an empty string for the variant, which broke the code. We passed it neutral as the default which fixed the issue.