### PR TITLE
Add dark mode to Fixed Confirmation Toast

### DIFF
--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag(:div,
+    aria: object.aria,
     id: object.id,
     data: object.data,
     class: object.classname) do %>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_dark.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_dark.html.erb
@@ -1,0 +1,21 @@
+<%= pb_rails("fixed_confirmation_toast", props: {
+  dark: true,
+  text: "Error Message",
+  status: "error"
+})%>
+
+<br><br>
+
+<%= pb_rails("fixed_confirmation_toast", props: {
+  dark: true,
+  text: "Items Successfully Moved",
+  status: "success"
+})%>
+
+<br><br>
+
+<%= pb_rails("fixed_confirmation_toast", props: {
+  dark: true,
+  text: "Scan to Assign Selected Items",
+  status: "neutral"
+})%>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_dark.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_dark.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { FixedConfirmationToast } from '../..'
+
+const FixedConfirmationToastDark = () => {
+  return (
+    <div>
+      <div>
+        <FixedConfirmationToast
+            dark
+            status="error"
+            text="Error Message"
+        />
+      </div>
+
+      <br />
+      <br />
+
+      <div>
+        <FixedConfirmationToast
+            dark
+            status="success"
+            text="Items Successfully Moved"
+        />
+      </div>
+
+      <br />
+      <br />
+
+      <div>
+        <FixedConfirmationToast
+            dark
+            status="neutral"
+            text="Scan to Assign Selected Items"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default FixedConfirmationToastDark

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.html.erb
@@ -1,0 +1,5 @@
+<%= pb_rails("fixed_confirmation_toast", props: {
+  dark: true,
+  text: "Scan to Assign Selected Items.\nClick X to close at any time",
+  status: "tip",
+}) %>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { FixedConfirmationToast } from '../../'
+
+const FixedConfirmationToastMultiLineDark = () => {
+  return (
+    <div>
+      <FixedConfirmationToast
+          dark
+          status="tip"
+          text={'Scan to Assign Selected Items.\n Click X to close at any time'}
+      />
+    </div>
+  )
+}
+
+export default FixedConfirmationToastMultiLineDark

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
@@ -3,9 +3,12 @@ examples:
   rails:
   - fixed_confirmation_toast_default: Default
   - fixed_confirmation_toast_multi_line: Multi Line
-  
+  - fixed_confirmation_toast_dark: Dark
+  - fixed_confirmation_toast_multi_line_dark: Multi Line Dark
   
   react:
   - fixed_confirmation_toast_default: Default
   - fixed_confirmation_toast_multi_line: Multi Line
+  - fixed_confirmation_toast_dark: Dark
+  - fixed_confirmation_toast_multi_line_dark: Multi Line Dark
   

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
@@ -1,2 +1,4 @@
 export { default as FixedConfirmationToastDefault } from './_fixed_confirmation_toast_default.jsx'
 export { default as FixedConfirmationToastMultiLine } from './_fixed_confirmation_toast_multi_line.jsx'
+export { default as FixedConfirmationToastDark } from './_fixed_confirmation_toast_dark.jsx'
+export { default as FixedConfirmationToastMultiLineDark } from './_fixed_confirmation_toast_multi_line_dark.jsx'

--- a/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
+++ b/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Playbook::PbFixedConfirmationToast::FixedConfirmationToast do
       expect(subject.new(text: text, status: "error").classname).to eq "pb_fixed_confirmation_toast_kit_error"
       expect(subject.new(text: text, status: "neutral").classname).to eq "pb_fixed_confirmation_toast_kit_neutral"
       expect(subject.new(text: text, status: "tip").classname).to eq "pb_fixed_confirmation_toast_kit_tip"
+      expect(subject.new(text: text, status: "tip", dark: true).classname).to eq "pb_fixed_confirmation_toast_kit_tip dark"
     end
   end
 end


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1323

#### Screens

<img width="1605" alt="Screen Shot 2020-08-11 at 3 16 16 PM" src="https://user-images.githubusercontent.com/51907753/89939385-e689b680-dbe5-11ea-974d-2feb8e550140.png">


<img width="1596" alt="Screen Shot 2020-08-11 at 3 16 34 PM" src="https://user-images.githubusercontent.com/51907753/89939399-ea1d3d80-dbe5-11ea-8b0e-90ac25787b1b.png">

#### Breaking Changes

None 

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [X] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
