### PR TITLE
[BOLT-71] Select Kit: Fix misuse of selected vs value props

### DIFF
--- a/app/pb_kits/playbook/pb_select/_select.jsx
+++ b/app/pb_kits/playbook/pb_select/_select.jsx
@@ -20,7 +20,6 @@ type SelectOption = {
   value: string,
   valueText: string,
   disabled?: boolean,
-  selected?: boolean,
 }
 
 type SelectProps = {
@@ -47,7 +46,6 @@ const createOptions = (options: SelectOption[]) => options.map((option, index) =
   <option
       disabled={option.disabled}
       key={index}
-      selected={option.selected}
       value={option.value}
   >
     {option.valueText || option.value}
@@ -68,6 +66,7 @@ const Select = ({
   onChange = () => {},
   options = [],
   required = false,
+  value,
 }: SelectProps) => {
   const errorClass = error ? ' error' : ''
   const css = buildCss({ 'pb_select': true, 'dark': dark === true }) + errorClass
@@ -106,6 +105,7 @@ const Select = ({
               name={name}
               onChange={onChange}
               required={required}
+              value={value}
           >
             <If condition={blankSelection}>
               <option value="">{blankSelection}</option>

--- a/app/pb_kits/playbook/pb_select/_select.jsx
+++ b/app/pb_kits/playbook/pb_select/_select.jsx
@@ -43,20 +43,16 @@ type SelectProps = {
   value?: string,
 }
 
-const optionsArray = (options: SelectOption[]) => {
-  return options.map((optionObject, index) => {
-    return (
-      <option
-          disabled={optionObject.disabled}
-          key={index}
-          selected={optionObject.selected}
-          value={optionObject.value}
-      >
-        {optionObject.valueText || optionObject.value}
-      </option>
-    )
-  })
-}
+const createOptions = (options: SelectOption[]) => options.map((option, index) => (
+  <option
+      disabled={option.disabled}
+      key={index}
+      selected={option.selected}
+      value={option.value}
+  >
+    {option.valueText || option.value}
+  </option>
+))
 
 const Select = ({
   aria = {},
@@ -77,7 +73,7 @@ const Select = ({
   const css = buildCss({ 'pb_select': true, 'dark': dark === true }) + errorClass
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const optionsList = optionsArray(options)
+  const optionsList = createOptions(options)
 
   return (
     <div

--- a/app/pb_kits/playbook/pb_select/_select.jsx
+++ b/app/pb_kits/playbook/pb_select/_select.jsx
@@ -69,7 +69,7 @@ const Select = ({
   value,
 }: SelectProps) => {
   const errorClass = error ? ' error' : ''
-  const css = buildCss({ 'pb_select': true, 'dark': dark === true }) + errorClass
+  const css = buildCss('pb_select', { dark }) + errorClass
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const optionsList = createOptions(options)

--- a/app/pb_kits/playbook/pb_select/_select.jsx
+++ b/app/pb_kits/playbook/pb_select/_select.jsx
@@ -14,27 +14,36 @@ import {
   buildDataProps,
 } from '../utilities/props'
 
-type SelectProps = {
-  aria?: object,
-  blankSelection?: String,
-  children?: Array<React.ReactChild>,
-  className?: String,
-  dark?: Boolean,
-  data?: object,
-  disabled?: Boolean,
-  error?: String,
-  onChange: PropTypes.func,
-  options: Array<Object>,
-  id?: String,
-  includeBlank?: String,
-  label?: String,
-  multiple?: Boolean,
-  name?: String,
-  required?: Boolean,
-  value?: String,
+import type { InputCallback } from '../types'
+
+type SelectOption = {
+  value: string,
+  valueText: string,
+  disabled?: boolean,
+  selected?: boolean,
 }
 
-const optionsArray = ({ options = [] }: SelectProps) => {
+type SelectProps = {
+  aria?: object,
+  blankSelection?: string,
+  children?: React.Node,
+  className?: string,
+  dark?: boolean,
+  data?: object,
+  disabled?: boolean,
+  error?: string,
+  onChange: InputCallback<HTMLSelectElement>,
+  options: SelectOption[],
+  id?: string,
+  includeBlank?: string,
+  label?: string,
+  multiple?: boolean,
+  name?: string,
+  required?: boolean,
+  value?: string,
+}
+
+const optionsArray = (options: SelectOption[]) => {
   return options.map((optionObject, index) => {
     return (
       <option
@@ -49,31 +58,26 @@ const optionsArray = ({ options = [] }: SelectProps) => {
   })
 }
 
-const Select = (props: SelectProps) => {
-  const {
-    aria = {},
-    blankSelection,
-    children,
-    dark = false,
-    data = {},
-    disabled = false,
-    error,
-    label,
-    multiple = false,
-    name,
-    onChange = () => {},
-    options,
-    required = false,
-  } = props
-
+const Select = ({
+  aria = {},
+  blankSelection,
+  children,
+  dark = false,
+  data = {},
+  disabled = false,
+  error,
+  label,
+  multiple = false,
+  name,
+  onChange = () => {},
+  options = [],
+  required = false,
+}: SelectProps) => {
   const errorClass = error ? ' error' : ''
-  const css = buildCss({
-    'pb_select': true,
-    'dark': dark === true,
-  }) + errorClass
+  const css = buildCss({ 'pb_select': true, 'dark': dark === true }) + errorClass
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const optionsList = optionsArray({ options })
+  const optionsList = optionsArray(options)
 
   return (
     <div

--- a/app/pb_kits/playbook/pb_select/_select.jsx
+++ b/app/pb_kits/playbook/pb_select/_select.jsx
@@ -18,7 +18,7 @@ import type { InputCallback } from '../types'
 
 type SelectOption = {
   value: string,
-  valueText: string,
+  text: string,
   disabled?: boolean,
 }
 
@@ -48,7 +48,7 @@ const createOptions = (options: SelectOption[]) => options.map((option, index) =
       key={index}
       value={option.value}
   >
-    {option.valueText || option.value}
+    {option.text || option.value}
   </option>
 ))
 

--- a/app/pb_kits/playbook/pb_select/docs/_select_blank.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_blank.jsx
@@ -2,26 +2,20 @@ import React from 'react'
 import { Select } from '../../'
 
 const SelectBlank = () => {
+  const options = [
+    { value: 'USA' },
+    { value: 'Canada' },
+    { value: 'Brazil' },
+    { value: 'Philippines' },
+  ]
+
   return (
     <div>
       <Select
           blankSelection="Select One..."
           label="Where do you live"
           name="location"
-          options={[
-          {
-            value: 'USA',
-          },
-          {
-            value: 'Canada',
-          },
-          {
-            value: 'Brazil',
-          },
-          {
-            value: 'Philippines',
-          },
-        ]}
+          options={options}
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_select/docs/_select_dark.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_dark.jsx
@@ -5,15 +5,15 @@ const SelectDark = () => {
   const options = [
     {
       value: '1',
-      valueText: 'Burgers',
+      text: 'Burgers',
     },
     {
       value: '2',
-      valueText: 'Pizza',
+      text: 'Pizza',
     },
     {
       value: '3',
-      valueText: 'Tacos',
+      text: 'Tacos',
     },
   ]
 

--- a/app/pb_kits/playbook/pb_select/docs/_select_dark.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_dark.jsx
@@ -2,27 +2,29 @@ import React from 'react'
 import { Select } from '../../'
 
 const SelectDark = () => {
+  const options = [
+    {
+      value: '1',
+      valueText: 'Burgers',
+    },
+    {
+      value: '2',
+      valueText: 'Pizza',
+    },
+    {
+      value: '3',
+      valueText: 'Tacos',
+    },
+  ]
+
   return (
     <div>
       <Select
           dark
           label="Favorite Food"
           name="food"
-          options={[
-          {
-            value: '1',
-            valueText: 'Burgers',
-          },
-          {
-            value: '2',
-            selected: true,
-            valueText: 'Pizza',
-          },
-          {
-            value: '3',
-            valueText: 'Tacos',
-          },
-        ]}
+          options={options}
+          value="2"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_select/docs/_select_dark_error.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_dark_error.jsx
@@ -5,15 +5,15 @@ const SelectDarkError = () => {
   const options = [
     {
       value: '1',
-      valueText: 'Burgers',
+      text: 'Burgers',
     },
     {
       value: '2',
-      valueText: 'Pizza',
+      text: 'Pizza',
     },
     {
       value: '3',
-      valueText: 'Tacos',
+      text: 'Tacos',
     },
   ]
 

--- a/app/pb_kits/playbook/pb_select/docs/_select_dark_error.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_dark_error.jsx
@@ -2,6 +2,21 @@ import React from 'react'
 import { Body, Select } from '../..'
 
 const SelectDarkError = () => {
+  const options = [
+    {
+      value: '1',
+      valueText: 'Burgers',
+    },
+    {
+      value: '2',
+      valueText: 'Pizza',
+    },
+    {
+      value: '3',
+      valueText: 'Tacos',
+    },
+  ]
+
   return (
     <div>
       <Select
@@ -9,21 +24,8 @@ const SelectDarkError = () => {
           error="Please make a valid selection"
           label="Favorite Food"
           name="food"
-          options={[
-          {
-            value: '1',
-            valueText: 'Burgers',
-          },
-          {
-            value: '2',
-            selected: true,
-            valueText: 'Pizza',
-          },
-          {
-            value: '3',
-            valueText: 'Tacos',
-          },
-        ]}
+          options={options}
+          value="2"
       />
       <Body
           dark

--- a/app/pb_kits/playbook/pb_select/docs/_select_default.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_default.jsx
@@ -5,15 +5,15 @@ const SelectDefault = () => {
   const options = [
     {
       value: '1',
-      valueText: 'Burgers',
+      text: 'Burgers',
     },
     {
       value: '2',
-      valueText: 'Pizza',
+      text: 'Pizza',
     },
     {
       value: '3',
-      valueText: 'Tacos',
+      text: 'Tacos',
     },
   ]
 

--- a/app/pb_kits/playbook/pb_select/docs/_select_default.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_default.jsx
@@ -2,26 +2,27 @@ import React from 'react'
 import { Select } from '../../'
 
 const SelectDefault = () => {
+  const options = [
+    {
+      value: '1',
+      valueText: 'Burgers',
+    },
+    {
+      value: '2',
+      valueText: 'Pizza',
+    },
+    {
+      value: '3',
+      valueText: 'Tacos',
+    },
+  ]
+
   return (
     <div>
       <Select
           label="Favorite Food"
           name="food"
-          options={[
-          {
-            value: '1',
-            valueText: 'Burgers',
-          },
-          {
-            value: '2',
-            selected: true,
-            valueText: 'Pizza',
-          },
-          {
-            value: '3',
-            valueText: 'Tacos',
-          },
-        ]}
+          options={options}
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_select/docs/_select_disabled.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_disabled.jsx
@@ -2,26 +2,20 @@ import React from 'react'
 import { Select } from '../../'
 
 const SelectDisabled = () => {
+  const options = [
+    { value: 'Apple Pie' },
+    { value: 'Cookies' },
+    { value: 'Ice Cream' },
+    { value: 'Brownies' },
+  ]
+
   return (
     <div>
       <Select
           disabled
           label="Favorite Dessert"
           name="dessert"
-          options={[
-          {
-            value: 'Apple Pie',
-          },
-          {
-            value: 'Cookies',
-          },
-          {
-            value: 'Ice Cream',
-          },
-          {
-            value: 'Brownies',
-          },
-        ]}
+          options={options}
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_select/docs/_select_disabled_options.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_disabled_options.jsx
@@ -6,28 +6,28 @@ const SelectDisabledOptions = () => {
     {
       value: '1',
       disabled: true,
-      valueText: 'Espresso',
+      text: 'Espresso',
     },
     {
       value: '2',
-      valueText: 'Americano',
+      text: 'Americano',
     },
     {
       value: '3',
       disabled: true,
-      valueText: 'Cappuccino',
+      text: 'Cappuccino',
     },
     {
       value: '4',
-      valueText: 'Mocha',
+      text: 'Mocha',
     },
     {
       value: '5',
-      valueText: 'Flat White',
+      text: 'Flat White',
     },
     {
       value: '6',
-      valueText: 'Latte',
+      text: 'Latte',
     },
   ]
 

--- a/app/pb_kits/playbook/pb_select/docs/_select_disabled_options.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_disabled_options.jsx
@@ -2,40 +2,42 @@ import React from 'react'
 import { Select } from '../../'
 
 const SelectDisabledOptions = () => {
+  const options = [
+    {
+      value: '1',
+      disabled: true,
+      valueText: 'Espresso',
+    },
+    {
+      value: '2',
+      valueText: 'Americano',
+    },
+    {
+      value: '3',
+      disabled: true,
+      valueText: 'Cappuccino',
+    },
+    {
+      value: '4',
+      valueText: 'Mocha',
+    },
+    {
+      value: '5',
+      valueText: 'Flat White',
+    },
+    {
+      value: '6',
+      valueText: 'Latte',
+    },
+  ]
+
   return (
     <div>
       <Select
           label="Favorite Coffee"
           name="coffee"
-          options={[
-          {
-            value: '1',
-            disabled: true,
-            valueText: 'Espresso',
-          },
-          {
-            value: '2',
-            selected: true,
-            valueText: 'Americano',
-          },
-          {
-            value: '3',
-            disabled: true,
-            valueText: 'Cappuccino',
-          },
-          {
-            value: '4',
-            valueText: 'Mocha',
-          },
-          {
-            value: '5',
-            valueText: 'Flat White',
-          },
-          {
-            value: '6',
-            valueText: 'Latte',
-          },
-        ]}
+          options={options}
+          value="2"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
@@ -5,15 +5,15 @@ const SelectError = () => {
   const options = [
     {
       value: '1',
-      valueText: 'Burgers',
+      text: 'Burgers',
     },
     {
       value: '2',
-      valueText: 'Pizza',
+      text: 'Pizza',
     },
     {
       value: '3',
-      valueText: 'Tacos',
+      text: 'Tacos',
     },
   ]
 

--- a/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
@@ -2,27 +2,29 @@ import React from 'react'
 import { Body, Select } from '../..'
 
 const SelectError = () => {
+  const options = [
+    {
+      value: '1',
+      valueText: 'Burgers',
+    },
+    {
+      value: '2',
+      valueText: 'Pizza',
+    },
+    {
+      value: '3',
+      valueText: 'Tacos',
+    },
+  ]
+
   return (
     <div>
       <Select
           error="Please make a valid selection"
           label="Favorite Food"
           name="food"
-          options={[
-          {
-            value: '1',
-            valueText: 'Burgers',
-          },
-          {
-            value: '2',
-            selected: true,
-            valueText: 'Pizza',
-          },
-          {
-            value: '3',
-            valueText: 'Tacos',
-          },
-        ]}
+          options={options}
+          value="2"
       />
       <Body
           error="Please make a valid selection"

--- a/app/pb_kits/playbook/pb_select/docs/_select_required.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_required.jsx
@@ -2,23 +2,19 @@ import React from 'react'
 import { Select } from '../../'
 
 const SelectRequired = () => {
+  const options = [
+    { value: 'Left' },
+    { value: 'Right' },
+    { value: 'I go without laces' },
+  ]
+
   return (
     <div>
       <Select
           blankSelection="Select One..."
           label="Which shoe do you tie first?"
           name="shoe"
-          options={[
-          {
-            value: 'Left',
-          },
-          {
-            value: 'Right',
-          },
-          {
-            value: 'I go without laces',
-          },
-        ]}
+          options={options}
           required
       />
     </div>

--- a/app/pb_kits/playbook/pb_select/docs/_select_value_text_same.jsx
+++ b/app/pb_kits/playbook/pb_select/docs/_select_value_text_same.jsx
@@ -2,25 +2,19 @@ import React from 'react'
 import { Select } from '../../'
 
 const SelectValueTextSame = () => {
+  const options = [
+    { value: 'Football' },
+    { value: 'Baseball' },
+    { value: 'Basketball' },
+    { value: 'Hockey' },
+  ]
+
   return (
     <div>
       <Select
           label="Favorite Sport"
           name="sports"
-          options={[
-          {
-            value: 'Football',
-          },
-          {
-            value: 'Baseball',
-          },
-          {
-            value: 'Basketball',
-          },
-          {
-            value: 'Hockey',
-          },
-        ]}
+          options={options}
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_selectable_card/_selectable_card.jsx
+++ b/app/pb_kits/playbook/pb_selectable_card/_selectable_card.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import classnames from 'classnames'
 import { Icon } from '../'
 
-import { type InputCallback } from '../types'
+import type { InputCallback } from '../types'
 
 import {
   buildAriaProps,
@@ -26,7 +26,7 @@ type Props = {
   inputId?: String,
   multi?: Boolean,
   name?: String,
-  onChange: InputCallback,
+  onChange: InputCallback<HTMLInputElement>,
   text?: String,
   value?: String
 }

--- a/app/pb_kits/playbook/pb_textarea/_textarea.jsx
+++ b/app/pb_kits/playbook/pb_textarea/_textarea.jsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { Body, Caption } from '../'
-import { type InputCallback } from '../types.js'
+import type { InputCallback } from '../types.js'
 
 type TextareaProps = {
   className?: String,
@@ -19,7 +19,7 @@ type TextareaProps = {
   name?: String,
   rows?: Number,
   dark?: Boolean,
-  onChange?: InputCallback,
+  onChange?: InputCallback<HTMLTextAreaElement>,
 }
 
 const Textarea = ({

--- a/app/pb_kits/playbook/pb_toggle/_toggle.jsx
+++ b/app/pb_kits/playbook/pb_toggle/_toggle.jsx
@@ -17,9 +17,9 @@ type Props = {
   aria: object,
   checked: boolean,
   data: object,
-  onChange: InputCallback,
-  onCheck: InputCallback,
-  onUncheck: InputCallback,
+  onChange: InputCallback<HTMLInputElement>,
+  onCheck: InputCallback<HTMLInputElement>,
+  onUncheck: InputCallback<HTMLInputElement>,
   size: 'sm' | 'md',
 }
 

--- a/app/pb_kits/playbook/types.js
+++ b/app/pb_kits/playbook/types.js
@@ -1,4 +1,4 @@
 // @flow
 
 export type Callback<T, K> = T => K
-export type InputCallback = Callback<SyntheticEvent<>, void>
+export type InputCallback<T> = Callback<SyntheticEvent<T>, void>


### PR DESCRIPTION
#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/BOLT-71

Fixes the following warning:

<img width="731" alt="Screen Shot 2020-02-07 at 2 56 17 PM" src="https://user-images.githubusercontent.com/508128/74062211-86af1a80-49cc-11ea-8e97-67e4e217e377.png">

#### Breaking Changes

1. Renamed the option `valueText` attribute to `text` for a more concise API.
1. Removed the ability to directly mark an option as `selected` in favor of the `value` prop on the `select` element.

#### How to Ninja test this (screenshots are really helpful)

There seems to be only one usage of the `Select` kit in `nitro-web` in the installation crews profile page which will need to be updated to meet the new `Select` API and be regression tested.

#### Checklist:

- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
