### PR TITLE
Add error state to TextArea kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added error state to Text Input kit [#554](https://github.com/powerhome/playbook/pull/554)
+- Added error state to Textarea kit [#555](https://github.com/powerhome/playbook/pull/555)
 
 ## [3.4.0] 2019-1-9
 

--- a/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -45,13 +45,11 @@
 
     &.error {
       .text_input_wrapper {
-        $lighten_error: lighten($error, 5%);
-
         > input:first-child {
-          border-color: $lighten_error;
+          border-color: $error_dark;
         }
         [class*=pb_body_kit] {
-          color: lighten($lighten_error, 2%);
+          color: $error_dark_body;
         }
       }
     }

--- a/app/pb_kits/playbook/pb_textarea/_textarea.html.erb
+++ b/app/pb_kits/playbook/pb_textarea/_textarea.html.erb
@@ -7,6 +7,9 @@
   <% end %>
   <% if object.children %>
     <%= capture(&object.children) %>
+    <% if object.error %>
+      <%= pb_rails("body", props: {status: "negative", text: object.error}) %>
+    <% end %>
   <% else %>
     <%= text_area(
         :object,
@@ -16,5 +19,8 @@
         :placeholder => object.placeholder,
         :rows => object.rows,
         :value => object.value )%>
+    <% if object.error %>
+      <%= pb_rails("body", props: {status: "negative", text: object.error}) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_textarea/_textarea.jsx
+++ b/app/pb_kits/playbook/pb_textarea/_textarea.jsx
@@ -2,13 +2,14 @@
 
 import React from 'react'
 import classnames from 'classnames'
-import { Caption } from '../'
+import { Body, Caption } from '../'
 import { type InputCallback } from '../types.js'
 
 type TextareaProps = {
   className?: String,
   children?: Array<React.ReactChild>,
   data?: String,
+  error?: String,
   id?: String,
   object?: String,
   method?: String,
@@ -24,18 +25,20 @@ type TextareaProps = {
 const Textarea = ({
   className,
   children,
+  dark = false,
+  error,
   label,
+  name,
   onChange = () => {},
   placeholder,
-  value,
-  dark = false,
   rows = 4,
-  name,
+  value,
 }: TextareaProps) => {
   const textareaClass = `pb_textarea_kit${dark ? '_dark' : ''}`
+  const errorClass = error ? 'error' : null
 
   return (
-    <div className={classnames(textareaClass, className)}>
+    <div className={classnames(textareaClass, className, errorClass)}>
       <Caption
           dark={dark}
           text={label}
@@ -51,6 +54,13 @@ const Textarea = ({
             rows={rows}
             value={value}
         />
+        <If condition={error}>
+          <Body
+              dark={dark}
+              status="negative"
+              text={error}
+          />
+        </If>
       </If>
     </div>
   )

--- a/app/pb_kits/playbook/pb_textarea/_textarea.scss
+++ b/app/pb_kits/playbook/pb_textarea/_textarea.scss
@@ -17,6 +17,15 @@
     @include pb_textarea_focus_light;
   }
 
+  &.error {
+    [class*=pb_body_kit] {
+      margin-top: $space_xs / 2;
+    }
+    > textarea {
+      border-color: $error;
+    }
+  }
+
   &[class*=_dark] {
     textarea::placeholder {
       @include pb_body_light_dark;
@@ -26,6 +35,14 @@
     }
     textarea:focus {
       @include pb_textarea_focus_dark;
+    }
+    &.error {
+      > textarea {
+        border-color: $error_dark;
+      }
+      [class*=pb_body_kit] {
+        color: $error_dark_body;
+      }
     }
   }
 }

--- a/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark_error.html.erb
+++ b/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark_error.html.erb
@@ -1,0 +1,6 @@
+<%= pb_rails("textarea", props: {
+  dark: true,
+  error: "This field has an error!",
+  label: "Label",
+  rows: 4
+}) %>

--- a/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark_error.jsx
+++ b/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark_error.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Textarea } from '../..'
+
+const TextareaDarkError = () => {
+  return (
+    <div>
+      <Textarea
+          dark
+          error="This field has an error!"
+          label="Label"
+          name="comment"
+          placeholder="Placeholder text"
+          value="Default value text"
+      />
+
+    </div>
+  )
+}
+
+export default TextareaDarkError

--- a/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.html.erb
+++ b/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("textarea", props: { error: "This field has an error!", label: "Label", rows: 4}) %>

--- a/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.jsx
+++ b/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Textarea } from '../..'
+
+const TextareaError = () => {
+  return (
+    <div>
+      <Textarea
+          error="This field has an error!"
+          label="Label"
+          name="comment"
+          placeholder="Placeholder text"
+          value="Default value text"
+      />
+
+    </div>
+  )
+}
+
+export default TextareaError

--- a/app/pb_kits/playbook/pb_textarea/docs/example.yml
+++ b/app/pb_kits/playbook/pb_textarea/docs/example.yml
@@ -4,6 +4,8 @@ examples:
   - textarea_default: Default
   - textarea_custom: Custom Textarea Input
   - textarea_dark: Dark
+  - textarea_error: Textarea w/ Error
+  - textarea_dark_error: Textarea w/ Error
 
   
   
@@ -11,5 +13,7 @@ examples:
   - textarea_default: Default
   - textarea_custom: Custom Textarea Input
   - textarea_dark: Dark
+  - textarea_error: Textarea w/ Error
+  - textarea_dark_error: Textarea w/ Error
 
   

--- a/app/pb_kits/playbook/pb_textarea/docs/index.js
+++ b/app/pb_kits/playbook/pb_textarea/docs/index.js
@@ -1,3 +1,5 @@
 export { default as TextareaDefault } from './_textarea_default.jsx'
 export { default as TextareaCustom } from './_textarea_custom.jsx'
 export { default as TextareaDark } from './_textarea_dark.jsx'
+export { default as TextareaError } from './_textarea_error.jsx'
+export { default as TextareaDarkError } from './_textarea_dark_error.jsx'

--- a/app/pb_kits/playbook/pb_textarea/textarea.rb
+++ b/app/pb_kits/playbook/pb_textarea/textarea.rb
@@ -7,23 +7,30 @@ module Playbook
 
       partial "pb_textarea/textarea"
 
-      prop :object
-      prop :method
-      prop :label
-      prop :placeholder
-      prop :value
-      prop :name
       prop :dark, type: Playbook::Props::Boolean,
                   default: false
+      prop :error
+      prop :object
+      prop :label
+      prop :method
+      prop :name
+      prop :placeholder
       prop :rows, type: Playbook::Props::Number,
             default: 4
+      prop :value
 
       def classname
-        generate_classname("pb_textarea_kit", dark_class)
+        generate_classname("pb_textarea_kit", dark_class) + error_class
       end
+
+    private
 
       def dark_class
         dark ? "dark" : nil
+      end
+
+      def error_class
+        error ? " error" : ""
       end
     end
   end

--- a/spec/pb_kits/playbook/kits/textarea_spec.rb
+++ b/spec/pb_kits/playbook/kits/textarea_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Playbook::PbTextarea::Textarea do
 
   it { is_expected.to define_partial }
 
+  it { is_expected.to define_string_prop(:error) }
   it { is_expected.to define_string_prop(:label) }
   it { is_expected.to define_string_prop(:object) }
   it { is_expected.to define_string_prop(:method) }
@@ -21,6 +22,11 @@ RSpec.describe Playbook::PbTextarea::Textarea do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_textarea_kit"
+      expect(subject.new({dark: true}).classname).to eq "pb_textarea_kit_dark"
+      expect(subject.new({error: "Something is wrong"}).classname).to eq "pb_textarea_kit error"
+      expect(subject.new({dark: true, error: "Something is wrong"}).classname).to eq "pb_textarea_kit_dark error"
     end
   end
+
+
 end


### PR DESCRIPTION
Based on https://github.com/powerhome/playbook/pull/554

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUX-559

#### Breaking Changes

_Please reflect if your changes may break in some way (changes like removing/renaming props are examples of breaking changes)_

#### How to Ninja test this (screenshots are really helpful)


#### Checklist:

- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
