### PR TITLE
Rename roofs to roofing

### DIFF
--- a/app/pb_kits/playbook/tokens/_colors.scss
+++ b/app/pb_kits/playbook/tokens/_colors.scss
@@ -178,14 +178,14 @@ $windows:             $royal;
 $siding:              $yellow;
 $doors:               $red;
 $solar:               $green;
-$roofs:               $teal;
+$roofing:             $teal;
 $gutters:             $purple;
 $product_colors: (
   windows:            $windows,
   siding:             $siding,
   doors:              $doors,
   solar:              $solar,
-  roofs:              $roofs,
+  roofing:            $roofing,
   gutters:            $gutters
 );
 

--- a/app/views/playbook/pages/utilities.html.slim
+++ b/app/views/playbook/pages/utilities.html.slim
@@ -84,5 +84,5 @@ br
         {name: "Siding", variable: "siding"},
         {name: "Doors", variable: "doors"},
         {name: "Solar", variable: "solar"},
-        {name: "Roofs", variable: "roofs"},
+        {name: "Roofing", variable: "roofing"},
         {name: "Gutters", variable: "gutters"}]}


### PR DESCRIPTION
Renames the `roofs` color to `roofing` to align with the industry standard naming convention.

<img width="746" alt="Screen Shot 2020-03-25 at 8 42 28 AM" src="https://user-images.githubusercontent.com/18668436/77650073-8513c480-6f30-11ea-94fa-75ade070497b.png">
