### PR TITLE
[BOP-368] Typeahead/add loading indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Added loading indicator to Typeahead kit ([#635](https://github.com/powerhome/playbook/pull/635) @web-kat)
 
 ## [4.4.0] 2020-2-20
 

--- a/app/pb_kits/playbook/pb_typeahead/_typeahead.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/_typeahead.html.erb
@@ -3,6 +3,9 @@
                 data: object.data,
                 class: object.classname) do %>
   <div class="pb_typeahead_wrapper">
+    <div class="pb_typeahead_loading_indicator" data-pb-typeahead-kit-loading-indicator>
+      <i class="far fa-spinner fa-spin"></i>
+    </div>
     <%= pb_rails("text_input", props: {
       type: "search",
       label: object.label,

--- a/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
+++ b/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
@@ -1,6 +1,20 @@
 [class^=pb_typeahead_kit] {
   .pb_typeahead_wrapper {
     position: relative;
+
+    .pb_typeahead_loading_indicator {
+      position: relative;
+      width: min-content;
+      top: 3.8em;
+      left: 1em;
+      visibility: hidden;
+    }
+  }
+
+  [class^=pb_text_input_kit] {
+    input {
+      padding-left: $space_xl !important;
+    }
   }
 
   .pb_item_kit {

--- a/app/pb_kits/playbook/pb_typeahead/index.js
+++ b/app/pb_kits/playbook/pb_typeahead/index.js
@@ -26,6 +26,7 @@ export default class PbTypeahead extends PbEnhancedElement {
   search() {
     if (this.searchTerm.length < this.searchTermMinimumLength) return this.clearResults()
 
+    this.toggleResultsLoadingIndicator('visible')
     this.showResults()
 
     const searchTerm = this.searchTerm
@@ -63,6 +64,7 @@ export default class PbTypeahead extends PbEnhancedElement {
   showResults() {
     if (!this.resultsOptionCache.has(this.searchTermAndContext)) return
 
+    this.toggleResultsLoadingIndicator('hidden')
     this.clearResults()
     for (const result of this.resultsOptionCache.get(this.searchTermAndContext)) {
       this.resultsElement.appendChild(this.newResultOption(result.cloneNode(true)))
@@ -181,5 +183,16 @@ export default class PbTypeahead extends PbEnhancedElement {
       this._resultsOptionCache ||
       new Map
     )
+  }
+
+  get resultsLoadingIndicator() {
+    return this._resultsLoadingIndicator = (
+      this._resultsLoadingIndicator ||
+      this.element.querySelector('[data-pb-typeahead-kit-loading-indicator]')
+    )
+  }
+
+  toggleResultsLoadingIndicator(visibilityProperty) {
+    this.resultsLoadingIndicator.style.visibility = visibilityProperty
   }
 }


### PR DESCRIPTION
#### Runway Ticket URL
[BOP-368]

![results-loading-indicator](https://user-images.githubusercontent.com/38359249/75184994-52996080-5713-11ea-853b-29e15eb752f4.gif)


#### Breaking Changes

_Please reflect if your changes may break in some way (changes like removing/renaming props are examples of breaking changes)_

#### How to Ninja test this (screenshots are really helpful)


#### Checklist:

- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
