### PR TITLE
Migrate cert-manager annotations to new version

### DIFF
--- a/config/deploy/templates/ingress.yaml.erb
+++ b/config/deploy/templates/ingress.yaml.erb
@@ -7,9 +7,7 @@ metadata:
     app: playbook
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: production-certs
-    certmanager.k8s.io/acme-challenge-type: dns01
-    certmanager.k8s.io/acme-dns01-provider: route53-powerapp-cloud
+    cert-manager.io/cluster-issuer: production-certs
     <% if environment == 'production' %>
     nginx.ingress.kubernetes.io/whitelist-source-range: '0.0.0.0/0'
     <% end %>


### PR DESCRIPTION
#### Screens

No GUI change.

#### Breaking Changes

Merge of this PR will prevent certs from being issued until cert-manager is updated on the cluster. Lack of merge of this PR will prevent certs from being issued after cert-manager is updated on the cluster.

Certificates are issued with a 90 day validity, renewed whenever there's less than 15 days to expire, and we plan on updating cert-manager on the cluster on the first half of this week, so this shouldn't be an issue.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/WTWR-149

#### How to test this

All functional tests have already been performed by the Watchtower team.