### PR TITLE
Add aria, data, id props to React LabelValue, aria to Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added 
+- Add aria, data, id props to React Label Value kit, add aria props to Ruby Label Value kit([#842](https://github.com/powerhome/playbook/pull/842) @kellyeryan)
+
 ## [4.16.0] 2020-5-29
 
 ### Added

--- a/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_label_value/_label_value.jsx
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.jsx
@@ -4,27 +4,42 @@ import React from 'react'
 import classnames from 'classnames'
 import { Body, Caption } from '../'
 
+import {
+  buildAriaProps,
+  buildCss,
+  buildDataProps,
+} from '../utilities/props'
+
 type LabelValueProps = {
+  aria?: object,
   className?: String,
+  dark?: Boolean,
+  data?: object,
+  id?: String,
   label: String,
   value: String,
-  dark?: Boolean
 }
 
 const LabelValue = ({
+  aria = {},
   className,
+  dark = false,
+  data = {},
+  id,
   label,
   value,
-  dark = false,
 }: LabelValueProps) => {
-  const themeStyle = dark === true ? '_dark' : ''
-  const css = classnames([
-    'pb_label_value_kit' + themeStyle,
-    className,
-  ])
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(className, buildCss('pb_label_value_kit', { 'dark': dark }))
 
   return (
-    <div className={css}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
+    >
       <Caption
           text={label}
       />


### PR DESCRIPTION
#### Issue

The React Label Value kit was missing aria, data, id props and the Rails Label Value kit was missing aria props.

#### Screens

I added the aria, data, id props in so that it would be clear in the html that they are functioning properly. I removed them before pushing up the PR.

<img width="1223" alt="Screen Shot 2020-06-05 at 11 01 32 AM" src="https://user-images.githubusercontent.com/51907753/83894254-0bae0480-a71f-11ea-9376-8b0ea1833715.png">

<img width="1225" alt="Screen Shot 2020-06-05 at 11 01 43 AM" src="https://user-images.githubusercontent.com/51907753/83894270-110b4f00-a71f-11ea-97b4-f6b747f45d6b.png">

<img width="1219" alt="Screen Shot 2020-06-05 at 11 13 36 AM" src="https://user-images.githubusercontent.com/51907753/83894286-16689980-a71f-11ea-85af-511784c3948f.png">

<img width="1223" alt="Screen Shot 2020-06-05 at 11 13 43 AM" src="https://user-images.githubusercontent.com/51907753/83894295-18caf380-a71f-11ea-9f0c-487ee281d9fe.png">

#### Breaking Changes

None

#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
