### PR TITLE
Bugfix: Caption sizing + spacing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed spacing conflicts with Caption sizing props ([#925](https://github.com/powerhome/playbook/pull/925) @jasperfurniss)
 - Limited Popover overflow property to popovers with max width or height ([#922](https://github.com/powerhome/playbook/pull/922) @bh247484)
+- Fixed matching for spacing and sizing on caption ([#930](https://github.com/powerhome/playbook/pull/930) @jasoncypret)
 
 
 

--- a/app/pb_kits/playbook/pb_caption/_caption.scss
+++ b/app/pb_kits/playbook/pb_caption/_caption.scss
@@ -3,15 +3,15 @@
 [class^=pb_caption_kit] {
   @include caption;
 
-  &[class^=pb_caption_kit_lg] {
-    @include caption_lg;
-  }
-
-  &[class^=pb_caption_kit_xs] {
-    @include caption_xs;
-  }
-
   &[class*=_dark] {
     @include caption_dark;
   }
+}
+
+[class^=pb_caption_kit_lg] {
+  @include caption_lg;
+}
+
+[class^=pb_caption_kit_xs] {
+  @include caption_xs;
 }


### PR DESCRIPTION
The way the css lookup worked was too greedy and matching on the spacing variables.

#### Screens

![image](https://user-images.githubusercontent.com/863031/88348249-8902f800-cd12-11ea-9c47-18000affa066.png)

#### Breaking Changes

_Please reflect if your changes may break in some way (changes like removing/renaming props are examples of breaking changes)_

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUX-1228

#### How to test this

Test that caption look ok in most places. To test the bug you need to add additional spacing to this kit.

#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [ ] **SCREENSHOT** Please add a screen shot or two
- [ ] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
