### PR TITLE
Card Highlight - Support Branch

### DIFF
--- a/app/pb_kits/playbook/pb_card/_card.jsx
+++ b/app/pb_kits/playbook/pb_card/_card.jsx
@@ -1,36 +1,48 @@
 /* @flow */
 
 import React from 'react'
+import classnames from 'classnames'
 
 type CardPropTypes = {
   children: Array<React.ReactNode> | React.ReactNode,
+  className?: String,
+  highlight?: {
+    position?: String,
+    color?: String
+  },
   padding?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl',
   selected?: Boolean,
   shadow?: 'none' | 'shallow' | 'default' | 'deep' | 'deeper' | 'deepest',
 }
 
 const cardCSS = ({
+  highlight={},
   selected=false,
-  shadow='none',
+  shadow='none'
 }: CardPropTypes) => {
-  let css = ''
+  let css = 'pb_card_kit'
+  css += highlight.position ? `_highlight_${highlight.position}` : null
+  css += highlight.color ? `_highlight_${highlight.color}` : null
   css += selected ? '_selected' : '_deselected'
   css += `_shadow_${shadow}`
   return css
 }
 
 const bodyCSS = ({padding='md'}: CardPropTypes) => {
-  let css = ''
+  let css = 'pb_card_body_kit'
   css += `_${padding}`
   return css
 }
 
 const Card = (props: CardPropTypes) => {
-  const {children} = props
+  const {
+    children,
+    className
+  } = props
 
   return (
-    <div className={`pb_card_kit${cardCSS(props)}`}>
-      <div className={`pb_card_body_kit${bodyCSS(props)}`}>
+    <div className={classnames(cardCSS(props), className)}>
+      <div className={bodyCSS(props)}>
         { children }
       </div>
     </div>

--- a/app/pb_kits/playbook/pb_card/_card.scss
+++ b/app/pb_kits/playbook/pb_card/_card.scss
@@ -6,6 +6,8 @@
 
 $pb_card_border_width: 1px;
 $pb_card_border_radius: $border_rad_heavier;
+$pb_card_highlight_colors: map-merge($status_colors, $product_colors);
+$pb_card_highlight_size: 4px;
 
 [class^=pb_card_kit] {
   position: relative;
@@ -30,28 +32,33 @@ $pb_card_border_radius: $border_rad_heavier;
     }
   }
 
-  $highlight_colors: map-merge($status_colors, $product_colors);
-
-  @mixin pb_card_highlight($borderTop, $borderSide) {
-    display: flex;
-    height: 4px;
-    content: '';
-    border-top-left-radius: $border_rad_heavier;
-    border-top-right-radius: $border_rad_heavier;
+  @mixin pb_card_highlight($width, $height, $background){
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: $width;
+    height: $height;
+    background: $background;
+    z-index: 10;
   }
 
-    &[class*=_highlight_side] {
-      @each $color_name, $color_value in $highlight_colors {
-        &[class*=_highlight_#{$color_name}]:before  {
-          @include pb_card_highlight(solid 1px $border_light, solid 4px $color_value);
-        }
+  &[class*=_highlight] {
+    overflow: hidden;
+  }
+
+  &[class*=_highlight_side] {
+    @each $color_name, $color_value in $pb_card_highlight_colors {
+      &[class*=_highlight_#{$color_name}]::before {
+        @include pb_card_highlight(100%, $pb_card_highlight_size, $color_value);
       }
     }
+  }
 
-    &[class*=_highlight_top] {
-    @each $color_name, $color_value in $highlight_colors {
-      &[class*=_highlight_#{$color_name}]:before  {
-        @include pb_card_highlight(solid 4px $color_value, solid 1px $border_light);
+  &[class*=_highlight_top] {
+    @each $color_name, $color_value in $pb_card_highlight_colors {
+      &[class*=_highlight_#{$color_name}]::before {
+        @include pb_card_highlight($pb_card_highlight_size, 100%, $color_value);
       }
     }
   }

--- a/app/pb_kits/playbook/pb_card/card.rb
+++ b/app/pb_kits/playbook/pb_card/card.rb
@@ -18,7 +18,11 @@ module Playbook
                        default: {}
 
       def classname
-        generate_classname("pb_card_kit", selected_class, shadow_class, highlight_position_class, highlight_color_class)
+        generate_classname("pb_card_kit",
+                           selected_class,
+                           shadow_class,
+                           highlight_position_class,
+                           highlight_color_class)
       end
 
     private

--- a/app/pb_kits/playbook/pb_card/docs/_card_highlight.jsx
+++ b/app/pb_kits/playbook/pb_card/docs/_card_highlight.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import {Card} from '../../'
+
+function CardHighlight() {
+  return (
+    <div>
+      <Card highlight={{position: "side", color: "windows"}}>
+        {`Card content`}
+      </Card>
+
+      <br/>
+
+      <Card highlight={{position: "top", color: "warning"}}>
+        {`Card content`}
+      </Card>
+    </div>
+  )
+}
+
+export default CardHighlight

--- a/app/pb_kits/playbook/pb_card/docs/example.yml
+++ b/app/pb_kits/playbook/pb_card/docs/example.yml
@@ -9,6 +9,7 @@ examples:
 
   react:
   - card_light: Default
+  - card_highlight: Highlight Cards
   - card_selected: Selected
   - card_padding: Padding Size
   - card_shadow: Shadow Size

--- a/app/pb_kits/playbook/pb_card/docs/index.js
+++ b/app/pb_kits/playbook/pb_card/docs/index.js
@@ -1,4 +1,5 @@
 export {default as CardLight} from './_card_light.jsx';
+export {default as CardHighlight} from './_card_highlight.jsx';
 export {default as CardSelected} from './_card_selected.jsx';
 export {default as CardPadding} from './_card_padding.jsx';
 export {default as CardShadow} from './_card_shadow.jsx';

--- a/spec/pb_kits/playbook/kits/card_spec.rb
+++ b/spec/pb_kits/playbook/kits/card_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Playbook::PbCard::Card do
   it { is_expected.to define_partial }
 
   it { is_expected.to define_boolean_prop(:selected).with_default(false) }
+
+  it { is_expected.to define_prop(:highlight)
+                      .of_type(Playbook::Props::Hash)
+                      .with_default({}) }
+
   it do
     is_expected.to define_enum_prop(:padding)
                    .with_default("md")
@@ -27,6 +32,10 @@ RSpec.describe Playbook::PbCard::Card do
       expect(subject.new(shadow: "deeper").classname).to eq "pb_card_kit_deselected_shadow_deeper"
       expect(subject.new(selected: true, shadow: "shallow").classname).to eq "pb_card_kit_selected_shadow_shallow"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_card_kit_deselected additional_class"
+      expect(subject.new(highlight: {position: "top"}).classname).to eq "pb_card_kit_deselected_highlight_top"
+      expect(subject.new(highlight: {position: "side"}).classname).to eq "pb_card_kit_deselected_highlight_side"
+      expect(subject.new(highlight: {color: "windows"}).classname).to eq "pb_card_kit_deselected_highlight_windows"
+      expect(subject.new(highlight: {color: "error"}).classname).to eq "pb_card_kit_deselected_highlight_error"
     end
   end
 end


### PR DESCRIPTION
Changes:

### Card Kit: React
* Added highlight prop to react kit
* Extended React Card kit to take a custom classname

---

### Card Kit: SCSS
* Updated SCSS to use pseudo element instead of border for highlight

---

### Card Kit: Docs
* Updated docs to make consistent between Rails and React

---

### Card Kit: Spec
* Updated Card Spec test to account for new highlight prop, as well as class name changes highlight adds