### PR TITLE
Shadow Shallow, Default & Dark Deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.0] Unreleased
 ### Changed
 - Modernize and update API of the Currency kit [#565](https://github.com/powerhome/playbook/pull/565)
+- Shadow Shallow, Default and Dark Deprecated, shadow_light changed to shadow, all affected files updated. ([#568][] @megantrimble)
 
 [#565]: https://github.com/powerhome/playbook/pull/565
+[#568]: https://github.com/powerhome/playbook/pull/568
 
 ## [3.5.0] 2020-1-16
 

--- a/app/pb_kits/playbook/packs/site_styles/docs/_kit_doc.scss
+++ b/app/pb_kits/playbook/packs/site_styles/docs/_kit_doc.scss
@@ -4,7 +4,7 @@
   margin-bottom: 20px;
   border: 1px solid $border-light;
   border-radius: 4px;
-  box-shadow: 0 4px 10px $shadow_light;
+  box-shadow: 0 4px 10px $shadow;
   background: $white;
   overflow: hidden;
 

--- a/app/pb_kits/playbook/packs/site_styles/docs/_markdown.scss
+++ b/app/pb_kits/playbook/packs/site_styles/docs/_markdown.scss
@@ -38,7 +38,7 @@
     color: #faf6e4;
     padding: 0.5rem 1.5rem;
     margin: 1rem 0;
-    box-shadow: 0 2px 10px $shadow_light;
+    box-shadow: 0 2px 10px $shadow;
     border-radius: 0.25rem;
     overflow: hidden;
     font-size: 1rem;

--- a/app/pb_kits/playbook/packs/site_styles/docs/_spacing_tokens.scss
+++ b/app/pb_kits/playbook/packs/site_styles/docs/_spacing_tokens.scss
@@ -67,6 +67,6 @@ ul {
   div.pb--spacing_#{$name}{
     width: #{$value};
     height: 78px;
-    background: $shadow_light;
+    background: $shadow;
   }
 }

--- a/app/pb_kits/playbook/pb_card/card.rb
+++ b/app/pb_kits/playbook/pb_card/card.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-# DEPRECATION NOTICE - DO NOT USE Shadow Shallow and Shadow Default!
-# Shadow Options: Shallow and Default targed to be removed in release v4.0.0.
-# [https://github.com/powerhome/playbook/issues/550]
-# END DEPRECATION NOTICE
-
 module Playbook
   module PbCard
     class Card
@@ -17,7 +12,7 @@ module Playbook
                      values: %w[none xs sm md lg xl],
                      default: "md"
       prop :shadow, type: Playbook::Props::Enum,
-                    values: %w[none shallow default deep deeper deepest],
+                    values: %w[none deep deeper deepest],
                     default: "none"
       prop :highlight, type: Playbook::Props::Hash,
                        default: {}

--- a/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -19,7 +19,7 @@ $pb_selectable_card_border: 2px;
     cursor: pointer;
 
     &:hover {
-      box-shadow: $shadow-default;
+      box-shadow: $shadow-deep;
       border-color: $slate;
     }
 

--- a/app/pb_kits/playbook/tokens/_colors.scss
+++ b/app/pb_kits/playbook/tokens/_colors.scss
@@ -103,20 +103,9 @@ $border_colors: (
 );
 
 // Shadow colors ----------------------
-$shadow_light:        rgba(#3C6AAC, $opacity_2);
-
-/*
-DEPRECATED - DO NOT USE! 
-This targed to be removed in release v4.0.0.
-[https://github.com/powerhome/playbook/issues/550]
-*/
-$shadow_dark:         rgba(#3C6AAC, $opacity_2);
-
-/* END DEPRECATION */
-
+$shadow:        rgba(#3C6AAC, $opacity_2);
 $shadow_colors: (
-  shadow_light:       $shadow_light,
-  shadow_dark:        $shadow_dark
+  shadow:       $shadow,
 );
 
 // Text colors ------------------------

--- a/app/pb_kits/playbook/tokens/_shadows.scss
+++ b/app/pb_kits/playbook/tokens/_shadows.scss
@@ -2,23 +2,11 @@
 @import "opacity";
 
 $shadow_none: 0 0 0 0 transparent;
-
-/*
-DEPRECATED - DO NOT USE! 
-This targed to be removed in release v4.0.0.
-[https://github.com/powerhome/playbook/issues/550]
-*/
-$shadow_shallow: 0 1px 1px 0 $shadow_light;
-$shadow_default: 0 1px 5px 0 $shadow_light;
-/* END DEPRECATED */
-
-$shadow_deep: 0 4px 10px 0 rgba($shadow_light, 0.16);
-$shadow_deeper: 0 12px 28px 0 rgba($shadow_light, 0.18);
-$shadow_deepest: 0 30px 38px 4px $shadow_light, 0 2px 14px 4px rgba($shadow_light, 0.1);
+$shadow_deep: 0 4px 10px 0 rgba($shadow, 0.16);
+$shadow_deeper: 0 12px 28px 0 rgba($shadow, 0.18);
+$shadow_deepest: 0 30px 38px 4px $shadow, 0 2px 14px 4px rgba($shadow, 0.1);
 $box_shadows: (
   shadow_none: $shadow_none,
-  shadow_shallow: $shadow_shallow,
-  shadow_default: $shadow_default,
   shadow_deep: $shadow_deep,
   shadow_deeper: $shadow_deeper,
   shadow_deepest: $shadow_deepest

--- a/app/views/playbook/pages/utilities.html.slim
+++ b/app/views/playbook/pages/utilities.html.slim
@@ -74,7 +74,7 @@ br
 // Shadow --------------------------
 = render :partial => "playbook/pages/utilities/pb_doc_color",
     locals:{ title: "Shadow",
-    colors: [{name: "Shadow Light", variable: "shadow_light"}]}
+    colors: [{name: "Shadow", variable: "shadow"}]}
 
 // Products ------------------------
 = render :partial => "playbook/pages/utilities/pb_doc_color",

--- a/spec/pb_kits/playbook/kits/card_spec.rb
+++ b/spec/pb_kits/playbook/kits/card_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe Playbook::PbCard::Card do
   it do
     is_expected.to define_enum_prop(:shadow)
                    .with_default("none")
-                   .with_values("none", "shallow", "default",
-                                "deep", "deeper", "deepest")
+                   .with_values("none", "deep", "deeper", "deepest")
   end
 
   describe "#classname" do
@@ -30,7 +29,7 @@ RSpec.describe Playbook::PbCard::Card do
       expect(subject.new({}).classname).to eq "pb_card_kit_deselected"
       expect(subject.new(selected: true).classname).to eq "pb_card_kit_selected"
       expect(subject.new(shadow: "deeper").classname).to eq "pb_card_kit_deselected_shadow_deeper"
-      expect(subject.new(selected: true, shadow: "shallow").classname).to eq "pb_card_kit_selected_shadow_shallow"
+      expect(subject.new(selected: true, shadow: "deep").classname).to eq "pb_card_kit_selected_shadow_deep"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_card_kit_deselected additional_class"
       expect(subject.new(highlight: {position: "top"}).classname).to eq "pb_card_kit_deselected_highlight_top"
       expect(subject.new(highlight: {position: "side"}).classname).to eq "pb_card_kit_deselected_highlight_side"


### PR DESCRIPTION
- There is now one shadow color for both light and dark eliminating the need for shadow_light & shadow_dark.
- Shadow values shallow and default removed and all files with those values were changed.

### Breaking Changes
- shadow_shallow removed
-shadow_default removed
-shadow_dark removed
-shadow_light renamed to shadow

#### How to Ninja test this (screenshots are really helpful)


#### Checklist:

- ✅ **SPECS** Please cover your changes with specs
- ✅ **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
