### PR TITLE
Modernize User Kit

### DIFF
--- a/app/pb_kits/playbook/pb_avatar/_avatar.html.erb
+++ b/app/pb_kits/playbook/pb_avatar/_avatar.html.erb
@@ -6,7 +6,7 @@
   <%= content_tag(:div,
       data: { initials: object.initials },
       class: "avatar_wrapper") do %>
-       <%= pb_rails("image", props: object.image) if object.image.present? %>
+       <%= pb_rails("image", props: { url: object.image_url }) if object.image_url.present? %>
       <% end %>
        <%= pb_rails("online_status", props: object.online_status_props) if object.status %>
 <% end %>

--- a/app/pb_kits/playbook/pb_avatar/avatar.rb
+++ b/app/pb_kits/playbook/pb_avatar/avatar.rb
@@ -7,7 +7,7 @@ module Playbook
 
       partial "pb_avatar/avatar"
 
-      prop :image, type: Playbook::Props::Hash, default: {}
+      prop :image_url
       prop :name, default: ""
       prop :size, type: Playbook::Props::Enum,
                   values: %w[xs sm md base lg xl],

--- a/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.html.erb
+++ b/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.html.erb
@@ -1,7 +1,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "xs",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "online"
   }) %>
 
@@ -10,7 +10,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "away"
   }) %>
 
@@ -19,7 +19,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "md",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "offline"
   }) %>
 
@@ -28,7 +28,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "lg",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "online"
   }) %>
 
@@ -37,6 +37,6 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "xl",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "away"
   }) %>

--- a/app/pb_kits/playbook/pb_avatar/docs/_avatar_status.html.erb
+++ b/app/pb_kits/playbook/pb_avatar/docs/_avatar_status.html.erb
@@ -1,7 +1,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"}
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg"
   }) %>
 
 <br>
@@ -9,7 +9,7 @@
   <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "online"
   }) %>
 
@@ -18,7 +18,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "away"
   }) %>
 
@@ -27,6 +27,6 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
-    image: {url: "https://randomuser.me/api/portraits/men/44.jpg"},
+    image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "offline"
   }) %>

--- a/app/pb_kits/playbook/pb_user/_user.html.erb
+++ b/app/pb_kits/playbook/pb_user/_user.html.erb
@@ -1,11 +1,22 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname(object.kit_class)) do %>
-  <%= object.avatar %>
+    class: object.classname) do %>
+  <% if object.avatar_url.present? || object.avatar %>
+    <%= pb_rails("avatar", props: {
+      name: object.name,
+      size: object.avatar_size,
+      image: {
+        url: object.avatar_url
+      }
+    }) %>
+  <% end %>
   <%= content_tag(:div,
       class: "content_wrapper") do %>
-    <%= object.name %>
-    <%= object.title %>
+    <%= pb_rails("title", props: { text: object.name, size: object.title_size }) %>
+    <%= pb_rails("body", props: {
+      text: object.title,
+      color: "light"
+    }) %>
   <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_user/docs/_user_default.html.erb
+++ b/app/pb_kits/playbook/pb_user/docs/_user_default.html.erb
@@ -6,8 +6,7 @@
       orientation: "vertical",
       align: "center",
       size: "lg",
-      avatar: {
-        image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
       }) %>
   </div>
   <div>
@@ -16,8 +15,7 @@
       title: "Remodeling Consultant",
       orientation: "horizontal",
       align: "left",
-      avatar: {
-        image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
       }) %>
   </div>
   <div>
@@ -25,8 +23,7 @@
       name: "Anna Black",
       orientation: "horizontal",
       align: "left",
-      avatar: {
-        image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
       }) %>
 
      <br>

--- a/app/pb_kits/playbook/pb_user/docs/_user_size.html.erb
+++ b/app/pb_kits/playbook/pb_user/docs/_user_size.html.erb
@@ -6,8 +6,7 @@
       orientation: "horizontal",
       align: "left",
       size: "sm",
-      avatar: {
-        image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
       }) %>
   </div>
   <div>
@@ -17,8 +16,7 @@
       orientation: "horizontal",
       align: "left",
       size: "md",
-      avatar: {
-        image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
       }) %>
   </div>
   <div>
@@ -28,8 +26,7 @@
       orientation: "horizontal",
       align: "left",
       size: "lg",
-      avatar: {
-        image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
       }) %>
   </div>
 </div>

--- a/app/pb_kits/playbook/pb_user/docs/_user_vertical_size.html.erb
+++ b/app/pb_kits/playbook/pb_user/docs/_user_vertical_size.html.erb
@@ -4,8 +4,7 @@
   orientation: "vertical",
   align: "center",
   size: "sm",
-  avatar: {
-    image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+  avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
   }) %>
 
 <br><br>
@@ -16,8 +15,7 @@
   orientation: "vertical",
   align: "center",
   size: "md",
-  avatar: {
-    image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+  avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
   }) %>
 
 <br><br>
@@ -28,6 +26,5 @@
   orientation: "vertical",
   align: "center",
   size: "lg",
-  avatar: {
-    image: { url: "https://randomuser.me/api/portraits/women/44.jpg"} }
+  avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
   }) %>

--- a/app/pb_kits/playbook/pb_user/user.rb
+++ b/app/pb_kits/playbook/pb_user/user.rb
@@ -2,40 +2,28 @@
 
 module Playbook
   module PbUser
-    class User < Playbook::PbKit::Base
-      PROPS = %i[configured_align
-                 configured_avatar
-                 configured_classname
-                 configured_data
-                 configured_id
-                 configured_name
-                 configured_orientation
-                 configured_size
-                 configured_title].freeze
+    class User
+      include Playbook::Props
 
-      def initialize(align: default_configuration,
-                     avatar: default_configuration,
-                     classname: default_configuration,
-                     data: default_configuration,
-                     id: default_configuration,
-                     name: default_configuration,
-                     orientation: default_configuration,
-                     size: default_configuration,
-                     title: default_configuration)
-        self.configured_align = align
-        self.configured_avatar = avatar
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_name = name
-        self.configured_orientation = orientation
-        self.configured_size = size
-        self.configured_title = title
-      end
+      partial "pb_user/user"
 
-      def align
-        align_options = %w[left center right]
-        one_of_value(configured_align, align_options, "left")
+      prop :align, type: Playbook::Props::Enum,
+                   values: %w[left center right],
+                   default: "left"
+      prop :avatar, type: Playbook::Props::Boolean,
+                    default: false
+      prop :avatar_url
+      prop :name
+      prop :orientation, type: Playbook::Props::Enum,
+                         values: %w[vertical horizontal],
+                         default: "horizontal"
+      prop :size, type: Playbook::Props::Enum,
+                  values: %w[lg md sm],
+                  default: "sm"
+      prop :title
+
+      def classname
+        generate_classname("pb_user_kit", align, orientation, size)
       end
 
       def avatar_size
@@ -49,69 +37,9 @@ module Playbook
         end
       end
 
-      def avatar
-        if is_set? configured_avatar
-          avatar_obj = configured_avatar == true ? {} : configured_avatar
-          avatar_obj[:size] = avatar_size
-          avatar_obj[:name] = configured_name if is_set? configured_name
-          pb_avatar = Playbook::PbAvatar::Avatar.new(avatar_obj)
-          ApplicationController.renderer.render(partial: pb_avatar, as: :object)
-        end
-      end
-
-      def name_size
+      def title_size
         size == "lg" ? 3 : 4
       end
-
-      def name
-        if is_set? configured_name
-          title_props = { text: configured_name, size: name_size }
-          pb_name = Playbook::PbTitle::Title.new(title_props)
-          ApplicationController.renderer.render(partial: pb_name, as: :object)
-        end
-      end
-
-      def orientation
-        orientation_options = %w[vertical horizontal]
-        one_of_value(configured_orientation, orientation_options, "horizontal")
-      end
-
-      def size
-        size_options = %w[lg md sm]
-        one_of_value(configured_size, size_options, "sm")
-      end
-
-      def title
-        if is_set? configured_title
-          pb_icon_element = Playbook::PbBody::Body.new(color: "light") do
-            configured_title
-          end
-          ApplicationController.renderer.render(partial: pb_icon_element, as: :object)
-        end
-      end
-
-      def kit_class
-        kit_options = [
-          "pb_user_kit",
-          align,
-          orientation,
-          size,
-        ]
-        kit_options.join("_")
-      end
-
-      def to_partial_path
-        "pb_user/user"
-      end
-
-    private
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/spec/pb_kits/playbook/kits/avatar_spec.rb
+++ b/spec/pb_kits/playbook/kits/avatar_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Playbook::PbAvatar::Avatar do
 
   it { is_expected.to define_partial }
   it { is_expected.to define_prop(:status) }
-  it { is_expected.to define_prop(:image)
-                      .with_default({}) }
+  it { is_expected.to define_prop(:image_url) }
   it { is_expected.to define_prop(:name)
                       .with_default("") }
   it { is_expected.to define_enum_prop(:size)

--- a/spec/pb_kits/playbook/kits/user_spec.rb
+++ b/spec/pb_kits/playbook/kits/user_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_user/user"
+
+RSpec.describe Playbook::PbUser::User do
+  subject { Playbook::PbUser::User }
+
+  it { is_expected.to define_partial }
+
+  it { is_expected.to define_enum_prop(:align)
+                      .with_default("left")
+                      .with_values("left", "center", "right")}
+  it { is_expected.to define_boolean_prop(:avatar)
+                      .with_default(false) }
+  it { is_expected.to define_prop(:avatar_url) }
+  it { is_expected.to define_prop(:name) }
+  it { is_expected.to define_enum_prop(:orientation)
+                      .with_default("horizontal")
+                      .with_values("vertical", "horizontal")}
+  it { is_expected.to define_enum_prop(:size)
+                      .with_default("sm")
+                      .with_values("lg", "md", "sm")}
+  it { is_expected.to define_prop(:title) }
+
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      expect(subject.new({}).classname).to eq "pb_user_kit_left_horizontal_sm"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_user_kit_left_horizontal_sm additional_class"
+      expect(subject.new({size: "lg"}).classname).to eq "pb_user_kit_left_horizontal_lg"
+      expect(subject.new({orientation: "vertical"}).classname).to eq "pb_user_kit_left_vertical_sm"
+      expect(subject.new({align: "right"}).classname).to eq "pb_user_kit_right_horizontal_sm"
+      expect(subject.new({size: "md", align: "center", orientation: "vertical"}).classname).to eq "pb_user_kit_center_vertical_md"
+    end
+  end
+end


### PR DESCRIPTION
Modernize the user kit, add specs, and modify the avatar image URL to be encapsulated in one prop as opposed to it being a nested hash. Updated the Avatar kit as well to simplify that hash.