### PR TITLE
Fix object rest syntax error

### DIFF
--- a/app/pb_kits/playbook/pb_toggle/_toggle.jsx
+++ b/app/pb_kits/playbook/pb_toggle/_toggle.jsx
@@ -31,7 +31,7 @@ const Toggle = ({
   onCheck = noop,
   onUncheck = noop,
   size = 'md',
-  ...props,
+  ...props
 }: Props) =>{
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)


### PR DESCRIPTION
https://github.com/powerhome/playbook/blob/master/app/pb_kits/playbook/pb_toggle/_toggle.jsx#L34

refs:

https://stackoverflow.com/questions/54282836/object-rest-spread-is-not-allowed-trailing-commas-in-babel-7

https://github.com/tc39/proposal-object-rest-spread/issues/47