### PR TITLE
Modernize dashboard value

### DIFF
--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
@@ -1,8 +1,16 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname(object.kit_class)) do %>
-  <%= object.stat_label %>
-  <%= object.stat_value %>
-  <%= object.stat_change %>
+    class: object.classname) do %>
+  <% if object.stat_label.present? %>
+    <%= pb_rails("body", props: { color: "light", text: object.stat_label[:label] } ) %>
+  <% end %>
+
+  <% if object.stat_value.present? %>
+    <%= pb_rails("stat_value", props: object.stat_value) %>
+  <% end %>
+
+  <% if object.stat_change.present? %>
+    <%= pb_rails("stat_change", props: object.stat_change) %>
+  <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
@@ -3,7 +3,7 @@
     data: object.data,
     class: object.classname) do %>
   <% if object.stat_label.present? %>
-    <%= pb_rails("body", props: { color: "light", text: object.stat_label[:label] } ) %>
+    <%= pb_rails("body", props: { color: "light", text: object.stat_label } ) %>
   <% end %>
 
   <% if object.stat_value.present? %>

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
@@ -17,9 +17,7 @@ type DashboardValueProps = {
     change?: String,
     value?: String | Number
   },
-  stat_label?: {
-    label?: String
-  },
+  stat_label?: String,
   stat_value?: {
     unit?: String,
     value?: String | Number
@@ -49,7 +47,7 @@ const DashboardValue = (props: DashboardValueProps) => {
   const statLabel = function(stat_label) {
     if (stat_label) {
       return (
-        <Body color="light">{stat_label.label}</Body>
+        <Body color="light">{stat_label}</Body>
       )
     }
   }

--- a/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -2,80 +2,24 @@
 
 module Playbook
   module PbDashboardValue
-    class DashboardValue < Playbook::PbKit::Base
-      PROPS = %i[configured_align
-                 configured_classname
-                 configured_data
-                 configured_id
-                 configured_stat_change
-                 configured_stat_label
-                 configured_stat_value].freeze
+    class DashboardValue
+      include Playbook::Props
 
-      def initialize(align: default_configuration,
-                     classname: default_configuration,
-                     data: default_configuration,
-                     id: default_configuration,
-                     stat_change: default_configuration,
-                     stat_label: default_configuration,
-                     stat_value: default_configuration)
+      partial "pb_dashboard_value/dashboard_value"
 
-        self.configured_align = align
-        self.configured_classname = classname
-        self.configured_data = data
-        self.configured_id = id
-        self.configured_stat_change = stat_change
-        self.configured_stat_label = stat_label
-        self.configured_stat_value = stat_value
+      prop :align, type: Playbook::Props::Enum,
+                   values: %w[left center right],
+                   default: "left"
+      prop :stat_change, type: Playbook::Props::Hash,
+                         default: {}
+      prop :stat_label, type: Playbook::Props::Hash,
+                        default: {}
+      prop :stat_value, type: Playbook::Props::Hash,
+                        default: {}
+
+      def classname
+        generate_classname("pb_dashboard_value_kit", align)
       end
-
-      def align
-        align_options = %w[left center right]
-        one_of_value(configured_align, align_options, "left")
-      end
-
-      def stat_label
-        if is_set? configured_stat_label
-          pb_label = Playbook::PbBody::Body.new(color: "light") do
-            configured_stat_label[:label]
-          end
-          ApplicationController.renderer.render(partial: pb_label, as: :object)
-        end
-      end
-
-      def stat_value
-        if is_set? configured_stat_value
-          pb_value = Playbook::PbStatValue::StatValue.new(configured_stat_value)
-          ApplicationController.renderer.render(partial: pb_value, as: :object)
-        end
-      end
-
-      def stat_change
-        if is_set? configured_stat_change
-          pb_change = Playbook::PbStatChange::StatChange.new(configured_stat_change)
-          ApplicationController.renderer.render(partial: pb_change, as: :object)
-        end
-      end
-
-      def kit_class
-        kit_options = [
-          "pb_dashboard_value_kit",
-          align,
-        ]
-        kit_options.join("_")
-      end
-
-      def to_partial_path
-        "pb_dashboard_value/dashboard_value"
-      end
-
-    private
-
-      DEFAULT = Object.new
-      private_constant :DEFAULT
-      def default_configuration
-        DEFAULT
-      end
-      attr_accessor(*PROPS)
     end
   end
 end

--- a/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -12,8 +12,7 @@ module Playbook
                    default: "left"
       prop :stat_change, type: Playbook::Props::Hash,
                          default: {}
-      prop :stat_label, type: Playbook::Props::Hash,
-                        default: {}
+      prop :stat_label
       prop :stat_value, type: Playbook::Props::Hash,
                         default: {}
 

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("dashboard_value", props: {
-  stat_label: {label: "Top Title Value"},
+  stat_label: "Top Title Value",
   stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: 26.1}
 }) %>
@@ -8,7 +8,7 @@
 
 <%= pb_rails("dashboard_value", props: {
   align: "center",
-  stat_label: {label: "Top Title Value"},
+  stat_label: "Top Title Value",
   stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: 56 }
 }) %>
@@ -17,7 +17,7 @@
 
 <%= pb_rails("dashboard_value", props: {
   align: "right",
-  stat_label: {label: "Top Title Value"},
+  stat_label: "Top Title Value",
   stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: 86.1 }
 }) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.jsx
@@ -5,7 +5,7 @@ function DashboardValueAlign() {
   return (
     <div>
       <DashboardValue
-          stat_label={{label: "Top Title Value"}}
+          stat_label="Top Title Value"
           stat_value={{value: "1,428", unit: "appts"}}
           stat_change={{change: "decrease", value: "26.1"}} />
 
@@ -13,7 +13,7 @@ function DashboardValueAlign() {
 
       <DashboardValue
           align="center"
-          stat_label={{label: "Top Title Value"}}
+          stat_label="Top Title Value"
           stat_value={{value: "1,428", unit: "appts"}}
           stat_change={{change: "decrease", value: 56.1}} />
 
@@ -21,7 +21,7 @@ function DashboardValueAlign() {
 
       <DashboardValue
           align="right"
-          stat_label={{label: "Top Title Value"}}
+          stat_label="Top Title Value"
           stat_value={{value: "1,428", unit: "appts"}}
           stat_change={{change: "decrease", value: 86}} />
     </div>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("dashboard_value", props: {
-  stat_label: {label: "Decreased Value"},
+  stat_label: "Decreased Value",
   stat_value: {value: 1428, unit: "appts"},
   stat_change: {change: "decrease", value: 26.1}
 }) %>
@@ -7,7 +7,7 @@
 <br><br>
 
 <%= pb_rails("dashboard_value", props: {
-  stat_label: {label: "Increased Value"},
+  stat_label: "Increased Value",
   stat_value: {value: 938, unit: "homes"},
   stat_change: {change: "increase", value: 56.1}
 }) %>
@@ -15,7 +15,7 @@
 <br><br>
 
 <%= pb_rails("dashboard_value", props: {
-  stat_label: {label: "Neutral Value"},
+  stat_label: "Neutral Value",
   stat_value: {value: 261, unit: "windows"},
   stat_change: {value: 86}
 }) %>

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.jsx
@@ -5,21 +5,21 @@ function DashboardValueDefault() {
   return (
     <div>
       <DashboardValue
-          stat_label={{label: "Decreased Value"}}
+          stat_label="Decreased Value"
           stat_value={{value: "1,428", unit: "appts"}}
           stat_change={{change: "decrease", value: "26.1"}} />
 
       <br/><br/>
 
       <DashboardValue
-          stat_label={{label: "Increased Value"}}
+          stat_label="Increased Value"
           stat_value={{value: "938", unit: "homes"}}
           stat_change={{change: "increase", value: 56.1}} />
 
       <br/><br/>
 
       <DashboardValue
-          stat_label={{label: "Neutral Value"}}
+          stat_label="Neutral Value"
           stat_value={{value: "261", unit: "windows"}}
           stat_change={{value: 86}} />
     </div>

--- a/spec/pb_kits/playbook/kits/dashboard_value_spec.rb
+++ b/spec/pb_kits/playbook/kits/dashboard_value_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Playbook::PbDashboardValue::DashboardValue do
                       .with_default("left") }
   it { is_expected.to define_prop(:stat_change)
                       .of_type(Playbook::Props::Hash) }
-  it { is_expected.to define_prop(:stat_label)
-                      .of_type(Playbook::Props::Hash) }
+  it { is_expected.to define_string_prop(:stat_label) }
   it { is_expected.to define_prop(:stat_value)
                       .of_type(Playbook::Props::Hash) }
 

--- a/spec/pb_kits/playbook/kits/dashboard_value_spec.rb
+++ b/spec/pb_kits/playbook/kits/dashboard_value_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_dashboard_value/dashboard_value"
+
+RSpec.describe Playbook::PbDashboardValue::DashboardValue do
+  subject { Playbook::PbDashboardValue::DashboardValue }
+
+  it { is_expected.to define_partial }
+
+  it { is_expected.to define_enum_prop(:align)
+                      .with_values("left", "center", "right")
+                      .with_default("left") }
+  it { is_expected.to define_prop(:stat_change)
+                      .of_type(Playbook::Props::Hash) }
+  it { is_expected.to define_prop(:stat_label)
+                      .of_type(Playbook::Props::Hash) }
+  it { is_expected.to define_prop(:stat_value)
+                      .of_type(Playbook::Props::Hash) }
+
+    describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      expect(subject.new({}).classname).to eq "pb_dashboard_value_kit_left"
+      expect(subject.new(align: "right").classname).to eq "pb_dashboard_value_kit_right"
+    end
+  end
+end


### PR DESCRIPTION
BAB-181: Modernize DashboardValue Playbook Kit

Note: This modernization changes the prop type of `:stat_label` in rails from a hash `stat_label: { label: "This is the label" }` to a string `stat_label: "This is the label"`. 

Backwards breaking changes: 
components/dev_docs/app/views/dev_docs/playbook/index.html.erb
components/solar_roofing/app/views/solar_roofing/solar_proposals/_overview.html.erb