### PR TITLE
Edit dark mode in Title kit to reflect globalProps changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Updated
+- Dark Mode Update for Title kit. ([#951](https://github.com/powerhome/playbook/pull/951)  @kellyeryan)
+
 ### Added
 - Global Prop Additions & Dark Mode Enabled ([#942](https://github.com/powerhome/playbook/pull/942)  @jasperfurniss)
 

--- a/app/pb_kits/playbook/pb_title/_title.jsx
+++ b/app/pb_kits/playbook/pb_title/_title.jsx
@@ -9,7 +9,6 @@ type TitleProps = {
   aria?: object,
   children?: Array<React.ReactNode> | React.ReactNode,
   className?: String,
-  dark?: Boolean,
   data?: object,
   id?: String,
   size?: 1 | 2 | 3 | 4,
@@ -23,7 +22,6 @@ const Title = (props: TitleProps) => {
     aria = {},
     children,
     className,
-    dark = false,
     data = {},
     id,
     size = 3,
@@ -32,10 +30,9 @@ const Title = (props: TitleProps) => {
     variant = null,
   } = props
 
-  const themeStyle = dark === true ? 'dark' : ''
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const classes = classnames(buildCss('pb_title_kit', size, themeStyle, variant), className, globalProps(props))
+  const classes = classnames(buildCss('pb_title_kit', size, variant), className, globalProps(props))
   const Tag = `${tag}`
 
   return (

--- a/app/pb_kits/playbook/pb_title/_title.scss
+++ b/app/pb_kits/playbook/pb_title/_title.scss
@@ -18,7 +18,7 @@
     @include pb_title_4;
   }
 
-  &[class*=_dark] {
+  &.dark {
     @include pb_title_dark;
   }
 

--- a/app/pb_kits/playbook/pb_title/title.rb
+++ b/app/pb_kits/playbook/pb_title/title.rb
@@ -7,8 +7,6 @@ module Playbook
 
       partial "pb_title/title"
 
-      prop :dark, type: Playbook::Props::Boolean,
-                  default: false
       prop :size, type: Playbook::Props::Enum,
                   values: [1, 2, 3, 4],
                   default: 3
@@ -21,13 +19,7 @@ module Playbook
                      default: nil
 
       def classname
-        generate_classname("pb_title_kit", size, dark_class, variant)
-      end
-
-    private
-
-      def dark_class
-        dark ? "dark" : nil
+        generate_classname("pb_title_kit", size, variant)
       end
     end
   end

--- a/spec/pb_kits/playbook/kits/title_spec.rb
+++ b/spec/pb_kits/playbook/kits/title_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Playbook::PbTitle::Title do
       expect(subject.new({}).classname).to eq "pb_title_kit_3"
 
       expect(subject.new(classname: "additional_class").classname).to eq "pb_title_kit_3 additional_class"
-      expect(subject.new(dark: true).classname).to eq "pb_title_kit_3_dark dark"
+      expect(subject.new(dark: true).classname).to eq "pb_title_kit_3 dark"
       expect(subject.new(size: nil).classname).to eq "pb_title_kit_3"
       expect(subject.new(size: 4).classname).to eq "pb_title_kit_4"
       expect(subject.new(tag: "h3").classname).to eq "pb_title_kit_3"


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1287

#### Screens

<img width="1620" alt="Screen Shot 2020-08-06 at 11 26 23 AM" src="https://user-images.githubusercontent.com/51907753/89550527-b7370c00-d7d7-11ea-9138-ae6eae8bb636.png">

<img width="1622" alt="Screen Shot 2020-08-06 at 11 26 09 AM" src="https://user-images.githubusercontent.com/51907753/89550552-bd2ced00-d7d7-11ea-88ac-4ed204d50377.png">

#### Breaking Changes

Dark prop was removed from Rails and React side of kit.

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
