### PR TITLE
Chart kit Additions

### DIFF
--- a/app/pb_kits/playbook/pb_bar_graph/_bar_graph.html.erb
+++ b/app/pb_kits/playbook/pb_bar_graph/_bar_graph.html.erb
@@ -8,17 +8,17 @@
     window.addEventListener('DOMContentLoaded', function() {
       new pbChart('.selector', {
         id: "<%= object.id %>",
-        chartData: <%= object.sanitized_data(chart_data) %>,
+        chartData: <%= object.sanitized_chart_data %>,
         type: "<%= object.chart_type %>",
         title: "<%= object.title %>",
         subtitle: "<%= object.subtitle %>",
         axisTitle: "<%= object.axis_title %>",
         pointStart: <%= object.point_start %>,
-        xCategories: <%= object.x_categories.any? ? object.sanitized_data(x_categories) : "undefined" %>,
+        xCategories: <%= object.x_categories.any? ? object.sanitized_x_categories : "undefined" %>,
         xMin: <%= object.x_min %>,
         xMax:<%= object.x_max %>,
         xTickInterval: <%= object.x_tick_interval %>,
-        yCategories: <%= object.y_categories.any? ? object.sanitized_data(y_categories) : "undefined"  %>,
+        yCategories: <%= object.y_categories.any? ? object.sanitized_y_categories : "undefined"  %>,
         yMin: <%= object.y_min %>,
         yMax: <%= object.y_max %>,
         yTickInterval:<%= object.y_tick_interval %>

--- a/app/pb_kits/playbook/pb_bar_graph/_bar_graph.html.erb
+++ b/app/pb_kits/playbook/pb_bar_graph/_bar_graph.html.erb
@@ -8,12 +8,20 @@
     window.addEventListener('DOMContentLoaded', function() {
       new pbChart('.selector', {
         id: "<%= object.id %>",
-        chartData: <%= object.sanitized_chart_data %>,
+        chartData: <%= object.sanitized_data(chart_data) %>,
         type: "<%= object.chart_type %>",
         title: "<%= object.title %>",
         subtitle: "<%= object.subtitle %>",
         axisTitle: "<%= object.axis_title %>",
         pointStart: <%= object.point_start %>,
+        xCategories: <%= object.x_categories.any? ? object.sanitized_data(x_categories) : "undefined" %>,
+        xMin: <%= object.x_min %>,
+        xMax:<%= object.x_max %>,
+        xTickInterval: <%= object.x_tick_interval %>,
+        yCategories: <%= object.y_categories.any? ? object.sanitized_data(y_categories) : "undefined"  %>,
+        yMin: <%= object.y_min %>,
+        yMax: <%= object.y_max %>,
+        yTickInterval:<%= object.y_tick_interval %>
       })
     })
   <% end %>

--- a/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
+++ b/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
@@ -12,9 +12,19 @@ module Playbook
       prop :orientation, type: Playbook::Props::Enum,
                          values: %w[vertical horizontal],
                          default: "vertical"
-      prop :point_start
+      prop :point_start, default: 0
       prop :subtitle
       prop :title
+      prop :x_min, default: "null"
+      prop :x_max, default: "null"
+      prop :x_tick_interval, default: "undefined"
+      prop :x_categories, type: Playbook::Props::Array,
+                          default: []
+      prop :y_min, default: "null"
+      prop :y_max, default: "null"
+      prop :y_tick_interval, default: "undefined"
+      prop :y_categories, type: Playbook::Props::Array,
+                          default: []
 
       def chart_type
         orientation == "horizontal" ? "bar" : "column"
@@ -24,8 +34,16 @@ module Playbook
         generate_classname("pb_bar_graph")
       end
 
-      def sanitized_chart_data
-        chart_data.to_json.html_safe
+      def sanitized_data(data)
+        data.to_json.html_safe
+      end
+
+      def sanitized_x_categories
+        x_categories.to_json.html_safe
+      end
+
+      def sanitized_y_categories
+        y_categories.to_json.html_safe
       end
     end
   end

--- a/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
+++ b/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
@@ -34,8 +34,8 @@ module Playbook
         generate_classname("pb_bar_graph")
       end
 
-      def sanitized_data(data)
-        data.to_json.html_safe
+      def sanitized_chart_data
+        chart_data.to_json.html_safe
       end
 
       def sanitized_x_categories
@@ -43,7 +43,7 @@ module Playbook
       end
 
       def sanitized_y_categories
-        y_categories.to_json.html_safe
+        x_categories.to_json.html_safe
       end
     end
   end

--- a/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_default.html.erb
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_default.html.erb
@@ -12,16 +12,18 @@
     data: [34227]
 }, {
     name: 'Other',
-    data: [18111]
+    data: [18111, 10000, 1999999]
 }] %>
+
+<% categories = ["apple", "bananas", "oranges"] %>
 
 <%= pb_rails("bar_graph", props: {
     axis_title: 'Number of Employees',
     chart_data: data,
     id: "bar-test",
-    point_start: "2012",
     subtitle: 'Source: thesolarfoundation.com',
-    title: 'Solar Employment Growth by Sector, 2010-2016'
+    title: 'Solar Employment Growth by Sector, 2010-2016',
+    x_categories: categories
 }) %>
 
 

--- a/app/pb_kits/playbook/plugins/pb_chart_plugin.js
+++ b/app/pb_kits/playbook/plugins/pb_chart_plugin.js
@@ -42,10 +42,20 @@ class pbChart {
       subtitle: {
         text: this.defaults.subtitle
       },
+      xAxis: {
+        tickInterval: this.defaults.xTickInterval,
+        min: this.defaults.xMin,
+        max: this.defaults.xMax,
+        categories: this.defaults.xCategories
+      }, 
       yAxis: {
         title: {
           text: this.defaults.axisTitle
-        }
+        },
+        tickInterval: this.defaults.yTickInterval,
+        min: this.defaults.yMin,
+        max: this.defaults.yMax,
+        categories: this.defaults.yCategories
       },
       plotOptions: {
         series: {


### PR DESCRIPTION
This PR adds a few additional to props to both the Y and X axis of the bar graph, enabling Jon to move forward with solar and style the bar graphs with our kit. It allows us to be able to define the tick interval, a min and max value for the labels on the axis, as well as custom categories. Looking for feedback!