### PR TITLE
Upgrade deprecated api to prepare for kubernetes v1.16

### DIFF
--- a/config/deploy/templates/deployment.yaml.erb
+++ b/config/deploy/templates/deployment.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: playbook
@@ -8,6 +8,9 @@ metadata:
     krane.shopify.io/required-rollout: "maxUnavailable"
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: playbook
   template:
     metadata:
       labels:

--- a/config/deploy/templates/ingress.yaml.erb
+++ b/config/deploy/templates/ingress.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: playbook


### PR DESCRIPTION
# What does this PR do?
We are preparing to upgrade to Kubernetes v1.16 and to do that we need to remove deprecated API endpoints. In the Repo the only issue was with the deployment:

* Deployment in the **extensions/v1beta1**, **apps/v1beta1**, and **apps/v1beta2** API versions is no longer served
    * Migrate to use the **apps/v1** API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.
    * Notable changes:
         * `spec.rollbackTo` is removed
         * `spec.selector` is now required and immutable after creation
         * `spec.progressDeadlineSeconds` now defaults to 600 seconds
         * `spec.revisionHistoryLimit` now defaults to 10
         * `maxSurge` and `maxUnavailable` now default to 25%

The kubernetes `v1.20` release will stop serving the following deprecated API versions in favor of newer and more stable API versions:
* Ingress in the **extensions/v1beta1** API version will no longer be served
    * Migrate to use the **networking.k8s.io/v1beta1** API version, available since `v1.14`. Existing persisted data can be retrieved/updated via the new version.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

#### Breaking Changes

This should not cause any kind of change to the app behavior, not even a restart.

_Please reflect if your changes may break in some way (changes like removing/renaming props are examples of breaking changes)_

#### How to Ninja test this (screenshots are really helpful)
Just check if the app is still available.

#### Checklist:

- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
