### PR TITLE
Fix bug where variant was passed an empty string

### DIFF
--- a/app/pb_kits/playbook/pb_label_pill/label_pill.rb
+++ b/app/pb_kits/playbook/pb_label_pill/label_pill.rb
@@ -39,7 +39,7 @@ module Playbook
       end
 
       def variant
-        default_value(configured_variant, "")
+        default_value(configured_variant, "neutral")
       end
 
       def to_partial_path


### PR DESCRIPTION
The Label Pill kit was using the pill kit in it and it was being passed an empty string for the variant, which broke the code. We passed it neutral as the default which fixed the issue.