### PR TITLE
Set circle icon button type to `button`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [4.2.0]
+
+### Changed
+- Add a type prop to the circle icon button kit to allow users to set a button type.[#579](ttps://github.com/powerhome/playbook/pull/579)
 
 ## [4.1.2] 2020-1-30
 

--- a/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.html.erb
+++ b/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.html.erb
@@ -3,7 +3,7 @@
   data: object.data,
   class: object.classname) do %>
 
-  <%= pb_rails("button", props: {variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
+  <%= pb_rails("button", props: {type: object.type, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
     <%= pb_rails("icon", props: {icon: object.icon, fixed_width: true, dark: object.dark}) %>
   <% end %>
 

--- a/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.jsx
+++ b/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Button, Icon } from '../'
 
 type CircleIconButtonProps = {
+  type?: 'button' | 'submit' | 'reset',
   variant?: 'primary' | 'secondary' | 'link',
   disabled?: Boolean,
   dark?: Boolean,
@@ -14,6 +15,7 @@ type CircleIconButtonProps = {
 
 const CircleIconButton = (props: CircleIconButtonProps) => {
   const {
+    type,
     variant,
     disabled,
     icon,
@@ -23,6 +25,7 @@ const CircleIconButton = (props: CircleIconButtonProps) => {
   return (
     <div className="pb_circle_icon_button_kit">
       <Button
+          type={type}
           dark={dark}
           disabled={disabled}
           text={null}

--- a/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.jsx
+++ b/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.jsx
@@ -25,10 +25,10 @@ const CircleIconButton = (props: CircleIconButtonProps) => {
   return (
     <div className="pb_circle_icon_button_kit">
       <Button
-          type={type}
           dark={dark}
           disabled={disabled}
           text={null}
+          type={type}
           variant={variant}
       >
         <Icon

--- a/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
+++ b/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
@@ -5,6 +5,9 @@ module Playbook
 
       partial "pb_circle_icon_button/circle_icon_button"
 
+      prop :type, type: Playbook::Props::Enum,
+                  values: %w[button submit reset],
+                  default: "button"
       prop :variant, type: Playbook::Props::Enum,
                      values: %w[primary secondary link],
                      default: "primary"


### PR DESCRIPTION
#### Runway Ticket URL

None..

#### Breaking Changes

Previously, a circle icon button's type is set to the default `submit`, which always causes forms with circle icon buttons to be submitted. There was no way to prevent this by setting type to `button`.

This PR adds a `type` prop to the circle icon button kit to allow users to set a button type. This also changes the circle icon button's default type to `button`, a more reasonable default since circle icon buttons are not primarily used for form submissions (is it?).

It will break forms that use circle icon buttons for submission.

#### How to Ninja test this (screenshots are really helpful)


#### Checklist:

- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
