### PR TITLE
Add aria, className, data, id props to React Logistic kit, add aria to Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add aria, className, data, id props to React Logistic kit and aria props to Rails Logistic kit ([#843](https://github.com/powerhome/playbook/pull/843) @kellyeryan)
+
 ## [4.16.0] 2020-5-29
 
 ### Added

--- a/app/pb_kits/playbook/pb_logistic/_logistic.html.erb
+++ b/app/pb_kits/playbook/pb_logistic/_logistic.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_logistic/_logistic.jsx
+++ b/app/pb_kits/playbook/pb_logistic/_logistic.jsx
@@ -5,6 +5,12 @@ import classnames from 'classnames'
 import DateTime from '../pb_kit/dateTime.js'
 import { Body, Caption, Icon, Title } from '../'
 
+import {
+  buildAriaProps,
+  buildCss,
+  buildDataProps,
+} from '../utilities/props'
+
 const dateString = (value: DateTime) => {
   const month = value.toMonthNum()
   const day = value.toDay()
@@ -13,25 +19,39 @@ const dateString = (value: DateTime) => {
 }
 
 type LogisticProps = {
+  aria?: object,
+  className?: String,
   dark?: Boolean,
+  data?: object,
   date: String,
+  id?: String,
   link?: String,
   projectName: String,
   projectNumber: Number,
 }
 
 const Logistic = ({
+  aria = {},
+  className,
   dark = false,
+  data = {},
   date,
+  id,
   link,
   projectName,
   projectNumber,
 }: LogisticProps) => {
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(className, buildCss('pb_logistic_kit', { 'dark': dark }))
   const formattedDate = new DateTime({ value: date })
 
   return (
     <div
-        className={classnames('pb_logistic_kit')}
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
     >
       <Body color="light">
         <Caption text="Project" />


### PR DESCRIPTION
#### Issue

The React Logistic kit did not have aria, data, className, or id props and Rails kit did not have aria props.

#### Screens

I added the aria, data, id props in to show that they work properly, but I deleted them before I pushed up the PR.

REACT:

<img width="1220" alt="Screen Shot 2020-06-05 at 11 53 22 AM" src="https://user-images.githubusercontent.com/51907753/83898413-e0c6af00-a724-11ea-8395-874f1f5ab3c4.png">

<img width="1222" alt="Screen Shot 2020-06-05 at 11 53 35 AM" src="https://user-images.githubusercontent.com/51907753/83898601-23888700-a725-11ea-906b-79069d0af2e8.png">

RAILS:

<img width="1220" alt="Screen Shot 2020-06-05 at 11 54 51 AM" src="https://user-images.githubusercontent.com/51907753/83898522-06ec4f00-a725-11ea-9be8-0181db793f72.png">

<img width="1220" alt="Screen Shot 2020-06-05 at 11 54 59 AM" src="https://user-images.githubusercontent.com/51907753/83898533-0a7fd600-a725-11ea-9cde-8fcfd35dd395.png">


You can see here the difference it makes in React Components. 
BEFORE:

<img width="1226" alt="Screen Shot 2020-06-05 at 11 54 12 AM" src="https://user-images.githubusercontent.com/51907753/83898690-4024bf00-a725-11ea-9cf6-f239ecfa3680.png">

AFTER:

<img width="1223" alt="Screen Shot 2020-06-05 at 12 02 16 PM" src="https://user-images.githubusercontent.com/51907753/83898506-fdfb7d80-a724-11ea-893b-e0b7c093bc6c.png">

#### Breaking Changes

None

#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs -NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
