### PR TITLE
Adds disabled attribute to button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- Added disabled attribute to button. ([#934](https://github.com/powerhome/playbook/pull/934)  @KatherineMuedas)
+
 ## [v5.5.1] 2020-7-24
 
 ### Added

--- a/app/pb_kits/playbook/pb_button/_button.jsx
+++ b/app/pb_kits/playbook/pb_button/_button.jsx
@@ -72,6 +72,7 @@ const Button = (props: ButtonPropTypes) => {
   const {
     children,
     className,
+    disabled,
     icon = null,
     id,
     loading = false,
@@ -120,6 +121,7 @@ const Button = (props: ButtonPropTypes) => {
       <button
           {...buttonAria}
           className={css}
+          disabled={disabled}
           id={id}
           onClick={onClick}
           type={htmlType}


### PR DESCRIPTION
#### Screens
Before disabled `true` was adding only a disabled class but it was missing to add the disabled attribute to button which was letting the key "Enter" to execute an action. 
<img width="537" alt="Screen Shot 2020-07-29 at 1 40 00 PM" src="https://user-images.githubusercontent.com/6829115/88833927-11651b00-d1a1-11ea-894a-71309bf7cdc8.png">


In this PR fix, we added the disabled attribute to button when disabled `true` to solve the problem. 
<img width="595" alt="Screen Shot 2020-07-29 at 12 33 57 PM" src="https://user-images.githubusercontent.com/6829115/88827920-897b1300-d198-11ea-9b81-2773355124c4.png">

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/LGA-232
#### How to test this
```
import React, { useState } from 'react'
import { Button } from '../../'

const ButtonDefault = () => {
  const [ myButton, setMyButton ] = useState(false)

    const handleError = () => {
      setMyButton(true)
      window.setTimeout(() => {
        setMyButton(false)
      }, 15000)
      console.log('Hello there')
    }

  return (
    <div>
      <Button
          disabled={myButton}
          onClick={handleError}
          text="Button Disabled"
      />
    </div>
  )
}

export default ButtonDefault
```
#### Checklist:

- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
