### PR TITLE
Edit dark mode in Caption kit to reflect globalProps changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Caption kit to implement dark mode correctly in html ([#950](https://github.com/powerhome/playbook/pull/950)  @kellyeryan)
+
 ### Added
 - Global Prop Additions & Dark Mode Enabled ([#942](https://github.com/powerhome/playbook/pull/942)  @jasperfurniss)
 

--- a/app/pb_kits/playbook/pb_caption/_caption.jsx
+++ b/app/pb_kits/playbook/pb_caption/_caption.jsx
@@ -9,7 +9,6 @@ type CaptionProps = {
   aria?: object,
   className?: String,
   children: Array<React.ReactNode> | React.ReactNode,
-  dark?: Boolean,
   data?: object,
   id?: String,
   size?: "xs" | "sm" | "md" | "lg" | "xl",
@@ -22,7 +21,6 @@ const Caption = (props: CaptionProps) => {
     aria = {},
     className,
     children,
-    dark = false,
     data = {},
     id,
     size = 'md',
@@ -34,9 +32,7 @@ const Caption = (props: CaptionProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const css = classnames(
-    buildCss('pb_caption_kit', size, {
-      dark: dark,
-    }),
+    buildCss('pb_caption_kit', size),
     className,
     globalProps(props)
   )

--- a/app/pb_kits/playbook/pb_caption/_caption.scss
+++ b/app/pb_kits/playbook/pb_caption/_caption.scss
@@ -10,8 +10,4 @@
   &[class^=pb_caption_kit_xs] {
     @include caption_xs;
   }
-
-  &[class*=_dark] {
-    @include caption_dark;
-  }
 }

--- a/app/pb_kits/playbook/pb_caption/caption.rb
+++ b/app/pb_kits/playbook/pb_caption/caption.rb
@@ -7,7 +7,6 @@ module Playbook
 
       partial "pb_caption/caption"
 
-      prop :dark, type: Playbook::Props::Boolean, default: false
       prop :size, type: Playbook::Props::Enum,
                   values: %w[xs sm md base lg xl],
                   default: "md"
@@ -17,13 +16,7 @@ module Playbook
       prop :text
 
       def classname
-        generate_classname("pb_caption_kit", size, dark_class)
-      end
-
-    private
-
-      def dark_class
-        dark ? "dark" : nil
+        generate_classname("pb_caption_kit", size)
       end
     end
   end

--- a/spec/pb_kits/playbook/kits/caption_spec.rb
+++ b/spec/pb_kits/playbook/kits/caption_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Playbook::PbCaption::Caption do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_caption_kit_md"
-      expect(subject.new(dark: true).classname).to eq "pb_caption_kit_md_dark dark"
+      expect(subject.new(dark: true).classname).to eq "pb_caption_kit_md dark"
       expect(subject.new(size: "lg").classname).to eq "pb_caption_kit_lg"
-      expect(subject.new(dark: true, size: "lg").classname).to eq "pb_caption_kit_lg_dark dark"
+      expect(subject.new(dark: true, size: "lg").classname).to eq "pb_caption_kit_lg dark"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_caption_kit_md additional_class"
     end
   end


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1287

#### Screens

<img width="1730" alt="Screen Shot 2020-08-06 at 10 56 28 AM" src="https://user-images.githubusercontent.com/51907753/89548615-40007880-d7d5-11ea-990e-13223bbf2e62.png">

<img width="1725" alt="Screen Shot 2020-08-06 at 10 56 53 AM" src="https://user-images.githubusercontent.com/51907753/89548627-4262d280-d7d5-11ea-8157-e3a173964739.png">

#### Breaking Changes

Removed dark prop from Rails and React Caption kits

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
