### PR TITLE
Add aria, data, id props to React Person kit, add aria props to Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add aria, data, id props to React Person kit; added aria props to Rails Person kit. ([#848](https://github.com/powerhome/playbook/pull/848) @kellyeryan)
+
 ## [4.17.0] 2020-6-5
 
 ### Added

--- a/app/pb_kits/playbook/pb_person/_person.html.erb
+++ b/app/pb_kits/playbook/pb_person/_person.html.erb
@@ -1,7 +1,14 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>
-      <%= pb_rails("body", props: { tag: "span", classname: "pb_person_first", children: -> { object.first_name } }) %>
-      <%= pb_rails("title", props: { text: object.last_name, size: 4 }) if object.last_name %>
+      <%= pb_rails("body", props: { 
+        tag: "span", 
+        classname: "pb_person_first", 
+        children: -> { object.first_name 
+      } }) %>
+      <%= pb_rails("title", props: { 
+        text: object.last_name, 
+        size: 4 }) if object.last_name %>
 <% end %>

--- a/app/pb_kits/playbook/pb_person/_person.jsx
+++ b/app/pb_kits/playbook/pb_person/_person.jsx
@@ -4,32 +4,56 @@ import React from 'react'
 import classnames from 'classnames'
 import { spacing } from '../utilities/spacing.js'
 
+import {
+  buildAriaProps,
+  buildCss,
+  buildDataProps,
+} from '../utilities/props'
+
 import { Body, Title } from '../'
 
 type PersonProps = {
+  aria?: object,
   className?: String | Array<String>,
-  dark?: Boolean,
+  data?: object,
   firstName: String,
+  id?: String,
   lastName: String,
 }
 
 const Person = (props: PersonProps) => {
-  const { className, dark = false, firstName, lastName } = props
+  const {
+    aria = {},
+    className,
+    data = {},
+    firstName,
+    id,
+    lastName } = props
+
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(buildCss('pb_person_kit'), className, spacing(props))
+
   return (
-    <div className={classnames('pb_person_kit', className, spacing(props))}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
+    >
       <Body
           className="pb_person_first"
-          dark={dark}
           tag="span"
       >
         {firstName}
       </Body>
-      <Title
-          className="pb_person_first"
-          dark={dark}
-          size={4}
-          text={` ${lastName}`}
-      />
+      <If condition={lastName}>
+        <Title
+            className="pb_person_first"
+            size={4}
+            text={` ${lastName}`}
+        />
+      </If>
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_person/docs/_person_default.html.erb
+++ b/app/pb_kits/playbook/pb_person/docs/_person_default.html.erb
@@ -1,1 +1,5 @@
-<%= pb_rails("person", props: { first_name: "Kyle", last_name: "Fadigan" }) %>
+<%= pb_rails("person", 
+    props: { 
+      first_name: "Kyle", 
+      last_name: "Fadigan" 
+      }) %>


### PR DESCRIPTION
#### Issue

React Person kit was missing aria, data, id props and Rails Person kit was missing aria props.

#### Screens

RAILS 

<img width="1183" alt="Screen Shot 2020-06-09 at 12 01 47 PM" src="https://user-images.githubusercontent.com/51907753/84173682-a07c6f00-aa4b-11ea-9ad8-aa1a3804c882.png">

REACT

<img width="1216" alt="Screen Shot 2020-06-09 at 12 13 50 PM" src="https://user-images.githubusercontent.com/51907753/84173701-a4a88c80-aa4b-11ea-8858-169e5795c57e.png">

#### Breaking Changes

None

#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
