### PR TITLE
Update kit generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Move popover and typeahead initialize to vendor.js ([#651](https://github.com/powerhome/playbook/pull/651) @thestephenmarshall)
+
 ## [4.5.2] 2020-3-03
 
 ### Changed

--- a/app/pb_kits/playbook/kits/pb_flex.js
+++ b/app/pb_kits/playbook/kits/pb_flex.js
@@ -1,4 +1,0 @@
-import Flex from '../pb_flex/_flex.jsx'
-
-import WebpackerReact from 'webpacker-react'
-WebpackerReact.setup({ Flex })

--- a/app/pb_kits/playbook/kits/pb_highlight.js
+++ b/app/pb_kits/playbook/kits/pb_highlight.js
@@ -1,4 +1,0 @@
-import Highlight from '../pb_highlight/_highlight.jsx'
-
-import WebpackerReact from 'webpacker-react'
-WebpackerReact.setup({ Highlight })

--- a/app/pb_kits/playbook/packs/examples.js
+++ b/app/pb_kits/playbook/packs/examples.js
@@ -78,12 +78,6 @@ import * as Toggle from 'pb_toggle/docs'
 import * as User from 'pb_user/docs'
 import * as UserBadge from 'pb_user_badge/docs'
 
-import PbTypeahead from 'pb_typeahead'
-PbTypeahead.start()
-
-import PbPopover from 'pb_popover'
-PbPopover.start()
-
 WebpackerReact.setup({
   ...Avatar,
   ...Badge,

--- a/app/pb_kits/playbook/vendor.js
+++ b/app/pb_kits/playbook/vendor.js
@@ -10,3 +10,6 @@ import 'lazysizes'
 
 import PbPopover from './pb_popover'
 PbPopover.start()
+
+import PbTypeahead from './pb_typeahead'
+PbTypeahead.start()

--- a/lib/generators/kit/kit_generator.rb
+++ b/lib/generators/kit/kit_generator.rb
@@ -72,12 +72,6 @@ class KitGenerator < Rails::Generators::NamedBase
         template "kit_jsx.erb", "#{full_kit_directory}/_#{@kit_name_underscore}.jsx"
         template "kit_example_react.erb", "#{full_kit_directory}/docs/_#{@kit_name_underscore}_default.jsx"
         template "kit_js.erb", "#{full_kit_directory}/docs/index.js"
-        template "kit_pack.erb", "app/pb_kits/playbook/kits/pb_#{@kit_name_underscore}.js"
-
-        # Import in all kits.js  =========================
-        append_to_file("app/pb_kits/playbook/packs/kits.js") do
-          "import '../kits/pb_#{@kit_name_underscore}.js'\n"
-        end
 
         # Import kit examples  ===========================
         append_to_file("app/pb_kits/playbook/packs/examples.js") do

--- a/lib/generators/kit/templates/kit_pack.erb.tt
+++ b/lib/generators/kit/templates/kit_pack.erb.tt
@@ -1,4 +1,0 @@
-import <%= @kit_name_pascal %> from '../pb_<%= @kit_name_underscore %>/_<%= @kit_name_underscore %>.jsx'
-
-import WebpackerReact from 'webpacker-react'
-WebpackerReact.setup({ <%= @kit_name_pascal %> })


### PR DESCRIPTION
Based on https://github.com/powerhome/playbook/pull/651

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUX-680

Removes invalid kits folder and updates the generator 

#### Breaking Changes

None

#### How to Ninja test this (screenshots are really helpful)

N/A

#### Checklist:

- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
