### PR TITLE
Aria data id fixes for text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Added aria, data, id props to Text Input kit on both React and Ruby sides.([#749](https://github.com/powerhome/playbook/pull/749)@kellyeryan)
+
 ## [4.15.0] 2020-5-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Added aria, data, id props to Text Input kit on both React and Ruby sides.([#749](https://github.com/powerhome/playbook/pull/749)@kellyeryan)
+- Added aria, data, id props to Text Input kit on both React and Ruby sides.([#812](https://github.com/powerhome/playbook/pull/812)@kellyeryan)
 
 ## [4.15.0] 2020-5-22
 

--- a/app/pb_kits/playbook/pb_text_input/_text_input.html.erb
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.html.erb
@@ -1,5 +1,8 @@
 <%= content_tag(:div,
-    class: object.classname) do %>
+    aria: object.aria,
+    class: object.classname,
+    data: object.data,
+    id: object.id) do %>
   <% if object.label.present? %>
     <%= pb_rails("caption", props: { text: object.label, dark: object.dark, classname: "pb_text_input_kit_label" }) %>
   <% end %>
@@ -12,9 +15,8 @@
       <% end %>
     <% else %>
       <%= tag(:input,
-          id: object.id,
-          class: object.classname,
-          data: object.data,
+          class: "text_input",
+          data: object.validation_data,
           name: object.name,
           pattern: object.validation_pattern,
           placeholder: object.placeholder,

--- a/app/pb_kits/playbook/pb_text_input/_text_input.html.erb
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.html.erb
@@ -1,8 +1,7 @@
 <%= content_tag(:div,
     aria: object.aria,
     class: object.classname,
-    data: object.data,
-    id: object.id) do %>
+    data: object.data) do %>
   <% if object.label.present? %>
     <%= pb_rails("caption", props: { text: object.label, dark: object.dark, classname: "pb_text_input_kit_label" }) %>
   <% end %>
@@ -17,6 +16,7 @@
       <%= tag(:input,
           class: "text_input",
           data: object.validation_data,
+          id: object.id,
           name: object.name,
           pattern: object.validation_pattern,
           placeholder: object.placeholder,

--- a/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -56,7 +56,6 @@ const TextInput = ({
         {...ariaProps}
         {...dataProps}
         className={css}
-        id={id}
     >
       <Caption
           className="pb_text_input_kit_label"
@@ -70,6 +69,7 @@ const TextInput = ({
           <input
               {...props}
               className="text_input"
+              id={id}
               name={name}
               onChange={onChange}
               placeholder={placeholder}

--- a/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -6,10 +6,18 @@ import {
   Caption,
 } from '../'
 
+import {
+  buildAriaProps,
+  buildDataProps,
+} from '../utilities/props'
+
 type TextInputProps = {
+  aria?: object,
   className: String,
   dark: boolean,
+  data?: object,
   error?: String,
+  id?: String,
   name: String,
   label: String,
   onChange: (String) => void,
@@ -20,9 +28,12 @@ type TextInputProps = {
 }
 
 const TextInput = ({
+  aria = {},
   className,
   dark = false,
+  data = {},
   error,
+  id,
   name,
   label,
   onChange = () => {},
@@ -32,6 +43,8 @@ const TextInput = ({
   children = null,
   ...props
 }: TextInputProps) => {
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
   const css = classnames([
     `pb_text_input_kit${dark === true ? '_dark' : ''}`,
     className,
@@ -39,7 +52,12 @@ const TextInput = ({
   ])
 
   return (
-    <div className={css}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={css}
+        id={id}
+    >
       <Caption
           className="pb_text_input_kit_label"
           dark={dark}

--- a/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
+++ b/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
@@ -1,5 +1,31 @@
-<%= pb_rails("text_input", props: { label: "First Name", placeholder: "Enter first name", value: "Timothy Wenhold" }) %>
-<%= pb_rails("text_input", props: { label: "Last Name", placeholder: "Enter last name" }) %>
-<%= pb_rails("text_input", props: { label: "Phone Number", type: "phone", placeholder: "Enter phone number" }) %>
-<%= pb_rails("text_input", props: { label: "Email Address", type: "email", placeholder: "Enter email address" }) %>
-<%= pb_rails("text_input", props: { label: "Zip Code", type: "number", placeholder: "Enter zip code" }) %>
+<%= pb_rails("text_input", props: {
+  label: "First Name",
+  placeholder: "Enter first name",
+  value: "Timothy Wenhold",
+  data: { say: "hi", yell: "go" },
+  aria: { something: "hello"},
+  id: "unique_id"
+}) %>
+
+<%= pb_rails("text_input", props: {
+  label: "Last Name",
+  placeholder: "Enter last name"
+}) %>
+
+<%= pb_rails("text_input", props: {
+    label: "Phone Number",
+    type: "phone",
+    placeholder: "Enter phone number"
+}) %>
+
+<%= pb_rails("text_input", props: {
+    label: "Email Address",
+    type: "email",
+    placeholder: "Enter email address"
+}) %>
+
+<%= pb_rails("text_input", props: {
+    label: "Zip Code",
+    type: "number",
+    placeholder: "Enter zip code"
+}) %>

--- a/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
+++ b/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
@@ -20,6 +20,9 @@ class TextInputDefault extends React.Component {
     return (
       <div>
         <TextInput
+            aria={{ something: 'hello' }}
+            data={{ say: 'hi', yell: 'go' }}
+            id="unique-id"
             label="First Name"
             placeholder="Enter first name"
             value="Timothy Wenhold"

--- a/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -34,7 +34,7 @@ module Playbook
         validation[:pattern] || nil
       end
 
-      def data
+      def validation_data
         fields = {}
         fields[:message] = validation_message unless validation_message.blank?
         fields


### PR DESCRIPTION
Originally started in #798 

#### Screens

<img width="1182" alt="Screen Shot 2020-05-25 at 10 51 02 AM" src="https://user-images.githubusercontent.com/51907753/82823487-aa13ad80-9e75-11ea-9c81-f18f63a4e8ec.png">

<img width="1177" alt="Screen Shot 2020-05-25 at 10 50 29 AM" src="https://user-images.githubusercontent.com/51907753/82823498-ae3fcb00-9e75-11ea-994d-c49d80e68b24.png">

#### Breaking Changes

Removes duplicate custom class name from Ruby input element.

#### Github Issue

#791 

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs - N/A
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
