### PR TITLE
Add aria, data props to React Badge kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v5.2.0] 2020-7-2
 
+### Added
+- Added aria, data props to Badge React kit; added aria props to Badge Rails kit ([#901](https://github.com/powerhome/playbook/pull/901) @kellyeryan)
+
 ### Fixed
 - Added User Badge Kit back to menu.yml ([#890](https://github.com/powerhome/playbook/pull/890) @christinaatai)
 

--- a/app/pb_kits/playbook/pb_badge/_badge.html.erb
+++ b/app/pb_kits/playbook/pb_badge/_badge.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_badge/_badge.jsx
+++ b/app/pb_kits/playbook/pb_badge/_badge.jsx
@@ -2,26 +2,37 @@
 
 import React from 'react'
 import classnames from 'classnames'
-import { buildCss } from '../utilities/props'
 import { spacing } from '../utilities/spacing.js'
 
+import {
+  buildAriaProps,
+  buildCss,
+  buildDataProps,
+} from '../utilities/props'
+
 type BadgeProps = {
+  aria?: object,
   className?: String,
   dark?: Boolean,
+  data?: object,
   id?: String,
-  text?: String,
-  variant?: "success" | "warning" | "error" | "info" | "neutral",
   rounded?: Boolean,
+  text?: String,
+  variant?: "error" | "info" | "neutral" | "primary" | "success" | "warning",
 }
 const Badge = (props: BadgeProps) => {
   const {
+    aria = {},
     className,
     dark = false,
+    data = {},
     id,
+    rounded = false,
     text,
     variant = 'neutral',
-    rounded = false,
   } = props
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
   const css = classnames(
     className,
     buildCss('pb_badge_kit', variant, {
@@ -33,6 +44,8 @@ const Badge = (props: BadgeProps) => {
 
   return (
     <div
+        {...ariaProps}
+        {...dataProps}
         className={css}
         id={id}
     >


### PR DESCRIPTION
#### Issue

The React Badge kit didn't have aria, data props; the Rails Badge kit didn't have aria props. I also alphabetized a few lists.

#### Screens

<img width="1443" alt="Screen Shot 2020-07-09 at 10 32 24 AM" src="https://user-images.githubusercontent.com/51907753/87053639-354fc500-c1d0-11ea-9eb2-ae4652ae1673.png">

<img width="1445" alt="Screen Shot 2020-07-09 at 10 32 00 AM" src="https://user-images.githubusercontent.com/51907753/87053659-397be280-c1d0-11ea-805c-899812d7ddac.png">

#### Breaking Changes

None

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
