### PR TITLE
NUX-1286 - Update dark props for Textarea kit

### DIFF
--- a/app/pb_kits/playbook/pb_textarea/_textarea.jsx
+++ b/app/pb_kits/playbook/pb_textarea/_textarea.jsx
@@ -19,7 +19,6 @@ type TextareaProps = {
   value?: string,
   name?: string,
   rows?: number,
-  dark?: boolean,
   resize: 'none' | 'both' | 'horizontal' | 'vertical',
   onChange?: InputCallback<HTMLTextAreaElement>,
 }
@@ -27,7 +26,6 @@ type TextareaProps = {
 const Textarea = ({
   className,
   children,
-  dark = false,
   resize = 'none',
   error,
   label,
@@ -38,14 +36,13 @@ const Textarea = ({
   value,
   ...props
 }: TextareaProps) => {
-  const textareaClass = `pb_textarea_kit${dark ? '_dark' : ''}`
   const errorClass = error ? 'error' : null
-  const resizeClass = ` resize_${resize}`
+  const resizeClass = `resize_${resize}`
+  const classes = classnames('pb_textarea_kit', className, errorClass, resizeClass, globalProps(props))
 
   return (
-    <div className={classnames(textareaClass, className, errorClass, resizeClass, globalProps(props))}>
+    <div className={classes}>
       <Caption
-          dark={dark}
           text={label}
       />
       <If condition={children}>
@@ -53,7 +50,7 @@ const Textarea = ({
         <Else />
         <textarea
             {...props}
-            className={textareaClass}
+            className="pb_textarea_kit"
             name={name}
             onChange={onChange}
             placeholder={placeholder}
@@ -62,7 +59,6 @@ const Textarea = ({
         />
         <If condition={error}>
           <Body
-              dark={dark}
               status="negative"
               text={error}
           />

--- a/app/pb_kits/playbook/pb_textarea/_textarea.jsx
+++ b/app/pb_kits/playbook/pb_textarea/_textarea.jsx
@@ -10,6 +10,7 @@ type TextareaProps = {
   className?: string,
   children?: array<React.ReactChild>,
   data?: string,
+  disabled?: boolean,
   error?: string,
   id?: string,
   object?: string,
@@ -18,6 +19,7 @@ type TextareaProps = {
   placeholder?: string,
   value?: string,
   name?: string,
+  required?: boolean,
   rows?: number,
   resize: 'none' | 'both' | 'horizontal' | 'vertical',
   onChange?: InputCallback<HTMLTextAreaElement>,
@@ -26,12 +28,14 @@ type TextareaProps = {
 const Textarea = ({
   className,
   children,
+  disabled,
   resize = 'none',
   error,
   label,
   name,
   onChange = () => {},
   placeholder,
+  required,
   rows = 4,
   value,
   ...props
@@ -51,9 +55,11 @@ const Textarea = ({
         <textarea
             {...props}
             className="pb_textarea_kit"
+            disabled={disabled}
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            required={required}
             rows={rows}
             value={value}
         />

--- a/app/pb_kits/playbook/pb_textarea/_textarea.scss
+++ b/app/pb_kits/playbook/pb_textarea/_textarea.scss
@@ -40,9 +40,7 @@
     overflow: auto;
   }
 
-
-
-  &[class*=_dark] {
+  &.dark {
     textarea::placeholder {
       @include pb_body_light_dark;
     }

--- a/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark.jsx
+++ b/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark.jsx
@@ -27,7 +27,6 @@ const TextareaDark = () => {
           placeholder="Placeholder text"
           value="Default value text"
       />
-
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark_error.jsx
+++ b/app/pb_kits/playbook/pb_textarea/docs/_textarea_dark_error.jsx
@@ -12,7 +12,6 @@ const TextareaDarkError = () => {
           placeholder="Placeholder text"
           value="Default value text"
       />
-
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_textarea/textarea.rb
+++ b/app/pb_kits/playbook/pb_textarea/textarea.rb
@@ -7,8 +7,6 @@ module Playbook
 
       partial "pb_textarea/textarea"
 
-      prop :dark, type: Playbook::Props::Boolean,
-                  default: false
       prop :error
       prop :object
       prop :label
@@ -23,14 +21,10 @@ module Playbook
       prop :value
 
       def classname
-        generate_classname("pb_textarea_kit", dark_class) + error_class + resize_class
+        generate_classname("pb_textarea_kit") + error_class + resize_class
       end
 
     private
-
-      def dark_class
-        dark ? "dark" : nil
-      end
 
       def error_class
         error ? " error" : ""

--- a/spec/pb_kits/playbook/kits/textarea_spec.rb
+++ b/spec/pb_kits/playbook/kits/textarea_spec.rb
@@ -22,11 +22,10 @@ RSpec.describe Playbook::PbTextarea::Textarea do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_textarea_kit resize_none"
-      expect(subject.new({dark: true}).classname).to eq "pb_textarea_kit_dark dark resize_none"
+      expect(subject.new({dark: true}).classname).to eq "pb_textarea_kit dark resize_none"
       expect(subject.new({error: "Something is wrong"}).classname).to eq "pb_textarea_kit error resize_none"
-      expect(subject.new({dark: true, error: "Something is wrong"}).classname).to eq "pb_textarea_kit_dark dark error resize_none"
+      expect(subject.new({dark: true, error: "Something is wrong"}).classname).to eq "pb_textarea_kit dark error resize_none"
     end
   end
-
 
 end


### PR DESCRIPTION
#### Screens
**Rails**
<img width="600" alt="textarea-dark-rails" src="https://user-images.githubusercontent.com/4315934/89673680-28042400-d8bd-11ea-86db-60b230f7d6f7.png">

**React**
<img width="600" alt="textarea-dark-react" src="https://user-images.githubusercontent.com/4315934/89673687-2c304180-d8bd-11ea-9350-fb35cc8f9354.png">

#### Runway Ticket URL
[https://nitro.powerhrg.com/runway/backlog_items/NUX-1286](https://nitro.powerhrg.com/runway/backlog_items/NUX-1286)

#### How to test this

#### Checklist:
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
