### PR TITLE
Radio kit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-<<<<<<< HEAD
+### Fixed
+- Made radio buttons a fixed width ([#833](https://github.com/powerhome/playbook/pull/833) @christinaatai)
+
+### Changed
+- Updated radio border dark color ([#833](https://github.com/powerhome/playbook/pull/833) @christinaatai)
+
 ## [5.0.1] 2020-6-19
 
 ### Added
@@ -28,9 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.18.1] 2020-6-15
 - Add toggling for legend click on bar and line graph
-=======
-## [4.18.1] 2020-6-15
->>>>>>> origin/master
 
 ### Updated
 - Increase Playbook Compilation Performance ([#866](https://github.com/powerhome/playbook/pull/866) @thestephenmarshall)

--- a/app/pb_kits/playbook/pb_radio/_radio.scss
+++ b/app/pb_kits/playbook/pb_radio/_radio.scss
@@ -8,6 +8,7 @@
 
   .pb_radio_button {
     width: 22px;
+    min-width: 22px;
     height: 22px;
     border-radius: 1000px;
     border: 2px solid $border_light;
@@ -29,6 +30,9 @@
     }
   }
   &[class*=_dark] {
+    .pb_radio_button {
+      border-color: $border_dark;
+    }
     input:checked ~ .pb_radio_button {
       border: 6px solid $primary;
     }


### PR DESCRIPTION
#### Issue
When the radio text is very long, it will squish the radio button. Also, the border color for radio dark needs to be updated.

#### Screens

_Radio before_
<img width="1360" alt="Screen Shot 2020-06-24 at 4 44 06 PM" src="https://user-images.githubusercontent.com/42459486/85627650-d66d4600-b63c-11ea-95a4-f0d460728f7c.png">

_Radio after_
<img width="1329" alt="Screen Shot 2020-06-24 at 4 45 12 PM" src="https://user-images.githubusercontent.com/42459486/85627688-e9801600-b63c-11ea-8ee0-9cab19715730.png">

Note: The doc example in the PR just says "Custom Power." The extra long radio option in the screenshots is to just demonstrate that the radio button gets squished.

_Updated border color for dark version_
<img width="1355" alt="Screen Shot 2020-06-24 at 4 54 09 PM" src="https://user-images.githubusercontent.com/42459486/85627826-23e9b300-b63d-11ea-85f7-e68735ccbf5b.png">

#### Breaking Changes
n/a

#### Runway Ticket URL
n/a

#### How to test this

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
