### PR TITLE
Fix bug displaying user kit in "typeahead" kit docs

### DIFF
--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_default.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_default.html.erb
@@ -46,6 +46,6 @@
     if (!event.target.dataset.typeaheadExample) return;
 
     document.querySelector("[data-typeahead-example-selected-option] [data-selected-option]").innerHTML = ""
-    document.querySelector("[data-typeahead-example-selected-option] [data-selected-option]").appendChild(event.detail.selected)
+    document.querySelector("[data-typeahead-example-selected-option] [data-selected-option]").innerHTML = event.detail.selected.innerHTML
   })
 <% end %>


### PR DESCRIPTION
#### Screens
Old View of Typeahead kit docs:
<img width="1680" alt="Screen Shot 2020-06-19 at 8 08 34 AM" src="https://user-images.githubusercontent.com/38434137/85147834-41b1b500-b204-11ea-92eb-3322f1603dc1.png">

New View of Typeahead kit docs:
<img width="1680" alt="Screen Shot 2020-06-19 at 8 08 19 AM" src="https://user-images.githubusercontent.com/38434137/85147875-4bd3b380-b204-11ea-86d3-47fc64fe2231.png">

#### Breaking Changes
No breaking changes. Only affects the example shown in the docs.

#### Runway Ticket URL
No related ticket.

#### How to test this

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- ~~**CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`~~
