### PR TITLE
Add dark mode to Icon Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Dark mode added to Icon Value kit ([#974](https://github.com/powerhome/playbook/pull/974)  @kellyeryan)
+
 ### Fixed
 - Update flow types to use literal vs class wrapper ([#969](https://github.com/powerhome/playbook/pull/969) @thestephenmarshall)
 

--- a/app/pb_kits/playbook/pb_icon_value/_icon_value.jsx
+++ b/app/pb_kits/playbook/pb_icon_value/_icon_value.jsx
@@ -30,13 +30,13 @@ const IconValue = (props: IconValueProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const pbCss = buildCss('pb_icon_value_kit', align)
+  const classes = classnames(buildCss('pb_icon_value_kit', align), className, globalProps(props))
 
   return (
     <div
         {...ariaProps}
         {...dataProps}
-        className={classnames(className, pbCss, globalProps(props))}
+        className={classes}
         id={id}
     >
       <Body color="light">

--- a/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_align.jsx
+++ b/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_align.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { IconValue } from '../../'
+
+const IconValueAlign = () => {
+  return (
+    <div>
+      <IconValue
+          icon="heart"
+          text="93"
+      />
+
+      <br />
+
+      <IconValue
+          align="center"
+          icon="comment"
+          text="5"
+      />
+
+      <br />
+
+      <IconValue
+          align="right"
+          icon="clock"
+          text="15min"
+      />
+    </div>
+  )
+}
+
+export default IconValueAlign

--- a/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_align_dark.html.erb
+++ b/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_align_dark.html.erb
@@ -1,0 +1,23 @@
+<%= pb_rails("icon_value", props: {
+  dark: true,
+  icon: "heart",
+  text: "93"
+}) %>
+
+<br>
+
+<%= pb_rails("icon_value", props: {
+  dark: true,
+  icon: "comment",
+  text: "5",
+  align: "center"
+}) %>
+
+<br>
+
+<%= pb_rails("icon_value", props: {
+  dark: true,
+  icon: "clock",
+  text: "15m",
+  align: "right"
+}) %>

--- a/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_align_dark.jsx
+++ b/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_align_dark.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { IconValue } from '../../'
+
+const IconValueAlignDark = () => {
+  return (
+    <div>
+      <IconValue
+          dark
+          icon="heart"
+          text="93"
+      />
+
+      <br />
+
+      <IconValue
+          align="center"
+          dark
+          icon="comment"
+          text="5"
+      />
+
+      <br />
+
+      <IconValue
+          align="right"
+          dark
+          icon="clock"
+          text="15min"
+      />
+    </div>
+  )
+}
+
+export default IconValueAlignDark

--- a/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_dark.html.erb
+++ b/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_dark.html.erb
@@ -1,0 +1,21 @@
+<%= pb_rails("icon_value", props: {
+  dark: true,
+  icon: "heart",
+  text: "93"
+}) %>
+
+<br>
+
+<%= pb_rails("icon_value", props: {
+  dark: true,
+  icon: "comment",
+  text: "5"
+}) %>
+
+<br>
+
+<%= pb_rails("icon_value", props: {
+  dark: true,
+  icon: "clock",
+  text: "15m"
+}) %>

--- a/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_dark.jsx
+++ b/app/pb_kits/playbook/pb_icon_value/docs/_icon_value_dark.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { IconValue } from '../../'
+
+const IconValueDark = () => {
+  return (
+    <div>
+      <IconValue
+          dark
+          icon="clipboard"
+          text="33-123456"
+      />
+
+      <br />
+
+      <IconValue
+          dark
+          icon="heart"
+          text="93"
+      />
+
+      <br />
+
+      <IconValue
+          dark
+          icon="clock"
+          text="15min"
+      />
+    </div>
+  )
+}
+
+export default IconValueDark

--- a/app/pb_kits/playbook/pb_icon_value/docs/example.yml
+++ b/app/pb_kits/playbook/pb_icon_value/docs/example.yml
@@ -3,7 +3,12 @@ examples:
   rails:
   - icon_value_default: Default
   - icon_value_align: Align
+  - icon_value_dark: Dark
+  - icon_value_align_dark: Align Dark
 
 
   react:
   - icon_value_default: Default
+  - icon_value_align: Align
+  - icon_value_dark: Dark
+  - icon_value_align_dark: Align Dark

--- a/app/pb_kits/playbook/pb_icon_value/docs/index.js
+++ b/app/pb_kits/playbook/pb_icon_value/docs/index.js
@@ -1,1 +1,4 @@
 export { default as IconValueDefault } from './_icon_value_default.jsx'
+export { default as IconValueAlign } from './_icon_value_align.jsx'
+export { default as IconValueDark } from './_icon_value_dark.jsx'
+export { default as IconValueAlignDark } from './_icon_value_align_dark.jsx'

--- a/spec/pb_kits/playbook/kits/icon_value_spec.rb
+++ b/spec/pb_kits/playbook/kits/icon_value_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Playbook::PbIconValue::IconValue do
 
       expect(subject.new(required_props).classname).to eq "pb_icon_value_kit_left"
       expect(subject.new(required_props.merge(align: "center")).classname).to eq "pb_icon_value_kit_center"
+      expect(subject.new(required_props.merge(align: "center", dark: true)).classname).to eq "pb_icon_value_kit_center dark"
       expect(subject.new(required_props.merge(classname: "additional_class")).classname).to eq "pb_icon_value_kit_left additional_class"
     end
 


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1310

#### Screens

<img width="1607" alt="Screen Shot 2020-08-10 at 3 47 14 PM" src="https://user-images.githubusercontent.com/51907753/89824348-fd1a0a00-db20-11ea-97d9-aecf1e39b5bd.png">

<img width="1592" alt="Screen Shot 2020-08-10 at 3 46 37 PM" src="https://user-images.githubusercontent.com/51907753/89824356-0014fa80-db21-11ea-9782-a96473aef39b.png">

#### Breaking Changes

None

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [x] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
