### PR TITLE
Fix PbPopover zindex

### DIFF
--- a/app/pb_kits/playbook/pb_popover/_popover.scss
+++ b/app/pb_kits/playbook/pb_popover/_popover.scss
@@ -3,10 +3,7 @@
 [class^="pb_popover_kit"] {
   .popover_tooltip {
     display: none;
-    &.show {
-      display: block;
-      z-index: $z_9;
-    }
+    z-index: $z_9;
   }
 }
 


### PR DESCRIPTION
#### Breaking Changes

FIxes PbPopover z-index not being applied (`.pb_tooltip.open` was never applied to any element)

#### How to Ninja test this (screenshots are really helpful)


#### Checklist:

- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
