### PR TITLE
Allow form field placeholder + select kit id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Allow form field placeholder + select field id [👹 #666 🤘🐐](https://github.com/powerhome/playbook/pull/666)
+
 ## [4.7.0] 2020-3-12
 
 ### Added

--- a/app/pb_kits/playbook/pb_form/form_builder/form_field_builder.rb
+++ b/app/pb_kits/playbook/pb_form/form_builder/form_field_builder.rb
@@ -11,6 +11,7 @@ module Playbook
 
             options[:skip_default_ids] = false unless options.key?(:skip_default_ids)
             options[:required] = true if props[:required]
+            options[:placeholder] = props[:placeholder] || ""
 
             if props.key?(:validation)
               validation = props[:validation]

--- a/app/pb_kits/playbook/pb_select/_select.html.erb
+++ b/app/pb_kits/playbook/pb_select/_select.html.erb
@@ -1,5 +1,4 @@
 <%= content_tag(:div,
-  id: object.id,
   data: object.data,
   aria: object.aria,
   class: object.classname) do %>
@@ -20,6 +19,7 @@
           selected: object.selected,
           disabled: object.disabled_options,
         ),
+        id: object.id,
         prompt: object.blank_selection,
         disabled: object.disabled,
         required: object.required,


### PR DESCRIPTION
#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUX-730

#### Breaking Changes

None

#### How to Ninja test this (screenshots are really helpful)

1. Test a form kit that uses placeholders such as Owner Referrals view. Form should show placeholders in the input field when no value is present.

#### Checklist:

- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
