### PR TITLE
Update dark mode in User kit

### DIFF
--- a/app/pb_kits/playbook/pb_user/_user.html.erb
+++ b/app/pb_kits/playbook/pb_user/_user.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname) do %>
+    aria: object.aria,
+    class: object.classname,
+    data: object.data
+    id: object.id) do %>
   <% if object.avatar_url.present? || object.avatar %>
     <%= pb_rails("avatar", props: {
       name: object.name,
@@ -11,10 +12,9 @@
   <% end %>
   <%= content_tag(:div,
       class: "content_wrapper") do %>
-    <%= pb_rails("title", props: { text: object.name, size: object.title_size, dark: object.dark }) %>
+    <%= pb_rails("title", props: { text: object.name, size: object.title_size }) %>
     <%= pb_rails("body", props: {
       text: "#{object.details}",
-      dark: object.dark,
       color: "light"
     }) %>
   <% end %>

--- a/app/pb_kits/playbook/pb_user/_user.jsx
+++ b/app/pb_kits/playbook/pb_user/_user.jsx
@@ -2,40 +2,68 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { Avatar, Body, Title } from '../'
 import { globalProps } from '../utilities/globalProps.js'
 
 type UserProps = {
-  className?: String,
-  id?: String,
-  name: String,
-  territory?: String,
-  title?: String,
-  size?: "sm" | "md" | "lg",
   align?: "left" | "center" | "right",
-  orientation?: "horiztonal" | "vertical",
+  aria?: object,
   avatar?: Boolean,
   avatarUrl?: String,
+  className?: String,
+  data?: object,
+  id?: String,
+  name: String,
+  orientation?: "horiztonal" | "vertical",
+  size?: "sm" | "md" | "lg",
+  territory?: String,
+  title?: String,
+}
+
+const avatarSizeMap = {
+  lg: 'xl',
+  md: 'md',
+  sm: 'sm',
 }
 
 const User = (props: UserProps) => {
   const {
-    name = '',
-    territory = '',
-    title = '',
     align = 'left',
-    orientation = 'horizontal',
-    size = 'sm',
+    aria = {},
     avatar = false,
     avatarUrl,
+    className,
+    data = {},
+    id,
+    name = '',
+    orientation = 'horizontal',
+    size = 'sm',
+    territory = '',
+    title = '',
   } = props
+
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+
+  const classes = classnames(
+    buildCss('pb_user_kit', align, orientation, size),
+    globalProps(props),
+    className,
+  )
+
   return (
-    <div className={classnames(`pb_user_kit_${align}_${orientation}_${size}`, globalProps(props))}>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
+    >
       <If condition={avatar || avatarUrl}>
         <Avatar
             imageUrl={avatarUrl}
             name={name}
-            size={size}
+            size={avatarSizeMap[size]}
         />
       </If>
 
@@ -45,7 +73,7 @@ const User = (props: UserProps) => {
             text={name}
         />
         <Body color="light">
-          {territory == '' ? title : `${territory} • ${title}`}
+          {territory === '' ? title : `${territory} • ${title}`}
         </Body>
       </div>
     </div>

--- a/app/pb_kits/playbook/pb_user/_user.scss
+++ b/app/pb_kits/playbook/pb_user/_user.scss
@@ -9,6 +9,15 @@
   align-items: flex-start;
   flex-direction: row;
 
+  &.dark {
+    .pb_title_kit_3 {
+      @include pb_title_dark;
+    }
+    .pb_title_kit_4 {
+      @include pb_title_dark;
+    }
+  }
+
   // Orientation =============
   &[class*=_vertical]  {
     flex-direction: column;

--- a/app/pb_kits/playbook/pb_user/docs/_user_dark.jsx
+++ b/app/pb_kits/playbook/pb_user/docs/_user_dark.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { User } from '../../'
+
+const UserDark = () => {
+  return (
+    <div className="pb--doc-demo-row">
+
+      <div>
+        <User
+            align="center"
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            dark
+            name="Anna Black"
+            orientation="vertical"
+            size="lg"
+            title="Remodeling Consultant"
+        />
+      </div>
+
+      <div>
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            dark
+            name="Anna Black"
+            orientation="horizontal"
+            title="Remodeling Consultant"
+        />
+      </div>
+
+      <div>
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            dark
+            name="Anna Black"
+            orientation="horizontal"
+        />
+
+        <br />
+
+        <User
+            align="left"
+            avatar
+            dark
+            name="Anna Black"
+            orientation="horizontal"
+        />
+      </div>
+
+    </div>
+  )
+}
+
+export default UserDark

--- a/app/pb_kits/playbook/pb_user/docs/_user_text_only_dark.jsx
+++ b/app/pb_kits/playbook/pb_user/docs/_user_text_only_dark.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { User } from '../../'
+
+const UserTextOnlyDark = () => {
+  return (
+    <div className="pb--doc-demo-row">
+      <User
+          align="center"
+          dark
+          name="Anna Black"
+          orientation="horizontal"
+          size="lg"
+          title="Remodeling Consultant"
+      />
+      <User
+          align="left"
+          dark
+          name="Anna Black"
+          orientation="horizontal"
+          title="Remodeling Consultant"
+      />
+    </div>
+  )
+}
+
+export default UserTextOnlyDark

--- a/app/pb_kits/playbook/pb_user/docs/example.yml
+++ b/app/pb_kits/playbook/pb_user/docs/example.yml
@@ -17,3 +17,5 @@ examples:
   - user_text_only: Text Only
   - user_size: Horizontal Size
   - user_vertical_size: Vertical Size
+  - user_dark: Dark
+  - user_text_only_dark: Text Only

--- a/app/pb_kits/playbook/pb_user/docs/index.js
+++ b/app/pb_kits/playbook/pb_user/docs/index.js
@@ -3,4 +3,6 @@ export { default as UserWithTerritory } from './_user_with_territory.jsx'
 export { default as UserTextOnly } from './_user_text_only.jsx'
 export { default as UserSize } from './_user_size.jsx'
 export { default as UserVerticalSize } from './_user_vertical_size.jsx'
+export { default as UserDark } from './_user_dark.jsx'
+export { default as UserTextOnlyDark } from './_user_text_only_dark.jsx'
 

--- a/app/pb_kits/playbook/pb_user/user.rb
+++ b/app/pb_kits/playbook/pb_user/user.rb
@@ -21,12 +21,10 @@ module Playbook
                   values: %w[lg md sm],
                   default: "sm"
       prop :title
-      prop :dark, type: Playbook::Props::Boolean,
-                          default: false
       prop :territory
 
       def classname
-        generate_classname("pb_user_kit", align, orientation, size, dark_class)
+        generate_classname("pb_user_kit", align, orientation, size)
       end
 
       def avatar_size
@@ -38,10 +36,6 @@ module Playbook
         else
           "sm"
         end
-      end
-
-      def dark_class
-        dark ? "dark" : nil
       end
 
       def title_size


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1296

I updated dark mode and also added two example docs and some props missing from the React side. I alphabetized the props because that is how I roll.

#### Screens

<img width="1510" alt="Screen Shot 2020-08-07 at 1 36 41 PM" src="https://user-images.githubusercontent.com/51907753/89672961-8fb57180-d8b3-11ea-9807-2c7534f35e70.png">

<img width="1500" alt="Screen Shot 2020-08-07 at 1 36 55 PM" src="https://user-images.githubusercontent.com/51907753/89672974-9348f880-d8b3-11ea-8871-42814e81153c.png">

#### Breaking Changes

Removed Dark mode from both sides of kit

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
