### PR TITLE
Legend kit dark mode

### DIFF
--- a/app/pb_kits/playbook/pb_legend/_legend.html.erb
+++ b/app/pb_kits/playbook/pb_legend/_legend.html.erb
@@ -5,7 +5,7 @@
     class: object.classname) do %>
   <%= pb_rails("body", props: {color: object.body_color}) do %>
     <span class="pb_legend_indicator_circle"></span>
-    <%= pb_rails("title", props: { dark: object.dark, text: object.prefix_text, tag: "span", size: 4 }) %>
+    <%= pb_rails("title", props: { text: object.prefix_text, tag: "span", size: 4 }) %>
     <%= object.text %>
   <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_legend/_legend.jsx
+++ b/app/pb_kits/playbook/pb_legend/_legend.jsx
@@ -17,7 +17,6 @@ type LegendProps = {
     | "data_5"
     | "data_6"
     | "data_7",
-  dark?: Boolean,
   data?: object,
   id?: String,
   prefixText?: String,
@@ -29,7 +28,6 @@ const Legend = (props: LegendProps) => {
     aria = {},
     className,
     color = 'data_1',
-    dark = false,
     data = {},
     id,
     prefixText,
@@ -38,24 +36,23 @@ const Legend = (props: LegendProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const darkClass = dark ? 'dark' : 'light'
-  const bodyCSS = classnames(
-    buildCss('pb_legend_kit', color, darkClass), className,
+  const bodyCss = classnames(
+    buildCss('pb_legend_kit', color), className,
     globalProps(props)
   )
+  const bodyColor = bodyCss.includes('dark') ? 'lighter' : 'light'
 
   return (
     <div
         {...ariaProps}
         {...dataProps}
-        className={bodyCSS}
+        className={bodyCss}
         id={id}
     >
-      <Body color={dark ? 'lighter' : 'light'}>
+      <Body color={bodyColor}>
         <span className="pb_legend_indicator_circle" />
         <If condition={prefixText}>
           <Title
-              dark={dark}
               size={4}
               tag="span"
               text={` ${prefixText} `}

--- a/app/pb_kits/playbook/pb_legend/_legend.scss
+++ b/app/pb_kits/playbook/pb_legend/_legend.scss
@@ -20,5 +20,11 @@
 }
 
 [class^=pb_legend_kit] {
-  @include indicator-colors($data_colors)
+  &.dark {
+    .pb_title_kit_4 {
+      @include pb_title_dark;
+    }
+  }
+  @include indicator-colors($data_colors) 
+
 }

--- a/app/pb_kits/playbook/pb_legend/legend.rb
+++ b/app/pb_kits/playbook/pb_legend/legend.rb
@@ -10,12 +10,7 @@ module Playbook
       prop :color, type: Playbook::Props::Enum,
                    values: (1..7).map { |n| "data_#{n}" },
                    default: "data_1"
-
-      prop :dark, type: Playbook::Props::Boolean,
-                  default: false
-
       prop :prefix_text
-
       prop :text, required: true
 
       def body_color
@@ -23,7 +18,7 @@ module Playbook
       end
 
       def classname
-        generate_classname("pb_legend_kit", color, dark ? "dark" : "light")
+        generate_classname("pb_legend_kit", color)
       end
     end
   end

--- a/spec/pb_kits/playbook/kits/legend_spec.rb
+++ b/spec/pb_kits/playbook/kits/legend_spec.rb
@@ -11,9 +11,6 @@ RSpec.describe Playbook::PbLegend::Legend do
                       .with_default("data_1")
                       .with_values("data_1", "data_2", "data_3", "data_4", "data_5", "data_6", "data_7") }
 
-  it { is_expected.to define_boolean_prop(:dark)
-                      .with_default(false) }
-
   it { is_expected.to define_string_prop(:prefix_text) }
   it { is_expected.to define_string_prop(:text) }
 
@@ -27,8 +24,7 @@ RSpec.describe Playbook::PbLegend::Legend do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       color = "data_1"
-      expect(subject.new(color: color, text: "Text").classname).to eq "pb_legend_kit_data_1_light"
-      expect(subject.new(color: color, dark: true, text: "Text").classname).to eq "pb_legend_kit_data_1_dark dark"
+      expect(subject.new(color: color, dark: true, text: "Text").classname).to eq "pb_legend_kit_data_1 dark"
     end
   end
 end


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1306

#### Screens

<img width="1498" alt="Screen Shot 2020-08-10 at 1 30 05 PM" src="https://user-images.githubusercontent.com/51907753/89813580-e61eec00-db0f-11ea-8097-cb06ef673593.png">

<img width="1471" alt="Screen Shot 2020-08-10 at 1 30 37 PM" src="https://user-images.githubusercontent.com/51907753/89813590-eb7c3680-db0f-11ea-8f3d-75b95e73035a.png">

#### Breaking Changes

Removed dark prop from both sides of the kit

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
