### PR TITLE
Eslint is a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "eslint-plugin-react": "^7.16.0",
     "extract-text-webpack-plugin": "3.0.0",
     "flow-bin": "0.54.1",
-    "webpack-dev-server": "^3.7.2"
+    "webpack-dev-server": "^3.7.2",
+    "eslint": "^6.6.0",
+    "eslint-plugin-flowtype": "^4.4.1"
   },
   "dependencies": {
     "@babel/cli": "7.2.3",
@@ -56,8 +58,6 @@
     "classnames": "^2.2.6",
     "css-modules-flow-types-loader": "0.3.1",
     "es5-shim": "4.5.9",
-    "eslint": "^6.6.0",
-    "eslint-plugin-flowtype": "^4.4.1",
     "fast-sass-loader": "^1.5.0",
     "flow-bin": "0.54.1",
     "flow-runtime": "0.14.0",


### PR DESCRIPTION
The eslint version used here depends on a newer version of node when comparing to nitro-web.
Moving this dep to the `devDependencies` is a short term solution to allow playbook_ui to be used with nitro-web.

Long term solution should be to upgrade nitro node version since [it's not gonna be supported anymore](https://nodejs.org/en/about/releases/).

We tested this pointing my nitro-web to my playbook on my local machine and it worked fine. Is there any other test I should do?