### PR TITLE
Add aria, data props to Dashboard Value kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Variant prop added to allow typography kit text to change to primary color ([#921](https://github.com/powerhome/playbook/pull/921)  @kellyeryan)
+- Added aria, data props to React Dashboard Value kit; added aria props to Rails kit. ([#909](https://github.com/powerhome/playbook/pull/909) @kellyeryan)
+
 
 ## [v5.3.0] 2020-7-9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v5.2.0] 2020-7-2
 
+### Added
+- Added aria, data props to Badge React kit; added aria props to Badge Rails kit ([#901](https://github.com/powerhome/playbook/pull/901) @kellyeryan)
+
 ### Fixed
 - Added User Badge Kit back to menu.yml ([#890](https://github.com/powerhome/playbook/pull/890) @christinaatai)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v5.2.0] 2020-7-2
 
-### Added
-- Added aria, data props to Badge React kit; added aria props to Badge Rails kit ([#901](https://github.com/powerhome/playbook/pull/901) @kellyeryan)
-
 ### Fixed
 - Added User Badge Kit back to menu.yml ([#890](https://github.com/powerhome/playbook/pull/890) @christinaatai)
 

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
-    id: object.id,
+    aria: object.aria,
+    class: object.classname,
     data: object.data,
-    class: object.classname) do %>
+    id: object.id) do %>
   <% if object.stat_label.present? %>
     <%= pb_rails("body", props: { color: "light", text: object.stat_label } ) %>
   <% end %>

--- a/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
+++ b/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { spacing } from '../utilities/spacing.js'
 import {
   Body,
@@ -11,7 +12,9 @@ import {
 
 type DashboardValueProps = {
   align?: 'left' | 'center' | 'right',
+  aria?: object,
   className?: String,
+  data?: object,
   id?: String,
   statChange?: {
     change?: String,
@@ -24,27 +27,27 @@ type DashboardValueProps = {
   }
 }
 
-const dashboardValueCSS = ({
-  align = 'left',
-
-}: DashboardValueProps) => {
-  const alignStyle = align !== '' ? `_${align}` : ''
-
-  return 'pb_dashboard_value_kit' + alignStyle
-}
-
 const DashboardValue = (props: DashboardValueProps) => {
   const {
+    align = 'left',
+    aria = {},
     className,
+    data = {},
     id,
-    statChange,
+    statChange = {},
     statLabel,
-    statValue,
+    statValue = {},
   } = props
+
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(buildCss('pb_dashboard_value_kit', align), className, spacing(props))
 
   return (
     <div
-        className={classnames(dashboardValueCSS(props), className, spacing(props))}
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
         id={id}
     >
       <If condition={statLabel}>


### PR DESCRIPTION
#### Issue

React Dashboard Value kit was missing aria, data props; Rails kit was missing aria props. There were also some minor inconsistencies between the default values on the React versus the Rails.

#### Screens

<img width="1531" alt="Screen Shot 2020-07-14 at 9 14 14 AM" src="https://user-images.githubusercontent.com/51907753/87430028-9ac9fa00-c5b2-11ea-8d00-730f616c46b9.png">

<img width="1542" alt="Screen Shot 2020-07-14 at 9 12 28 AM" src="https://user-images.githubusercontent.com/51907753/87430038-9dc4ea80-c5b2-11ea-8513-f146b02419f4.png">

#### Breaking Changes

None

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
