### PR TITLE
Modernize Stat Value Playbook Kit

### DIFF
--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.html.erb
@@ -1,6 +1,6 @@
 <%= pb_rails("dashboard_value", props: {
   stat_label: {label: "Top Title Value"},
-  stat_value: {value: "1,428", unit: "appts"},
+  stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: "26.1%"}
 }) %>
 
@@ -9,7 +9,7 @@
 <%= pb_rails("dashboard_value", props: {
   align: "center",
   stat_label: {label: "Top Title Value"},
-  stat_value: {value: "1,428", unit: "appts"},
+  stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: "26.1%"}
 }) %>
 
@@ -18,6 +18,6 @@
 <%= pb_rails("dashboard_value", props: {
   align: "right",
   stat_label: {label: "Top Title Value"},
-  stat_value: {value: "1,428", unit: "appts"},
+  stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: "26.1%"}
 }) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
@@ -1,6 +1,6 @@
 <%= pb_rails("dashboard_value", props: {
   stat_label: {label: "Decreased Value"},
-  stat_value: {value: "1,428", unit: "appts"},
+  stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: "26.1%"}
 }) %>
 
@@ -8,7 +8,7 @@
 
 <%= pb_rails("dashboard_value", props: {
   stat_label: {label: "Increased Value"},
-  stat_value: {value: "938", unit: "homes"},
+  stat_value: {value: 938, unit: "homes"},
   stat_change: {change: "increase", value: "26.1%"}
 }) %>
 
@@ -16,6 +16,6 @@
 
 <%= pb_rails("dashboard_value", props: {
   stat_label: {label: "Neutral Value"},
-  stat_value: {value: "261", unit: "windows"},
+  stat_value: {value: 261, unit: "windows"},
   stat_change: {value: "26.1%"}
 }) %>

--- a/app/pb_kits/playbook/pb_stat_value/_stat_value.html.erb
+++ b/app/pb_kits/playbook/pb_stat_value/_stat_value.html.erb
@@ -1,10 +1,16 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname(object.kit_class)) do %>
+    class: object.classname) do %>
   <div class="pb_stat_value_wrapper">
-    <%= object.display_value %>
-    &nbsp;
-    <%= object.display_unit %>
+    <%= pb_rails "title", props: {
+      classname: "pb_stat_value_kit",
+      size: 1,
+      text: object.value } %>
+      &nbsp;
+      <%= pb_rails "title", props: {
+      classname: "pb_stat_value_kit",
+      size: 3,
+      text: object.unit } %>
   </div>
 <% end %>

--- a/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_unit.html.erb
+++ b/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_unit.html.erb
@@ -1,1 +1,1 @@
-<%= pb_rails("stat_value", props: { value: "5,294", unit: "appt" }) %>
+<%= pb_rails("stat_value", props: { value: 5294, unit: "appt" }) %>

--- a/app/pb_kits/playbook/pb_stat_value/stat_value.rb
+++ b/app/pb_kits/playbook/pb_stat_value/stat_value.rb
@@ -2,61 +2,17 @@
 
 module Playbook
   module PbStatValue
-    class StatValue < Playbook::PbKit::Base
-      PROPS = %i[configured_classname
-                 configured_data
-                 configured_id
-                 configured_unit
-                 configured_value].freeze
+    class StatValue
+      include Playbook::Props
 
-      def initialize(classname: default_configuration,
-                     data: default_configuration,
-                     id: default_configuration,
-                     unit: default_configuration,
-                     value: default_configuration)
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_unit = unit
-        self.configured_value = value
+      partial "pb_stat_value/stat_value"
+
+      prop :unit
+      prop :value, type: Playbook::Props::Number
+
+      def classname
+        generate_classname("pb_stat_value_kit")
       end
-
-      def value
-        default_value(configured_value, 0)
-      end
-
-      def display_value
-        pb_title = Playbook::PbTitle::Title.new(size: 1, text: value)
-        ApplicationController.renderer.render(partial: pb_title, as: :object)
-      end
-
-      def unit
-        default_value(configured_unit, nil)
-      end
-
-      def display_unit
-        unless unit.nil?
-          pb_unit = Playbook::PbTitle::Title.new(size: 3, text: unit)
-          ApplicationController.renderer.render(partial: pb_unit, as: :object)
-        end
-      end
-
-      def kit_class
-        "pb_stat_value_kit"
-      end
-
-      def to_partial_path
-        "pb_stat_value/stat_value"
-      end
-
-    private
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/spec/pb_kits/playbook/kits/stat_value_spec.rb
+++ b/spec/pb_kits/playbook/kits/stat_value_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_stat_value/stat_value"
+
+RSpec.describe Playbook::PbStatValue::StatValue do
+  subject { Playbook::PbStatValue::StatValue }
+
+  it { is_expected.to define_partial }
+
+  it { is_expected.to define_prop(:unit) }
+  it { is_expected.to define_prop(:value)
+                  .of_type(Playbook::Props::Number) }
+
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      expect(subject.new({}).classname).to eq "pb_stat_value_kit"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_stat_value_kit additional_class"
+    end
+  end
+end


### PR DESCRIPTION
Common modernization to the Stat Value kit to match our current formatting.

Additional Information:
This kit originally accepted strings or integers where it was displaying values. The values were always an integer, but it was formatted this way in the examples if the end user typed in a string. To better stream line, we made the prop always a number, however this may effect previous uses that contained strings. With that in mind, we should watch any previous Stat Value pbkit or Dashboard Value kit (which inherits Stat Value in it) for backwards compatibility issues. It will be an easy fix of adjusting the value to an integer. 