### PR TITLE
Added link & new window props to circle icon button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
 ### Added
 - Added legend prop to Bar Graph Kit and Line Graph Kit ([#818](https://github.com/powerhome/playbook/pull/818)@christinaatai)
 - Add React to LabelPill kit ([#813](https://github.com/powerhome/playbook/pull/813) @kellyeryan)
 - Updated Bar Graph Kit and Line Graph Kit with height prop ([#819](https://github.com/powerhome/playbook/pull/819)@christinaatai)
-
+- Added link & new_window props to circle_icon_button rails/react ()
 ### Fixed
 - Added aria, data, id props to Text Input kit on both React and Ruby sides.([#812](https://github.com/powerhome/playbook/pull/812)@kellyeryan)
 - Add aria to Ruby LabelPill kit ([#813](https://github.com/powerhome/playbook/pull/813) @kellyeryan)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added legend prop to Bar Graph Kit and Line Graph Kit ([#818](https://github.com/powerhome/playbook/pull/818)@christinaatai)
 - Add React to LabelPill kit ([#813](https://github.com/powerhome/playbook/pull/813) @kellyeryan)
 - Updated Bar Graph Kit and Line Graph Kit with height prop ([#819](https://github.com/powerhome/playbook/pull/819)@christinaatai)
-- Added link & new_window props to circle_icon_button rails/react ()
+- Added link & new_window props to circle_icon_button rails/react ([#823](https://github.com/powerhome/playbook/pull/823)@kre8sions)
 ### Fixed
 - Added aria, data, id props to Text Input kit on both React and Ruby sides.([#812](https://github.com/powerhome/playbook/pull/812)@kellyeryan)
 - Add aria to Ruby LabelPill kit ([#813](https://github.com/powerhome/playbook/pull/813) @kellyeryan)

--- a/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.html.erb
+++ b/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.html.erb
@@ -3,7 +3,7 @@
   data: object.data,
   class: object.classname) do %>
 
-  <%= pb_rails("button", props: {type: object.type,link: object.link, new_window:object.new_window, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
+  <%= pb_rails("button", props: {type: object.type, link: object.link, new_window:object.new_window, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
     <%= pb_rails("icon", props: {icon: object.icon, fixed_width: true, dark: object.dark}) %>
   <% end %>
 

--- a/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.html.erb
+++ b/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.html.erb
@@ -3,7 +3,7 @@
   data: object.data,
   class: object.classname) do %>
 
-  <%= pb_rails("button", props: {type: object.type, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
+  <%= pb_rails("button", props: {type: object.type,link: object.link, new_window:object.new_window, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
     <%= pb_rails("icon", props: {icon: object.icon, fixed_width: true, dark: object.dark}) %>
   <% end %>
 

--- a/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.jsx
+++ b/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.jsx
@@ -15,7 +15,9 @@ type CircleIconButtonProps = {
   disabled?: Boolean,
   icon: String,
   id?: String,
+  link?: String,
   onClick?: Callback,
+  newWindow?: Boolean,
   type?: 'button' | 'submit' | 'reset',
   variant?: 'primary' | 'secondary' | 'link',
 }
@@ -27,6 +29,8 @@ const CircleIconButton = (props: CircleIconButtonProps) => {
     icon,
     onClick = noop,
     type,
+    link,
+    newWindow,
     variant,
   } = props
 
@@ -35,6 +39,8 @@ const CircleIconButton = (props: CircleIconButtonProps) => {
       <Button
           dark={dark}
           disabled={disabled}
+          link={link}
+          newWindow={newWindow}
           onClick={onClick}
           text={null}
           type={type}

--- a/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
+++ b/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
@@ -16,7 +16,9 @@ module Playbook
       prop :icon, required: true
       prop :dark, type: Playbook::Props::Boolean,
                      default: false
-
+      prop :link
+      prop :new_window, type: Playbook::Props::Boolean,
+                     default: false
       def classname
         generate_classname("pb_circle_icon_button_kit")
       end

--- a/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_link.html.erb
+++ b/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_link.html.erb
@@ -1,0 +1,11 @@
+<%= pb_rails("circle_icon_button", props: {
+  variant: "primary",
+  icon: "search",
+  link: "https://google.com"
+}) %>
+<%= pb_rails("circle_icon_button", props: {
+  variant: "primary",
+  icon: "window",
+  link: "https://google.com",
+  new_window: true
+}) %>

--- a/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_link.jsx
+++ b/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_link.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { CircleIconButton } from '../../'
+
+const CircleIconButtonLink = () => (
+  <div>
+    <CircleIconButton
+        icon="search"
+        link="https://google.com"
+        variant="primary"
+
+    />
+
+    <br />
+
+    <CircleIconButton
+        icon="window"
+        link="https://google.com"
+        newWindow
+        variant="secondary"
+    />
+
+  </div>
+)
+
+export default CircleIconButtonLink

--- a/app/pb_kits/playbook/pb_circle_icon_button/docs/example.yml
+++ b/app/pb_kits/playbook/pb_circle_icon_button/docs/example.yml
@@ -3,8 +3,10 @@ examples:
   rails:
   - circle_icon_button_default: Default
   - circle_icon_button_dark: Dark
+  - circle_icon_button_link: Link
   
   react:
   - circle_icon_button_default: Default
   - circle_icon_button_click: Click Handler
   - circle_icon_button_dark: Dark
+  - circle_icon_button_link: Link

--- a/app/pb_kits/playbook/pb_circle_icon_button/docs/index.js
+++ b/app/pb_kits/playbook/pb_circle_icon_button/docs/index.js
@@ -1,3 +1,4 @@
 export { default as CircleIconButtonDefault } from './_circle_icon_button_default.jsx'
 export { default as CircleIconButtonClick } from './_circle_icon_button_click.jsx'
 export { default as CircleIconButtonDark } from './_circle_icon_button_dark.jsx'
+export { default as CircleIconButtonLink } from './_circle_icon_button_link.jsx'

--- a/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
+++ b/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Playbook::PbCircleIconButton::CircleIconButton do
   it { is_expected.to define_boolean_prop(:dark).with_default(false) }
   it { is_expected.to define_boolean_prop(:disabled).with_default(false) }
   it { is_expected.to define_prop(:icon).that_is_required }
-
+  it { is_expected.to define_boolean_prop(:new_window).with_default(false) }
+  it { is_expected.to define_prop(:link) }
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       icon = "user"


### PR DESCRIPTION
#### Screens
Added link and newWindow prop to circle icon button

<img width="1392" alt="Screen Shot 2020-05-27 at 7 06 55 PM" src="https://user-images.githubusercontent.com/9784112/83080847-4ba12780-a04d-11ea-9455-c1411ec728cd.png">


#### Breaking Changes

_Please reflect if your changes may break in some way (changes like removing/renaming props are examples of breaking changes)_

#### Runway Ticket URL

#### How to test this

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
