### PR TITLE
Display wrong contacts correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sets image build status for Milano compatibility ([#472][] @viniciusgama)
 - Add node binding for node-sass ([#465][] @thestephenmarshall)
 - Enable ESLint in overcommit ([#462][] @thestephenmarshall)
+- Display wrong numbers in Person Contact Kit ([#499][] @KFad11)
 
 [#436]: https://github.com/powerhome/playbook/pull/436
 [#479]: https://github.com/powerhome/playbook/pull/479
@@ -74,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#472]: https://github.com/powerhome/playbook/pull/472
 [#465]: https://github.com/powerhome/playbook/pull/465
 [#462]: https://github.com/powerhome/playbook/pull/462
+[#499]: https://github.com/powerhome/playbook/pull/499
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Display wrong numbers in Person Contact Kit ([#499][] @KFad11)
+- Display wrong numbers in Person Contact Kit. The Kit will now display a caption "wrong number" and have the wrong numbers listed beneath the caption ([#499][] @KFad11)
 
 [#499]: https://github.com/powerhome/playbook/pull/499
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#498]: https://github.com/powerhome/playbook/pull/498
 [#439]: https://github.com/powerhome/playbook/pull/439
 
+### Fixed
+
+- Display wrong numbers in Person Contact Kit ([#499][] @KFad11)
+
+[#499]: https://github.com/powerhome/playbook/pull/499
+
 
 ## [3.0.1] - 2019-12-06
 
 ### Fixed
 
 - Move `eslint` to devDependencies ([#489][] @gmfvpereira)
-- Display wrong numbers in Person Contact Kit ([#499][] @KFad11)
 
 [#489]: https://github.com/powerhome/playbook/pull/489
-[#499]: https://github.com/powerhome/playbook/pull/499
 
 ## [3.0.0] - 2019-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Move `eslint` to devDependencies ([#489][] @gmfvpereira)
+- Display wrong numbers in Person Contact Kit ([#499][] @KFad11)
 
 [#489]: https://github.com/powerhome/playbook/pull/489
+[#499]: https://github.com/powerhome/playbook/pull/499
 
 ## [3.0.0] - 2019-12-05
 
@@ -63,7 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sets image build status for Milano compatibility ([#472][] @viniciusgama)
 - Add node binding for node-sass ([#465][] @thestephenmarshall)
 - Enable ESLint in overcommit ([#462][] @thestephenmarshall)
-- Display wrong numbers in Person Contact Kit ([#499][] @KFad11)
 
 [#436]: https://github.com/powerhome/playbook/pull/436
 [#479]: https://github.com/powerhome/playbook/pull/479
@@ -75,7 +76,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#472]: https://github.com/powerhome/playbook/pull/472
 [#465]: https://github.com/powerhome/playbook/pull/465
 [#462]: https://github.com/powerhome/playbook/pull/462
-[#499]: https://github.com/powerhome/playbook/pull/499
 
 ### Fixed
 

--- a/app/pb_kits/playbook/pb_contact/contact.rb
+++ b/app/pb_kits/playbook/pb_contact/contact.rb
@@ -28,7 +28,7 @@ module Playbook
           "phone-office"
         when "email"
           "envelope"
-        when "wrong number"
+        when "wrong-phone"
           "phone-slash"
         else # "unknown" || "other"
           "phone"

--- a/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
@@ -14,7 +14,7 @@
     }) %>
   <% end %>
   <% unless object.wrong_contacts.empty? %>
-    <%= pb_rails("caption", props: { text: "wrong number" }) %>
+    <div style="padding-top: 10px"> <%= pb_rails("caption", props: { text: "wrong number" }) %></div>
 
     <% object.wrong_contacts.each do |wrong_number| %>
       <%= pb_rails("contact", props: {

--- a/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
@@ -14,7 +14,7 @@
     }) %>
   <% end %>
   <% unless object.wrong_contacts.empty? %>
-    <div style="padding-top: 10px"> <%= pb_rails("caption", props: { text: "wrong number" }) %></div>
+    <div class="wrong_numbers"> <%= pb_rails("caption", props: { text: "wrong number" }) %></div>
 
     <% object.wrong_contacts.each do |wrong_number| %>
       <%= pb_rails("contact", props: {

--- a/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
@@ -1,25 +1,26 @@
 <%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname) do %>
-    <%= pb_rails("person", props: {
-        first_name: object.first_name,
-        last_name: object.last_name,
+  id: object.id,
+  data: object.data,
+  class: object.classname) do %>
+  <%= pb_rails("person", props: {
+      first_name: object.first_name,
+      last_name: object.last_name,
+  }) %>
+  <% object.valid_contacts.each do |contact| %>
+    <%= pb_rails("contact", props: {
+        contact_type: contact[:contact_type],
+        contact_value: contact[:contact_value],
+        contact_detail: contact[:contact_detail],
     }) %>
-    <% object.contacts.each do |contact| %>
+  <% end %>
+  <% unless object.wrong_contacts.empty? %>
+    <%= pb_rails("caption", props: { text: "wrong number" }) %>
+
+    <% object.wrong_contacts.each do |wrong_number| %>
       <%= pb_rails("contact", props: {
-          contact_type: contact[:contact_type],
-          contact_value: contact[:contact_value],
-          contact_detail: contact[:contact_detail],
+        contact_type: wrong_number[:contact_type],
+        contact_value: wrong_number[:contact_value],
       }) %>
     <% end %>
-    <% unless object.wrong_contacts.empty? %>
-      <%= pb_rails("caption", props: { text: "wrong number" })%>
-    <% end %>
-      <% object.wrong_contacts.each do |wrong_number| %>
-        <%= pb_rails("contact", props: {
-            contact_type: wrong_number[:contact_type],
-            contact_value: wrong_number[:contact_value],
-        }) %>
-      <% end %>
+  <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/_person_contact.html.erb
@@ -13,8 +13,8 @@
         contact_detail: contact[:contact_detail],
     }) %>
   <% end %>
-  <% unless object.wrong_contacts.empty? %>
-    <div class="wrong_numbers"> <%= pb_rails("caption", props: { text: "wrong number" }) %></div>
+  <% if object.wrong_contacts.present? %>
+    <%= pb_rails("caption", props: { classname: "wrong_numbers", text: "wrong number" }) %>
 
     <% object.wrong_contacts.each do |wrong_number| %>
       <%= pb_rails("contact", props: {

--- a/app/pb_kits/playbook/pb_person_contact/_person_contact.scss
+++ b/app/pb_kits/playbook/pb_person_contact/_person_contact.scss
@@ -9,3 +9,7 @@
   flex-direction: column;
   margin-bottom: $space_xs;
 }
+
+.wrong_numbers {
+  padding-top: $space_xs
+}

--- a/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_with_wrong_numbers.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_with_wrong_numbers.html.erb
@@ -1,0 +1,17 @@
+<%= pb_rails("person_contact", props: {
+  first_name: "Pauline",
+  last_name: "Smith",
+  contacts: [
+    {
+      contact_type: "email",
+      contact_value: "email@example.com",
+    },
+    {
+      contact_value: 5555555555
+    },
+    {
+      contact_type: "wrong number",
+      contact_value: "3245627482",
+    }
+  ]
+}) %>

--- a/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_with_wrong_numbers.html.erb
+++ b/app/pb_kits/playbook/pb_person_contact/docs/_person_contact_with_wrong_numbers.html.erb
@@ -10,8 +10,12 @@
       contact_value: 5555555555
     },
     {
-      contact_type: "wrong number",
+      contact_type: "wrong-phone",
       contact_value: "3245627482",
-    }
+    },
+    {
+      contact_type: "phone",
+      contact_value: "3048615385",
+    },
   ]
 }) %>

--- a/app/pb_kits/playbook/pb_person_contact/docs/example.yml
+++ b/app/pb_kits/playbook/pb_person_contact/docs/example.yml
@@ -6,8 +6,6 @@ examples:
   - person_contact_with_detail: With Detail
   - person_contact_with_wrong_numbers: With Wrong Numbers
 
-
-
   react:
   - person_contact_default: Default
   - person_contact_multiple: Multiple People

--- a/app/pb_kits/playbook/pb_person_contact/docs/example.yml
+++ b/app/pb_kits/playbook/pb_person_contact/docs/example.yml
@@ -4,6 +4,7 @@ examples:
   - person_contact_default: Default
   - person_contact_multiple: Multiple People
   - person_contact_with_detail: With Detail
+  - person_contact_with_wrong_numbers: With Wrong Numbers
 
 
 

--- a/app/pb_kits/playbook/pb_person_contact/person_contact.rb
+++ b/app/pb_kits/playbook/pb_person_contact/person_contact.rb
@@ -12,11 +12,11 @@ module Playbook
       prop :last_name
 
       def wrong_contacts
-        contacts.select { |contact| contact[:contact_type] == "wrong number" }
+        contacts.select { |contact| contact[:contact_type] == "wrong-phone" }
       end
 
       def valid_contacts
-        contacts.reject { |contact| contact[:contact_type] == "wrong number" }
+        contacts.reject { |contact| contact[:contact_type] == "wrong-phone" }
       end
 
       def classname

--- a/spec/pb_kits/playbook/kits/contact_spec.rb
+++ b/spec/pb_kits/playbook/kits/contact_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Playbook::PbContact::Contact do
       expect(subject.new(contact_type: "work").contact_icon).to eq "phone-office"
       expect(subject.new(contact_type: "email").contact_icon).to eq "envelope"
       expect(subject.new(contact_type: "wrong-phone").contact_icon).to eq "phone-slash"
+      expect(subject.new(contact_type: "intentionally-wrong-type").contact_icon).to eq "phone"
       expect(subject.new(contact_type: "").contact_icon).to eq "phone"
     end
   end

--- a/spec/pb_kits/playbook/kits/contact_spec.rb
+++ b/spec/pb_kits/playbook/kits/contact_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Playbook::PbContact::Contact do
       expect(subject.new(contact_type: "home").contact_icon).to eq "phone"
       expect(subject.new(contact_type: "work").contact_icon).to eq "phone-office"
       expect(subject.new(contact_type: "email").contact_icon).to eq "envelope"
+      expect(subject.new(contact_type: "wrong-phone").contact_icon).to eq "phone-slash"
       expect(subject.new(contact_type: "").contact_icon).to eq "phone"
     end
   end


### PR DESCRIPTION
Currently, the kit wasn't displaying the wrong number caption, wasn't arranging the contacts with valid contacts above incorrect contacts, nor documenting this functionality in the kit. 

This PR adds that documentation referenced above, it detects valid contacts, then displays them above a wrong number caption and displays the wrong numbers beneath with the correct icon. 

**This in no way is a backward breaking change to the Nitro repo, as it isn't implemented there yet.**

<img width="378" alt="Screen Shot 2019-12-11 at 11 35 03 AM" src="https://user-images.githubusercontent.com/48073883/70640671-4caedb80-1c0a-11ea-8568-6786b22d87b6.png">

