### PR TITLE
Fix form kit dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ end
 gemspec
 
 gem "health_check"
+gem "simple_form", ">= 5.0.1", "< 6.0.0"


### PR DESCRIPTION
Make sure that simple form will be available in the production mode
of the playbook web app. This is needed so we can show the example of
how to use playbook with simple form. The previous code only had a
development dependency defined in the gemspec, moving this to the
Gemfile will make it available in the production web app.