### PR TITLE
Update dark mode for Hashtag kit

### DIFF
--- a/app/pb_kits/playbook/pb_hashtag/_hashtag.html.erb
+++ b/app/pb_kits/playbook/pb_hashtag/_hashtag.html.erb
@@ -1,10 +1,10 @@
 <%= content_tag(:span,
-    id: object.id,
+    aria: object.aria,
+    class: object.classname,
     data: object.data,
-    class: object.classname) do %>
+    id: object.id) do %>
 
   <%= link_to object.url do %>
-    <%= pb_rails("badge", props: { variant: "primary", text: object.hashtag_text, dark: object.dark }) %>
+    <%= pb_rails("badge", props: { variant: "primary", text: object.hashtag_text }) %>
   <% end %>
-
 <% end %>

--- a/app/pb_kits/playbook/pb_hashtag/_hashtag.jsx
+++ b/app/pb_kits/playbook/pb_hashtag/_hashtag.jsx
@@ -5,13 +5,13 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { Badge } from '../'
-import { buildCss } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
 
 type HashtagProps = {
+  aria?: object,
   className?: String,
   data?: String,
-  dark?: Boolean,
   id?: String,
   text?: String,
   type: "default" | "home" | "project" | "appointment",
@@ -26,18 +26,29 @@ const typeMap = {
 }
 
 const Hashtag = (props: HashtagProps) => {
-  const { className, dark = false, text, type, url } = props
+  const {
+    aria = {},
+    className,
+    data = {},
+    id,
+    text,
+    type = 'default',
+    url,
+  } = props
+
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const classes = classnames(buildCss('pb_hashtag_kit'), className, globalProps(props))
+
   return (
     <span
-        className={classnames(
-        className,
-        buildCss('pb_hashtag_kit', { dark: dark }),
-        globalProps(props)
-      )}
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
     >
       <a href={url}>
         <Badge
-            dark={dark}
             text={typeMap[type] + text}
             variant="primary"
         />

--- a/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_dark.jsx
+++ b/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_dark.jsx
@@ -11,6 +11,7 @@ const HashtagDark = () => {
           url="https://google.com"
       />
       <br />
+      <br />
       <Hashtag
           dark
           text="123456"
@@ -18,12 +19,14 @@ const HashtagDark = () => {
           url="https://google.com"
       />
       <br />
+      <br />
       <Hashtag
           dark
           text="456789"
           type="appointment"
           url="https://google.com"
       />
+      <br />
       <br />
       <Hashtag
           dark

--- a/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_default.jsx
+++ b/app/pb_kits/playbook/pb_hashtag/docs/_hashtag_default.jsx
@@ -10,17 +10,20 @@ const HashtagDefault = () => {
           url="https://google.com"
       />
       <br />
+      <br />
       <Hashtag
           text="123456"
           type="home"
           url="https://google.com"
       />
       <br />
+      <br />
       <Hashtag
           text="456789"
           type="appointment"
           url="https://google.com"
       />
+      <br />
       <br />
       <Hashtag
           text="654321"

--- a/app/pb_kits/playbook/pb_hashtag/hashtag.rb
+++ b/app/pb_kits/playbook/pb_hashtag/hashtag.rb
@@ -8,14 +8,13 @@ module Playbook
       partial "pb_hashtag/hashtag"
 
       prop :text
-      prop :dark, type: Playbook::Props::Boolean, default: false
       prop :type, type: Playbook::Props::Enum,
                   values: %w[default project home appointment],
                   default: "default"
       prop :url
 
       def classname
-        generate_classname("pb_hastag_kit", dark_class)
+        generate_classname("pb_hastag_kit")
       end
 
       def hashtag_text
@@ -23,10 +22,6 @@ module Playbook
       end
 
     private
-
-      def dark_class
-        dark ? "dark" : nil
-      end
 
       def type_text
         if type === "home"

--- a/spec/pb_kits/playbook/kits/hashtag_spec.rb
+++ b/spec/pb_kits/playbook/kits/hashtag_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Playbook::PbHashtag::Hashtag do
   it { is_expected.to define_partial }
 
   it { is_expected.to define_prop(:text) }
-  it { is_expected.to define_boolean_prop(:dark).with_default(false) }
   it { is_expected.to define_enum_prop(:type)
                       .with_default("default")
                       .with_values("default", "project", "home", "appointment") }
@@ -17,7 +16,7 @@ RSpec.describe Playbook::PbHashtag::Hashtag do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_hastag_kit"
-      expect(subject.new(dark: true).classname).to eq "pb_hastag_kit_dark dark"
+      expect(subject.new(dark: true).classname).to eq "pb_hastag_kit dark"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_hastag_kit additional_class"
     end
   end


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1306

#### Screens

<img width="1498" alt="Screen Shot 2020-08-10 at 11 06 21 AM" src="https://user-images.githubusercontent.com/51907753/89799476-874f7780-dafb-11ea-81a5-3abb8d09e5d8.png">

<img width="1483" alt="Screen Shot 2020-08-10 at 11 07 05 AM" src="https://user-images.githubusercontent.com/51907753/89799491-8b7b9500-dafb-11ea-97c5-e37b7e5cc841.png">

#### Breaking Changes

Removed dark mode prop from both side of kit

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
