### PR TITLE
Add aria, className, data, id props to React Message kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added aria, data, id, className props to React Message kit; added aria props to Rails Message kit ([#847](https://github.com/powerhome/playbook/pull/847) @kellyeryan)
+
 ## [4.17.0] 2020-6-5
 
 ### Added

--- a/app/pb_kits/playbook/pb_message/_message.html.erb
+++ b/app/pb_kits/playbook/pb_message/_message.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/app/pb_kits/playbook/pb_message/_message.jsx
@@ -3,12 +3,17 @@
 import React from 'react'
 import { Avatar, Body, Caption } from '../'
 import classnames from 'classnames'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { spacing } from '../utilities/spacing.js'
 
 type MessageProps = {
+  aria: object,
   avatarName?: String,
   avatarStatus?: String,
   avatarUrl?: String,
+  className?: String,
+  data?: object,
+  id?: String,
   label?: String,
   message: String,
   timestamp?: String,
@@ -16,20 +21,33 @@ type MessageProps = {
 
 const Message = (props: MessageProps) => {
   const {
-    avatarName = '',
-    avatarUrl = '',
-    label = '',
-    message = '',
-    timestamp = '',
+    aria = {},
+    avatarName,
     avatarStatus = null,
+    avatarUrl,
+    className,
+    data = {},
+    id,
+    label,
+    message,
+    timestamp,
   } = props
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
   const shouldDisplayAvatar = avatarUrl || avatarName
-  const classes = shouldDisplayAvatar
+  const baseClassName = shouldDisplayAvatar
     ? 'pb_message_kit_avatar'
     : 'pb_message_kit'
 
+  const classes = classnames(buildCss(baseClassName), className, spacing(props))
+
   return (
-    <div className={classnames(classes, spacing(props))}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
+    >
       <If condition={shouldDisplayAvatar}>
         <Avatar
             imageUrl={avatarUrl}

--- a/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
+++ b/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
@@ -4,7 +4,6 @@ import { Message } from '../../'
 const MessageDefault = () => {
   return (
     <div>
-
       <Message
           avatarName="Mike Bishop"
           avatarStatus="online"
@@ -31,7 +30,7 @@ const MessageDefault = () => {
       <Message
           avatarName="Lisa Thompson"
           avatarUrl="https://randomuser.me/api/portraits/women/39.jpg"
-          message="To processs your order, I will need your full name."
+          message="To process your order, I will need your full name."
           timestamp="4 hours ago"
       />
 

--- a/app/pb_kits/playbook/pb_message/message.rb
+++ b/app/pb_kits/playbook/pb_message/message.rb
@@ -25,7 +25,7 @@ module Playbook
     private
 
       def avatar_class
-        avatar_name ? "avatar" : nil
+        valid? ? "avatar" : nil
       end
     end
   end


### PR DESCRIPTION
#### Issue

React Message kit did not contain aria, className, id, data props and Rail Message kit did not contain aria props.

#### Screens

RAILS: 

<img width="1212" alt="Screen Shot 2020-06-08 at 4 34 00 PM" src="https://user-images.githubusercontent.com/51907753/84078970-c7816500-a9a7-11ea-9758-65bccb92c5f5.png">

<img width="1214" alt="Screen Shot 2020-06-08 at 4 34 07 PM" src="https://user-images.githubusercontent.com/51907753/84078981-ccdeaf80-a9a7-11ea-9721-12637e02a642.png">

REACT: 

<img width="1208" alt="Screen Shot 2020-06-08 at 4 41 32 PM" src="https://user-images.githubusercontent.com/51907753/84078996-d23bfa00-a9a7-11ea-9053-c5289b568964.png">


<img width="1210" alt="Screen Shot 2020-06-08 at 4 41 40 PM" src="https://user-images.githubusercontent.com/51907753/84079012-d700ae00-a9a7-11ea-9cb3-60ebb5523457.png">


#### Breaking Changes

None 

#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
