### PR TITLE
Add home_url prop to home_address_street kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.5.0] Unreleased
 
+### Added
+- Rails/JS kit `HomeAddressStreet`: added home_url prop. Defaults to `"#"` ([#557][] @stephenagreer)
+
+
+[#557]: https://github.com/powerhome/playbook/pull/557
+
 ## [3.4.0] 2019-1-9
 
 ### Added

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -26,7 +26,7 @@
   <% if object.home_id %>
     <%= pb_rails("hashtag", props: {
       text: "#{object.home_id}",
-      url: "#",
+      url: object.home_url || "#",
       type: "home",
       dark: object.dark,
       classname: "home-hashtag"}) %>

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -14,6 +14,7 @@ type HomeAddressStreetProps = {
   dark?: Boolean,
   homeId: Number,
   houseStyle: String,
+  homeUrl: String,
   state: String,
   zipcode: String,
   territory: String,
@@ -33,6 +34,7 @@ const HomeAddressStreet = ({
   className,
   dark = false,
   homeId,
+  homeUrl,
   houseStyle,
   state,
   zipcode,
@@ -63,7 +65,7 @@ const HomeAddressStreet = ({
           dark={dark}
           text={homeId}
           type="home"
-          url="#"
+          url={homeUrl || '#'}
       />
     </If>
     <Body

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.html.erb
@@ -3,6 +3,7 @@
   address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,
+  home_url: "https://powerhrg.com/",
   house_style: "Colonial",
   state: "PA",
   zipcode: "19382",

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_dark.jsx
@@ -9,6 +9,7 @@ const HomeAddressStreetDark = () => {
         city="West Chester"
         dark
         homeId={8250263}
+        homeUrl="https://powerhrg.com/"
         state="PA"
         territory="PHL"
         zipcode="19382"

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.html.erb
@@ -3,6 +3,7 @@
   address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,
+  home_url: "https://powerhrg.com/",
   house_style: "Colonial",
   state: "PA",
   zipcode: "19382",

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default.jsx
@@ -8,6 +8,7 @@ const HomeAddressStreetDefault = () => {
         addressCont="Apt M18"
         city="West Chester"
         homeId={8250263}
+        homeUrl="https://powerhrg.com/"
         houseStyle="Colonial"
         state="PA"
         territory="PHL"

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -11,6 +11,7 @@ module Playbook
       prop :address_cont
       prop :city
       prop :home_id, type: Playbook::Props::Number
+      prop :home_url
       prop :house_style
       prop :state
       prop :zipcode

--- a/spec/pb_kits/playbook/kits/home_address_street_spec.rb
+++ b/spec/pb_kits/playbook/kits/home_address_street_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Playbook::PbHomeAddressStreet::HomeAddressStreet do
   it { is_expected.to define_prop(:city) }
   it { is_expected.to define_prop(:home_id)
                       .of_type(Playbook::Props::Number) }
+  it { is_expected.to define_prop(:home_url) }
   it { is_expected.to define_prop(:house_style) }
   it { is_expected.to define_prop(:state) }
   it { is_expected.to define_prop(:zipcode) }


### PR DESCRIPTION
#### Runway Ticket URL

Adds url support to the `Home Address Street` kit. Defaults to "#" if prop is not used. 


![2020-01-15 08 40 20](https://user-images.githubusercontent.com/18668436/72447569-ce96a500-3772-11ea-9cd9-d4ff704b5488.gif)


#### Breaking Changes

There are no breaking changes. 

#### How to Ninja test this (screenshots are really helpful)
The home_id link should direct to the link given to the `home_url` prop.

#### Checklist:

- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
