### PR TITLE
Move onClick prop out of Icon and in to FormPill

### DIFF
--- a/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
+++ b/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
@@ -47,11 +47,13 @@ const FormPill = ({
             text={text}
         />
       </If>
-      <div className="pb_form_pill_close">
+      <div
+          className="pb_form_pill_close"
+          onClick={onClick}
+      >
         <Icon
             fixedWidth
             icon="times"
-            onClick={onClick}
         />
       </div>
     </div>

--- a/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.jsx
+++ b/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.jsx
@@ -5,9 +5,7 @@ const FormPillDefault = () => {
   return (
     <div>
       <FormPill
-          onClick={() => {
-alert('Click!')
-}}
+          onClick={() => alert('Click!')}
           text="this is a tag"
       />
     </div>

--- a/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.jsx
+++ b/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.jsx
@@ -4,7 +4,12 @@ import FormPill from '../_form_pill.jsx'
 const FormPillDefault = () => {
   return (
     <div>
-      <FormPill text="this is a tag" />
+      <FormPill
+          onClick={() => {
+alert('Click!')
+}}
+          text="this is a tag"
+      />
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.jsx
+++ b/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.jsx
@@ -8,17 +8,13 @@ const FormPillDefault = () => {
       <FormPill
           avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
           name="Anna Black"
-          onClick={() => {
-alert('Click!')
-}}
+          onClick={() => alert('Click!')}
       />
       <br />
       <br />
       <FormPill
           name="Anna Black"
-          onClick={() => {
-alert('Click!')
-}}
+          onClick={() => alert('Click!')}
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.jsx
+++ b/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.jsx
@@ -8,10 +8,18 @@ const FormPillDefault = () => {
       <FormPill
           avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
           name="Anna Black"
+          onClick={() => {
+alert('Click!')
+}}
       />
       <br />
       <br />
-      <FormPill name="Anna Black" />
+      <FormPill
+          name="Anna Black"
+          onClick={() => {
+alert('Click!')
+}}
+      />
     </div>
   )
 }


### PR DESCRIPTION
@gmfvpereira I was running your branch for a PR that I need to create regarding cleanup of `onClick` handlers across the board. Upon testing, I noticed that the `<i onClick=...` does not actually fire at all (which is sort of surprising - sorta not). Since it isn't doing anything, I moved the prop to the wrapping `<div>` within `FormPill`. This time, the `onClick` is fired as seen here in the doc examples for React. Let me know if you have any questions or concerns. I would like to know if you had this working for you locally and perhaps there is some strange delta I am seeing here.. Thanks!

BTW - I did create the [revert PR](https://github.com/powerhome/playbook/pull/693)