### PR TITLE
[GOG-146] Add ephemeral-storage quota

### DIFF
--- a/config/deploy/templates/deployment.yaml.erb
+++ b/config/deploy/templates/deployment.yaml.erb
@@ -56,6 +56,8 @@ spec:
             limits:
               cpu: 0.5
               memory: 256Mi
+              ephemeral-storage: 500Mi
             requests:
               cpu: 0.5
               memory: 256Mi
+              ephemeral-storage: 500Mi


### PR DESCRIPTION
Attempting to help prevent evictions. At least 50Mi are needed just
for logs and the playbook pods themselves seem to be running around
150MB. This gives us a bit of headroom to play with for now.
