### PR TITLE
Add React Version of Time Kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Global Prop Additions & Dark Mode Enabled ([#942](https://github.com/powerhome/playbook/pull/942)  @jasperfurniss)
 - Gauge Kit ([#910](https://github.com/powerhome/playbook/pull/910) @bh247484)
+- Added React version of Time Kit ([#947](https://github.com/powerhome/playbook/pull/947) @coleerikson)
 
 ### Updated
 - Dark Mode Update Badge, Button, Circle Icon Button, Card, Checkbox and Body Kits ([#948](https://github.com/powerhome/playbook/pull/948)  @thestephenmarshall)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated failing spec test after update ([#940](https://github.com/powerhome/playbook/pull/940) @jasoncypret)
 
-
 ## [v6.0.0] 2020-7-30
 
 ### Changed

--- a/app/pb_kits/playbook/pb_kit/dateTime.js
+++ b/app/pb_kits/playbook/pb_kit/dateTime.js
@@ -76,6 +76,8 @@ export default class DateTime {
   toTime() {
     const time = this.value.strftime('%I:%M')
 
+    // strftime adds a leading 0 on single hour times. ie 08:31.
+    // this removes that 0 to match the rails kit.
     return time.charAt() === '0' ? time.slice(1) : time
   }
 

--- a/app/pb_kits/playbook/pb_kit/dateTime.js
+++ b/app/pb_kits/playbook/pb_kit/dateTime.js
@@ -74,7 +74,9 @@ export default class DateTime {
   }
 
   toTime() {
-    return this.value.strftime('%I:%M')
+    const time = this.value.strftime('%I:%M')
+
+    return time.charAt() === '0' ? time.slice(1) : time
   }
 
   toTimezone() {

--- a/app/pb_kits/playbook/pb_time/_time.jsx
+++ b/app/pb_kits/playbook/pb_time/_time.jsx
@@ -1,46 +1,67 @@
 /* @flow */
 
-import React from "react";
+import React from 'react'
 import classnames from 'classnames'
 
 import DateTime from '../pb_kit/dateTime.js'
 import { buildCss } from '../utilities/props'
 import { spacing } from '../utilities/spacing.js'
 
-import { Title } from "../";
+import { Body, Icon, Title  } from '../'
 
-type TimeStackedProps = {
+type TimeProps = {
+  align?: 'left" | "center' | 'right',
   className?: String | Array<String>,
   dark?: Boolean,
   data?: String,
   date: String,
   id?: String,
-  align?: "left" | "center" | "right",
-  // tag?: "body" | "caption",
+  showIcon?: Boolean,
+  showTimezone?: Boolean,
+  size?: 'lg' | 'sm' | 'xs',
 }
 
-const Time = (props: TimeStackedProps) => {
-  
-  
-    const { className, dark = false, date, tag = "body" } = props;
-    const classes = classnames(
-      className,
-      buildCss("pb_time_stacked_kit", {
-        dark: dark,
-      }),
-      spacing(props)
-    );
+const Time = (props: TimeProps) => {
+  const { align, className, dark = false, date, showIcon, showTimezone, size } = props
+  const classes = classnames(
+    className,
+    buildCss('pb_time_kit', align, size, {
+      dark: dark,
+    }),
+    spacing(props)
+  )
 
-    const dateTimestamp = new DateTime({ value: date });
-    
-    return (
-      <div className={classes}>
-        <div className="pb_time">
-          <Title tag="span" size={3} text={dateTimestamp.toTimeWithMeridian()} color="light" />
-          <span className="pb_time_timezone">{dateTimestamp.toTimezone()}</span>
-        </div>
+  const dateTimestamp = new DateTime({ value: date })
+
+  return (
+    <div className={classes}>
+      <div className="pb_time">
+        { showIcon && <Icon
+            fixedWidth
+            icon="clock"
+                      /> }
+
+        <time dateTime={date}>
+          <If condition={size !== 'lg'}>
+            <Body
+                size={3}
+                tag="span"
+                text={dateTimestamp.toTimeWithMeridian()}
+            />
+          </If>
+          <If condition={size === 'lg'}>
+            <Title
+                color="light"
+                size={3}
+                tag="span"
+                text={dateTimestamp.toTimeWithMeridian()}
+            />
+          </If>
+        </time>
+        { showTimezone && <span className="pb_time_timezone">{dateTimestamp.toTimezone()}</span> }
       </div>
-    );
+    </div>
+  )
 }
 
-export default Time;
+export default Time

--- a/app/pb_kits/playbook/pb_time/_time.jsx
+++ b/app/pb_kits/playbook/pb_time/_time.jsx
@@ -1,21 +1,46 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+/* @flow */
 
-const propTypes = {
-  className: PropTypes.string,
-  id: PropTypes.string,
+import React from "react";
+import classnames from 'classnames'
+
+import DateTime from '../pb_kit/dateTime.js'
+import { buildCss } from '../utilities/props'
+import { spacing } from '../utilities/spacing.js'
+
+import { Title } from "../";
+
+type TimeStackedProps = {
+  className?: String | Array<String>,
+  dark?: Boolean,
+  data?: String,
+  date: String,
+  id?: String,
+  align?: "left" | "center" | "right",
+  // tag?: "body" | "caption",
 }
 
-class Time extends React.Component {
-  render() {
+const Time = (props: TimeStackedProps) => {
+  
+  
+    const { className, dark = false, date, tag = "body" } = props;
+    const classes = classnames(
+      className,
+      buildCss("pb_time_stacked_kit", {
+        dark: dark,
+      }),
+      spacing(props)
+    );
+
+    const dateTimestamp = new DateTime({ value: date });
+    
     return (
-      <div className="pb_time">
-        <span>{'TIME CONTENT'}</span>
+      <div className={classes}>
+        <div className="pb_time">
+          <Title tag="span" size={3} text={dateTimestamp.toTimeWithMeridian()} color="light" />
+          <span className="pb_time_timezone">{dateTimestamp.toTimezone()}</span>
+        </div>
       </div>
-    )
-  }
+    );
 }
 
-Time.propTypes = propTypes
-
-export default Time
+export default Time;

--- a/app/pb_kits/playbook/pb_time/_time.jsx
+++ b/app/pb_kits/playbook/pb_time/_time.jsx
@@ -5,14 +5,13 @@ import classnames from 'classnames'
 
 import DateTime from '../pb_kit/dateTime.js'
 import { buildCss } from '../utilities/props'
-import { spacing } from '../utilities/spacing.js'
+import { globalProps } from '../utilities/globalProps.js'
 
 import { Body, Icon, Title  } from '../'
 
 type TimeProps = {
   align?: 'left" | "center' | 'right',
   className?: String | Array<String>,
-  dark?: Boolean,
   data?: String,
   date: String,
   id?: String,
@@ -21,13 +20,11 @@ type TimeProps = {
 }
 
 const Time = (props: TimeProps) => {
-  const { align, className, dark = false, date, showTimezone, size } = props
+  const { align, className, date, showTimezone, size } = props
   const classes = classnames(
     className,
-    buildCss('pb_time_kit', align, size, {
-      dark: dark,
-    }),
-    spacing(props)
+    buildCss('pb_time_kit', align, size),
+    globalProps(props)
   )
 
   const dateTimestamp = new DateTime({ value: date })
@@ -40,19 +37,17 @@ const Time = (props: TimeProps) => {
               fixedWidth
               icon="clock"
           />
+          {' '}
         </If>
         <time dateTime={date}>
           <span>
             <If condition={size !== 'lg'}>
               <Body
-                  color={dark ? 'light' : ''}
                   tag="span"
                   text={dateTimestamp.toTimeWithMeridian()}
               />
-            </If>
-            <If condition={size === 'lg'}>
+              <Else />
               <Title
-                  color="light"
                   size={3}
                   tag="span"
                   text={dateTimestamp.toTimeWithMeridian()}

--- a/app/pb_kits/playbook/pb_time/_time.jsx
+++ b/app/pb_kits/playbook/pb_time/_time.jsx
@@ -16,13 +16,12 @@ type TimeProps = {
   data?: String,
   date: String,
   id?: String,
-  showIcon?: Boolean,
   showTimezone?: Boolean,
   size?: 'lg' | 'sm' | 'xs',
 }
 
 const Time = (props: TimeProps) => {
-  const { align, className, dark = false, date, showIcon, showTimezone, size } = props
+  const { align, className, dark = false, date, showTimezone, size } = props
   const classes = classnames(
     className,
     buildCss('pb_time_kit', align, size, {
@@ -35,31 +34,34 @@ const Time = (props: TimeProps) => {
 
   return (
     <div className={classes}>
-      <div className="pb_time">
-        { showIcon && <Icon
-            fixedWidth
-            icon="clock"
-                      /> }
-
+      <span className="pb_body_kit">
+        <If condition={size === 'sm'}>
+          <Icon
+              fixedWidth
+              icon="clock"
+          />
+        </If>
         <time dateTime={date}>
-          <If condition={size !== 'lg'}>
-            <Body
-                size={3}
-                tag="span"
-                text={dateTimestamp.toTimeWithMeridian()}
-            />
-          </If>
-          <If condition={size === 'lg'}>
-            <Title
-                color="light"
-                size={3}
-                tag="span"
-                text={dateTimestamp.toTimeWithMeridian()}
-            />
-          </If>
+          <span>
+            <If condition={size !== 'lg'}>
+              <Body
+                  color={dark ? 'light' : ''}
+                  tag="span"
+                  text={dateTimestamp.toTimeWithMeridian()}
+              />
+            </If>
+            <If condition={size === 'lg'}>
+              <Title
+                  color="light"
+                  size={3}
+                  tag="span"
+                  text={dateTimestamp.toTimeWithMeridian()}
+              />
+            </If>
+            { showTimezone && <span className="pb_time_timezone">{dateTimestamp.toTimezone()}</span> }
+          </span>
         </time>
-        { showTimezone && <span className="pb_time_timezone">{dateTimestamp.toTimezone()}</span> }
-      </div>
+      </span>
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_time/_time.scss
+++ b/app/pb_kits/playbook/pb_time/_time.scss
@@ -5,6 +5,14 @@
 @import "../pb_title/title";
 
 [class^=pb_time_kit] {
+  &[class*=_center]  {
+    text-align: center;
+  }
+
+  &[class*=_right]  {
+    text-align: right;
+  }
+
   [class^=pb_body] {
     font-weight: $bold !important;
   }
@@ -23,6 +31,15 @@
     [class^=pb_time_timezone] {
       font-size: $font-large !important;
       color: $text-lt-light;
+    }
+  }
+
+  &[class*=_dark] {
+    & > * [class^=pb_title_kit] {
+      color: $text_dk_default;
+    }
+    & > * [class^=pb_body_kit] {
+      color: $text_dk_light;
     }
   }
 }

--- a/app/pb_kits/playbook/pb_time/_time.scss
+++ b/app/pb_kits/playbook/pb_time/_time.scss
@@ -17,6 +17,10 @@
     font-weight: $bold !important;
   }
 
+  [class*=pb_icon_kit] {
+    margin-right: 4px;
+  }
+
   [class^=pb_time_timezone] {
     font-size: $font-small;
     font-weight: $regular;

--- a/app/pb_kits/playbook/pb_time/_time.scss
+++ b/app/pb_kits/playbook/pb_time/_time.scss
@@ -17,10 +17,6 @@
     font-weight: $bold !important;
   }
 
-  [class*=pb_icon_kit] {
-    margin-right: 4px;
-  }
-
   [class^=pb_time_timezone] {
     font-size: $font-small;
     font-weight: $regular;
@@ -38,7 +34,7 @@
     }
   }
 
-  &[class*=_dark] {
+  &.dark {
     & > * [class^=pb_title_kit] {
       color: $text_dk_default;
     }

--- a/app/pb_kits/playbook/pb_time/docs/_time_align.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_align.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import Time from '../_time.jsx'
+
+const TimeAlign = () => {
+  return (
+    <div>
+      <Time
+          date={new Date()}
+          size="lg"
+      />
+      <br />
+      <Time
+          align="center"
+          date={new Date()}
+          size="lg"
+      />
+      <br />
+      <Time
+          align="right"
+          date={new Date()}
+          size="lg"
+      />
+    </div>
+  )
+}
+
+export default TimeAlign

--- a/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
@@ -18,7 +18,6 @@ const TimeDark = () => {
       <Time
           dark
           date={new Date()}
-          showIcon
           showTimezone
       />
     </div>

--- a/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
@@ -13,6 +13,7 @@ const TimeDark = () => {
           dark
           date={new Date()}
           showTimezone
+          size="lg"
       />
       <br />
       <Time

--- a/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
@@ -1,29 +1,28 @@
 import React from 'react'
 import Time from '../_time.jsx'
 
-const TimeDefault = () => {
+const TimeDark = () => {
   return (
     <div>
       <Time
+          dark
+          date={new Date()}
+      />
+      <br />
+      <Time
+          dark
           date={new Date()}
           showTimezone
-          size="lg"
       />
       <br />
       <Time
-          date={new Date().getTime()}
+          dark
+          date={new Date()}
           showIcon
           showTimezone
-          size="sm"
-      />
-      <br />
-      <Time
-          date="2012-08-02T09:49:29Z"
-          showTimezone
-          size="xs"
       />
     </div>
   )
 }
 
-export default TimeDefault
+export default TimeDark

--- a/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
@@ -12,7 +12,6 @@ const TimeDefault = () => {
       <br />
       <Time
           date={new Date().getTime()}
-          showIcon
           showTimezone
           size="sm"
       />

--- a/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import Time from '../_time.jsx'
+
+const TimeDefault = () => {
+  return (
+    <div>
+      <Time date={new Date()} />
+    </div>
+  )
+}
+
+export default TimeDefault

--- a/app/pb_kits/playbook/pb_time/docs/_time_timestamp.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timestamp.jsx
@@ -6,15 +6,14 @@ const TimeStamp = () => {
     <div>
       <Time
           date={new Date()}
-          showIcon
           showTimezone
+          size="sm"
       />
 
       <br />
 
       <Time
           date={new Date().getTime()}
-          showIcon
           showTimezone
           size="sm"
       />
@@ -23,9 +22,8 @@ const TimeStamp = () => {
 
       <Time
           date="2012-08-02T15:49:29Z"
-          showIcon
           showTimezone
-          size="xs"
+          size="sm"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_time/docs/_time_timestamp.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timestamp.jsx
@@ -1,24 +1,29 @@
 import React from 'react'
 import Time from '../_time.jsx'
 
-const TimeDefault = () => {
+const TimeStamp = () => {
   return (
     <div>
       <Time
           date={new Date()}
+          showIcon
           showTimezone
-          size="lg"
       />
+
       <br />
+
       <Time
           date={new Date().getTime()}
           showIcon
           showTimezone
           size="sm"
       />
+
       <br />
+
       <Time
-          date="2012-08-02T09:49:29Z"
+          date="2012-08-02T15:49:29Z"
+          showIcon
           showTimezone
           size="xs"
       />
@@ -26,4 +31,4 @@ const TimeDefault = () => {
   )
 }
 
-export default TimeDefault
+export default TimeStamp

--- a/app/pb_kits/playbook/pb_time/docs/example.yml
+++ b/app/pb_kits/playbook/pb_time/docs/example.yml
@@ -5,4 +5,7 @@ examples:
   - time_timestamp: Timestamp Values
 
   react:
-  - time_default: Default
+  - time_default: Sizes
+  - time_timestamp: Timestamp Values
+  - time_align: Alignment
+  - time_dark: Dark

--- a/app/pb_kits/playbook/pb_time/docs/example.yml
+++ b/app/pb_kits/playbook/pb_time/docs/example.yml
@@ -5,3 +5,4 @@ examples:
   - time_timestamp: Timestamp Values
 
   react:
+  - time_default: Default

--- a/app/pb_kits/playbook/pb_time/docs/index.js
+++ b/app/pb_kits/playbook/pb_time/docs/index.js
@@ -1,1 +1,4 @@
 export { default as TimeDefault } from './_time_default.jsx'
+export { default as TimeTimestamp } from './_time_timestamp.jsx'
+export { default as TimeAlign } from './_time_align.jsx'
+export { default as TimeDark } from './_time_dark.jsx'

--- a/app/pb_kits/playbook/pb_time/docs/index.js
+++ b/app/pb_kits/playbook/pb_time/docs/index.js
@@ -1,0 +1,1 @@
+export { default as TimeDefault } from './_time_default.jsx'

--- a/app/pb_kits/playbook/pb_title/_title.jsx
+++ b/app/pb_kits/playbook/pb_title/_title.jsx
@@ -13,7 +13,7 @@ type TitleProps = {
   data?: object,
   id?: String,
   size?: 1 | 2 | 3 | 4,
-  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div",
+  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div" | "span",
   text?: String,
   variant?: null | "primary",
 }


### PR DESCRIPTION
#### Screens

<img width="800" alt="react-time" src="https://user-images.githubusercontent.com/4315934/89464430-d9347e00-d746-11ea-9da1-7f3bd31fa5f6.png">

#### Breaking Changes

Not breaking, but of note, running into a weird bug where the Rails version of this kit adds 'invisible' spacing between the icon and time.

#### Runway Ticket URL
https://github.com/powerhome/playbook/issues/616

#### How to test this
Checkout the branch.

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
