### PR TITLE
Move popover and typeahead initialize to vendor.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Move popover and typeahead initialize to vendor.js ([#651](https://github.com/powerhome/playbook/pull/651) @thestephenmarshall)
+
 ## [4.5.2] 2020-3-03
 
 ### Changed

--- a/app/pb_kits/playbook/packs/examples.js
+++ b/app/pb_kits/playbook/packs/examples.js
@@ -78,12 +78,6 @@ import * as Toggle from 'pb_toggle/docs'
 import * as User from 'pb_user/docs'
 import * as UserBadge from 'pb_user_badge/docs'
 
-import PbTypeahead from 'pb_typeahead'
-PbTypeahead.start()
-
-import PbPopover from 'pb_popover'
-PbPopover.start()
-
 WebpackerReact.setup({
   ...Avatar,
   ...Badge,

--- a/app/pb_kits/playbook/vendor.js
+++ b/app/pb_kits/playbook/vendor.js
@@ -10,3 +10,6 @@ import 'lazysizes'
 
 import PbPopover from './pb_popover'
 PbPopover.start()
+
+import PbTypeahead from './pb_typeahead'
+PbTypeahead.start()


### PR DESCRIPTION
#### Runway Ticket URL

Move popover and typeahead initialize to vendor.js. This was in the wrong area for Nitro and should not exist in examples.js since application.js imports vendor.js. This may have prevented popover from working in Playbook and Typeahead from working in Nitro. 

#### Breaking Changes

N/A

#### How to Ninja test this (screenshots are really helpful)

1. Ensure both Popover and Typeahead kits work on dev docs page
2. Ensure typeahead works on Corp Directory
3. Ensure popover works on Corp Directory

#### Checklist:

- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
