### PR TITLE
Titleize Home Address Street Playbook Kit

### DIFF
--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -15,6 +15,24 @@ const dot = (houseStyle) =>
   }
 }
 
+function titleize(sentence) {
+    if(!sentence.split) return sentence;
+    var _titleizeWord = function(string) {
+            return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+        },
+        result = [];
+    sentence.split(" ").forEach(function(w) {
+        result.push(_titleizeWord(w));
+    });
+    return result.join(" ");
+}
+
+function titleize_address_cont(address_cont) {
+  if (!!address_cont) {
+   return titleize(address_cont);
+  }
+}
+
 type HomeAddressStreetProps = {
   address: String,
   address_cont: String,
@@ -53,16 +71,17 @@ const HomeAddressStreet = ({
         className="pb_home_address_street_address"
         size={4}
     >
-      {address} {dot(houseStyle)} {houseStyle}
+      {titleize(address)} {dot(houseStyle)} {houseStyle}
     </Title>
+
     <Title
         className="pb_home_address_street_address"
         size={4}
     >
-      {address_cont}
+      {titleize_address_cont(address_cont)}
     </Title>
     <Body color="light">
-      {city}, {state} {zipcode}
+      {titleize(city)}, {state} {zipcode}
     </Body>
     <Body
         className="home-hashtag"

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -16,16 +16,12 @@ const dot = (houseStyle) =>
     return "\u00b7"
   }
 }
+const titleizeAddessCont = (addressCont) => addressCont ? titleize(addressCont) : null;
 
-function titleize_address_cont(address_cont) {
-  if (!!address_cont) {
-   return titleize(address_cont);
-  }
-}
 
 type HomeAddressStreetProps = {
   address: String,
-  address_cont: String,
+  addressCont: String,
   city: String,
   className?: String,
   dark?: Boolean,
@@ -46,7 +42,7 @@ const classes = (className, dark) => (
 
 const HomeAddressStreet = ({
   address,
-  address_cont,
+  addressCont,
   city,
   className,
   dark=false,
@@ -68,7 +64,7 @@ const HomeAddressStreet = ({
         className="pb_home_address_street_address"
         size={4}
     >
-      {titleize_address_cont(address_cont)}
+      {titleizeAddessCont(addressCont)}
     </Title>
     <Body color="light">
       {titleize(city)}, {state} {zipcode}

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -3,6 +3,8 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import { titleize } from '../utilities/text.js'
+
 
 import {
   Body,
@@ -13,18 +15,6 @@ const dot = (houseStyle) =>
   { if (houseStyle !== undefined) {
     return "\u00b7"
   }
-}
-
-function titleize(sentence) {
-    if(!sentence.split) return sentence;
-    var _titleizeWord = function(string) {
-            return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
-        },
-        result = [];
-    sentence.split(" ").forEach(function(w) {
-        result.push(_titleizeWord(w));
-    });
-    return result.join(" ");
 }
 
 function titleize_address_cont(address_cont) {

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("home_address_street", props: {
-  address: "70 Prospect Ave",
+  address: "70 prospect AVE",
   address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("home_address_street", props: {
-  address: "70 prospect AVE",
+  address: "70 Prospect Ave",
   address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
@@ -5,7 +5,7 @@ function HomeAddressStreetDark() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
-        address_cont="Apt M18"
+        addressCont="Apt M18"
         city="West Chester"
         dark
         homeId={8250263}

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
@@ -5,7 +5,7 @@ function HomeAddressStreetDefault() {
   return (
     <HomeAddressStreet
         address="70 Prospect Ave"
-        address_cont="Apt M18"
+        addressCont="Apt M18"
         city="West Chester"
         homeId={8250263}
         houseStyle="Colonial"

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
@@ -4,9 +4,9 @@ import {HomeAddressStreet} from "../../"
 function HomeAddressStreetModified() {
   return (
     <HomeAddressStreet
-        address="70 prospect ave"
-        city="WEST CHESTER"
-        address_cont="m18"
+        address="70 Prospect Ave"
+        city="West Chester"
+        address_cont="M18"
         homeId={8250263}
         state="PA"
         zipcode="19382"

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
@@ -4,8 +4,9 @@ import {HomeAddressStreet} from "../../"
 function HomeAddressStreetModified() {
   return (
     <HomeAddressStreet
-        address="70 Prospect Ave"
-        city="West Chester"
+        address="70 prospect ave"
+        city="WEST CHESTER"
+        address_cont="m18"
         homeId={8250263}
         state="PA"
         zipcode="19382"

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified.jsx
@@ -6,7 +6,7 @@ function HomeAddressStreetModified() {
     <HomeAddressStreet
         address="70 Prospect Ave"
         city="West Chester"
-        address_cont="M18"
+        addressCont="M18"
         homeId={8250263}
         state="PA"
         zipcode="19382"

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -22,15 +22,15 @@ module Playbook
       end
 
       def city_state_zip
-        "#{city}, #{state} #{zipcode}"
+        "#{city.titleize}, #{state} #{zipcode}"
       end
 
       def address_house_style
-        "#{address} #{separator} #{house_style}"
+        "#{address.titleize} #{separator} #{house_style}"
       end
 
       def address_house_style2
-        address_cont
+        address_cont&.titleize
       end
 
       def separator

--- a/app/pb_kits/playbook/utilities/text.js
+++ b/app/pb_kits/playbook/utilities/text.js
@@ -1,0 +1,16 @@
+function titleize(sentence) {
+    if(!sentence.split) return sentence
+
+    const titleizedWord = function(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase()
+    }
+
+    let result = []
+    sentence.split(' ').forEach(function(w) {
+        result.push(titleizedWord(w))
+    })
+
+    return result.join(' ')
+}
+
+export { titleize }


### PR DESCRIPTION
This will titleize the Address and City props.

Additional Information:
I had only placed a safety navigator on the address_cont since this is the only field that needs to be titleized but also optional. Street and City will always exist. 