### PR TITLE
Modernize Icon Value pbkit

### DIFF
--- a/app/pb_kits/playbook/pb_icon_value/_icon_value.html.erb
+++ b/app/pb_kits/playbook/pb_icon_value/_icon_value.html.erb
@@ -3,7 +3,7 @@
   data: object.data,
   class: object.classname) do %>
     <%= pb_rails("body", props: { color: "light" }) do %>
-      object.value %>
+      <%= pb_rails("icon", props: { icon: object.icon, fixed_width: true }) %>
+      <%= object.text %>
     <% end %>
-    <%= pb_rails("icon", props: { icon: object.icon, fixed_width: true }) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_icon_value/_icon_value.html.erb
+++ b/app/pb_kits/playbook/pb_icon_value/_icon_value.html.erb
@@ -1,6 +1,9 @@
 <%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname(object.kit_class)) do %>
-  <%= object.value %>
+  id: object.id,
+  data: object.data,
+  class: object.classname) do %>
+    <%= pb_rails("body", props: { color: "light" }) do %>
+      object.value %>
+    <% end %>
+    <%= pb_rails("icon", props: { icon: object.icon, fixed_width: true }) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_icon_value/icon_value.rb
+++ b/app/pb_kits/playbook/pb_icon_value/icon_value.rb
@@ -2,77 +2,30 @@
 
 module Playbook
   module PbIconValue
-    class IconValue < Playbook::PbKit::Base
-      PROPS = %i[configured_align
-                 configured_classname
-                 configured_data
-                 configured_icon
-                 configured_id
-                 configured_text].freeze
+    class IconValue
+      include Playbook::Props
 
-      def initialize(align: default_configuration,
-                     classname: default_configuration,
-                     data: default_configuration,
-                     icon: default_configuration,
-                     id: default_configuration,
-                     text: default_configuration)
-        self.configured_align = align
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_icon = icon
-        self.configured_id = id
-        self.configured_text = text
-      end
+      partial "pb_icon_value/icon_value"
+
+      prop :value, type: Playbook::Props::
+      prop :text
+      prop :icon, required: true
+      prop :align, type: Playbook::Props::Enum,
+                  values: %w[left center right],
+                  default: "left"
 
       def value
         if is_set? configured_text
           pb_icon_value = Playbook::PbBody::Body.new(color: "light") do
-            icon +
-              text
+            icon + text
           end
           ApplicationController.renderer.render(partial: pb_icon_value, as: :object)
         end
       end
 
-      def kit_class
-        kit_options = [
-          "pb_icon_value_kit",
-          align,
-        ]
-        kit_options.compact.join("_")
+      def classname
+        generate_classname("pb_icon_value_kit", align)
       end
-
-      def to_partial_path
-        "pb_icon_value/icon_value"
-      end
-
-    private
-
-      def align
-        align_options = %w[left center right]
-        one_of_value(configured_align, align_options, "left")
-      end
-
-      def icon
-        if is_set? configured_icon
-          icon_props = { icon: configured_icon, fixed_width: true }
-          pb_icon = Playbook::PbIcon::Icon.new(icon_props)
-          ApplicationController.renderer.render(partial: pb_icon, as: :object)
-        else
-          ""
-        end
-      end
-
-      def text
-        default_value(configured_text, "")
-      end
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/app/pb_kits/playbook/pb_icon_value/icon_value.rb
+++ b/app/pb_kits/playbook/pb_icon_value/icon_value.rb
@@ -7,21 +7,11 @@ module Playbook
 
       partial "pb_icon_value/icon_value"
 
-      prop :value, type: Playbook::Props::
-      prop :text
+      prop :text, required: true
       prop :icon, required: true
       prop :align, type: Playbook::Props::Enum,
-                  values: %w[left center right],
-                  default: "left"
-
-      def value
-        if is_set? configured_text
-          pb_icon_value = Playbook::PbBody::Body.new(color: "light") do
-            icon + text
-          end
-          ApplicationController.renderer.render(partial: pb_icon_value, as: :object)
-        end
-      end
+                   values: %w[left center right],
+                   default: "left"
 
       def classname
         generate_classname("pb_icon_value_kit", align)

--- a/spec/pb_kits/playbook/kits/icon_value_spec.rb
+++ b/spec/pb_kits/playbook/kits/icon_value_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_icon_value/icon_value"
+
+RSpec.describe Playbook::PbIconValue::IconValue do
+  subject { Playbook::PbIconValue::IconValue }
+
+  it { is_expected.to define_partial }
+
+  it { is_expected.to define_prop(:icon).that_is_required }
+  it { is_expected.to define_prop(:text) }
+  it { is_expected.to define_enum_prop(:align)
+                  .with_default("left")
+                  .with_values("left", "center", "right") }
+
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      required_props = { icon: "user", text: "test" }
+
+      expect(subject.new(required_props).classname).to eq "pb_icon_value_kit_left"
+      expect(subject.new(required_props.merge(align: "center")).classname).to eq "pb_icon_value_kit_center"
+      expect(subject.new(required_props.merge(classname: "additional_class")).classname).to eq "pb_icon_value_kit_left additional_class"
+    end
+
+    it "raises an error when not given an icon" do
+      expect { subject.new(text: "test") }.to raise_error(Playbook::Props::Error)
+    end
+
+    it "raises an error when not given text" do
+      expect { subject.new(icon: "user") }.to raise_error(Playbook::Props::Error)
+    end
+  end
+end


### PR DESCRIPTION
Modernizes the Icon Value kit, also makes the icon and text within required. Adds a spec to the kit as well.