### PR TITLE
Add className support to React version of icon circle kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed broken eslint ref + removed unused file ([#540][] @jasoncypret)
+- Add className support to React version of icon circle kit ([#537][] @drborges)
 
 [#540]: https://github.com/powerhome/playbook/pull/540
+[#537]: https://github.com/powerhome/playbook/pull/537
 
 
 ## [3.2.0] 2019-12-19

--- a/app/pb_kits/playbook/pb_icon_circle/_icon_circle.jsx
+++ b/app/pb_kits/playbook/pb_icon_circle/_icon_circle.jsx
@@ -1,24 +1,31 @@
 /* @flow */
 
 import React from 'react'
-import { Icon } from '../'
+import classnames from 'classnames'
 
-const IconCircleProps = {
-  className: String,
-  icon: String,
-  id: String,
-  size: String,
-  variant: String,
+import { Icon } from '../'
+import { buildCss } from '../utilities/props'
+
+type IconCircleProps = {
+  className?: string,
+  icon: string,
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl',
+  variant?: 'default' | 'royal' | 'blue' | 'purple' | 'teal' | 'red' | 'yellow' | 'green',
 }
 
 const IconCircle = ({
+  className,
   icon,
   size = 'md',
   variant = 'default',
-}: IconCircleProps) => (
-  <div className={`pb_icon_circle_kit_${size}_${variant}`}>
-    <Icon icon={icon} />
-  </div>
-)
+}: IconCircleProps) => {
+  const css = buildCss('pb_icon_circle_kit', size, variant)
+
+  return (
+    <div className={classnames(className, css)}>
+      <Icon icon={icon} />
+    </div>
+  )
+}
 
 export default IconCircle


### PR DESCRIPTION
#### Runway Ticket URL

Add support to the existent but unused `className` prop on the React version of the icon circle kit.

#### Breaking Changes

There are no breaking changes.

#### How to Ninja test this (screenshots are really helpful)

1. Usages of the react version of the icon circle component should allow for additional styles to be applied via the `className` prop.

#### Checklist:

- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
