### PR TITLE
Add ability to toggle if the legend is clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [4.18.1] 2020-6-15
+- Add toggling for legend click on bar and line graph
 
 ### Updated
 - Increase Playbook Compilation Performance ([#866](https://github.com/powerhome/playbook/pull/866) @thestephenmarshall)

--- a/app/pb_kits/playbook/pb_bar_graph/_bar_graph.jsx
+++ b/app/pb_kits/playbook/pb_bar_graph/_bar_graph.jsx
@@ -21,7 +21,7 @@ type BarGraphProps = {
   title: String,
   type?: String,
   legend?: Boolean,
-  legendClick?: Boolean,
+  toggleLegendClick?: Boolean,
   height?: String,
 }
 
@@ -30,7 +30,7 @@ export default class BarGraph extends React.Component<BarGraphProps> {
     className: 'pb_bar_graph',
     type: 'column',
     legend: false,
-    legendClick: true,
+    toggleLegendClick: true,
   }
 
   componentDidMount() {
@@ -48,7 +48,7 @@ export default class BarGraph extends React.Component<BarGraphProps> {
       type,
       legend,
       height,
-      legendClick,
+      toggleLegendClick,
     } = this.props
 
     new pbChart(`.${className}`, {
@@ -63,7 +63,7 @@ export default class BarGraph extends React.Component<BarGraphProps> {
       yAxisMin: yAxisMin,
       yAxisMax: yAxisMax,
       legend: legend,
-      legendClick: legendClick,
+      toggleLegendClick: toggleLegendClick,
       height: height,
     })
   }

--- a/app/pb_kits/playbook/pb_bar_graph/_bar_graph.jsx
+++ b/app/pb_kits/playbook/pb_bar_graph/_bar_graph.jsx
@@ -21,6 +21,7 @@ type BarGraphProps = {
   title: String,
   type?: String,
   legend?: Boolean,
+  legendClick?: Boolean,
   height?: String,
 }
 
@@ -28,6 +29,8 @@ export default class BarGraph extends React.Component<BarGraphProps> {
   static defaultProps = {
     className: 'pb_bar_graph',
     type: 'column',
+    legend: false,
+    legendClick: true,
   }
 
   componentDidMount() {
@@ -45,6 +48,7 @@ export default class BarGraph extends React.Component<BarGraphProps> {
       type,
       legend,
       height,
+      legendClick,
     } = this.props
 
     new pbChart(`.${className}`, {
@@ -59,6 +63,7 @@ export default class BarGraph extends React.Component<BarGraphProps> {
       yAxisMin: yAxisMin,
       yAxisMax: yAxisMax,
       legend: legend,
+      legendClick: legendClick,
       height: height,
     })
   }

--- a/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
+++ b/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
@@ -21,8 +21,8 @@ module Playbook
       prop :y_axis_max, type: Playbook::Props::Numeric
       prop :legend, type: Playbook::Props::Boolean,
                     default: false
-      prop :legend_click, type: Playbook::Props::Boolean,
-                          default: true
+      prop :toggle_legend_click, type: Playbook::Props::Boolean,
+                                 default: true
       prop :height
 
       def chart_type
@@ -42,7 +42,7 @@ module Playbook
           yAxisMin: y_axis_min,
           yAxisMax: y_axis_max,
           legend: legend,
-          legendClick: legend_click,
+          toggleLegendClick: toggle_legend_click,
           height: height,
         }.to_json.html_safe
       end

--- a/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
+++ b/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
@@ -21,6 +21,8 @@ module Playbook
       prop :y_axis_max, type: Playbook::Props::Numeric
       prop :legend, type: Playbook::Props::Boolean,
                     default: false
+      prop :legend_click, type: Playbook::Props::Boolean,
+                          default: true
       prop :height
 
       def chart_type
@@ -40,6 +42,7 @@ module Playbook
           yAxisMin: y_axis_min,
           yAxisMax: y_axis_max,
           legend: legend,
+          legendClick: legend_click,
           height: height,
         }.to_json.html_safe
       end

--- a/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.html.erb
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.html.erb
@@ -11,5 +11,5 @@
     x_axis_categories: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
     title: 'Bar Graph with Legend Non Clickable',
     legend: true,
-    legend_click: false,
+    toggle_legend_click: false,
 }) %>

--- a/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.html.erb
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.html.erb
@@ -1,0 +1,15 @@
+<% data = [{
+    name: 'Number of Installations',
+    data: [1475,200,3000,654,656]
+}] %>
+
+<%= pb_rails("bar_graph", props: {
+    axis_title: 'Number of Employees',
+    chart_data: data,
+    id: "bar-test-3",
+    y_axis_min: 0,
+    x_axis_categories: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+    title: 'Bar Graph with Legend Non Clickable',
+    legend: true,
+    legend_click: false,
+}) %>

--- a/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.jsx
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { BarGraph } from '../..'
+
+const chartData = [{
+  name: 'Number of Installations',
+  data: [1475, 200, 3000, 654, 656],
+}]
+
+const BarGraphLegendNonClickable = () => (
+  <div>
+    <BarGraph
+        axisTitle="Number of Employees"
+        chartData={chartData}
+        id="bar-test-3"
+        legend
+        legendClick={false}
+        title="Bar Graph with Legend Non Clickable"
+        xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May']}
+        yAxisMin={0}
+    />
+  </div>
+)
+
+export default BarGraphLegendNonClickable

--- a/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.jsx
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.jsx
@@ -13,8 +13,8 @@ const BarGraphLegendNonClickable = () => (
         chartData={chartData}
         id="bar-test-3"
         legend
-        toggleLegendClick={false}
         title="Bar Graph with Legend Non Clickable"
+        toggleLegendClick={false}
         xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May']}
         yAxisMin={0}
     />

--- a/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.jsx
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_legend_non_clickable.jsx
@@ -13,7 +13,7 @@ const BarGraphLegendNonClickable = () => (
         chartData={chartData}
         id="bar-test-3"
         legend
-        legendClick={false}
+        toggleLegendClick={false}
         title="Bar Graph with Legend Non Clickable"
         xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May']}
         yAxisMin={0}

--- a/app/pb_kits/playbook/pb_bar_graph/docs/example.yml
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/example.yml
@@ -1,13 +1,15 @@
 examples:
-  
+
   rails:
   - bar_graph_default: Default
   - bar_graph_legend: Legend
+  - bar_graph_legend_non_clickable: Legend Non Clickable
   - bar_graph_height: Height
-  
-  
+
+
   react:
   - bar_graph_default: Default
   - bar_graph_legend: Legend
+  - bar_graph_legend_non_clickable: Legend Non Clickable
   - bar_graph_height: Height
-  
+

--- a/app/pb_kits/playbook/pb_bar_graph/docs/index.js
+++ b/app/pb_kits/playbook/pb_bar_graph/docs/index.js
@@ -1,3 +1,4 @@
 export { default as BarGraphDefault } from './_bar_graph_default.jsx'
 export { default as BarGraphLegend } from './_bar_graph_legend.jsx'
+export { default as BarGraphLegendNonClickable } from './_bar_graph_legend_non_clickable.jsx'
 export { default as BarGraphHeight } from './_bar_graph_height.jsx'

--- a/app/pb_kits/playbook/pb_line_graph/_line_graph.jsx
+++ b/app/pb_kits/playbook/pb_line_graph/_line_graph.jsx
@@ -22,6 +22,7 @@ type LineGraphProps = {
   title: String,
   type?: String,
   legend?: Boolean,
+  legendClick?: Boolean,
   height?: String,
 }
 
@@ -30,6 +31,8 @@ export default class LineGraph extends React.Component<LineGraphProps> {
     className: 'pb_bar_graph',
     gradient: false,
     type: 'line',
+    legend: false,
+    legendClick: true,
   }
 
   componentDidMount() {
@@ -46,6 +49,7 @@ export default class LineGraph extends React.Component<LineGraphProps> {
       title,
       type,
       legend,
+      legendClick,
       height,
     } = this.props
 
@@ -61,6 +65,7 @@ export default class LineGraph extends React.Component<LineGraphProps> {
       yAxisMin: yAxisMin,
       yAxisMax: yAxisMax,
       legend: legend,
+      legendClick: legendClick,
       height: height,
     })
   }

--- a/app/pb_kits/playbook/pb_line_graph/_line_graph.jsx
+++ b/app/pb_kits/playbook/pb_line_graph/_line_graph.jsx
@@ -22,7 +22,7 @@ type LineGraphProps = {
   title: String,
   type?: String,
   legend?: Boolean,
-  legendClick?: Boolean,
+  toggleLegendClick?: Boolean,
   height?: String,
 }
 
@@ -32,7 +32,7 @@ export default class LineGraph extends React.Component<LineGraphProps> {
     gradient: false,
     type: 'line',
     legend: false,
-    legendClick: true,
+    toggleLegendClick: true,
   }
 
   componentDidMount() {
@@ -49,7 +49,7 @@ export default class LineGraph extends React.Component<LineGraphProps> {
       title,
       type,
       legend,
-      legendClick,
+      toggleLegendClick,
       height,
     } = this.props
 
@@ -65,7 +65,7 @@ export default class LineGraph extends React.Component<LineGraphProps> {
       yAxisMin: yAxisMin,
       yAxisMax: yAxisMax,
       legend: legend,
-      legendClick: legendClick,
+      toggleLegendClick: toggleLegendClick,
       height: height,
     })
   }

--- a/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.html.erb
+++ b/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.html.erb
@@ -1,0 +1,16 @@
+<% data = [{
+    name: 'Number of Installations',
+    data: [43934, 52503, 57177, 69658, 97031, 119931, 137133, 154175]
+}] %>
+
+<%= pb_rails("line_graph", props: {
+    id: "line-test-3",
+    gradient: false,
+    chart_data: data,
+    x_axis_categories: ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug'],
+    title: 'Line Graph with Legend Non Clickable',
+    axis_title: 'Number of Employees',
+    legend: true,
+    legend_click: false,
+}) %>
+

--- a/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.html.erb
+++ b/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.html.erb
@@ -11,6 +11,6 @@
     title: 'Line Graph with Legend Non Clickable',
     axis_title: 'Number of Employees',
     legend: true,
-    legend_click: false,
+    toggle_legend_click: false,
 }) %>
 

--- a/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
+++ b/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
@@ -13,8 +13,8 @@ const LineGraphLegendNonclickable = () => (
         chartData={data}
         id="line-test-3"
         legend
-        toggleLegendClick={false}
         title="Line Graph with Legend Non Clickable"
+        toggleLegendClick={false}
         xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']}
     />
   </div>

--- a/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
+++ b/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { LineGraph } from '../..'
+
+const data = [{
+  name: 'Number of Installations',
+  data: [43934, 52503, 57177, 69658, 97031, 119931, 137133, 154175],
+}]
+
+const LineGraphLegendNonclickable = () => (
+  <div>
+    <LineGraph
+        axisTitle="Number of Employees"
+        chartData={data}
+        id="line-test-3"
+        legendClick={false}
+        legend
+        title="Line Graph with Legend Non Clickable"
+        xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']}
+    />
+  </div>
+)
+
+export default LineGraphLegendNonclickable

--- a/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
+++ b/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
@@ -13,7 +13,7 @@ const LineGraphLegendNonclickable = () => (
         chartData={data}
         id="line-test-3"
         legend
-        legendClick={false}
+        toggleLegendClick={false}
         title="Line Graph with Legend Non Clickable"
         xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']}
     />

--- a/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
+++ b/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_legend_nonclickable.jsx
@@ -12,8 +12,8 @@ const LineGraphLegendNonclickable = () => (
         axisTitle="Number of Employees"
         chartData={data}
         id="line-test-3"
-        legendClick={false}
         legend
+        legendClick={false}
         title="Line Graph with Legend Non Clickable"
         xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']}
     />

--- a/app/pb_kits/playbook/pb_line_graph/docs/example.yml
+++ b/app/pb_kits/playbook/pb_line_graph/docs/example.yml
@@ -1,12 +1,14 @@
 examples:
-  
+
   rails:
   - line_graph_default: Default
   - line_graph_legend: Legend
+  - line_graph_legend_nonclickable: Legend Nonclickable
   - line_graph_height: Height
-  
-  
+
+
   react:
   - line_graph_default: Default
   - line_graph_legend: Legend
+  - line_graph_legend_nonclickable: Legend Nonclickable
   - line_graph_height: Height

--- a/app/pb_kits/playbook/pb_line_graph/docs/index.js
+++ b/app/pb_kits/playbook/pb_line_graph/docs/index.js
@@ -1,3 +1,4 @@
 export { default as LineGraphDefault } from './_line_graph_default.jsx'
 export { default as LineGraphLegend } from './_line_graph_legend.jsx'
+export { default as LineGraphLegendNonclickable } from './_line_graph_legend_nonclickable.jsx'
 export { default as LineGraphHeight } from './_line_graph_height.jsx'

--- a/app/pb_kits/playbook/pb_line_graph/line_graph.rb
+++ b/app/pb_kits/playbook/pb_line_graph/line_graph.rb
@@ -21,8 +21,8 @@ module Playbook
       prop :y_axis_max, type: Playbook::Props::Numeric
       prop :legend, type: Playbook::Props::Boolean,
                     default: false
-      prop :legend_click, type: Playbook::Props::Boolean,
-                          default: true
+      prop :toggle_legend_click, type: Playbook::Props::Boolean,
+                                 default: true
       prop :height
 
       def chart_type
@@ -42,7 +42,7 @@ module Playbook
           yAxisMin: y_axis_min,
           yAxisMax: y_axis_max,
           legend: legend,
-          legendClick: legend_click,
+          toggleLegendClick: toggle_legend_click,
           height: height,
         }.to_json.html_safe
       end

--- a/app/pb_kits/playbook/pb_line_graph/line_graph.rb
+++ b/app/pb_kits/playbook/pb_line_graph/line_graph.rb
@@ -21,6 +21,8 @@ module Playbook
       prop :y_axis_max, type: Playbook::Props::Numeric
       prop :legend, type: Playbook::Props::Boolean,
                     default: false
+      prop :legend_click, type: Playbook::Props::Boolean,
+                          default: true
       prop :height
 
       def chart_type
@@ -40,6 +42,7 @@ module Playbook
           yAxisMin: y_axis_min,
           yAxisMax: y_axis_max,
           legend: legend,
+          legendClick: legend_click,
           height: height,
         }.to_json.html_safe
       end

--- a/app/pb_kits/playbook/plugins/pb_chart.js
+++ b/app/pb_kits/playbook/plugins/pb_chart.js
@@ -77,7 +77,7 @@ class pbChart {
   setupChart() {
     Highcharts.setOptions(highchartsTheme)
 
-    Highcharts.chart(this.defaults.id, {
+    let configOptions = {
       title: {
         text: this.defaults.title,
       },
@@ -111,7 +111,13 @@ class pbChart {
       },
       series: this.defaults.chartData,
       credits: false,
-    })
+    }
+
+    if (!this.defaults.legendClick) {
+      configOptions.plotOptions.series.events = { legendItemClick: () => false }
+    }
+
+    Highcharts.chart(this.defaults.id, configOptions)
   }
 
   refresh(silent = false) {

--- a/app/pb_kits/playbook/plugins/pb_chart.js
+++ b/app/pb_kits/playbook/plugins/pb_chart.js
@@ -113,7 +113,7 @@ class pbChart {
       credits: false,
     }
 
-    if (!this.defaults.legendClick) {
+    if (!this.defaults.toggleLegendClick) {
       configOptions.plotOptions.series.events = { legendItemClick: () => false }
     }
 

--- a/app/pb_kits/playbook/plugins/pb_chart.js
+++ b/app/pb_kits/playbook/plugins/pb_chart.js
@@ -77,7 +77,7 @@ class pbChart {
   setupChart() {
     Highcharts.setOptions(highchartsTheme)
 
-    let configOptions = {
+    const configOptions = {
       title: {
         text: this.defaults.title,
       },

--- a/spec/pb_kits/playbook/kits/bar_graph_spec.rb
+++ b/spec/pb_kits/playbook/kits/bar_graph_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Playbook::PbBarGraph::BarGraph do
   it { is_expected.to define_prop(:point_start).of_type(Playbook::Props::Numeric) }
   it { is_expected.to define_prop(:subtitle) }
   it { is_expected.to define_prop(:legend).of_type(Playbook::Props::Boolean).with_default(false) }
-  it { is_expected.to define_prop(:legend_click).of_type(Playbook::Props::Boolean).with_default(true) }
+  it { is_expected.to define_prop(:toggle_legend_click).of_type(Playbook::Props::Boolean).with_default(true) }
   it { is_expected.to define_prop(:title) }
   it { is_expected.to define_enum_prop(:orientation)
                       .with_default("vertical")

--- a/spec/pb_kits/playbook/kits/bar_graph_spec.rb
+++ b/spec/pb_kits/playbook/kits/bar_graph_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Playbook::PbBarGraph::BarGraph do
   it { is_expected.to define_prop(:axis_title) }
   it { is_expected.to define_prop(:point_start).of_type(Playbook::Props::Numeric) }
   it { is_expected.to define_prop(:subtitle) }
+  it { is_expected.to define_prop(:legend).of_type(Playbook::Props::Boolean).with_default(false) }
+  it { is_expected.to define_prop(:legend_click).of_type(Playbook::Props::Boolean).with_default(true) }
   it { is_expected.to define_prop(:title) }
   it { is_expected.to define_enum_prop(:orientation)
                       .with_default("vertical")

--- a/spec/pb_kits/playbook/kits/line_graph_spec.rb
+++ b/spec/pb_kits/playbook/kits/line_graph_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Playbook::PbLineGraph::LineGraph do
   it { is_expected.to define_string_prop(:title) }
   it { is_expected.to define_prop(:chart_data).of_type(Playbook::Props::Array).with_default([]) }
   it { is_expected.to define_prop(:gradient).of_type(Playbook::Props::Boolean).with_default(false) }
+  it { is_expected.to define_prop(:legend).of_type(Playbook::Props::Boolean).with_default(false) }
+  it { is_expected.to define_prop(:legend_click).of_type(Playbook::Props::Boolean).with_default(true) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do

--- a/spec/pb_kits/playbook/kits/line_graph_spec.rb
+++ b/spec/pb_kits/playbook/kits/line_graph_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Playbook::PbLineGraph::LineGraph do
   it { is_expected.to define_prop(:chart_data).of_type(Playbook::Props::Array).with_default([]) }
   it { is_expected.to define_prop(:gradient).of_type(Playbook::Props::Boolean).with_default(false) }
   it { is_expected.to define_prop(:legend).of_type(Playbook::Props::Boolean).with_default(false) }
-  it { is_expected.to define_prop(:legend_click).of_type(Playbook::Props::Boolean).with_default(true) }
+  it { is_expected.to define_prop(:toggle_legend_click).of_type(Playbook::Props::Boolean).with_default(true) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do


### PR DESCRIPTION
This PR allows for the legend's click functionality on the Bar and Line graph to be toggled on and off.

I have set the default to true because it is being used in several places around Nitro and I don't want to have to change them all.

