### PR TITLE
Modernize Icon Playbook Kit

### DIFF
--- a/app/pb_kits/playbook/pb_icon/_icon.html.erb
+++ b/app/pb_kits/playbook/pb_icon/_icon.html.erb
@@ -1,7 +1,4 @@
-<% if !object.icon_class.nil? %>
-  <%= content_tag(:i, nil,
-      id: object.id,
-      data: object.data,
-      class: object.classname(object.kit_class),
-      aria: object.aria) %>
-<% end %>
+<%= content_tag(:i, nil,
+    id: object.id,
+    data: object.data,
+    class: object.classname) %>

--- a/app/pb_kits/playbook/pb_icon/_icon.html.erb
+++ b/app/pb_kits/playbook/pb_icon/_icon.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:i, nil,
     id: object.id,
     data: object.data,
-    class: object.classname) %>
+    class: object.classname,
+    aria: object.aria) %>

--- a/app/pb_kits/playbook/pb_icon/icon.rb
+++ b/app/pb_kits/playbook/pb_icon/icon.rb
@@ -2,130 +2,39 @@
 
 module Playbook
   module PbIcon
-    class Icon < Playbook::PbKit::Base
-      PROPS = %i[configured_aria
-                 configured_border
-                 configured_classname
-                 configured_data
-                 configured_fixed_width
-                 configured_flip
-                 configured_icon
-                 configured_id
-                 configured_inverse
-                 configured_list_item
-                 configured_pull
-                 configured_pulse
-                 configured_rotation
-                 configured_size
-                 configured_spin].freeze
+    class Icon
+      include Playbook::Props
 
-      def initialize(aria: default_configuration,
-                     border: default_configuration,
-                     classname: default_configuration,
-                     data: default_configuration,
-                     fixed_width: default_configuration,
-                     flip: default_configuration,
-                     icon: default_configuration,
-                     id: default_configuration,
-                     inverse: default_configuration,
-                     list_item: default_configuration,
-                     pull: default_configuration,
-                     pulse: default_configuration,
-                     rotation: default_configuration,
-                     size: default_configuration,
-                     spin: default_configuration)
-        self.configured_aria = aria
-        self.configured_border = border
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_fixed_width = fixed_width
-        self.configured_flip = flip
-        self.configured_icon = icon
-        self.configured_id = id
-        self.configured_inverse = inverse
-        self.configured_list_item = list_item
-        self.configured_pull = pull
-        self.configured_pulse = pulse
-        self.configured_rotation = rotation
-        self.configured_size = size
-        self.configured_spin = spin
-      end
+      partial "pb_icon/icon"
 
-      def border_class
-        true_value(configured_border, "fa-border", nil)
-      end
+      prop :border, type: Playbook::Props::Boolean,
+                    default: false
+      prop :fixed_width, type: Playbook::Props::Boolean,
+                         default: false
+      prop :flip, type: Playbook::Props::Enum,
+                  values: ["horizontal", "vertical", "both", nil],
+                  default: nil
+      prop :icon, required: true
+      prop :inverse, type: Playbook::Props::Boolean,
+                     default: false
+      prop :list_item, type: Playbook::Props::Boolean,
+                       default: false
+      prop :pull, type: Playbook::Props::Enum,
+                  values: ["left", "right", nil],
+                  default: nil
+      prop :pulse, type: Playbook::Props::Boolean,
+                   default: false
+      prop :rotation, type: Playbook::Props::Enum,
+                      values: [90, 180, 270, nil],
+                      default: nil
+      prop :size, type: Playbook::Props::Enum,
+                  values: ["lg", "xs", "sm", "1x", "2x", "3x", "4x", "5x", "6x", "7x", "8x", "9x", "10x", nil],
+                  default: nil
+      prop :spin, type: Playbook::Props::Boolean,
+                  default: false
 
-      def fixed_width_class
-        true_value(configured_fixed_width, "fa-fw", nil)
-      end
-
-      def flip
-        flip_options = %w[horizontal vertical both]
-        one_of_value(configured_flip, flip_options, nil)
-      end
-
-      def flip_class
-        h_class = "fa-flip-horizontal"
-        v_class = "fa-flip-vertical"
-        case flip
-        when "horizontal"
-          h_class
-        when "vertical"
-          v_class
-        when "both"
-          [h_class, v_class].join(" ")
-        end
-      end
-
-      def icon_class
-        adjusted_value(configured_icon, "fa-#{configured_icon}", nil)
-      end
-
-      def inverse_class
-        true_value(configured_inverse, "fa-inverse", nil)
-      end
-
-      def list_item_class
-        true_value(configured_list_item, "fa-li", nil)
-      end
-
-      def pull
-        pull_options = %w[left right]
-        one_of_value(configured_pull, pull_options, default_configuration)
-      end
-
-      def pull_class
-        adjusted_value(pull, "fa-pull-#{pull}", nil)
-      end
-
-      def pulse_class
-        true_value(configured_pulse, "fa-pulse", nil)
-      end
-
-      def rotation
-        rotation_options = [90, 180, 270]
-        one_of_value(configured_rotation, rotation_options, default_configuration)
-      end
-
-      def rotation_class
-        adjusted_value(rotation, "fa-rotate-#{rotation}", nil)
-      end
-
-      def size
-        size_options = %w[lg xs sm 1x 2x 3x 4x 5x 6x 7x 8x 9x 10x]
-        one_of_value(configured_size, size_options, default_configuration)
-      end
-
-      def size_class
-        adjusted_value(size, "fa-#{size}", nil)
-      end
-
-      def spin_class
-        true_value(configured_spin, "fa-spin", nil)
-      end
-
-      def kit_class
-        icon_options = [
+      def classname
+        generate_classname(
           "pb_icon_kit",
           "far",
           icon_class,
@@ -139,22 +48,62 @@ module Playbook
           rotation_class,
           size_class,
           spin_class,
-        ]
-        icon_options.reject(&:nil?).join(" ")
-      end
-
-      def to_partial_path
-        "pb_icon/icon"
+          separator: " "
+        )
       end
 
     private
 
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
+      def border_class
+        border ? "fa-border" : nil
       end
-      attr_accessor(*PROPS)
+
+      def fixed_width_class
+        fixed_width ? "fa-fw" : nil
+      end
+
+      def icon_class
+        icon ? "fa-#{icon}" : nil
+      end
+
+      def inverse_class
+        inverse ? "fa-inverse" : nil
+      end
+
+      def list_item_class
+        list_item ? "fa-li" : nil
+      end
+
+      def flip_class
+        case flip
+        when "horizontal"
+          "fa-flip-horizontal"
+        when "vertical"
+          "fa-flip-vertical"
+        when "both"
+          "fa-flip-horizontal fa-flip-vertical"
+        end
+      end
+
+      def pull_class
+        pull ? "fa-pull-#{pull}" : nil
+      end
+
+      def pulse_class
+        pulse ? "fa-pulse" : nil
+      end
+
+      def rotation_class
+        rotation ? "fa-rotate-#{rotation}" : nil
+      end
+
+      def size_class
+        size ? "fa-#{size}" : nil
+      end
+
+      def spin_class
+        spin ? "fa-spin" : nil
+      end
     end
   end
 end

--- a/spec/pb_kits/playbook/kits/icon_spec.rb
+++ b/spec/pb_kits/playbook/kits/icon_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_icon/icon"
+
+RSpec.describe Playbook::PbIcon::Icon do
+  subject { Playbook::PbIcon::Icon }
+
+  it { is_expected.to define_partial }
+
+
+  it { is_expected.to define_prop(:border)
+                      .of_type(Playbook::Props::Boolean) }
+  it { is_expected.to define_prop(:fixed_width)
+                      .of_type(Playbook::Props::Boolean) }
+  it { is_expected.to define_enum_prop(:flip)
+                      .with_values("horizontal", "vertical", "both", nil) }
+  it { is_expected.to define_prop(:icon).that_is_required }
+  it { is_expected.to define_prop(:inverse)
+                      .of_type(Playbook::Props::Boolean) }
+  it { is_expected.to define_prop(:list_item)
+                      .of_type(Playbook::Props::Boolean) }
+  it { is_expected.to define_enum_prop(:pull)
+                      .with_values("left", "right", nil) }
+  it { is_expected.to define_prop(:pulse)
+                      .of_type(Playbook::Props::Boolean) }
+  it { is_expected.to define_enum_prop(:rotation)
+                      .with_values(90, 180, 270, nil) }
+  it { is_expected.to define_enum_prop(:size)
+                      .with_values("lg", "xs", "sm", "1x", "2x", "3x", "4x", "5x", "6x", "7x", "8x", "9x", "10x", nil) }
+  it { is_expected.to define_prop(:spin)
+                      .of_type(Playbook::Props::Boolean) }
+
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      icon = "user"
+      pull ="right"
+      rotation = 90
+      size = "sm"
+
+      expect(subject.new(icon: icon, border: true).classname).to eq "pb_icon_kit far fa-user fa-border"
+      expect(subject.new(icon: icon, fixed_width: true).classname).to eq "pb_icon_kit far fa-user fa-fw"
+      expect(subject.new(icon: icon, flip: "horizontal").classname).to eq "pb_icon_kit far fa-user fa-flip-horizontal"
+      expect(subject.new(icon: icon,).classname).to eq "pb_icon_kit far fa-user"
+      expect(subject.new(icon: icon, inverse: true).classname).to eq "pb_icon_kit far fa-user fa-inverse"
+      expect(subject.new(icon: icon, list_item: true).classname).to eq "pb_icon_kit far fa-user fa-li"
+      expect(subject.new(icon: icon, pull: pull).classname).to eq "pb_icon_kit far fa-user fa-pull-#{pull}"
+      expect(subject.new(icon: icon, pulse: true).classname).to eq "pb_icon_kit far fa-user fa-pulse"
+      expect(subject.new(icon: icon, rotation: rotation).classname).to eq "pb_icon_kit far fa-user fa-rotate-#{rotation}"
+      expect(subject.new(icon: icon, size: size).classname).to eq "pb_icon_kit far fa-user fa-#{size}"
+      expect(subject.new(icon: icon, spin: true).classname).to eq "pb_icon_kit far fa-user fa-spin"
+      expect(subject.new(icon: icon, classname: "additional_class").classname).to eq "pb_icon_kit far fa-user additional_class"
+    end
+
+    it "raises an error when not given an icon" do
+      expect { subject.new({}) }.to raise_error(Playbook::Props::Error)
+    end
+  end
+end
+

--- a/spec/support/playbook/rspec.rb
+++ b/spec/support/playbook/rspec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pry"
+
 module Playbook
   module Rspec
     extend RSpec::Matchers::DSL
@@ -69,11 +71,11 @@ module Playbook
 
         if @default && @values
           subject_class.props[prop_key].default == @default &&
-            values.sort == @values.sort
+            values.map(&:to_s).sort == @values.map(&:to_s).sort
         elsif @default && !@values
           subject_class.props[prop_key].default == @default
         elsif !@default && @values
-          values.sort == @values.sort
+          values.map(&:to_s).sort == @values.map(&:to_s).sort
         else
           true
         end

--- a/spec/support/playbook/rspec.rb
+++ b/spec/support/playbook/rspec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pry"
-
 module Playbook
   module Rspec
     extend RSpec::Matchers::DSL


### PR DESCRIPTION
Modernize Icon kit to match new formatting

Additional Information:
Commit 5d69785 adjusts the Enum specs to coerce array into strings for comparison. This allows the default to be nil. 