### PR TITLE
Fix className concat problem in nav.jsx

### DIFF
--- a/app/pb_kits/playbook/pb_nav/_nav.jsx
+++ b/app/pb_kits/playbook/pb_nav/_nav.jsx
@@ -37,7 +37,7 @@ const Nav = (props: NavProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const cardCss = classnames(buildCss('pb_nav_list', variant, orientation, {
-    highlight: highlight }, className, globalProps(props)))
+    highlight: highlight }), globalProps(props), className)
 
   return (
     <div


### PR DESCRIPTION
#### Issue

Fix potential concatenation problem with className in nav. To be honest, the html looks the same for both, but that was the case with the selectable card icon kit (see screen shot of issue below) and it caused problems because of a misplaced parentheses.

#### Screens

Bug problem with selectable icon card kit caused by misplaced parentheses:

<img width="1085" alt="Screen Shot 2020-08-25 at 11 52 14 AM" src="https://user-images.githubusercontent.com/51907753/91197601-89076680-e6c9-11ea-84c4-4bfbe7231558.png">

**nav html** output with changes:

<img width="1315" alt="Screen Shot 2020-08-25 at 11 48 14 AM" src="https://user-images.githubusercontent.com/51907753/91197271-1dbd9480-e6c9-11ea-9897-5decfcf52553.png">


#### Breaking Changes

None

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [X] **SCREENSHOT** Please add a screen shot or two
- [X] **SPECS** Please cover your changes with specs - NA only correction on react side
