### PR TITLE
Fix underscored DashboardValue

### DIFF
--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
@@ -13,12 +13,12 @@ type DashboardValueProps = {
   align?: 'left' | 'center' | 'right',
   className?: String,
   id?: String,
-  stat_change?: {
+  statChange?: {
     change?: String,
     value?: String | Number
   },
-  stat_label?: String,
-  stat_value?: {
+  statLabel?: String,
+  statValue?: {
     unit?: String,
     value?: String | Number
   }
@@ -39,40 +39,22 @@ const DashboardValue = (props: DashboardValueProps) => {
     align='left',
     className,
     id,
-    stat_change,
-    stat_label,
-    stat_value,
+    statChange,
+    statLabel,
+    statValue,
   } = props
-
-  const statLabel = function(stat_label) {
-    if (stat_label) {
-      return (
-        <Body color="light">{stat_label}</Body>
-      )
-    }
-  }
-
-  const statChange = function(stat_change) {
-    if (stat_change) {
-      return (
-        <StatChange change={stat_change.change} value={stat_change.value} />
-      )
-    }
-  }
-
-  const statValue = function(stat_value) {
-    if (stat_value) {
-      return (
-        <StatValue value={stat_value.value} unit={stat_value.unit} />
-      )
-    }
-  }
 
   return (
     <div id={id} className={classnames(dashboardValueCSS(props), className)}>
-      {statLabel(stat_label)}
-      {statValue(stat_value)}
-      {statChange(stat_change)}
+      <If condition={statLabel}>
+        <Body color="light">{statLabel}</Body>
+      </If>
+      <If condition={statValue}>
+        <StatValue value={statValue.value} unit={statValue.unit} />
+      </If>
+      <If condition={statChange}>
+        <StatChange change={statChange.change} value={statChange.value} />
+      </If>
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_align.jsx
@@ -5,25 +5,28 @@ function DashboardValueAlign() {
   return (
     <div>
       <DashboardValue
-          stat_label="Top Title Value"
-          stat_value={{value: "1,428", unit: "appts"}}
-          stat_change={{change: "decrease", value: "26.1"}} />
+          statChange={{change: "decrease", value: "26.1"}}
+          statLabel="Top Title Value"
+          statValue={{value: "1,428", unit: "appts"}}
+      />
 
       <br/><br/>
 
       <DashboardValue
           align="center"
-          stat_label="Top Title Value"
-          stat_value={{value: "1,428", unit: "appts"}}
-          stat_change={{change: "decrease", value: 56.1}} />
+          statChange={{change: "decrease", value: 56.1}}
+          statLabel="Top Title Value"
+          statValue={{value: "1,428", unit: "appts"}}
+      />
 
       <br/><br/>
 
       <DashboardValue
           align="right"
-          stat_label="Top Title Value"
-          stat_value={{value: "1,428", unit: "appts"}}
-          stat_change={{change: "decrease", value: 86}} />
+          statChange={{change: "decrease", value: 86}}
+          statLabel="Top Title Value"
+          statValue={{value: "1,428", unit: "appts"}}
+      />
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/docs/_dashboard_value_default.jsx
@@ -5,23 +5,26 @@ function DashboardValueDefault() {
   return (
     <div>
       <DashboardValue
-          stat_label="Decreased Value"
-          stat_value={{value: "1,428", unit: "appts"}}
-          stat_change={{change: "decrease", value: "26.1"}} />
+          statChange={{change: "decrease", value: "26.1"}}
+          statLabel="Decreased Value"
+          statValue={{value: "1,428", unit: "appts"}}
+      />
 
       <br/><br/>
 
       <DashboardValue
-          stat_label="Increased Value"
-          stat_value={{value: "938", unit: "homes"}}
-          stat_change={{change: "increase", value: 56.1}} />
+          statChange={{change: "increase", value: 56.1}}
+          statLabel="Increased Value"
+          statValue={{value: "938", unit: "homes"}}
+      />
 
       <br/><br/>
 
       <DashboardValue
-          stat_label="Neutral Value"
-          stat_value={{value: "261", unit: "windows"}}
-          stat_change={{value: 86}} />
+          statChange={{value: 86}}
+          statLabel="Neutral Value"
+          statValue={{value: "261", unit: "windows"}}
+      />
     </div>
   )
 }


### PR DESCRIPTION
- Removes props with `_` in `DashboardValue kit
- tested in Nitro to ensure label appears for React version
![Screenshot from 2019-11-20 15-54-28](https://user-images.githubusercontent.com/2293844/69281865-aba2a700-0bae-11ea-9591-2435621a3283.png)
