### PR TITLE
Table dark mode

### DIFF
--- a/app/pb_kits/playbook/pb_table/_table.html.erb
+++ b/app/pb_kits/playbook/pb_table/_table.html.erb
@@ -1,8 +1,9 @@
 <%= content_tag(:div) do %>
   <%= content_tag(:table,
-      id: object.id,
+      aria: object.aria,
+      class: object.classname,
       data: object.data,
-      class: object.classname) do %>
+      id: object.id) do %>
     <%= capture(&object.children) %>
   <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_table/_table.jsx
+++ b/app/pb_kits/playbook/pb_table/_table.jsx
@@ -2,7 +2,7 @@
 
 import React, { type Node } from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
 
 type TableProps = {
@@ -41,7 +41,6 @@ const Table = (props: TableProps) => {
     <table
         {...ariaProps}
         {...dataProps}
-        id={id}
         className={classnames(
         className,
         'pb_table',
@@ -55,6 +54,7 @@ const Table = (props: TableProps) => {
         },
         globalProps(props)
       )}
+        id={id}
     >
       {children}
     </table>

--- a/app/pb_kits/playbook/pb_table/_table.jsx
+++ b/app/pb_kits/playbook/pb_table/_table.jsx
@@ -2,15 +2,18 @@
 
 import React, { type Node } from 'react'
 import classnames from 'classnames'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
 
 type TableProps = {
+  aria?: object,
   children: array<Node> | Node,
   className: string,
   container: boolean,
-  dark: boolean,
+  data?: object,
   dataTable: boolean,
   disableHover: boolean,
+  id?: string,
   responsive: "collapse" | "scroll" | "none",
   singleLine: boolean,
   size: "sm" | "md" | "lg",
@@ -18,19 +21,27 @@ type TableProps = {
 
 const Table = (props: TableProps) => {
   const {
+    aria = {},
     children,
     className,
     container = true,
-    dark = false,
+    data = {},
     dataTable = false,
     disableHover = false,
+    id,
     responsive = 'collapse',
     singleLine = false,
     size = 'sm',
   } = props
 
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+
   return (
     <table
+        {...ariaProps}
+        {...dataProps}
+        id={id}
         className={classnames(
         className,
         'pb_table',
@@ -38,7 +49,6 @@ const Table = (props: TableProps) => {
         `table-responsive-${responsive}`,
         {
           'table-card': container,
-          'table-dark': dark,
           'data_table': dataTable,
           'single-line': singleLine,
           'no-hover': disableHover,

--- a/app/pb_kits/playbook/pb_table/_table_row.html.erb
+++ b/app/pb_kits/playbook/pb_table/_table_row.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:tr,
-    id: object.id,
+    aria: object.aria,
+    class: object.classname,
     data: object.data,
-    class: object.classname) do %>
+    id: object.id) do %>
   <%= capture(&object.children) %>
 <% end %>

--- a/app/pb_kits/playbook/pb_table/_table_row.jsx
+++ b/app/pb_kits/playbook/pb_table/_table_row.jsx
@@ -27,7 +27,7 @@ const TableRow = (props: TableRowPropTypes) => {
   const dataProps = buildDataProps(data)
   const sideHighlightClass =
     sideHighlightColor != '' ? `side_highlight_${sideHighlightColor}` : null
-  const classes = classnames(buildCss('pb_table_row_kit', sideHighlightClass), className, globalProps(props))
+  const classes = classnames(buildCss('pb_table_row_kit', sideHighlightClass), globalProps(props), className)
 
   return (
     <tr

--- a/app/pb_kits/playbook/pb_table/_table_row.jsx
+++ b/app/pb_kits/playbook/pb_table/_table_row.jsx
@@ -1,23 +1,41 @@
 /* @flow */
 import React from 'react'
 import classnames from 'classnames'
-import { buildCss } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
 
 type TableRowPropTypes = {
+  aria?: object,
   children: array<React.ReactNode> | React.ReactNode,
   className: string,
+  data?: object,
+  id?: string,
   sideHighlightColor: string,
 }
 
 const TableRow = (props: TableRowPropTypes) => {
-  const { children, className, sideHighlightColor = 'windows' } = props
+  const {
+    aria = {},
+    children,
+    className,
+    data = {},
+    id,
+    sideHighlightColor = 'windows',
+  } = props
+
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
   const sideHighlightClass =
     sideHighlightColor != '' ? `side_highlight_${sideHighlightColor}` : null
-  const tableRowCss = buildCss('pb_table_row_kit', sideHighlightClass)
+  const classes = classnames(buildCss('pb_table_row_kit', sideHighlightClass), className, globalProps(props))
 
   return (
-    <tr className={classnames(tableRowCss, className, globalProps(props))}>
+    <tr
+        {...ariaProps}
+        {...dataProps}
+        className={classes}
+        id={id}
+    >
       {children}
     </tr>
   )

--- a/app/pb_kits/playbook/pb_table/table.rb
+++ b/app/pb_kits/playbook/pb_table/table.rb
@@ -25,7 +25,7 @@ module Playbook
 
       def classname
         generate_classname(
-          "pb_table", "table-#{size}", single_line_class,
+          "pb_table", "table-#{size}", single_line_class, 
           disable_hover_class, container_class, data_table_class,
           "table-responsive-#{responsive}", separator: " "
         )

--- a/app/pb_kits/playbook/pb_table/table.rb
+++ b/app/pb_kits/playbook/pb_table/table.rb
@@ -12,8 +12,6 @@ module Playbook
                   default: "md"
       prop :single_line, type: Playbook::Props::Boolean,
                          default: false
-      prop :dark, type: Playbook::Props::Boolean,
-                  default: false
       prop :disable_hover, type: Playbook::Props::Boolean,
                            default: false
       prop :data_table, type: Playbook::Props::Boolean,
@@ -27,17 +25,13 @@ module Playbook
 
       def classname
         generate_classname(
-          "pb_table", "table-#{size}", single_line_class, dark_class,
+          "pb_table", "table-#{size}", single_line_class,
           disable_hover_class, container_class, data_table_class,
           "table-responsive-#{responsive}", separator: " "
         )
       end
 
     private
-
-      def dark_class
-        dark ? "dark" : nil
-      end
 
       def data_table_class
         data_table ? "data_table" : nil

--- a/spec/pb_kits/playbook/kits/table_spec.rb
+++ b/spec/pb_kits/playbook/kits/table_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe Playbook::PbTable::Table do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_table table-md table-card table-responsive-collapse"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_table table-md table-card table-responsive-collapse additional_class"
-      expect(subject.new(dark: true).classname).to eq "pb_table table-md dark table-card table-responsive-collapse dark"
+      expect(subject.new(dark: true).classname).to eq "pb_table table-md table-card table-responsive-collapse dark"
       expect(subject.new(data_table: true).classname).to eq "pb_table table-md table-card data_table table-responsive-collapse"
       expect(subject.new(size: "sm").classname).to eq "pb_table table-sm table-card table-responsive-collapse"
       expect(subject.new(single_line: true).classname).to eq "pb_table table-md single-line table-card table-responsive-collapse"
       expect(subject.new(container: false).classname).to eq "pb_table table-md table-responsive-collapse"
       expect(subject.new(disable_hover: true).classname).to eq "pb_table table-md no-hover table-card table-responsive-collapse"
-      expect(subject.new(disable_hover: true, dark: true, size: "lg", single_line: true).classname).to eq "pb_table table-lg single-line dark no-hover table-card table-responsive-collapse dark"
+      expect(subject.new(disable_hover: true, dark: true, size: "lg", single_line: true).classname).to eq "pb_table table-lg single-line no-hover table-card table-responsive-collapse dark"
     end
   end
 end


### PR DESCRIPTION
#### Runway Ticket URL

NUX-1326

I also added aria, data, id props.

#### Screens

<img width="1695" alt="Screen Shot 2020-08-12 at 1 51 32 PM" src="https://user-images.githubusercontent.com/51907753/90049651-1e0a6880-dca3-11ea-8dbe-134d0ec2c66f.png">

<img width="1691" alt="Screen Shot 2020-08-12 at 1 51 53 PM" src="https://user-images.githubusercontent.com/51907753/90049655-1fd42c00-dca3-11ea-82a7-d8afa78dda88.png">

#### Breaking Changes

Removed dark prop from both sides of kit.

#### Checklist:

- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs
- [X] **CHANGELOG** Please add an entry on `[Unreleased]` section to every functionality `ADDED`/`CHANGED`/`DEPRECATED`/`REMOVED`/`FIXED`
