### PR TITLE
Ignore timezone on date stacked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed timezone issue on DateStacked ([#592][] @gmfvpereira)
 
 ## [4.2.0] 2020-2-6
 

--- a/app/pb_kits/playbook/pb_date_stacked/_date_stacked.jsx
+++ b/app/pb_kits/playbook/pb_date_stacked/_date_stacked.jsx
@@ -2,8 +2,8 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import moment from 'moment'
 
-import DateTime from '../pb_kit/dateTime.js'
 import { buildCss } from '../utilities/props'
 import { Caption, Title } from '../'
 
@@ -36,20 +36,20 @@ const DateStacked = ({
     'reverse': reverse,
   }))
 
-  const currentYear = new Date().getFullYear().toString()
-  const dateTimestamp = new DateTime({ value: date })
-  const inputYear = dateTimestamp.toYear().toString()
+  const currentYear = moment().year()
+  const dateObject = moment(date)
+  const inputYear = dateObject.format('Y')
 
   return (
     <div className={classes}>
       <div className="pb_date_stacked_day_month">
         <Caption
-            text={dateTimestamp.toMonth().toUpperCase()}
+            text={dateObject.format('MMM').toUpperCase()}
         />
         <Title
             dark={dark}
             size={sizes[size]}
-            text={dateTimestamp.toDay()}
+            text={dateObject.format('D')}
         />
       </div>
       <If condition={currentYear != inputYear}>

--- a/app/pb_kits/playbook/pb_date_stacked/_date_stacked.jsx
+++ b/app/pb_kits/playbook/pb_date_stacked/_date_stacked.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import classnames from 'classnames'
-import moment from 'moment'
+import DateTime from '../pb_kit/dateTime.js'
 
 import { buildCss } from '../utilities/props'
 import { Caption, Title } from '../'
@@ -36,20 +36,20 @@ const DateStacked = ({
     'reverse': reverse,
   }))
 
-  const currentYear = moment().year()
-  const dateObject = moment(date)
-  const inputYear = dateObject.format('Y')
+  const currentYear = new Date().getFullYear().toString()
+  const dateTimestamp = new DateTime({ value: date })
+  const inputYear = dateTimestamp.toYear().toString()
 
   return (
     <div className={classes}>
       <div className="pb_date_stacked_day_month">
         <Caption
-            text={dateObject.format('MMM').toUpperCase()}
+            text={dateTimestamp.toMonth().toUpperCase()}
         />
         <Title
             dark={dark}
             size={sizes[size]}
-            text={dateObject.format('D')}
+            text={dateTimestamp.toDay()}
         />
       </div>
       <If condition={currentYear != inputYear}>

--- a/app/pb_kits/playbook/pb_date_stacked/docs/_date_stacked_not_current_year.jsx
+++ b/app/pb_kits/playbook/pb_date_stacked/docs/_date_stacked_not_current_year.jsx
@@ -13,7 +13,7 @@ const DateStackedNotCurrentYear = () => {
       <br />
 
       <DateStacked
-          date={new Date('20 Mar 2018')}
+          date="2018-03-20"
           size="md"
       />
 

--- a/app/pb_kits/playbook/pb_kit/dateTime.js
+++ b/app/pb_kits/playbook/pb_kit/dateTime.js
@@ -11,12 +11,12 @@ type DateTimeType = {
 }
 
 export default class DateTime {
-  constructor({ value, zone = 'America/New_York' }: DateTimeType) {
+  constructor({ value, zone = null }: DateTimeType) {
     this.value = this.convertToTimestampZone(value, zone)
   }
 
   convertToTimestampZone(value, zone) {
-    return moment(value).tz(zone)
+    return zone ? moment(value).tz(zone) : moment(value)
   }
 
   convertToTimezone() {


### PR DESCRIPTION
#### Runway Ticket URL
Without these changes a usage like this
```
      <DateStacked
          date="2018-03-20"
          size="md"
      />
```
would create different results depending on the timezone, it could say that the date is "March 19th, 2018", for instance. 

Since this is a Date only kit my assumption is that timezones are not desired.

<img width="484" alt="Screen Shot 2020-02-13 at 2 42 08 PM" src="https://user-images.githubusercontent.com/386460/74462514-1d695480-4e6f-11ea-902b-d6d83fa03c2b.png">


#### Breaking Changes

This should not break anything. This kit still accepts `new Date` or formatted date strings like `"2020-08-30"` as a valid date.

#### How to Ninja test this (screenshots are really helpful)
The `/compliance` page in Nitro uses this Kit, so we can verify that it's still working as expected:
- If the date is in the same year as the current year, it should only show day and month
- If the date is NOT in the same year as the current year, it should show the year as well.

#### Checklist:

- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
