### PR TITLE
Remove flex kit doc highlighting for other kits

### DIFF
--- a/app/pb_kits/playbook/packs/site_styles/docs/_flex_examples.scss
+++ b/app/pb_kits/playbook/packs/site_styles/docs/_flex_examples.scss
@@ -1,4 +1,12 @@
+.pb--kit-show.flex-kit {
   [class^=pb_flex_kit] { background: #F3F7FB; }
-  .flex-item,
-  [class^=pb_flex_item_kit] { background: #E4E8F0; min-width: 30px; min-height: 30px; color: #242B42; }
-  .tall {min-height: 200px;}
+
+  .flex-item, [class^=pb_flex_item_kit] {
+    background: #E4E8F0;
+    min-width: 30px;
+    min-height: 30px;
+    color: #242B42;
+  }
+
+  .tall { min-height: 200px; }
+}

--- a/app/views/playbook/pages/kit_show.html.slim
+++ b/app/views/playbook/pages/kit_show.html.slim
@@ -1,4 +1,4 @@
-.pb--kit-show
+div class="pb--kit-show #{@kit}-kit"
   = pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1 })
 
   .pb--kit-type-nav


### PR DESCRIPTION

<img width="791" alt="Screen Shot 2020-02-13 at 10 37 56 AM" src="https://user-images.githubusercontent.com/2293844/74456808-fe59cb00-4e4c-11ea-8a05-7501e2bcc4f9.png">


Removes the gray backgrounds for other kits using `flex` / `flex/flex-item` kit. 

#### Runway Ticket URL

N/A

#### Breaking Changes

None

#### How to Ninja test this (screenshots are really helpful)

N/A

