### PR TITLE
Fixes Spacing Conflicts with Caption Sizing Props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Don't break page when changing icon with condition in with icon nav ([#913](https://github.com/powerhome/playbook/pull/913) @KatherineMuedas)
+- Fixed spacing conflicts with Caption sizing props ([#925](https://github.com/powerhome/playbook/pull/925) @jasperfurniss)
 
 ### Changed
 - Updated kit generator to include data, aria props ([#916](https://github.com/powerhome/playbook/pull/916) @kellyeryan)

--- a/app/pb_kits/playbook/pb_caption/_caption.scss
+++ b/app/pb_kits/playbook/pb_caption/_caption.scss
@@ -3,11 +3,11 @@
 [class^=pb_caption_kit] {
   @include caption;
 
-  &[class*=_lg] {
+  &[class^=pb_caption_kit_lg] {
     @include caption_lg;
   }
 
-  &[class*=_xs] {
+  &[class^=pb_caption_kit_xs] {
     @include caption_xs;
   }
 


### PR DESCRIPTION
I tested this on both React & Rails, with spacing props added in the docs example. The conflicts are now gone. 🎉

#### Breaking Changes

_Please reflect if your changes may break in some way (changes like removing/renaming props are examples of breaking changes)_

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/NUX-1228

#### How to test this

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
