### PR TITLE
Add aria, data, id props to React Title kit and aria to Rails Title kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added full page example of a registration dashboard ([#854](https://github.com/powerhome/playbook/pull/854)@christinaatai)
 - Added id props to React Avatar Action Button kit; Added aria props to Rails Avatar Action Button kit ([#857](https://github.com/powerhome/playbook/pull/857) @kellyeryan)
 
+### Added
+
+- Added id, aria, data props to React Title kit, added aria props to Rails Title kit ([#853](https://github.com/powerhome/playbook/pull/853) @kellyeryan)
+
 ## [4.17.0] 2020-6-5
 
 ### Added

--- a/app/pb_kits/playbook/pb_title/_title.html.erb
+++ b/app/pb_kits/playbook/pb_title/_title.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(object.tag, object.text,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) %>

--- a/app/pb_kits/playbook/pb_title/_title.jsx
+++ b/app/pb_kits/playbook/pb_title/_title.jsx
@@ -13,7 +13,7 @@ type TitleProps = {
   data?: object,
   id?: String,
   size?: 1 | 2 | 3 | 4,
-  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "div" | "span",
+  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div",
   text?: String,
 }
 

--- a/app/pb_kits/playbook/pb_title/_title.jsx
+++ b/app/pb_kits/playbook/pb_title/_title.jsx
@@ -2,38 +2,45 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { spacing } from '../utilities/spacing.js'
 
 type TitleProps = {
+  aria?: object,
   className?: String,
   children?: Array<React.ReactNode> | React.ReactNode,
   dark?: Boolean,
+  data?: object,
+  id?: String,
   size?: 1 | 2 | 3 | 4,
+  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "div" | "span",
   text?: String,
-  tag?: "h1" | "h2" | "h3",
-}
-
-const tagCSS = ({ dark = false, size = 3 }) => {
-  let css = ''
-
-  css += `_${size}`
-  css += dark === true ? '_dark' : ''
-
-  return css
 }
 
 const Title = (props: TitleProps) => {
-  const { children, className, tag = 'h3', text } = props
+  const {
+    aria = {},
+    children,
+    className,
+    dark = false,
+    data = {},
+    id,
+    size = 3,
+    tag = 'h3',
+    text } = props
 
+  const themeStyle = dark === true ? '_dark' : ''
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(buildCss('pb_title_kit', size, themeStyle), className, spacing(props))
   const Tag = `${tag}`
 
   return (
     <Tag
-        className={classnames(
-        `pb_title_kit${tagCSS(props)}`,
-        className,
-        spacing(props),
-      )}
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
     >
       {text || children}
     </Tag>

--- a/app/pb_kits/playbook/pb_title/title.rb
+++ b/app/pb_kits/playbook/pb_title/title.rb
@@ -13,7 +13,7 @@ module Playbook
                   values: [1, 2, 3, 4],
                   default: 3
       prop :tag, type: Playbook::Props::Enum,
-                 values: %w[h1 h2 h3 h4 h5 h6 p div span],
+                 values: %w[h1 h2 h3 h4 h5 h6 div],
                  default: "h3"
       prop :text
 

--- a/lib/playbook/version.rb
+++ b/lib/playbook/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Playbook
-  VERSION = "4.18.0"
+  VERSION = "4.19.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playbook-ui",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "description": "Nitro's Design System",
   "main": "./app/pb_kits/playbook/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-jsx-control-statements": "2.2.1",
     "eslint-plugin-react": "git://github.com/rafbgarcia/eslint-plugin-react#fix-other-curly-brace-presence-edge-cases",
     "extract-text-webpack-plugin": "3.0.0",
-    "flow-bin": "0.126.1",
+    "flow-bin": "0.127.0",
     "husky": "3.1.0",
     "lint-staged": "10.2.9",
     "webpack-dev-server": "3.7.2"
@@ -61,7 +61,7 @@
     "css-modules-flow-types-loader": "0.3.1",
     "es5-shim": "4.5.9",
     "fast-sass-loader": "^1.5.0",
-    "flow-bin": "0.126.1",
+    "flow-bin": "0.127.0",
     "flow-runtime": "0.14.0",
     "highcharts": "^7.2.0",
     "jsx-control-statements": "^3.2.8",

--- a/spec/pb_kits/playbook/kits/title_spec.rb
+++ b/spec/pb_kits/playbook/kits/title_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Playbook::PbTitle::Title do
     .with_default(false) }
   it { is_expected.to define_prop(:size).of_type(Playbook::Props::Enum).with_default(3) }
   it { is_expected.to define_enum_prop(:tag)
-    .with_values("h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "span")
+    .with_values("h1", "h2", "h3", "h4", "h5", "h6", "div")
     .with_default("h3")
      }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4136,10 +4136,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@0.126.1:
-  version "0.126.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.126.1.tgz#2726595e1891dc35b379b5994627432df4ead52c"
-  integrity sha512-RI05x7rVzruRVJQN3M4vLEjZMwUHJKhGz9FmL8HN7WiSo66/131EyJS6Vo8PkKyM2pgT9GRWfGP/tXlqS54XUg==
+flow-bin@0.127.0:
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.127.0.tgz#0614cff4c1b783beef1feeb7108d536e09d77632"
+  integrity sha512-ywvCCdV4NJWzrqjFrMU5tAiVGyBiXjsJQ1+/kj8thXyX15V17x8BFvNwoAH97NrUU8T1HzmFBjLzWc0l2319qg==
 
 flow-config-parser@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
#### Issue

React Title kit was missing aria, data, id props and Rails Title kit was missing aria props.

#### Screens

RAILS

<img width="1219" alt="Screen Shot 2020-06-11 at 10 29 24 AM" src="https://user-images.githubusercontent.com/51907753/84400392-f8dc7980-abcf-11ea-9a51-58f532304948.png">

<img width="1214" alt="Screen Shot 2020-06-11 at 10 29 30 AM" src="https://user-images.githubusercontent.com/51907753/84400402-fed25a80-abcf-11ea-9503-16b6deafa7b6.png">

REACT

<img width="1214" alt="Screen Shot 2020-06-11 at 10 29 59 AM" src="https://user-images.githubusercontent.com/51907753/84400440-0a258600-abd0-11ea-9546-4502b98d2b69.png">

<img width="1217" alt="Screen Shot 2020-06-11 at 10 30 04 AM" src="https://user-images.githubusercontent.com/51907753/84400465-10b3fd80-abd0-11ea-8650-0ff9d0d43937.png">

#### Breaking Changes

None

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
