### PR TITLE
Adjust HomeAddressStreet kit to have optional H#

### DIFF
--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -20,8 +20,10 @@
     text: object.city_state_zip,
   } %>
 
-  <%= pb_rails "body", props: { classname: "home-hashtag", tag: "span" } do %>
-    H#<%= object.home_id %>
+  <% if object.home_id %>
+    <%= pb_rails "body", props: { classname: "home-hashtag", tag: "span" } do %>
+      H#<%= object.home_id %>
+    <% end %>
   <% end %>
 
   <%= pb_rails "body", props: { color: "light", tag: "span" } do %>

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.html.erb
@@ -1,7 +1,6 @@
 <%= pb_rails("home_address_street", props: {
   address: "70 Prospect Ave",
   city: "West Chester",
-  home_id: 8250263,
   state: "PA",
   zipcode: "19382",
   territory: "PHL",

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -15,7 +15,6 @@ module Playbook
       prop :state
       prop :zipcode
       prop :territory
-      prop :url
       prop :dark, type: Playbook::Props::Boolean, default: false
 
       def classname

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -15,6 +15,7 @@ module Playbook
       prop :state
       prop :zipcode
       prop :territory
+      prop :url
       prop :dark, type: Playbook::Props::Boolean, default: false
 
       def classname


### PR DESCRIPTION
Currently if a Home Address Street kit was not passed an home_id, a bubble would still appear with H#. This wraps that prop in a conditional that will only display if home_id is not nil. If no home_id is passed, territory will simply fill the space. 

Additional information:
The H# is currently not using the Hashtag kit, but instead a badge kit. I made an initial attempt to migrate this to the Hashtag kit so we dont have to hardcode "H#" before the home_id, however the Hashtag kit requires a url prop taking this out of the scope of this card. This is something I will bring up to Garett as a possibly follow up card. 