### PR TITLE
Selectable Card Kit Bug - Error in Code Example

### DIFF
--- a/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_dark.html.erb
+++ b/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_dark.html.erb
@@ -33,9 +33,9 @@
   <% end %>
 
   <%= pb_rails("selectable_card", props: {
-    input_id: "unselected_dark",
-    name: "unselected_dark",
-    value: "unselected_dark",
+    input_id: "disabled_dark",
+    name: "disabled_dark",
+    value: "disabled_dark",
     disabled: true,
     dark: true
   }) do %>

--- a/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_dark.jsx
+++ b/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_dark.jsx
@@ -52,9 +52,9 @@ class SelectableCardDark extends React.Component {
 
         <SelectableCard
             dark
-            inputId="unselected_dark"
-            name="unselected_dark"
-            value="unselected_dark"
+            inputId="disabled_dark"
+            name="disabled_dark"
+            value="disabled_dark"
             disabled={true}
             onChange={this.handleSelect}>
           {'Unselected'}


### PR DESCRIPTION
There was bug found in the code example of Selectable Card Kit. In the dark versions of both Rails and React, when the disabled card is clicked, it would make the adjacent card turn off or on. This was due to having the same name for both cards in the code example when they should've been different.

To fix this bug, the input_id, name, and value were changed so that the clicking would be affecting the correct card.