### PR TITLE
Create Optional House Style and Second Address Line for Home Address Street Playbook kit

### DIFF
--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -9,6 +9,12 @@
     text: object.address_house_style
   } %>
 
+  <%= pb_rails "title", props: {
+    classname: "pb_home_address_street_address",
+    size: 4,
+    text: object.address_house_style2
+  } %>
+
   <%= pb_rails "body", props: {
     color: "light",
     text: object.city_state,

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
@@ -1,8 +1,9 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
+  address2: "Apt M18",
   city: "North Arlington",
   home_id: 8250263,
-  house_style: "Colonial",
+  house_style: nil,
   state: "NJ",
   zipcode: "07031",
   dark: true,

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
@@ -1,5 +1,6 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
+  address2: nil,
   city: "North Arlington",
   home_id: 8250263,
   house_style: "Colonial",

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -8,6 +8,7 @@ module Playbook
       partial "pb_home_address_street/home_address_street"
 
       prop :address
+      prop :address2
       prop :city
       prop :home_id, type: Playbook::Props::Number
       prop :house_style
@@ -24,7 +25,15 @@ module Playbook
       end
 
       def address_house_style
-        "#{address} \u00b7 #{house_style}"
+        "#{address} #{separator} #{house_style}"
+      end
+
+      def address_house_style2
+        address2
+      end
+
+      def separator
+        house_style ? "\u00b7" : ""
       end
 
     private


### PR DESCRIPTION
Currently, if house_style is left blank, it will not appear which is what we want; however, the dash between street and house_style will still appear. Step one is to make this dash dependent on existence of house_style. Dark mode is nil, showing no dash or house_style, while light mode is standard with Col style present, separated by a dash. 

Second, our addresses do not have a prop for a second address line such as an apartment number, which exists in Nitro. We want this to only appear with the existence of a second address line, otherwise there should be no white space. This is opposite, with light mode showing nil for second address line, to show no extra white space; Dark mode is set with the value "Apt M18" to show a second address line present. 


<img width="459" alt="Screen Shot 2019-10-16 at 1 50 15 PM" src="https://user-images.githubusercontent.com/42282446/66945635-5e666f00-f01d-11e9-81f9-7cc4300bd057.png">
