### PR TITLE
Add props to legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## Added
+- Added className prop as well as aria, data, id props to React Legend kit. Added aria props to Rails Legend kit. ([#924](https://github.com/powerhome/playbook/pull/924)  @kellyeryan)
+
+## Added
 - Variant prop added to allow typography kit text to change to primary color ([#921](https://github.com/powerhome/playbook/pull/921)  @kellyeryan)
 
 ## [v5.3.0] 2020-7-9

--- a/app/pb_kits/playbook/pb_legend/_legend.html.erb
+++ b/app/pb_kits/playbook/pb_legend/_legend.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div, object.text,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_legend/_legend.jsx
+++ b/app/pb_kits/playbook/pb_legend/_legend.jsx
@@ -2,12 +2,14 @@
 
 import React from 'react'
 import classnames from 'classnames'
-import { buildCss } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { spacing } from '../utilities/spacing.js'
 
 import { Body, Title } from '../'
 
 type LegendProps = {
+  aria?: object,
+  className?: String,
   color?: | "data_1"
     | "data_2"
     | "data_3"
@@ -16,20 +18,39 @@ type LegendProps = {
     | "data_6"
     | "data_7",
   dark?: Boolean,
+  data?: object,
+  id?: String,
   prefixText?: String,
   text: String,
 }
 
 const Legend = (props: LegendProps) => {
-  const { color = 'data_1', dark = false, prefixText, text } = props
+  const {
+    aria = {},
+    className,
+    color = 'data_1',
+    dark = false,
+    data = {},
+    id,
+    prefixText,
+    text,
+  } = props
+
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
   const darkClass = dark ? 'dark' : 'light'
   const bodyCSS = classnames(
-    buildCss('pb_legend_kit', color, darkClass),
+    buildCss('pb_legend_kit', color, darkClass), className,
     spacing(props)
   )
 
   return (
-    <div className={bodyCSS}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={bodyCSS}
+        id={id}
+    >
       <Body color={dark ? 'lighter' : 'light'}>
         <span className="pb_legend_indicator_circle" />
         <If condition={prefixText}>

--- a/app/pb_kits/playbook/pb_legend/docs/_legend_default.jsx
+++ b/app/pb_kits/playbook/pb_legend/docs/_legend_default.jsx
@@ -8,10 +8,7 @@ const LegendDefault = () => (
     {
       products.map((product, i) => (
         <Legend
-            aria={{ 'piratesOf': 'theCaribbean' }}
             color={`data_${i + 1}`}
-            data={{ 'golden': 'apple' }}
-            id="uniqueNewYork"
             key={`legend_${i + 1}`}
             text={product}
         />

--- a/app/pb_kits/playbook/pb_legend/docs/_legend_default.jsx
+++ b/app/pb_kits/playbook/pb_legend/docs/_legend_default.jsx
@@ -8,7 +8,10 @@ const LegendDefault = () => (
     {
       products.map((product, i) => (
         <Legend
+            aria={{ 'piratesOf': 'theCaribbean' }}
             color={`data_${i + 1}`}
+            data={{ 'golden': 'apple' }}
+            id="uniqueNewYork"
             key={`legend_${i + 1}`}
             text={product}
         />


### PR DESCRIPTION
#### Github Issue

#269

Added className prop as well as aria, data, id props to React Legend kit. Added aria props to Rails Legend kit.

#### Screens

<img width="1371" alt="Screen Shot 2020-07-22 at 12 56 24 PM" src="https://user-images.githubusercontent.com/51907753/88205883-693cd880-cc1b-11ea-8c26-3f435fc12990.png">


<img width="1368" alt="Screen Shot 2020-07-22 at 12 57 12 PM" src="https://user-images.githubusercontent.com/51907753/88205894-6cd05f80-cc1b-11ea-8ccb-a983e4b95735.png">


#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
