### PR TITLE
Show Zipcode and Add Territory to Home Address Street Playbook

### DIFF
--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -17,7 +17,7 @@
 
   <%= pb_rails "body", props: {
     color: "light",
-    text: object.city_state,
+    text: object.city_state_zip,
   } %>
 
   <%= pb_rails "body", props: { classname: "home-hashtag", tag: "span" } do %>
@@ -25,7 +25,7 @@
   <% end %>
 
   <%= pb_rails "body", props: { color: "light", tag: "span" } do %>
-    <small><%= object.state %></small>
+    <small><%= object.territory %></small>
   <% end %>
 
 <% end %>

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -47,7 +47,7 @@ const HomeAddressStreet = ({
       {address} {`\u00b7`} {houseStyle}
     </Title>
     <Body color="light">
-      {city}, {state}
+      {city}, {state} {zipcode}
     </Body>
     <Body
         className="home-hashtag"
@@ -59,7 +59,7 @@ const HomeAddressStreet = ({
         color="light"
         tag="span"
     >
-      <small>{state}</small>
+      <small>{territory}</small>
     </Body>
   </div>
 )

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -18,6 +18,7 @@ type HomeAddressStreetProps = {
   houseStyle: String,
   state: String,
   zipcode: String,
+  territory: String,
 }
 
 const classes = (className, dark) => (
@@ -36,6 +37,7 @@ const HomeAddressStreet = ({
   houseStyle,
   state,
   zipcode,
+  territory,
 }: HomeAddressStreetProps) => (
   <div className={classes(className, dark)}>
     <Title

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -9,8 +9,18 @@ import {
   Title,
 } from '../'
 
+
+  const selector = (houseStyle) =>
+    { if (houseStyle == "") {
+      return ""
+    } else {
+      "\u00b7"
+    }
+  }
+
 type HomeAddressStreetProps = {
   address: String,
+  address_cont: String,
   city: String,
   className?: String,
   dark?: Boolean,
@@ -28,8 +38,10 @@ const classes = (className, dark) => (
   })
 )
 
+
 const HomeAddressStreet = ({
   address,
+  address_cont,
   city,
   className,
   dark=false,
@@ -44,7 +56,13 @@ const HomeAddressStreet = ({
         className="pb_home_address_street_address"
         size={4}
     >
-      {address} {`\u00b7`} {houseStyle}
+      {address} {selector} {houseStyle}
+    </Title>
+    <Title
+        className="pb_home_address_street_address"
+        size={4}
+    >
+      {address_cont}
     </Title>
     <Body color="light">
       {city}, {state} {zipcode}

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -9,14 +9,11 @@ import {
   Title,
 } from '../'
 
-
-  const selector = (houseStyle) =>
-    { if (houseStyle == "") {
-      return ""
-    } else {
-      "\u00b7"
-    }
+const dot = (houseStyle) =>
+  { if (houseStyle !== undefined) {
+    return "\u00b7"
   }
+}
 
 type HomeAddressStreetProps = {
   address: String,
@@ -56,7 +53,7 @@ const HomeAddressStreet = ({
         className="pb_home_address_street_address"
         size={4}
     >
-      {address} {selector} {houseStyle}
+      {address} {dot(houseStyle)} {houseStyle}
     </Title>
     <Title
         className="pb_home_address_street_address"

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
@@ -1,10 +1,11 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
   address2: "Apt M18",
-  city: "North Arlington",
+  city: "West Chester",
   home_id: 8250263,
   house_style: nil,
-  state: "NJ",
-  zipcode: "07031",
+  state: "PA",
+  zipcode: "19382",
+  territory: "PHL",
   dark: true,
 }) %>

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
@@ -1,6 +1,6 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
-  address2: "Apt M18",
+  address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,
   house_style: nil,

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
@@ -5,12 +5,13 @@ function HomeAddressStreetDark() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
-        city="North Arlington"
+        city="West Chester"
         dark
         homeId={8250263}
         houseStyle="Colonial"
-        state="NJ"
-        zipcode="07031"
+        state="PA"
+        zipcode="19382"
+        territory= "PHL"
     />
   )
 }

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
@@ -5,10 +5,10 @@ function HomeAddressStreetDark() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
+        address_cont="Apt M18"
         city="West Chester"
         dark
         homeId={8250263}
-        houseStyle="Colonial"
         state="PA"
         zipcode="19382"
         territory= "PHL"

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
@@ -1,6 +1,6 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
-  address2: nil,
+  address_cont: "Apt2",
   city: "West Chester",
   home_id: 8250263,
   house_style: "Colonial",

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
@@ -1,6 +1,6 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
-  address_cont: "Apt2",
+  address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,
   house_style: "Colonial",

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
@@ -1,9 +1,10 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
   address2: nil,
-  city: "North Arlington",
+  city: "West Chester",
   home_id: 8250263,
   house_style: "Colonial",
-  state: "NJ",
-  zipcode: "07031",
+  state: "PA",
+  zipcode: "19382",
+  territory: "PHL",
 }) %>

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
@@ -5,11 +5,12 @@ function HomeAddressStreetDefault() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
-        city="North Arlington"
+        city="West Chester"
         homeId={8250263}
         houseStyle="Colonial"
-        state="NJ"
-        zipcode="07031"
+        state="PA"
+        zipcode="19382"
+        territory="PHL"
     />
   )
 }

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
@@ -5,6 +5,7 @@ function HomeAddressStreetDefault() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
+        address_cont="Apt M18"
         city="West Chester"
         homeId={8250263}
         houseStyle="Colonial"

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.html.erb
@@ -1,11 +1,8 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
-  address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,
-  house_style: "Colonial",
   state: "PA",
   zipcode: "19382",
   territory: "PHL",
-  dark: true,
 }) %>

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
@@ -1,13 +1,11 @@
 import React from "react"
 import {HomeAddressStreet} from "../../"
 
-function HomeAddressStreetDark() {
+function HomeAddressStreetDefault() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
-        address_cont="Apt M18"
         city="West Chester"
-        dark
         homeId={8250263}
         state="PA"
         zipcode="19382"
@@ -16,4 +14,4 @@ function HomeAddressStreetDark() {
   )
 }
 
-export default HomeAddressStreetDark;
+export default HomeAddressStreetDefault;

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import {HomeAddressStreet} from "../../"
 
-function HomeAddressStreetDefault() {
+function HomeAddressStreetModified() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
@@ -14,4 +14,4 @@ function HomeAddressStreetDefault() {
   )
 }
 
-export default HomeAddressStreetDefault;
+export default HomeAddressStreetModified;

--- a/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
@@ -2,10 +2,12 @@ examples:
 
   rails:
   - home_address_street_default: Default
+  - home_address_street_modified: Modified
   - home_address_street_dark: Dark
 
 
   react:
   - home_address_street_default: Default
+  - home_address_street_modified: Modified
   - home_address_street_dark: Dark
 

--- a/app/pb_kits/playbook/pb_home_address_street/docs/index.js
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/index.js
@@ -1,2 +1,3 @@
 export {default as HomeAddressStreetDefault} from './_home_address_street_default.jsx';
+export {default as HomeAddressStreetModified} from './_home_address_street_modified.jsx';
 export {default as HomeAddressStreetDark} from './_home_address_street_dark.jsx';

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -14,14 +14,15 @@ module Playbook
       prop :house_style
       prop :state
       prop :zipcode
+      prop :territory
       prop :dark, type: Playbook::Props::Boolean, default: false
 
       def classname
         generate_classname("pb_home_address_street_kit", dark_class)
       end
 
-      def city_state
-        "#{city}, #{state}"
+      def city_state_zip
+        "#{city}, #{state} #{zipcode}"
       end
 
       def address_house_style

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -8,7 +8,7 @@ module Playbook
       partial "pb_home_address_street/home_address_street"
 
       prop :address
-      prop :address2
+      prop :address_cont
       prop :city
       prop :home_id, type: Playbook::Props::Number
       prop :house_style
@@ -30,7 +30,7 @@ module Playbook
       end
 
       def address_house_style2
-        address2
+        address_cont
       end
 
       def separator


### PR DESCRIPTION
Originally, the zipcode was an accepted prop that was not displayed anywhere in the kit. Also the territory was not an accepted prop, and the position the territory would take was filled in by the state. In Nitro there is a difference between state and territory (example: Delaware state is PHL territory) so prop added and also displayed. 

This was the original pbkit without Zip or proper territory:
<img width="306" alt="Screen Shot 2019-10-21 at 9 49 34 AM" src="https://user-images.githubusercontent.com/42282446/67213638-56774800-f3ec-11e9-82be-13d8ed75e0c3.png">

Compared to old Nitro with correct fields: 
<img width="342" alt="Screen Shot 2019-10-21 at 10 00 19 AM" src="https://user-images.githubusercontent.com/42282446/67213675-6b53db80-f3ec-11e9-90e5-fa00e5d19e0a.png">


This is the new kit with proper values and displays:

<img width="517" alt="Screen Shot 2019-10-21 at 10 24 03 AM" src="https://user-images.githubusercontent.com/42282446/67213973-f03ef500-f3ec-11e9-9e2c-b53285904b84.png">

