### PR TITLE
Emphasis Prop Added

### DIFF
--- a/app/pb_kits/playbook/pb_home_address_street/_city_emphasis.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_city_emphasis.html.erb
@@ -1,0 +1,38 @@
+<%= pb_rails "body", props: {
+  classname: "pb_home_address_street_address",
+  color: "light",
+  text: object.address_house_style,
+  dark: object.dark
+} %>
+<%= pb_rails "body", props: {
+  classname: "pb_home_address_street_address",
+  color: "light",
+  text: object.address_house_style2,
+  dark: object.dark
+} %>
+<span>
+  <%= pb_rails "title", props: {
+    size: 4,
+    text: object.city_state,
+    dark: object.dark
+  } %>
+  <%= pb_rails "body", props: {
+    classname: "pb_home_zip",
+    color: "light",
+    text: object.zip,
+    dark: object.dark
+  } %>
+</span>
+
+<% if object.home_id %>
+  <%= pb_rails("hashtag", props: {
+    text: "#{object.home_id}",
+    url: object.home_url || "#",
+    type: "home",
+    dark: object.dark,
+    classname: "home-hashtag"}) %>
+<% end %>
+
+<%= pb_rails "body", props: { color: "light", tag: "span", dark: object.dark } do %>
+  <small><%= object.territory %></small>
+<% end %>

--- a/app/pb_kits/playbook/pb_home_address_street/_city_emphasis.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_city_emphasis.html.erb
@@ -10,13 +10,15 @@
   text: object.address_house_style2,
   dark: object.dark
 } %>
-<div class="pb_city_street_zip_container">
+<div>
   <%= pb_rails "title", props: {
+    tag: "span",
     size: 4,
     text: object.city_state,
     dark: object.dark
   } %>
   <%= pb_rails "body", props: {
+    tag: "span",
     classname: "pb_home_zip",
     color: "light",
     text: object.zip,

--- a/app/pb_kits/playbook/pb_home_address_street/_city_emphasis.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_city_emphasis.html.erb
@@ -10,7 +10,7 @@
   text: object.address_house_style2,
   dark: object.dark
 } %>
-<span>
+<div class="pb_city_street_zip_container">
   <%= pb_rails "title", props: {
     size: 4,
     text: object.city_state,
@@ -22,7 +22,7 @@
     text: object.zip,
     dark: object.dark
   } %>
-</span>
+</div>
 
 <% if object.home_id %>
   <%= pb_rails("hashtag", props: {

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -5,7 +5,7 @@
     
 	<% if object.emphasis == "city" %>
 		<%= render partial:"pb_home_address_street/city_emphasis.html.erb", locals: {object: object}%>
-	<% else %>
+	<% elsif object.emphasis == "street" %>
 		<%= render partial:"pb_home_address_street/street_emphasis.html.erb", locals: {object: object} %>
 	<% end %>
 

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -2,60 +2,11 @@
     id: object.id,
     data: object.data,
     class: object.classname) do %>
-
-  <% if object.emphasis == "2" %>
-    <%= pb_rails "body", props: {
-      classname: "pb_home_address_street_address",
-      color: "light",
-      text: object.address_house_style,
-      dark: object.dark
-    } %>
-
-    <%= pb_rails "body", props: {
-      classname: "pb_home_address_street_address",
-      color: "light",
-      text: object.address_house_style2,
-      dark: object.dark
-    } %>
-
-    <%= pb_rails "title", props: {
-      size: 4,
-      text: object.city_state_zip,
-      dark: object.dark
-    } %>
-  <% else %>
-    <%= pb_rails "title", props: {
-      classname: "pb_home_address_street_address",
-      size: 4,
-      text: object.address_house_style,
-      dark: object.dark
-    } %>
-
-    <%= pb_rails "title", props: {
-      classname: "pb_home_address_street_address",
-      size: 4,
-      text: object.address_house_style2,
-      dark: object.dark
-    } %>
-
-    <%= pb_rails "body", props: {
-      color: "light",
-      text: object.city_state_zip,
-      dark: object.dark
-    } %>
-  <% end %>
-
-  <% if object.home_id %>
-    <%= pb_rails("hashtag", props: {
-      text: "#{object.home_id}",
-      url: object.home_url || "#",
-      type: "home",
-      dark: object.dark,
-      classname: "home-hashtag"}) %>
-  <% end %>
-
-  <%= pb_rails "body", props: { color: "light", tag: "span", dark: object.dark } do %>
-    <small><%= object.territory %></small>
-  <% end %>
+    
+	<% if object.emphasis == "city" %>
+		<%= render partial:"pb_home_address_street/city_emphasis.html.erb", locals: {object: object}%>
+	<% else %>
+		<%= render partial:"pb_home_address_street/street_emphasis.html.erb", locals: {object: object} %>
+	<% end %>
 
 <% end %>

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -3,25 +3,47 @@
     data: object.data,
     class: object.classname) do %>
 
-  <%= pb_rails "title", props: {
-    classname: "pb_home_address_street_address",
-    size: 4,
-    text: object.address_house_style,
-    dark: object.dark
-  } %>
+  <% if object.emphasis == "2" %>
+    <%= pb_rails "body", props: {
+      classname: "pb_home_address_street_address",
+      color: "light",
+      text: object.address_house_style,
+      dark: object.dark
+    } %>
 
-  <%= pb_rails "title", props: {
-    classname: "pb_home_address_street_address",
-    size: 4,
-    text: object.address_house_style2,
-    dark: object.dark
-  } %>
+    <%= pb_rails "body", props: {
+      classname: "pb_home_address_street_address",
+      color: "light",
+      text: object.address_house_style2,
+      dark: object.dark
+    } %>
 
-  <%= pb_rails "body", props: {
-    color: "light",
-    text: object.city_state_zip,
-    dark: object.dark
-  } %>
+    <%= pb_rails "title", props: {
+      size: 4,
+      text: object.city_state_zip,
+      dark: object.dark
+    } %>
+  <% elsif %>
+    <%= pb_rails "title", props: {
+      classname: "pb_home_address_street_address",
+      size: 4,
+      text: object.address_house_style,
+      dark: object.dark
+    } %>
+
+    <%= pb_rails "title", props: {
+      classname: "pb_home_address_street_address",
+      size: 4,
+      text: object.address_house_style2,
+      dark: object.dark
+    } %>
+
+    <%= pb_rails "body", props: {
+      color: "light",
+      text: object.city_state_zip,
+      dark: object.dark
+    } %>
+  <% end %>
 
   <% if object.home_id %>
     <%= pb_rails("hashtag", props: {

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -23,7 +23,7 @@
       text: object.city_state_zip,
       dark: object.dark
     } %>
-  <% elsif %>
+  <% else %>
     <%= pb_rails "title", props: {
       classname: "pb_home_address_street_address",
       size: 4,

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.html.erb
@@ -2,11 +2,9 @@
     id: object.id,
     data: object.data,
     class: object.classname) do %>
-    
-	<% if object.emphasis == "city" %>
+  <% if object.emphasis == "city" %>
 		<%= render partial:"pb_home_address_street/city_emphasis.html.erb", locals: {object: object}%>
 	<% elsif object.emphasis == "street" %>
 		<%= render partial:"pb_home_address_street/street_emphasis.html.erb", locals: {object: object} %>
 	<% end %>
-
 <% end %>

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.jsx
@@ -12,6 +12,7 @@ type HomeAddressStreetProps = {
   city: String,
   className?: String,
   dark?: Boolean,
+  emphasis: 'street' | 'city',
   homeId: Number,
   houseStyle: String,
   homeUrl: String,
@@ -33,6 +34,7 @@ const HomeAddressStreet = ({
   city,
   className,
   dark = false,
+  emphasis = 'street',
   homeId,
   homeUrl,
   houseStyle,
@@ -41,24 +43,58 @@ const HomeAddressStreet = ({
   territory,
 }: HomeAddressStreetProps) => (
   <div className={classes(className, dark)}>
-    <Title
-        className="pb_home_address_street_address"
-        dark={dark}
-        size={4}
-    >
-      {joinPresent([titleize(address), houseStyle], ' · ')}
-    </Title>
+    {
+      <Choose>
+        <When condition={emphasis == 'street'}>
+          <div>
+            <Title
+                className="pb_home_address_street_address"
+                dark={dark}
+                size={4}
+            >
+              {joinPresent([titleize(address), houseStyle], ' · ')}
+            </Title>
+            <Title
+                className="pb_home_address_street_address"
+                dark={dark}
+                size={4}
+            >
+              {titleize(addressCont)}
+            </Title>
+            <Body color="light">
+              {`${titleize(city)}, ${state} ${zipcode}`}
+            </Body>
+          </div>
+        </When>
+        <When condition={emphasis == 'city'}>
+          <div>
+            <Body color="light">
+              {joinPresent([titleize(address), houseStyle], ' · ')}
+            </Body>
+            <Body color="light">
+              {titleize(addressCont)}
+            </Body>
+            <div>
+              <Title
+                  className="pb_home_address_street_address"
+                  dark={dark}
+                  size={4}
+                  tag="span"
+              >
+                {`${titleize(city)}, ${state}`}
+              </Title>
+              <Body
+                  color="light"
+                  tag="span"
+              >
+                {` ${zipcode}`}
+              </Body>
+            </div>
+          </div>
+        </When>
+      </Choose>
+    }
 
-    <Title
-        className="pb_home_address_street_address"
-        dark={dark}
-        size={4}
-    >
-      {titleize(addressCont)}
-    </Title>
-    <Body color="light">
-      {`${titleize(city)}, ${state} ${zipcode}`}
-    </Body>
     <If condition={homeId}>
       <Hashtag
           classname="home-hashtag"

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.scss
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.scss
@@ -1,0 +1,3 @@
+.pb_city_street_zip_container > * {
+  display: inline;
+}

--- a/app/pb_kits/playbook/pb_home_address_street/_home_address_street.scss
+++ b/app/pb_kits/playbook/pb_home_address_street/_home_address_street.scss
@@ -1,3 +1,0 @@
-.pb_city_street_zip_container > * {
-  display: inline;
-}

--- a/app/pb_kits/playbook/pb_home_address_street/_street_emphasis.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/_street_emphasis.html.erb
@@ -1,0 +1,31 @@
+<%= pb_rails "title", props: {
+  classname: "pb_home_address_street_address",
+  size: 4,
+  text: object.address_house_style,
+  dark: object.dark
+} %>
+<%= pb_rails "title", props: {
+  classname: "pb_home_address_street_address",
+  size: 4,
+  text: object.address_house_style2,
+  dark: object.dark
+} %>
+<%= pb_rails "body", props: {
+  color: "light",
+  text: object.city_state_zip,
+  dark: object.dark
+} %>
+
+<% if object.home_id %>
+  <%= pb_rails("hashtag", props: {
+    text: "#{object.home_id}",
+    url: object.home_url || "#",
+    type: "home",
+    dark: object.dark,
+    classname: "home-hashtag"}) %>
+<% end %>
+
+<%= pb_rails "body", props: { color: "light", tag: "span", dark: object.dark } do %>
+  <small><%= object.territory %></small>
+<% end %>
+

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
@@ -2,7 +2,6 @@
   address: "70 Prospect Ave",
   address_cont: "Apt M18",
   city: "West Chester",
-  emphasis: "street",
   home_id: 8250263,
   home_url: "https://powerhrg.com/",
   house_style: "Colonial",

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
@@ -1,0 +1,12 @@
+<%= pb_rails("home_address_street", props: {
+  address: "70 Prospect Ave",
+  address_cont: "Apt M18",
+  city: "West Chester",
+  emphasis: "2",
+  home_id: 8250263,
+  home_url: "https://powerhrg.com/",
+  house_style: "Colonial",
+  state: "PA",
+  zipcode: "19382",
+  territory: "PHL",
+}) %>

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
@@ -2,7 +2,23 @@
   address: "70 Prospect Ave",
   address_cont: "Apt M18",
   city: "West Chester",
-  emphasis: "2",
+  emphasis: "street",
+  home_id: 8250263,
+  home_url: "https://powerhrg.com/",
+  house_style: "Colonial",
+  state: "PA",
+  zipcode: "19382",
+  territory: "PHL",
+}) %>
+
+<br>
+<br>
+
+<%= pb_rails("home_address_street", props: {
+  address: "70 Prospect Ave",
+  address_cont: "Apt M18",
+  city: "West Chester",
+  emphasis: "city",
   home_id: 8250263,
   home_url: "https://powerhrg.com/",
   house_style: "Colonial",

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.jsx
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { HomeAddressStreet } from '../../'
+
+const HomeAddressStreetEmphasis = () => {
+  return (
+    <div>
+      <HomeAddressStreet
+          address="70 Prospect Ave"
+          addressCont="Apt M18"
+          city="West Chester"
+          homeId={8250263}
+          homeUrl="https://powerhrg.com/"
+          houseStyle="Colonial"
+          state="PA"
+          territory="PHL"
+          zipcode="19382"
+      />
+      <br />
+      <br />
+      <HomeAddressStreet
+          address="70 Prospect Ave"
+          addressCont="Apt M18"
+          city="West Chester"
+          emphasis="city"
+          homeId={8250263}
+          homeUrl="https://powerhrg.com/"
+          houseStyle="Colonial"
+          state="PA"
+          territory="PHL"
+          zipcode="19382"
+      />
+    </div>
+  )
+}
+
+export default HomeAddressStreetEmphasis

--- a/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.md
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.md
@@ -1,0 +1,2 @@
+Emphasis on street happens by default. (no prop needed)
+Emphasis on "city" makes the city emphasized, rather than the street.

--- a/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
@@ -2,6 +2,7 @@ examples:
 
   rails:
   - home_address_street_default: Default
+  - home_address_street_emphasis: Emphasis
   - home_address_street_modified: Modified
   - home_address_street_dark: Dark
 

--- a/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
@@ -9,6 +9,7 @@ examples:
 
   react:
   - home_address_street_default: Default
+  - home_address_street_emphasis: Emphasis
   - home_address_street_modified: Modified
   - home_address_street_dark: Dark
 

--- a/app/pb_kits/playbook/pb_home_address_street/docs/index.js
+++ b/app/pb_kits/playbook/pb_home_address_street/docs/index.js
@@ -1,3 +1,4 @@
 export { default as HomeAddressStreetDefault } from './_home_address_street_default.jsx'
+export { default as HomeAddressStreetEmphasis } from './_home_address_street_emphasis.jsx'
 export { default as HomeAddressStreetModified } from './_home_address_street_modified.jsx'
 export { default as HomeAddressStreetDark } from './_home_address_street_dark.jsx'

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -10,7 +10,9 @@ module Playbook
       prop :address
       prop :address_cont
       prop :city
-      prop :emphasis
+      prop :emphasis, type: Playbook::Props::Enum,
+                      values: %w[street city],
+                      default: "street"
       prop :home_id, type: Playbook::Props::Number
       prop :home_url
       prop :house_style

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -27,6 +27,14 @@ module Playbook
         "#{city.titleize}, #{state} #{zipcode}"
       end
 
+      def city_state
+        "#{city.titleize}, #{state}"
+      end
+
+      def zip
+        zipcode.to_s
+      end
+
       def address_house_style
         "#{address.titleize} #{separator} #{house_style}"
       end

--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -10,6 +10,7 @@ module Playbook
       prop :address
       prop :address_cont
       prop :city
+      prop :emphasis
       prop :home_id, type: Playbook::Props::Number
       prop :home_url
       prop :house_style

--- a/spec/pb_kits/playbook/kits/home_address_street_spec.rb
+++ b/spec/pb_kits/playbook/kits/home_address_street_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Playbook::PbHomeAddressStreet::HomeAddressStreet do
 
   it { is_expected.to define_prop(:address) }
   it { is_expected.to define_prop(:city) }
-  it { is_expected.to define_prop(:emphasis)
+  it { is_expected.to define_prop(:emphasis) }
   it { is_expected.to define_prop(:home_id)
                       .of_type(Playbook::Props::Number) }
   it { is_expected.to define_prop(:home_url) }

--- a/spec/pb_kits/playbook/kits/home_address_street_spec.rb
+++ b/spec/pb_kits/playbook/kits/home_address_street_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Playbook::PbHomeAddressStreet::HomeAddressStreet do
 
   it { is_expected.to define_prop(:address) }
   it { is_expected.to define_prop(:city) }
+  it { is_expected.to define_prop(:emphasis)
   it { is_expected.to define_prop(:home_id)
                       .of_type(Playbook::Props::Number) }
   it { is_expected.to define_prop(:home_url) }


### PR DESCRIPTION
#### Runway Ticket URL
https://github.com/powerhome/playbook/issues/210


#### Breaking Changes
Currently, none. The display **defaults** to the street being emphasized, which is how they currently are in Nitro-- so nothing from this PR would break any of the kit occurrences in Nitro. 

If we want to make the emphasis prop **required**, this would require a small change to this PR and _would_ result in breaking changes and a new major release of Playbook.


#### Checklist:
- [X] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`


#### Screenshots:
![Screen Shot 2020-03-11 at 12 50 47 PM](https://user-images.githubusercontent.com/9158723/76442224-fc752000-6396-11ea-897f-81caa3c78053.png)


