### PR TITLE
Add Appointment to Hashtag kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add Appointment type to Hashtag kit ([#599](https://github.com/powerhome/nitro-web/pull/14015) @garettarrowood)
 
 ## [4.2.0] 2020-2-6
 

--- a/app/pb_kits/playbook/pb_hashtag/_hashtag.jsx
+++ b/app/pb_kits/playbook/pb_hashtag/_hashtag.jsx
@@ -13,13 +13,14 @@ type HashtagProps = {
   dark?: Boolean,
   id?: String,
   text?: String,
-  type: 'default' | 'home' | 'project',
+  type: 'default' | 'home' | 'project' | 'appointment',
   url?: String,
 }
 
 const typeMap = {
   'home': 'H#',
   'project': 'P#',
+  'appointment': 'A#',
   'default': '#',
 }
 

--- a/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_dark.html.erb
+++ b/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_dark.html.erb
@@ -6,4 +6,8 @@
 
 <br/><br/>
 
+<%= pb_rails("hashtag", props: {text: "345678", url: "https://google.com", type: "appointment", dark: true}) %>
+
+<br/><br/>
+
 <%= pb_rails("hashtag", props: {text: "123456", url: "https://google.com", type: "default", dark: true}) %>

--- a/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_dark.jsx
+++ b/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_dark.jsx
@@ -20,6 +20,13 @@ const HashtagDark = () => {
       <br />
       <Hashtag
           dark
+          text="456789"
+          type="appointment"
+          url="https://google.com"
+      />
+      <br />
+      <Hashtag
+          dark
           text="654321"
           type="default"
           url="https://google.com"

--- a/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_default.html.erb
+++ b/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_default.html.erb
@@ -6,4 +6,8 @@
 
 <br/><br/>
 
+<%= pb_rails("hashtag", props: {text: "345678", url: "https://google.com", type: "appointment"}) %>
+
+<br/><br/>
+
 <%= pb_rails("hashtag", props: {text: "123456", url: "https://google.com", type: "default"}) %>

--- a/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_default.jsx
+++ b/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_default.jsx
@@ -17,6 +17,12 @@ const HashtagDefault = () => {
       />
       <br />
       <Hashtag
+          text="456789"
+          type="appointment"
+          url="https://google.com"
+      />
+      <br />
+      <Hashtag
           text="654321"
           type="default"
           url="https://google.com"

--- a/app/pb_kits/playbook/pb_hashtag/hashtag.rb
+++ b/app/pb_kits/playbook/pb_hashtag/hashtag.rb
@@ -10,7 +10,7 @@ module Playbook
       prop :text
       prop :dark, type: Playbook::Props::Boolean, default: false
       prop :type, type: Playbook::Props::Enum,
-                  values: %w[default project home],
+                  values: %w[default project home appointment],
                   default: "default"
       prop :url
 
@@ -33,6 +33,8 @@ module Playbook
           "H#"
         elsif type === "project"
           "P#"
+        elsif type === "appointment"
+          "A#"
         else
           "#"
         end

--- a/spec/pb_kits/playbook/kits/hashtag_spec.rb
+++ b/spec/pb_kits/playbook/kits/hashtag_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Playbook::PbHashtag::Hashtag do
   it { is_expected.to define_boolean_prop(:dark).with_default(false) }
   it { is_expected.to define_enum_prop(:type)
                       .with_default("default")
-                      .with_values("default", "project", "home") }
+                      .with_values("default", "project", "home", "appointment") }
   it { is_expected.to define_prop(:url) }
 
   describe "#classname" do


### PR DESCRIPTION
#### Runway Ticket URL

No ticket URL. This PR has been opened to follow up on SpotNitro additions during Create. Our team was informed to use the Appointment hashtag for viewing Estimate Appointments in SpotNitro. Unfortunately, we could only get the hashtag to appear as `#A123456` instead of `A#123456`.

With this addition, we can align SpotNitro's representation of an  Estimate Appointment with that of a Home.

As it looks like now.

<img width="447" alt="Screen Shot 2020-02-09 at 1 38 21 PM" src="https://user-images.githubusercontent.com/12770108/74107834-027ea380-4b42-11ea-88c7-2208836d9f91.png">


#### Breaking Changes

There are no breaking changes in this PR.

#### How to Ninja test this (screenshots are really helpful)

<img width="566" alt="Screen Shot 2020-02-09 at 1 53 49 PM" src="https://user-images.githubusercontent.com/12770108/74108018-a61c8380-4b43-11ea-89b7-ca0f32f3bdeb.png">

<img width="487" alt="Screen Shot 2020-02-09 at 1 53 54 PM" src="https://user-images.githubusercontent.com/12770108/74108019-a87edd80-4b43-11ea-9f0c-4f7fbc1beedf.png">

#### Checklist:

- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
