### PR TITLE
Add Dark Mode to the Icon Circle

### DIFF
--- a/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_color_dark.html.erb
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_color_dark.html.erb
@@ -1,0 +1,42 @@
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "comment",
+  variant: "royal",
+  size: "sm"
+}) %>
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "archive",
+  variant: "blue",
+  size: "sm"
+}) %>
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "arrow-alt-right",
+  variant: "purple",
+  size: "sm"
+}) %>
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "cloud",
+  variant: "teal",
+  size: "sm"
+}) %>
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "award",
+  variant: "red",
+  size: "sm"
+}) %>
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "bolt",
+  variant: "yellow",
+  size: "sm"
+}) %>
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "calendar",
+  variant: "green",
+  size: "sm"
+}) %>

--- a/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_color_dark.jsx
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_color_dark.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { IconCircle } from '../../'
+
+const IconCircleColorDark = () => {
+  return (
+    <div>
+      <IconCircle
+          dark
+          icon="rocket"
+          size="sm"
+          variant="royal"
+      />
+      <br />
+      <IconCircle
+          dark
+          icon="rocket"
+          size="sm"
+          variant="blue"
+      />
+      <br />
+      <IconCircle
+          dark
+          icon="rocket"
+          size="sm"
+          variant="purple"
+      />
+      <br />
+      <IconCircle
+          dark
+          icon="rocket"
+          size="sm"
+          variant="teal"
+      />
+      <br />
+      <IconCircle
+          dark
+          icon="rocket"
+          size="sm"
+          variant="red"
+      />
+      <br />
+      <IconCircle
+          dark
+          icon="rocket"
+          size="sm"
+          variant="yellow"
+      />
+      <br />
+      <IconCircle
+          dark
+          icon="rocket"
+          size="sm"
+          variant="green"
+      />
+    </div>
+  )
+}
+
+export default IconCircleColorDark

--- a/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_dark.html.erb
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_dark.html.erb
@@ -1,0 +1,4 @@
+<%= pb_rails("icon_circle", props: {
+  dark: true,
+  icon: "user"
+}) %>

--- a/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_dark.jsx
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_dark.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { IconCircle } from '../../'
+
+const IconCircleDark = () => {
+  return (
+    <div>
+      <IconCircle
+          dark
+          icon="rocket"
+          size="md"
+      />
+    </div>
+  )
+}
+
+export default IconCircleDark

--- a/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes.jsx
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { IconCircle } from '../..'
+
+const IconCircleSizes = () => {
+  return (
+    <div>
+      <IconCircle
+          icon="rocket"
+          size="sm"
+      />
+      <br />
+      <IconCircle
+          icon="rocket"
+          size="md"
+      />
+      <br />
+      <IconCircle
+          icon="rocket"
+          size="lg"
+      />
+      <br />
+      <IconCircle
+          icon="rocket"
+          size="xl"
+      />
+    </div>
+  )
+}
+
+export default IconCircleSizes

--- a/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes_dark.html.erb
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes_dark.html.erb
@@ -1,24 +1,29 @@
 <%= pb_rails("icon_circle", props: {
+  dark: true,
   icon: "comment",
   size: "xs"
 }) %>
 <br />
 <%= pb_rails("icon_circle", props: {
+  dark: true,
   icon: "comment",
   size: "sm"
 }) %>
 <br />
 <%= pb_rails("icon_circle", props: {
+  dark: true,
   icon: "comment",
   size: "md"
 }) %>
 <br />
 <%= pb_rails("icon_circle", props: {
+  dark: true,
   icon: "comment",
   size: "lg"
 }) %>
 <br />
 <%= pb_rails("icon_circle", props: {
+  dark: true,
   icon: "comment",
   size: "xl"
 }) %>

--- a/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes_dark.jsx
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes_dark.jsx
@@ -1,25 +1,29 @@
 import React from 'react'
 import { IconCircle } from '../..'
 
-const IconCircleSize = () => {
+const IconCircleSizesDark = () => {
   return (
     <div>
       <IconCircle
+          dark
           icon="rocket"
           size="sm"
       />
       <br />
       <IconCircle
+          dark
           icon="rocket"
           size="md"
       />
       <br />
       <IconCircle
+          dark
           icon="rocket"
           size="lg"
       />
       <br />
       <IconCircle
+          dark
           icon="rocket"
           size="xl"
       />
@@ -27,4 +31,4 @@ const IconCircleSize = () => {
   )
 }
 
-export default IconCircleSize
+export default IconCircleSizesDark

--- a/app/pb_kits/playbook/pb_icon_circle/docs/example.yml
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/example.yml
@@ -4,8 +4,15 @@ examples:
   - icon_circle_default: Default
   - icon_circle_sizes: Size
   - icon_circle_color: Color
+  - icon_circle_dark: Dark
+  - icon_circle_sizes_dark: Dark Size
+  - icon_circle_color_dark: Dark Color
+  
 
   react:
   - icon_circle_default: Default
-  - icon_circle_size: Size
+  - icon_circle_sizes: Size
   - icon_circle_color: Color
+  - icon_circle_dark: Dark
+  - icon_circle_sizes_dark: Dark Size
+  - icon_circle_color_dark: Dark Color

--- a/app/pb_kits/playbook/pb_icon_circle/docs/index.js
+++ b/app/pb_kits/playbook/pb_icon_circle/docs/index.js
@@ -1,3 +1,6 @@
 export { default as IconCircleColor } from './_icon_circle_color.jsx'
 export { default as IconCircleDefault } from './_icon_circle_default.jsx'
-export { default as IconCircleSize } from './_icon_circle_size.jsx'
+export { default as IconCircleSize } from './_icon_circle_sizes.jsx'
+export { default as IconCircleDark } from './_icon_circle_dark.jsx'
+export { default as IconCircleColorDark } from './_icon_circle_color_dark.jsx'
+export { default as IconCircleSizesDark } from './_icon_circle_sizes_dark.jsx'

--- a/spec/pb_kits/playbook/kits/icon_circle_spec.rb
+++ b/spec/pb_kits/playbook/kits/icon_circle_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Playbook::PbIconCircle::IconCircle do
       icon = "user"
       expect(subject.new(icon: icon, variant: "royal").classname).to eq "pb_icon_circle_kit_md_royal"
       expect(subject.new(icon: icon, size: "sm").classname).to eq "pb_icon_circle_kit_sm_default"
+      expect(subject.new(icon: icon, size: "sm", dark: true).classname).to eq "pb_icon_circle_kit_sm_default dark"
       expect(subject.new(icon: icon, variant: "purple", size: "lg").classname).to eq "pb_icon_circle_kit_lg_purple"
       expect(subject.new(icon: icon, classname: "additional_class").classname).to eq "pb_icon_circle_kit_md_default additional_class"
     end


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1310

#### Screens

<img width="1484" alt="Screen Shot 2020-08-10 at 3 25 57 PM" src="https://user-images.githubusercontent.com/51907753/89822344-048be400-db1e-11ea-9cdd-d648900ea61e.png">


<img width="1485" alt="Screen Shot 2020-08-10 at 3 25 39 PM" src="https://user-images.githubusercontent.com/51907753/89822322-fd64d600-db1d-11ea-8af7-8df90e54279f.png">

<img width="1479" alt="Screen Shot 2020-08-10 at 3 26 51 PM" src="https://user-images.githubusercontent.com/51907753/89822365-0c4b8880-db1e-11ea-964c-78637727bf8e.png">

<img width="1480" alt="Screen Shot 2020-08-10 at 3 27 08 PM" src="https://user-images.githubusercontent.com/51907753/89822375-11103c80-db1e-11ea-9dba-82054f39fd40.png">


#### Breaking Changes

None

#### How to test this

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [ ] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
