### PR TITLE
Pb Card: Swap implementation of highlight position values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed broken eslint ref + removed unused file ([#540][] @jasoncypret)
+- Swap implementation of highlight position values for Card Kit ([#536][] @drborges)
 
 [#540]: https://github.com/powerhome/playbook/pull/540
+[#536]: https://github.com/powerhome/playbook/pull/536
 
 
 ## [3.2.0] 2019-12-19

--- a/app/pb_kits/playbook/pb_card/_card.jsx
+++ b/app/pb_kits/playbook/pb_card/_card.jsx
@@ -7,7 +7,7 @@ type CardPropTypes = {
   children: Array<React.ReactNode> | React.ReactNode,
   className?: String,
   highlight?: {
-    position?: String,
+    position?: 'side' | 'top',
     color?: String
   },
   padding?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl',

--- a/app/pb_kits/playbook/pb_card/_card.jsx
+++ b/app/pb_kits/playbook/pb_card/_card.jsx
@@ -3,6 +3,8 @@
 import React from 'react'
 import classnames from 'classnames'
 
+import { buildCss } from '../utilities/props'
+
 type CardPropTypes = {
   children: Array<React.ReactNode> | React.ReactNode,
   className?: String,
@@ -15,35 +17,26 @@ type CardPropTypes = {
   shadow?: 'none' | 'shallow' | 'default' | 'deep' | 'deeper' | 'deepest',
 }
 
-const cardCSS = ({
+const Card = ({
+  children,
+  className,
   highlight = {},
+  padding = 'md',
   selected = false,
   shadow = 'none',
 }: CardPropTypes) => {
-  let css = 'pb_card_kit'
-  css += highlight.position ? `_highlight_${highlight.position}` : ''
-  css += highlight.color ? `_highlight_${highlight.color}` : ''
-  css += selected ? '_selected' : '_deselected'
-  css += `_shadow_${shadow}`
-  return css
-}
-
-const bodyCSS = ({ padding = 'md' }: CardPropTypes) => {
-  let css = 'pb_card_body_kit'
-  css += `_${padding}`
-  return css
-}
-
-const Card = (props: CardPropTypes) => {
-  const {
-    children,
-    className,
-  } = props
+  const bodyCSS = buildCss('pb_card_body_kit', padding)
+  const cardCss = buildCss('pb_card_kit', `shadow_${shadow}`, {
+    selected,
+    deselected: !selected,
+    [`highlight_${highlight.position}`]: highlight.position,
+    [`highlight_${highlight.color}`]: highlight.color,
+  })
 
   return (
-    <div className={classnames(cardCSS(props), className)}>
-      <div className={bodyCSS(props)}>
-        { children }
+    <div className={classnames(cardCss, className)}>
+      <div className={bodyCSS}>
+        {children}
       </div>
     </div>
   )

--- a/app/pb_kits/playbook/pb_card/_card.scss
+++ b/app/pb_kits/playbook/pb_card/_card.scss
@@ -80,7 +80,7 @@ $pb_card_highlight_size: 4px;
     overflow: hidden;
   }
 
-  &[class*=_highlight_side] {
+  &[class*=_highlight_top] {
     @each $color_name, $color_value in $pb_card_highlight_colors {
       &[class*=_highlight_#{$color_name}]::before {
         @include pb_card_highlight(100%, $pb_card_highlight_size, $color_value);
@@ -88,7 +88,7 @@ $pb_card_highlight_size: 4px;
     }
   }
 
-  &[class*=_highlight_top] {
+  &[class*=_highlight_side] {
     @each $color_name, $color_value in $pb_card_highlight_colors {
       &[class*=_highlight_#{$color_name}]::before {
         @include pb_card_highlight($pb_card_highlight_size, 100%, $color_value);


### PR DESCRIPTION
#### Runway Ticket URL

It seems that the highlight position values (`side` vs `top`) have their implementations inverted (see screenshots below).

This PR makes it so that setting the highlight position to `side`, causes the highlight to be actually rendered on the side of the card rather than on the top. Similarly, the highlight position set to `top` will render the highlight on the top of the card rather than on its side.

#### Breaking Changes

This PR **could** introduce some regression on apps using the `position` prop of the `Card` kit. As of this writing, it seems that at least `nitro-web` **would not** experience any changes to the behavior of card components since there's no usage instance of the position prop.

#### How to Ninja test this (screenshots are really helpful)

**Before**

**Rails** Version:

<img width="1311" alt="rails-before" src="https://user-images.githubusercontent.com/508128/71373689-cc3b9380-2596-11ea-9b14-ac9dd4d77c2f.png">

**React** Version:

<img width="1301" alt="react-before" src="https://user-images.githubusercontent.com/508128/71373690-ce055700-2596-11ea-95a5-e44becfee284.png">

**After**

**Rails** Version:

<img width="1306" alt="rails-after" src="https://user-images.githubusercontent.com/508128/71373703-d78ebf00-2596-11ea-8a8d-060fbea4c09c.png">

**React** Version:

<img width="1307" alt="react-after" src="https://user-images.githubusercontent.com/508128/71373700-d493ce80-2596-11ea-89e9-f6fe5f24d71c.png">

#### Checklist:

- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
