### PR TITLE
Upgrade ci-kubed for bugfixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library identifier: 'ci-kubed@v3.0.0', retriever: modernSCM([
+library identifier: 'ci-kubed@v3.1.0', retriever: modernSCM([
   $class: 'GitSCMSource',
   remote: 'git@github.com:powerhome/ci-kubed.git',
   credentialsId: 'powerci-github-ssh-key'


### PR DESCRIPTION
See https://github.com/powerhome/ci-kubed/pull/29

This played out on https://github.com/powerhome/playbook/pull/621 where the merge commit f2b0c81 had its image build reported against the previous commit 092039f in the CI job at https://ci.powerhrg.com/blue/organizations/jenkins/powerhome%2Fplaybook/detail/PR-621/6/pipeline/15