### PR TITLE
Update webpacker to version 4.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       sassc-rails (= 1.3.0)
       slim-rails (= 3.2.0)
       sprockets-rails (= 2.3.3)
-      webpacker (= 4.0.7)
+      webpacker (= 4.2.2)
       webpacker-react (~> 0.3.2)
 
 GEM
@@ -196,7 +196,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webpacker (4.0.7)
+    webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)

--- a/playbook_ui.gemspec
+++ b/playbook_ui.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sassc-rails", "1.3.0"
   s.add_dependency "slim-rails", "3.2.0"
   s.add_dependency "sprockets-rails", "2.3.3"
-  s.add_dependency "webpacker", "4.0.7"
+  s.add_dependency "webpacker", "4.2.2"
   s.add_dependency "webpacker-react", "~> 0.3.2"
 
   s.add_development_dependency "better_errors", "2.5.1"


### PR DESCRIPTION
Uses newer version of webpacker. This is required in order to also upgrade webpacker on `nitro-web` so we can get a fix for the `webpacker:clean` rake task that was buggy in previous versions.