### PR TITLE
Add textarea kit to form kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include Card Separator example in Card kit docs ([#439][] @rruiz85)
 - Text Input Dark mode added, Text Input updated to use Textarea mixins and Textarea mixin fix to remove number field arrows ([#494][] @megantrimble)
 - Introduce Pull Request Template ([#508][] @rafbgarcia)
+- Extend Form Kit to use Textarea Kit for textarea form fields ([#506][] @roxannecojocariu)
 
 [#498]: https://github.com/powerhome/playbook/pull/498
 [#439]: https://github.com/powerhome/playbook/pull/439
+[#494]: https://github.com/powerhome/playbook/pull/494
 [#508]: https://github.com/powerhome/playbook/pull/508
+[#506]: https://github.com/powerhome/playbook/pull/506
 
 ### Fixed
 

--- a/app/pb_kits/playbook/pb_form/docs/_form_form_with.html.erb
+++ b/app/pb_kits/playbook/pb_form/docs/_form_form_with.html.erb
@@ -6,6 +6,7 @@
   <%= form.search_field :example_search_field, props: { label: true } %>
   <%= form.password_field :example_password_field, props: { label: true } %>
   <%= form.url_field :example_url_field, props: { label: true } %>
+  <%= form.text_area :example_text_area, props: { label: true } %>
 
   <%= form.actions do |action| %>
     <%= action.submit %>

--- a/app/pb_kits/playbook/pb_form/docs/_form_simple_form.html.erb
+++ b/app/pb_kits/playbook/pb_form/docs/_form_simple_form.html.erb
@@ -10,7 +10,8 @@
                   :example_number_field,
                   :example_search_field,
                   :example_password_field,
-                  :example_url_field
+                  :example_url_field,
+                  :example_text_area
 
 
    def self.model_name
@@ -28,6 +29,7 @@
   <%= form.input :example_search_field, as: :search %>
   <%= form.input :example_password_field, as: :password %>
   <%= form.input :example_url_field, as: :url %>
+  <%= form.input :example_text_area, as: :text %>
 
   <%= form.actions do |action| %>
     <%= action.submit %>

--- a/app/pb_kits/playbook/pb_form/form_builder.rb
+++ b/app/pb_kits/playbook/pb_form/form_builder.rb
@@ -6,13 +6,14 @@ module Playbook
       extend ActiveSupport::Concern
 
       included do
-        prepend(TextInputBuilder.new(:email_field))
-        prepend(TextInputBuilder.new(:number_field))
-        prepend(TextInputBuilder.new(:search_field))
-        prepend(TextInputBuilder.new(:telephone_field))
-        prepend(TextInputBuilder.new(:text_field))
-        prepend(TextInputBuilder.new(:password_field))
-        prepend(TextInputBuilder.new(:url_field))
+        prepend(FormFieldBuilder.new(:email_field, kit_name: "text_input"))
+        prepend(FormFieldBuilder.new(:number_field, kit_name: "text_input"))
+        prepend(FormFieldBuilder.new(:search_field, kit_name: "text_input"))
+        prepend(FormFieldBuilder.new(:telephone_field, kit_name: "text_input"))
+        prepend(FormFieldBuilder.new(:text_field, kit_name: "text_input"))
+        prepend(FormFieldBuilder.new(:password_field, kit_name: "text_input"))
+        prepend(FormFieldBuilder.new(:url_field, kit_name: "text_input"))
+        prepend(FormFieldBuilder.new(:text_area, kit_name: "textarea"))
 
         def actions(&block)
           ActionArea.new(self).wrapper(&block)

--- a/app/pb_kits/playbook/pb_form/form_builder/form_field_builder.rb
+++ b/app/pb_kits/playbook/pb_form/form_builder/form_field_builder.rb
@@ -3,15 +3,15 @@
 module Playbook
   module PbForm
     module FormBuilder
-      class TextInputBuilder < Module
-        def initialize(method_name)
+      class FormFieldBuilder < Module
+        def initialize(method_name, kit_name:)
           define_method method_name do |name, props: {}, **options, &block|
             props[:label] = @template.label(@object_name, name) if props[:label] == true
             options = Hash(options)
             options[:skip_default_ids] = false unless options.has_key?(:skip_default_ids)
             input = super(name, **options, &block)
 
-            @template.pb_rails("text_input", props: props) do
+            @template.pb_rails(kit_name, props: props) do
               input
             end
           end

--- a/app/pb_kits/playbook/pb_text_input/_text_input.html.erb
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag(:div,
     class: object.classname) do %>
   <% if object.label.present? %>
-    <%= pb_rails("caption", props: {text: object.label, dark: object.dark}) %>
+    <%= pb_rails("caption", props: { text: object.label, dark: object.dark, classname: "pb_text_input_kit_label" }) %>
   <% end %>
   <%= content_tag(:div,
       class: "text_input_wrapper") do %>

--- a/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -2,7 +2,10 @@
 @import "../pb_body/body_mixins";
 
 [class^=pb_text_input_kit] {
-  margin: $space_xs;
+  .pb_text_input_kit_label {
+    margin-bottom: $space_xs;
+    display: block;
+  }
 
   .text_input_wrapper {
     margin-bottom: $space_sm;
@@ -11,7 +14,7 @@
     input::placeholder {
       @include pb_body_light;
     }
-    
+
     > input:first-child {
       @include pb_textarea_light;
       overflow: hidden;


### PR DESCRIPTION
Tickets: [BOP-309]

Extend the form builder for the form kit to add in a text area.
Previously the form builder used the default text area method provided
by ActionView::Helpers::FormBuilder and SimpleForm::FormBuilder. This
new version uses the text area element built buy these implementations,
but wraps them using the pb_textarea kit.

Generalize the text input builder to allow a kit name to be passed in.
This allows us to reuse the builder for the text_area field as well as
the existing text type inputs fields.

**Form With Example**
<img width="1288" alt="Screen Shot 2019-12-11 at 1 28 40 PM" src="https://user-images.githubusercontent.com/35009869/70649714-b4215700-1c1b-11ea-852b-1d1796a43c07.png">
**Simple Form Example**
<img width="1294" alt="Screen Shot 2019-12-11 at 1 28 30 PM" src="https://user-images.githubusercontent.com/35009869/70649800-d87d3380-1c1b-11ea-85e9-5ba0df5d9434.png">
