### PR TITLE
Add aria, id, data props to React Section Separator kit; Add aria props to Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added id, aria, data props to React Section Separator kit. Added aria props to Rails Section Separator kit. ([#852](https://github.com/powerhome/playbook/pull/852) @kellyeryan)
+
 ## [4.17.0] 2020-6-5
 
 ### Added

--- a/app/pb_kits/playbook/pb_section_separator/_section_separator.html.erb
+++ b/app/pb_kits/playbook/pb_section_separator/_section_separator.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_section_separator/_section_separator.jsx
+++ b/app/pb_kits/playbook/pb_section_separator/_section_separator.jsx
@@ -1,36 +1,45 @@
 /* @flow */
 import React from 'react'
 import classnames from 'classnames'
-import Caption from '../pb_caption/_caption.jsx'
+import { Caption } from '../'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { spacing } from '../utilities/spacing.js'
 
 type SectionSeparatorProps = {
+  aria: object,
   className: String,
-  text: String,
-  orientation?: "horizontal" | "vertical",
-  variant?: "card" | "background",
   dark?: Boolean,
+  data: object,
+  id: String,
+  orientation?: "horizontal" | "vertical",
+  text: String,
+  variant?: "card" | "background",
 }
 
 const SectionSeparator = (props: SectionSeparatorProps) => {
   const {
+    aria = {},
     className,
-    text,
-    orientation = 'horizontal',
-    variant = 'card',
     dark = false,
+    data = {},
+    id,
+    orientation = 'horizontal',
+    text,
+    variant = 'card',
   } = props
   const themeStyle = dark === true ? '_dark' : ''
-  const css = classnames(
-    [
-      `pb_section_separator_kit_${variant}_${orientation}` + themeStyle,
-      className,
-    ],
-    spacing(props)
-  )
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(buildCss('pb_section_separator_kit', variant, orientation, themeStyle), className, spacing(props))
 
   return (
-    <div className={css}>
+
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
+    >
       <span>
         <Caption text={text} />
       </span>

--- a/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.jsx
+++ b/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.jsx
@@ -3,7 +3,9 @@ import { SectionSeparator } from '../../'
 
 const SectionSeparatorText = () => {
   return (
-    <SectionSeparator text="Title Separator" />
+    <SectionSeparator
+        text="Title Separator"
+    />
   )
 }
 


### PR DESCRIPTION
#### Issue

React Section Separator kit was missing aria, data, id props. Rails Section Separator kit was missing aria props.

#### Screens

RAILS

<img width="1216" alt="Screen Shot 2020-06-11 at 9 35 21 AM" src="https://user-images.githubusercontent.com/51907753/84393029-16f2ab80-abc9-11ea-95a2-643304c958a6.png">

<img width="1220" alt="Screen Shot 2020-06-11 at 9 35 30 AM" src="https://user-images.githubusercontent.com/51907753/84393061-1d812300-abc9-11ea-9a81-122c57c64d45.png">

<img width="1217" alt="Screen Shot 2020-06-11 at 9 35 36 AM" src="https://user-images.githubusercontent.com/51907753/84393084-240f9a80-abc9-11ea-8f17-8cfbb82a7a68.png">

REACT

<img width="1213" alt="Screen Shot 2020-06-11 at 9 36 44 AM" src="https://user-images.githubusercontent.com/51907753/84393121-2eca2f80-abc9-11ea-992f-89676274a1e2.png">

<img width="1215" alt="Screen Shot 2020-06-11 at 9 36 52 AM" src="https://user-images.githubusercontent.com/51907753/84393136-325db680-abc9-11ea-899e-63de4ae85fb0.png">

<img width="1214" alt="Screen Shot 2020-06-11 at 9 36 58 AM" src="https://user-images.githubusercontent.com/51907753/84393147-3689d400-abc9-11ea-898c-95e5619d6fb5.png">


#### Breaking Changes

None

#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
