### PR TITLE
Added category colors to table side highlight kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated index.js to include ProgressStepItem ([#831](https://github.com/powerhome/playbook/pull/831)@christinaatai)
 
-## [4.16.0] 2020-5-28
+### Added
+- Added category colors to table side highlight kit ([#829](https://github.com/powerhome/playbook/pull/829)@christinaatai)
+
+## [4.16.0] 2020-5-29
 
 ### Added
 - Add React Star Rating kit ([#822](https://github.com/powerhome/playbook/pull/822) @kellyeryan)

--- a/app/pb_kits/playbook/pb_table/_table.scss
+++ b/app/pb_kits/playbook/pb_table/_table.scss
@@ -1,7 +1,7 @@
 @import "styles/all";
 @import "../tokens/colors";
 
-$pb_table_row_kit_side_highlight_colors: map-merge($status_colors, $product_colors);
+$pb_table_row_kit_side_highlight_colors: map-merge(map-merge($status_colors, $product_colors), $category_colors);
 
 @mixin pb_table_row_kit_side_highlight($background) {
     box-shadow: inset 4px 0 0 0 $background;

--- a/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.html.erb
+++ b/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.html.erb
@@ -119,7 +119,7 @@
 			<td>Value 5</td>
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "none" }) do %>
-			<td>Category Color 4</td>
+			<td>None</td>
 			<td>Value 2</td>
 			<td>Value 3</td>
 			<td>Value 4</td>

--- a/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.html.erb
+++ b/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.html.erb
@@ -1,4 +1,4 @@
-<%= pb_rails("table", props: { size: "md" }) do %>
+<%= pb_rails("table", props: { size: "sm" }) do %>
   <thead>
     <tr>
       <th>Product Colors</th>
@@ -9,22 +9,22 @@
     </tr>
   </thead>
   <tbody>
-    <%= pb_rails("table/table_row", props: { side_highlight_color: "windows" }) do %>
-			<td>Windows</td>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "solar" }) do %>
+			<td>Solar</td>
 			<td>Value 2</td>
 			<td>Value 3</td>
 			<td>Value 4</td>
 			<td>Value 5</td>
     <% end %>
-		<%= pb_rails("table/table_row", props: { side_highlight_color: "siding" }) do %>
-			<td>Siding</td>
+		<%= pb_rails("table/table_row", props: { side_highlight_color: "roofing" }) do %>
+			<td>Roofing</td>
 			<td>Value 2</td>
 			<td>Value 3</td>
 			<td>Value 4</td>
 			<td>Value 5</td>
     <% end %>
-    <%= pb_rails("table/table_row", props: { side_highlight_color: "doors" }) do %>
-			<td>Doors</td>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "gutters" }) do %>
+			<td>Gutters</td>
 			<td>Value 2</td>
 			<td>Value 3</td>
 			<td>Value 4</td>
@@ -42,7 +42,7 @@
 
 <br/>
 
-<%= pb_rails("table", props: { size: "md" }) do %>
+<%= pb_rails("table", props: { size: "sm" }) do %>
   <thead>
     <tr>
       <th>Status Colors</th>
@@ -76,6 +76,50 @@
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "none" }) do %>
 			<td>None</td>
+			<td>Value 2</td>
+			<td>Value 3</td>
+			<td>Value 4</td>
+			<td>Value 5</td>
+    <% end %>
+  </tbody>
+<% end %>
+
+<br/>
+
+<%= pb_rails("table", props: { size: "sm" }) do %>
+  <thead>
+    <tr>
+      <th>Cateogry Colors</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+      <th>Column 4</th>
+      <th>Column 5</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "category_1" }) do %>
+			<td>Category Color 1</td>
+			<td>Value 2</td>
+			<td>Value 3</td>
+			<td>Value 4</td>
+			<td>Value 5</td>
+    <% end %>
+		<%= pb_rails("table/table_row", props: { side_highlight_color: "category_2" }) do %>
+			<td>Category Color 2</td>
+			<td>Value 2</td>
+			<td>Value 3</td>
+			<td>Value 4</td>
+			<td>Value 5</td>
+    <% end %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "category_3" }) do %>
+			<td>Category Color 3</td>
+			<td>Value 2</td>
+			<td>Value 3</td>
+			<td>Value 4</td>
+			<td>Value 5</td>
+    <% end %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "none" }) do %>
+			<td>Category Color 4</td>
 			<td>Value 2</td>
 			<td>Value 3</td>
 			<td>Value 4</td>

--- a/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.jsx
+++ b/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.jsx
@@ -4,7 +4,7 @@ import { Table, TableRow } from '../../'
 const TableSideHighlight = () => {
   return (
     <div>
-      <Table size="md">
+      <Table size="sm">
         <thead>
           <tr>
             <th>{'Product colors'}</th>
@@ -15,22 +15,22 @@ const TableSideHighlight = () => {
           </tr>
         </thead>
         <tbody>
-          <TableRow sideHighlightColor="windows">
-            <td>{'Windows'}</td>
+          <TableRow sideHighlightColor="solar">
+            <td>{'Solar'}</td>
             <td>{'Value 2'}</td>
             <td>{'Value 3'}</td>
             <td>{'Value 4'}</td>
             <td>{'Value 5'}</td>
           </TableRow>
-          <TableRow sideHighlightColor="siding">
-            <td>{'Siding'}</td>
+          <TableRow sideHighlightColor="roofing">
+            <td>{'Roofing'}</td>
             <td>{'Value 2'}</td>
             <td>{'Value 3'}</td>
             <td>{'Value 4'}</td>
             <td>{'Value 5'}</td>
           </TableRow>
-          <TableRow sideHighlightColor="doors">
-            <td>{'Doors'}</td>
+          <TableRow sideHighlightColor="gutters">
+            <td>{'Gutters'}</td>
             <td>{'Value 2'}</td>
             <td>{'Value 3'}</td>
             <td>{'Value 4'}</td>
@@ -48,7 +48,7 @@ const TableSideHighlight = () => {
 
       <br />
 
-      <Table size="md">
+      <Table size="sm">
         <thead>
           <tr>
             <th>{'Status colors'}</th>
@@ -75,6 +75,50 @@ const TableSideHighlight = () => {
           </TableRow>
           <TableRow sideHighlightColor="error">
             <td>{'Error'}</td>
+            <td>{'Value 2'}</td>
+            <td>{'Value 3'}</td>
+            <td>{'Value 4'}</td>
+            <td>{'Value 5'}</td>
+          </TableRow>
+          <TableRow sideHighlightColor="none">
+            <td>{'None'}</td>
+            <td>{'Value 2'}</td>
+            <td>{'Value 3'}</td>
+            <td>{'Value 4'}</td>
+            <td>{'Value 5'}</td>
+          </TableRow>
+        </tbody>
+      </Table>
+
+      <br />
+
+      <Table size="sm">
+        <thead>
+          <tr>
+            <th>{'Category Colors'}</th>
+            <th>{'Column 2'}</th>
+            <th>{'Column 3'}</th>
+            <th>{'Column 4'}</th>
+            <th>{'Column 5'}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <TableRow sideHighlightColor="category_1">
+            <td>{'Category Color 1'}</td>
+            <td>{'Value 2'}</td>
+            <td>{'Value 3'}</td>
+            <td>{'Value 4'}</td>
+            <td>{'Value 5'}</td>
+          </TableRow>
+          <TableRow sideHighlightColor="category_2">
+            <td>{'Category Color 2'}</td>
+            <td>{'Value 2'}</td>
+            <td>{'Value 3'}</td>
+            <td>{'Value 4'}</td>
+            <td>{'Value 5'}</td>
+          </TableRow>
+          <TableRow sideHighlightColor="category_3">
+            <td>{'Category Color 3'}</td>
             <td>{'Value 2'}</td>
             <td>{'Value 3'}</td>
             <td>{'Value 4'}</td>

--- a/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.md
+++ b/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.md
@@ -1,1 +1,3 @@
-Side highlight can pass status and product colors.
+Side highlight can take product, status, and category colors. To view full list of product, status, and category colors, visit <a href="https://playbook.powerapp.cloud/utilities" target="_blank">token colors</a>.
+
+Note: Only use category colors for categories. Do not mix it with product or status colors.

--- a/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.md
+++ b/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.md
@@ -1,3 +1,3 @@
-Side highlight can take product, status, and category colors. To view full list of product, status, and category colors, visit <a href="https://playbook.powerapp.cloud/utilities" target="_blank">token colors</a>.
+Side highlight can take product, status, and category colors. To view full list of colors, visit <a href="https://playbook.powerapp.cloud/utilities" target="_blank">token colors</a>.
 
 Note: Only use category colors for categories. Do not mix it with product or status colors.

--- a/spec/pb_kits/playbook/kits/table_row_spec.rb
+++ b/spec/pb_kits/playbook/kits/table_row_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe Playbook::PbTable::TableRow do
       expect(subject.new({side_highlight_color: "success"}).classname).to eq "pb_table_row_kit_side_highlight_success"
       expect(subject.new({side_highlight_color: "warning"}).classname).to eq "pb_table_row_kit_side_highlight_warning"
       expect(subject.new({side_highlight_color: "error"}).classname).to eq "pb_table_row_kit_side_highlight_error"
+      expect(subject.new({side_highlight_color: "category_1"}).classname).to eq "pb_table_row_kit_side_highlight_category_1"
+      expect(subject.new({side_highlight_color: "category_2"}).classname).to eq "pb_table_row_kit_side_highlight_category_2"
+      expect(subject.new({side_highlight_color: "category_3"}).classname).to eq "pb_table_row_kit_side_highlight_category_3"
     end
   end
 end


### PR DESCRIPTION
#### Screens
<img width="1347" alt="Screen Shot 2020-06-02 at 4 16 11 PM" src="https://user-images.githubusercontent.com/42459486/83565429-690e3f80-a4ec-11ea-898d-b2ea15995f56.png">
<img width="1351" alt="Screen Shot 2020-06-02 at 4 27 41 PM" src="https://user-images.githubusercontent.com/42459486/83566456-07e76b80-a4ee-11ea-9d14-39df075becf4.png">

#### Breaking Changes

No breaking changes.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUX-1028

#### How to test this

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
