### PR TITLE
Add aria, data, id props to React LabelValue kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+-Added aria, data, id props to React Label Value kit, added aria props to Rails Label Value kit ([#845](https://github.com/powerhome/playbook/pull/845) @kellyeryan)
+
 ## Unreleased
 
 ## [4.17.0] 2020-6-5

--- a/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_label_value/_label_value.jsx
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.jsx
@@ -2,18 +2,32 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import { buildAriaProps, buildDataProps } from '../utilities/props'
 import { Body, Caption } from '../'
 import { spacing } from '../utilities/spacing.js'
 
 type LabelValueProps = {
+  aria?: object,
   className?: String,
+  dark?: Boolean,
+  data?: object,
+  id?: String,
   label: String,
   value: String,
-  dark?: Boolean,
 }
 
 const LabelValue = (props: LabelValueProps) => {
-  const { className, label, value, dark = false } = props
+  const {
+    aria = {},
+    className,
+    dark = false,
+    data = {},
+    id,
+    label,
+    value } = props
+
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
   const themeStyle = dark === true ? '_dark' : ''
   const css = classnames(
     ['pb_label_value_kit' + themeStyle, className],
@@ -21,7 +35,12 @@ const LabelValue = (props: LabelValueProps) => {
   )
 
   return (
-    <div className={css}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={css}
+        id={id}
+    >
       <Caption text={label} />
       <Body text={value} />
     </div>


### PR DESCRIPTION
#### Issue

Aria, data, id props were missing from React Label Value kit; aria props were missing from Rails Label Value kit.

NOTE: This PR will replace #842. 

#### Screens

I added in examples of data, aria, id to make sure the props were working correctly and took screenshots of the html. Before I pushed up the PR, I removed the examples.

REACT

<img width="1222" alt="Screen Shot 2020-06-08 at 12 03 06 PM" src="https://user-images.githubusercontent.com/51907753/84056952-f508e700-a984-11ea-9e11-79028ed01930.png">

<img width="1231" alt="Screen Shot 2020-06-08 at 12 03 15 PM" src="https://user-images.githubusercontent.com/51907753/84056956-f76b4100-a984-11ea-9e36-071519f3b015.png">

RAILS

<img width="1207" alt="Screen Shot 2020-06-08 at 12 24 42 PM" src="https://user-images.githubusercontent.com/51907753/84056988-fe924f00-a984-11ea-82b0-97578821b2ff.png">

<img width="1207" alt="Screen Shot 2020-06-08 at 12 24 49 PM" src="https://user-images.githubusercontent.com/51907753/84056995-0225d600-a985-11ea-9420-7f20e5a39dc6.png">


#### Breaking Changes

None 

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
