### PR TITLE
NUX-1286 - Global Props for Dark on typeahead

### DIFF
--- a/app/pb_kits/playbook/pb_typeahead/_typeahead.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/_typeahead.html.erb
@@ -11,10 +11,9 @@
       label: object.label,
       name: object.name,
       value: object.value,
-      placeholder: object.placeholder,
-      dark: object.dark
+      placeholder: object.placeholder
     }) %>
-    <%= pb_rails("list", props: { ordered: false, dark: false, borderless: false, xpadding: true, role: "status", aria: { live: "polite" }, data: { pb_typeahead_kit_results: true } }) do %>
+    <%= pb_rails("list", props: { ordered: false, borderless: false, xpadding: true, role: "status", aria: { live: "polite" }, data: { pb_typeahead_kit_results: true } }) do %>
     <% end %>
   </div>
 

--- a/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
+++ b/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
@@ -79,7 +79,7 @@
     }
   }
 
-  &[class*=_dark] {
+  .dark {
     .pb_typeahead_wrapper .pb_typeahead_loading_indicator {
       color: $text_dk_light;
     }

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_context_dark.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_context_dark.html.erb
@@ -16,7 +16,6 @@
 
 <br><br><br>
 
-
 <%= javascript_tag defer: "defer" do %>
   document.addEventListener("pb-typeahead-kit-search", function(event) {
     if (!event.target.dataset.typeaheadExample2) return;

--- a/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -11,13 +11,11 @@ module Playbook
       prop :placeholder
       prop :search_term_minimum_length, default: 3
       prop :search_debounce_timeout, default: 250
-      prop :dark, type: Playbook::Props::Boolean,
-                  default: false
 
       partial "pb_typeahead/typeahead"
 
       def classname
-        generate_classname("pb_typeahead_kit", dark_class)
+        generate_classname("pb_typeahead_kit")
       end
 
       def data
@@ -26,12 +24,6 @@ module Playbook
           pb_typeahead_kit_search_term_minimum_length: search_term_minimum_length,
           pb_typeahead_kit_search_debounce_timeout: search_debounce_timeout
         )
-      end
-
-    private
-
-      def dark_class
-        dark ? "dark" : nil
       end
     end
   end


### PR DESCRIPTION
This is a composite kit that should show dark components once its children components are updated.

#### Screens

<img width="600" alt="typeahead-dark" src="https://user-images.githubusercontent.com/4315934/89668862-dbb4e600-d8b4-11ea-8f88-40c1fb3a9c49.png">

#### Breaking Changes
None I'm aware of.

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/NUX-1286

#### How to test this
Playbook Docs or Nitro Docs

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
