### PR TITLE
Add aria, className, data, id props to React Progress Pills kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+-Added aria, className, data, id props to React Progress Pills kit, add aria to Rails Progress Pills kit ([#850](https://github.com/powerhome/playbook/pull/850) @kellyeryan)
+
 ## [4.17.0] 2020-6-5
 
 ### Added

--- a/app/pb_kits/playbook/pb_progress_pills/_progress_pills.html.erb
+++ b/app/pb_kits/playbook/pb_progress_pills/_progress_pills.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_progress_pills/_progress_pills.jsx
+++ b/app/pb_kits/playbook/pb_progress_pills/_progress_pills.jsx
@@ -3,10 +3,21 @@
 import React from 'react'
 import { Body, Title } from '../'
 import classnames from 'classnames'
+
+import {
+  buildAriaProps,
+  buildCss,
+  buildDataProps,
+} from '../utilities/props'
+
 import { spacing } from '../utilities/spacing.js'
 
 type ProgressPillsProps = {
   active?: Number,
+  aria?: object,
+  className?: String,
+  data?: object,
+  id?: String,
   steps?: Number,
   title?: String,
   value?: String,
@@ -26,7 +37,7 @@ const showSteps = (steps, active, dark) => {
 const ProgressPill = ({ active, dark, step }: ProgressPillProps) => (
   <div
       className={`pb_progress_pill${step <= active ? '_active' : '_inactive'}${
-      dark ? '_dark' : null
+      dark ? '_dark' : ''
     }`}
       key={step}
   />
@@ -35,15 +46,29 @@ const ProgressPill = ({ active, dark, step }: ProgressPillProps) => (
 const ProgressPills = (props: ProgressPillsProps) => {
   const {
     active = 0,
+    aria = {},
+    className,
+    data = {},
+    id,
     steps = 3,
-    title = null,
-    value = null,
+    title,
+    value,
     dark = false,
   } = props
   const darkClass = dark ? '_dark' : ''
 
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(buildCss('pb_progress_pills_kit', darkClass), className, spacing(props))
+
   return (
-    <div className={classnames(`pb_progress_pills_kit${darkClass}`, spacing(props))}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
+    >
+
       <If condition={title}>
         <div className="progress_pills_status">
           <Title
@@ -59,7 +84,6 @@ const ProgressPills = (props: ProgressPillsProps) => {
           />
         </div>
       </If>
-
       <div className="progress_pills">{showSteps(steps, active, dark)}</div>
     </div>
   )


### PR DESCRIPTION
#### Issue

React Progress Pills kit was missing aria, className, data, and id props. Rails Progress Pills kit was missing aria props. 

#### Screens

REACT

<img width="1214" alt="Screen Shot 2020-06-10 at 2 11 18 PM" src="https://user-images.githubusercontent.com/51907753/84303353-d04b7580-ab24-11ea-9b35-f4ce2c3cc711.png">

<img width="1216" alt="Screen Shot 2020-06-10 at 2 11 24 PM" src="https://user-images.githubusercontent.com/51907753/84303359-d3defc80-ab24-11ea-88b8-000cd044cc09.png">

RAILS

<img width="1218" alt="Screen Shot 2020-06-10 at 2 12 21 PM" src="https://user-images.githubusercontent.com/51907753/84303372-d6d9ed00-ab24-11ea-9530-6f94f0a9c342.png">

<img width="1216" alt="Screen Shot 2020-06-10 at 2 12 29 PM" src="https://user-images.githubusercontent.com/51907753/84303380-d9d4dd80-ab24-11ea-9b9a-61588183d814.png">

#### Breaking Changes

None

#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
