### PR TITLE
Modernize DateRangeInline Playbook kit

### DIFF
--- a/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.html.erb
+++ b/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.html.erb
@@ -8,7 +8,7 @@
     <% end %>
 
     <%= pb_rails("body", props: { tag: "span"}) do %>
-      <%= object.start_date %>
+      <%= object.start_date_display %>
     <% end %>
 
     <%= pb_rails("body", props: { tag: "span", color: "light" }) do %>
@@ -16,7 +16,7 @@
     <% end %>
 
     <%= pb_rails("body", props: { tag: "span"}) do %>
-      <%= object.end_date %>
+      <%= object.end_date_display %>
     <% end %>
 
 <% end %>

--- a/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.html.erb
+++ b/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname("pb_date_range_inline")) do %>
+    class: object.classname) do %>
 
     <%= pb_rails("body", props: { tag: "span", color: "light" }) do %>
       <%= pb_rails("icon", props: { icon: "calendar-alt", fixed_width: true }) %>

--- a/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.rb
+++ b/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.rb
@@ -2,54 +2,34 @@
 
 module Playbook
   module PbDateRangeInline
-    class DateRangeInline < Playbook::PbKit::Base
+    class DateRangeInline
       include ActionView::Helpers::TagHelper
       include ActionView::Context
+      include Playbook::Props
 
-      PROPS = %i[configured_classname
-                 configured_data
-                 configured_end_date
-                 configured_id
-                 configured_start_date].freeze
+      partial "pb_date_range_inline/date_range_inline"
 
-      def initialize(classname: default_configuration,
-                     data: default_configuration,
-                     end_date: default_configuration,
-                     id: default_configuration,
-                     start_date: default_configuration)
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_end_date = end_date
-        self.configured_start_date = start_date
+      prop :end_date
+      prop :start_date
+
+
+      def classname
+        generate_classname("pb_date_range_inline_kit", end_date_display, start_date_display)
       end
 
-      def end_date
-        date_time = Playbook::PbKit::PbDateTime.new(default_value(configured_end_date, ""))
+def end_date_display
+        date_time = Playbook::PbKit::PbDateTime.new(end_date)
         content_tag(:time, datetime: date_time.to_iso) do
           "#{date_time.to_day} #{date_time.to_month_downcase} #{date_time.to_year}"
         end
       end
 
-      def start_date
-        date_time = Playbook::PbKit::PbDateTime.new(default_value(configured_start_date, ""))
+      def start_date_display
+        date_time = Playbook::PbKit::PbDateTime.new(start_date)
         content_tag(:time, datetime: date_time.to_iso) do
           "#{date_time.to_day} #{date_time.to_month_downcase} #{date_time.to_year}"
         end
       end
-
-      def to_partial_path
-        "pb_date_range_inline/date_range_inline"
-      end
-
-    private
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.rb
+++ b/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.rb
@@ -9,15 +9,14 @@ module Playbook
 
       partial "pb_date_range_inline/date_range_inline"
 
-      prop :end_date
-      prop :start_date
-
+      prop :end_date, type: Playbook::Props::Date, required: true
+      prop :start_date, type: Playbook::Props::Date, required: true
 
       def classname
-        generate_classname("pb_date_range_inline_kit", end_date_display, start_date_display)
+        generate_classname("pb_date_range_inline_kit")
       end
 
-def end_date_display
+      def end_date_display
         date_time = Playbook::PbKit::PbDateTime.new(end_date)
         content_tag(:time, datetime: date_time.to_iso) do
           "#{date_time.to_day} #{date_time.to_month_downcase} #{date_time.to_year}"

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -7,6 +7,7 @@ require_relative "./props/base"
 
 require_relative "./props/array"
 require_relative "./props/boolean"
+require_relative "./props/date"
 require_relative "./props/enum"
 require_relative "./props/hash"
 require_relative "./props/hash_array"

--- a/app/pb_kits/playbook/props/date.rb
+++ b/app/pb_kits/playbook/props/date.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Playbook
+  module Props
+    class Date < Playbook::Props::Base
+      def validate(value)
+        value.is_a?(::Date)
+      end
+    end
+  end
+end

--- a/spec/pb_kits/playbook/kits/date_range_inline_spec.rb
+++ b/spec/pb_kits/playbook/kits/date_range_inline_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_date_range_inline/date_range_inline"
+
+RSpec.describe Playbook::PbDateRangeInline::DateRangeInline do
+  subject { Playbook::PbDateRangeInline::DateRangeInline }
+
+  it { is_expected.to define_partial }
+
+  it { is_expected.to define_prop(:start_date).of_type(Playbook::Props::Date)
+                                              .that_is_required }
+  it { is_expected.to define_prop(:end_date).of_type(Playbook::Props::Date)
+                                              .that_is_required }
+
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      required_props = { start_date: Date.today, end_date: Date.tomorrow }
+      expect(subject.new(required_props).classname).to eq "pb_date_range_inline_kit"
+      expect(subject.new(required_props.merge(classname: "additional_class")).classname).to eq "pb_date_range_inline_kit additional_class"
+    end
+  end
+end

--- a/spec/pb_kits/playbook/props/date_spec.rb
+++ b/spec/pb_kits/playbook/props/date_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Playbook::Props::Date do
+  describe "#validate" do
+    it "returns true given a Ruby:Date", :aggregate_failures do
+      expect(Playbook::Props::Date.new.validate(Date.new(2020, 03, 02))).to eq true
+    end
+
+    it "returns false given anything else", :aggregate_failures do
+      expect(Playbook::Props::Date.new.validate("foo")).to eq false
+      expect(Playbook::Props::Date.new.validate(true)).to eq false
+      expect(Playbook::Props::Date.new.validate(:foo)).to eq false
+      expect(Playbook::Props::Date.new.validate(1)).to eq false
+      expect(Playbook::Props::Date.new.validate([])).to eq false
+      expect(Playbook::Props::Date.new.validate(nil)).to eq false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "../lib/playbook"
-require_relative "../app/pb_kits/playbook/props.rb"
+require_relative "../app/pb_kits/playbook/props"
+require_relative "../app/pb_kits/playbook/pb_kit/pb_date_time"
 Dir[File.expand_path("support/**/*.rb", __dir__)].each { |f| require f }
 require "byebug"
 


### PR DESCRIPTION
Modernizes the DateRangeInline kit to our new method. 

Additional information:
Also adds a Date prop to playbook. 