### PR TITLE
Add a context option for the typeahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Date range stacked Kit [#559](https://github.com/powerhome/playbook/pull/559)
 
+### Changed
+- Adds ability to give context to the Typeahead kit ([#621](https://github.com/powerhome/playbook/pull/621) @terryfinn @web-kat)
+
+
 ## [4.3.0] 2020-2-14
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library identifier: 'ci-kubed@v3.0.0', retriever: modernSCM([
+library identifier: 'ci-kubed@v3.1.0', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'git@github.com:powerhome/ci-kubed.git',
   credentialsId: 'powerci-github-ssh-key'

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_context.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_context.html.erb
@@ -1,0 +1,51 @@
+<%= pb_rails("select", props: {
+  label: "Colors",
+  name: "foo",
+  data: { context_select: true },
+  options: [
+    { value: "red", value_text: "Red" },
+    { value: "orange", value_text: "Orange" },
+    { value: "yellow", value_text: "Yellow" },
+    { value: "green", value_text: "Green" },
+    { value: "blue", value_text: "Blue" },
+    { value: "purple", value_text: "Purple" },
+  ]
+  }) %>
+<%= pb_rails("typeahead", props: { label: "Crayola Crayons", name: :foo, data: { typeahead_example2: true, search_context_value_selector: "[data-context-select] select" } }) %>
+
+<br><br><br>
+
+
+<%= javascript_tag defer: "defer" do %>
+  document.addEventListener("pb-typeahead-kit-search", function(event) {
+    if (!event.target.dataset.typeaheadExample2) return;
+
+    const fuzzyMatch = function(string, term) {
+      const ratio = 0.5;
+      string = string.toLowerCase();
+      const compare = term.toLowerCase();
+      let matches = 0;
+
+      if (string.indexOf(compare) > -1) return true;
+
+      for (let index = 0; index < compare.length; index++) {
+        if (string.indexOf(compare[index]) > -1) {
+          matches += 1
+        } else {
+          matches -=1;
+        }
+      }
+
+      return (matches / string.length >= ratio || term == "")
+    };
+
+    const colors = { red: ["Red", "Scarlet", "Chestnut", "Mahogany"],
+                     orange: ["Orange", "Apricot", "Peach", "Melon", "Burnt Sienna", "Macaroni and Cheese"],
+                     yellow: ["Yellow", "Gold", "Goldenrod", "Canary", "Laser Lemon"],
+                     green: ["Green", "Olive Green", "Granny Smith Apple", "Spring Green", "Sea Green"],
+                     blue: ["Blue", "Cerulean", "Bluetiful", "Sky Blue", "Cadet Blue", "Cornflower"],
+                     purple: ["Violet", "Indigo", "Wisteria", "Purple Mountain Majesty", "Lavender"] };
+
+    event.detail.setResults(colors[event.detail.searchingContext].filter((color) => fuzzyMatch(color, event.detail.searchingFor)).map((color) => document.createTextNode(color)));
+  })
+<% end %>

--- a/app/pb_kits/playbook/pb_typeahead/docs/example.yml
+++ b/app/pb_kits/playbook/pb_typeahead/docs/example.yml
@@ -1,3 +1,4 @@
 examples:
   rails:
   - typeahead_default: Default
+  - typeahead_with_context: With Context


### PR DESCRIPTION
Allow the typeahead to use a context to make searches distinct when
using the same typeahead to provide results with different
conditions.

The typeahead has a cache, but that might not be the best name for
it. This structure was primarily added to provide coordination for
asynchronous searches. We can get the benefits of a cache,
and always provide the user with fresh results. We change the search
to always show the cached values when results are present but also
always issuing a event to get new results.

#### Runway Ticket URL
[BOP-357](https://nitro.powerhrg.com/runway/backlog_items/BOP-357)

#### How to Ninja test this (screenshots are really helpful)


#### Checklist:

- [x] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
