### PR TITLE
Update label value dark mode

### DIFF
--- a/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.html.erb
@@ -3,10 +3,10 @@
     id: object.id,
     data: object.data,
     class: object.classname) do %>
-    <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>
+    <%= pb_rails("caption", props: { text: object.label }) %>
     <% if object.variant == "details" %>
         <%= pb_rails("flex", props: {inline: true, vertical: "center"}) do %>
-            <%= pb_rails("body", props: { color: "light", dark: object.dark }) do %>
+            <%= pb_rails("body", props: { color: "light" }) do %>
                 <%= pb_rails("icon", props: { icon: object.icon, fixed_width: true, margin_right: "xs", }) if object.icon.present? %>
             <% end %>
             <%= pb_rails("body", props: { text: object.description, color: "light", margin_right: "xs", dark: object.dark }) if object.description.present? %>
@@ -21,6 +21,6 @@
             <% end %>
         <% end %>
     <% else %>
-        <%= pb_rails("body", props: { text: object.value, dark: object.dark }) if object.value.present? %>
+        <%= pb_rails("body", props: { text: object.value }) if object.value.present? %>
     <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_label_value/_label_value.jsx
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.jsx
@@ -3,24 +3,23 @@
 import React from 'react'
 import classnames from 'classnames'
 import DateTime from '../pb_kit/dateTime.js'
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
 import { Body, Caption, Flex, Icon, Title } from '../'
 
 type LabelValueProps = {
+  active?: Boolean,
   aria?: object,
   className?: String,
-  dark?: Boolean,
   data?: object,
+  date?: Date,
+  description?: String,
+  icon?: String,
   id?: String,
   label: String,
+  title?: String,
   value?: String,
   variant?: "default" | "details",
-  icon?: String,
-  description?: String,
-  title?: String,
-  date?: Date,
-  active?: Boolean
 }
 
 const dateString = (value: DateTime) => {
@@ -35,7 +34,6 @@ const LabelValue = (props: LabelValueProps) => {
     active = false,
     aria = {},
     className,
-    dark = false,
     data = {},
     date,
     description,
@@ -50,25 +48,21 @@ const LabelValue = (props: LabelValueProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const formattedDate = new DateTime({ value: date })
-  const themeStyle = dark === true ? '_dark' : ''
-  const css = classnames(
-    ['pb_label_value_kit' + themeStyle, className],
-    globalProps(props)
-  )
+  const variantClass = variant === 'details' ? 'details' : ''
+  const classes = classnames(buildCss('pb_label_value_kit', variantClass), className,
+    globalProps(props))
 
   return (
     <div
         {...ariaProps}
         {...dataProps}
-        className={css}
-        dark={dark}
+        className={classes}
         description={description}
         icon={icon}
         id={id}
         title={title}
     >
       <Caption
-          dark={dark}
           text={label}
       />
       <If condition={variant === 'details'}>
@@ -79,11 +73,9 @@ const LabelValue = (props: LabelValueProps) => {
           <If condition={icon}>
             <Body
                 color="light"
-                dark={dark}
                 marginRight="xs"
             >
               <Icon
-                  dark={dark}
                   fixedWidth
                   icon={icon}
               />
@@ -92,7 +84,6 @@ const LabelValue = (props: LabelValueProps) => {
           <If condition={description}>
             <Body
                 color="light"
-                dark={dark}
                 marginRight="xs"
                 text={description}
             />
@@ -105,7 +96,6 @@ const LabelValue = (props: LabelValueProps) => {
               >
                 <If condition={title}>
                   <Title
-                      dark={dark}
                       size={4}
                       text={title}
                       variant="link"
@@ -113,7 +103,6 @@ const LabelValue = (props: LabelValueProps) => {
                 </If>
                 <If condition={date}>
                   <Title
-                      dark={dark}
                       marginLeft="xs"
                       size={4}
                       text={' ' + dateString(formattedDate)}
@@ -125,14 +114,12 @@ const LabelValue = (props: LabelValueProps) => {
             <Otherwise>
               <If condition={title}>
                 <Title
-                    dark={dark}
                     size={4}
                     text={title}
                 />
               </If>
               <If condition={date}>
                 <Title
-                    dark={dark}
                     marginLeft="xs"
                     size={4}
                     text={' ' + dateString(formattedDate)}
@@ -143,7 +130,6 @@ const LabelValue = (props: LabelValueProps) => {
         </Flex>
         <Else />
         <Body
-            dark={dark}
             text={value}
         />
       </If>

--- a/app/pb_kits/playbook/pb_label_value/_label_value.scss
+++ b/app/pb_kits/playbook/pb_label_value/_label_value.scss
@@ -4,4 +4,12 @@
   [class^=pb_caption_kit]  {
     margin-bottom: $space-xs/1.5;
   }
+  &.dark {
+    .pb_body_kit {
+      @include pb_body_dark
+    }
+    .pb_title_kit_4 {
+      @include pb_title_dark;
+    }
+  }
 }

--- a/app/pb_kits/playbook/pb_label_value/label_value.rb
+++ b/app/pb_kits/playbook/pb_label_value/label_value.rb
@@ -9,7 +9,6 @@ module Playbook
 
       prop :label, required: true
       prop :value
-      prop :dark, type: Playbook::Props::Boolean, default: false
       prop :variant, type: Playbook::Props::Enum,
                      values: %w[default details],
                      default: "default"
@@ -21,7 +20,7 @@ module Playbook
 
 
       def classname
-        generate_classname("pb_label_value_kit", variant_class, dark_class)
+        generate_classname("pb_label_value_kit", variant_class)
       end
 
       def date_element
@@ -29,10 +28,6 @@ module Playbook
       end
 
     private
-
-      def dark_class
-        dark ? "dark" : nil
-      end
 
       def variant_class
         variant == "details" ? "details" : nil

--- a/spec/pb_kits/playbook/kits/label_value_spec.rb
+++ b/spec/pb_kits/playbook/kits/label_value_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Playbook::PbLabelValue::LabelValue do
   it { is_expected.to define_enum_prop(:variant)
                       .with_values("default", "details")
                       .with_default("default") }
-  it { is_expected.to define_boolean_prop(:dark).with_default(false) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
@@ -20,10 +19,10 @@ RSpec.describe Playbook::PbLabelValue::LabelValue do
       expect(subject.new(label: label, value: value).classname).to eq "pb_label_value_kit"
       expect(subject.new(label: label, variant: "default").classname).to eq "pb_label_value_kit"
       expect(subject.new(label: label, variant: "details").classname).to eq "pb_label_value_kit_details"
-      expect(subject.new(label: label, variant: "details", dark: true).classname).to eq "pb_label_value_kit_details_dark dark"
-      expect(subject.new(label: label, value: value, dark: true).classname).to eq "pb_label_value_kit_dark dark"
+      expect(subject.new(label: label, variant: "details", dark: true).classname).to eq "pb_label_value_kit_details dark"
+      expect(subject.new(label: label, value: value, dark: true).classname).to eq "pb_label_value_kit dark"
       expect(subject.new(label: label, value: value, classname: "additional_class").classname).to eq "pb_label_value_kit additional_class"
-      expect(subject.new(label: label, value: value, classname: "additional_class", dark: true).classname).to eq "pb_label_value_kit_dark additional_class dark"
+      expect(subject.new(label: label, value: value, classname: "additional_class", dark: true).classname).to eq "pb_label_value_kit additional_class dark"
     end
   end
 end


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1306

#### Screens

<img width="1506" alt="Screen Shot 2020-08-10 at 11 45 36 AM" src="https://user-images.githubusercontent.com/51907753/89802416-802a6880-daff-11ea-9228-74714a65ce85.png">

<img width="1480" alt="Screen Shot 2020-08-10 at 11 45 52 AM" src="https://user-images.githubusercontent.com/51907753/89802424-81f42c00-daff-11ea-9968-0f31eb2ec6fb.png">

<img width="1487" alt="Screen Shot 2020-08-10 at 11 46 06 AM" src="https://user-images.githubusercontent.com/51907753/89802433-83bdef80-daff-11ea-9e26-21c2ce12e20d.png">

<img width="1484" alt="Screen Shot 2020-08-10 at 11 46 24 AM" src="https://user-images.githubusercontent.com/51907753/89802440-84ef1c80-daff-11ea-9447-221bd444e721.png">

#### Breaking Changes

Removed dark prop from both sides of kit

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
