### PR TITLE
Use number_with_delimiter for stat_value.value

### DIFF
--- a/app/pb_kits/playbook/pb_stat_value/_stat_value.html.erb
+++ b/app/pb_kits/playbook/pb_stat_value/_stat_value.html.erb
@@ -6,7 +6,7 @@
     <%= pb_rails "title", props: {
       classname: "pb_stat_value_kit",
       size: 1,
-      text: object.value } %>
+      text: object.formatted_value } %>
       &nbsp;
       <%= pb_rails "title", props: {
       classname: "pb_stat_value_kit",

--- a/app/pb_kits/playbook/pb_stat_value/stat_value.rb
+++ b/app/pb_kits/playbook/pb_stat_value/stat_value.rb
@@ -4,11 +4,16 @@ module Playbook
   module PbStatValue
     class StatValue
       include Playbook::Props
+      include ActionView::Helpers::NumberHelper
 
       partial "pb_stat_value/stat_value"
 
       prop :unit
       prop :value, type: Playbook::Props::Number
+
+      def formatted_value
+        number_with_delimiter(value, delimiter: ",")
+      end
 
       def classname
         generate_classname("pb_stat_value_kit")


### PR DESCRIPTION
This PR adds [`number_with_delimiter`](https://api.rubyonrails.org/classes/ActionView/Helpers/NumberHelper.html#M001972) to `stat_value` Rails kit so that `5567` is always represented as `5,567`