### PR TITLE
Add contact_details prop to contact kit

### DIFF
--- a/app/pb_kits/playbook/pb_contact/_contact.html.erb
+++ b/app/pb_kits/playbook/pb_contact/_contact.html.erb
@@ -4,6 +4,6 @@
     class: object.classname) do %>
   <%= pb_rails("body", props: { tag: "span", classname: "pb_contact_kit", color: "light" }) do %>
     <%= pb_rails("icon", props: { icon: object.contact_icon, fixed_width: true }) %>
-    <%= object.formatted_contact_value if object.contact_value%>
+    <%= object.formatted_contact_details if object.contact_value%>
   <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_contact/_contact.html.erb
+++ b/app/pb_kits/playbook/pb_contact/_contact.html.erb
@@ -4,6 +4,6 @@
     class: object.classname) do %>
   <%= pb_rails("body", props: { tag: "span", classname: "pb_contact_kit", color: "light" }) do %>
     <%= pb_rails("icon", props: { icon: object.contact_icon, fixed_width: true }) %>
-    <%= object.formatted_contact_details if object.contact_value%>
+    <%= object.formatted_contact_info if object.contact_value%>
   <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_contact/_contact.jsx
+++ b/app/pb_kits/playbook/pb_contact/_contact.jsx
@@ -27,14 +27,14 @@ const Contact = ({
   className,
   dark=false,
   contactValue,
-  contactDetail,
+  contactDetail="",
 }: ContactProps) => {
 
   const formatDetail = (contactDetail) => {
     if (contactDetail !== undefined) {
       return `\u00b7 ${contactDetail}`
     } else {
-      return ""
+      return contactDetail
     }
   }
 
@@ -44,11 +44,11 @@ const Contact = ({
     if (contactType == "email") {
       return contactString
     } else {
-      let cleaned = ('' + contactString).replace(/\D/g, '')
-      let match = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/)
-      if (match) {
-        let intlCode = (match[1] ? '+1 ' : '')
-        return [intlCode, '(', match[2], ') ', match[3], '-', match[4]].join('')
+      const cleaned = contactString.replace(/\D/g, '')
+      const phoneNumber = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/)
+      if (phoneNumber) {
+        let intlCode = (phoneNumber[1] ? '+1 ' : '')
+        return [intlCode, '(', phoneNumber[2], ') ', phoneNumber[3], '-', phoneNumber[4]].join('')
       }
       return null
     }

--- a/app/pb_kits/playbook/pb_contact/_contact.jsx
+++ b/app/pb_kits/playbook/pb_contact/_contact.jsx
@@ -14,6 +14,7 @@ type ContactProps = {
   className?: String | Array<String>,
   dark?: Boolean,
   contactValue: String,
+  contactDetail?: String,
 }
 
 const kitClasses = ({}: ContactProps) => {
@@ -26,15 +27,24 @@ const Contact = ({
   className,
   dark=false,
   contactValue,
+  contactDetail,
 }: ContactProps) => {
+
+  const formatDetail = (contactDetail) => {
+    if (contactDetail !== undefined) {
+      return `\u00b7 ${contactDetail}`
+    } else {
+      return ""
+    }
+  }
 
   const css = classnames(kitClasses({contactType}), className)
 
-  const formatPhoneNumber = (phoneNumberString, contactType) => {
+  const formatContact = (contactString, contactType) => {
     if (contactType == "email") {
-      return phoneNumberString
+      return contactString
     } else {
-      let cleaned = ('' + phoneNumberString).replace(/\D/g, '')
+      let cleaned = ('' + contactString).replace(/\D/g, '')
       let match = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/)
       if (match) {
         let intlCode = (match[1] ? '+1 ' : '')
@@ -63,7 +73,7 @@ const Contact = ({
     <div className={css}>
       <Body dark={dark} color="light" >
         <Icon icon={contactTypeIcon} fixedWidth="true" />
-        {` ${formatPhoneNumber(contactValue, contactType)}`}
+        {` ${formatContact(contactValue, contactType)} ${formatDetail(contactDetail)}`}
       </Body>
     </div>
   )

--- a/app/pb_kits/playbook/pb_contact/contact.rb
+++ b/app/pb_kits/playbook/pb_contact/contact.rb
@@ -33,7 +33,7 @@ module Playbook
         end
       end
 
-      def formatted_contact_details
+      def formatted_contact_info
         "#{formatted_contact_value} #{separator} #{contact_detail}"
       end
 

--- a/app/pb_kits/playbook/pb_contact/contact.rb
+++ b/app/pb_kits/playbook/pb_contact/contact.rb
@@ -33,6 +33,12 @@ module Playbook
         end
       end
 
+      def formatted_contact_details
+        "#{formatted_contact_value} #{separator} #{contact_detail}"
+      end
+
+    private
+
       def formatted_contact_value
         if contact_type == "email"
           contact_value
@@ -40,12 +46,6 @@ module Playbook
           number_to_phone(formatted_value, area_code: true)
         end
       end
-
-      def formatted_contact_details
-        "#{formatted_contact_value} #{separator} #{contact_detail}"
-      end
-
-    private
 
       def formatted_value
         contact_value.to_s.gsub(/\D/, "")

--- a/app/pb_kits/playbook/pb_contact/contact.rb
+++ b/app/pb_kits/playbook/pb_contact/contact.rb
@@ -12,6 +12,7 @@ module Playbook
 
       prop :contact_type
       prop :contact_value
+      prop :contact_detail
 
       def classname
         generate_classname("pb_contact_kit")
@@ -40,10 +41,18 @@ module Playbook
         end
       end
 
+      def formatted_contact_details
+        "#{formatted_contact_value} #{separator} #{contact_detail}"
+      end
+
     private
 
       def formatted_value
         contact_value.to_s.gsub(/\D/, "")
+      end
+
+      def separator
+        contact_detail ? "\u00b7" : ""
       end
     end
   end

--- a/app/pb_kits/playbook/pb_contact/docs/_contact_default.html.erb
+++ b/app/pb_kits/playbook/pb_contact/docs/_contact_default.html.erb
@@ -1,18 +1,22 @@
 <%= pb_rails("contact", props: {
   contact_type: "cell",
   contact_value: "349-185-9988",
+  contact_detail: "John's Cell",
 }) %>
 
 <%= pb_rails("contact", props: {
   contact_value: 5555555555,
+  contact_detail: "Home",
 }) %>
 
 <%= pb_rails("contact", props: {
   contact_type: "email",
   contact_value: "email@example.com",
+  contact_detail: "John's Email",
 }) %>
 
 <%= pb_rails("contact", props: {
   contact_type: "work",
   contact_value: "3245627482",
+  contact_detail: "John's Work",
 }) %>

--- a/app/pb_kits/playbook/pb_contact/docs/_contact_default.html.erb
+++ b/app/pb_kits/playbook/pb_contact/docs/_contact_default.html.erb
@@ -11,8 +11,7 @@
 
 <%= pb_rails("contact", props: {
   contact_type: "email",
-  contact_value: "email@example.com",
-  contact_detail: "John's Email",
+  contact_value: "email@example.com"
 }) %>
 
 <%= pb_rails("contact", props: {

--- a/app/pb_kits/playbook/pb_contact/docs/_contact_default.jsx
+++ b/app/pb_kits/playbook/pb_contact/docs/_contact_default.jsx
@@ -7,9 +7,11 @@ function ContactDefault() {
       <Contact
         contactType="cell"
         contactValue="349-185-9988"
+        contactDetail="John's Cell"
       />
       <Contact
         contactValue="5555555555"
+        contactDetail="Home"
       />
       <Contact
         contactType="email"
@@ -18,6 +20,7 @@ function ContactDefault() {
       <Contact
         contactType="work"
         contactValue="3245627482"
+        contactDetail="John's Work"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
@@ -12,6 +12,7 @@
       <%= pb_rails("contact", props: {
           contact_type: contact[:contact_type],
           contact_value: contact[:contact_value],
+          contact_detail: contact[:contact_detail],
       }) %>
     <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_person_contact/_person_contact.jsx
+++ b/app/pb_kits/playbook/pb_person_contact/_person_contact.jsx
@@ -13,7 +13,7 @@ type PersonContactProps = {
   className?: String | Array<String>,
   dark?: Boolean,
   people?: Array<{firstName: String, lastName: String}>,
-  contacts?: Array<{contactType: String, contactValue: String}>,
+  contacts?: Array<{contactType: String, contactValue: String, contactDetail: String}>,
 }
 
 const contactsArray = ({contacts=[]}: PersonContactProps) => {
@@ -22,6 +22,7 @@ const contactsArray = ({contacts=[]}: PersonContactProps) => {
       <Contact
         contactType={contactObject.contactType}
         contactValue={contactObject.contactValue}
+        contactDetail={contactObject.contactDetail}
       />
     );
   })

--- a/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_default.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_default.html.erb
@@ -12,10 +12,12 @@
   contacts: [
     {
       contact_type: "email",
-      contact_value: "email@example.com"
+      contact_value: "email@example.com",
+      contact_detail: "Pauline's Email"
     },
     {
       contact_value: 5555555555,
+      contact_detail: "Home"
     },
     {
       contact_type: "email",
@@ -24,6 +26,7 @@
     {
       contact_type: "work",
       contact_value: "3245627482",
+      contact_detail: "Harvey's Work"
     }
   ]
 }) %>

--- a/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_default.jsx
+++ b/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_default.jsx
@@ -18,10 +18,12 @@ function PersonContactDefault() {
         contacts={[
           {
             contactType: "email",
-            contactValue: "email@example.com"
+            contactValue: "email@example.com",
+            contactDetail: "Pauline's Email",
           },
           {
             contactValue: "5555555555",
+            contactDetail: "Home",
           },
           {
             contactType: "email",
@@ -30,6 +32,7 @@ function PersonContactDefault() {
           {
             contactType: "work",
             contactValue: "3245627482",
+            contactDetail: "Harvey's Work"
           }
         ]}
       />

--- a/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_single_person.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_single_person.html.erb
@@ -8,14 +8,17 @@
   contacts: [
     {
       contact_type: "email",
-      contact_value: "email@example.com"
+      contact_value: "email@example.com",
+      contact_detail: "Harvey's Email"
     },
     {
       contact_value: 5555555555,
+      contact_detail: "Home",
     },
     {
       contact_type: "work",
       contact_value: "3245627482",
+      contact_detail: "Harvey's Work"
     }
   ]
 }) %>

--- a/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_single_person.jsx
+++ b/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_single_person.jsx
@@ -14,14 +14,17 @@ function PersonContactSinglePerson() {
         contacts={[
           {
             contactType: "email",
-            contactValue: "email@example.com"
+            contactValue: "email@example.com",
+            contactDetail: "Harvey's Email",
           },
           {
             contactValue: "5555555555",
+            contactDetail: "Home",
           },
           {
             contactType: "work",
             contactValue: "3245627482",
+            contactDetail: "Harvey's Work",
           }
         ]}
       />

--- a/spec/pb_kits/playbook/kits/contact_spec.rb
+++ b/spec/pb_kits/playbook/kits/contact_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Playbook::PbContact::Contact do
 
   it { is_expected.to define_prop(:contact_type) }
   it { is_expected.to define_prop(:contact_value) }
+  it { is_expected.to define_prop(:contact_detail) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do


### PR DESCRIPTION
Added a new prop to contact kit so we can show who's contact info the specific entries belong to. ex: John's Cell, Home, Pauline's Work. 