### PR TITLE
[NUX-1347] - Reduce input css specificity

### DIFF
--- a/app/pb_kits/playbook/pb_date/date.rb
+++ b/app/pb_kits/playbook/pb_date/date.rb
@@ -13,6 +13,7 @@ module Playbook
       prop :size, type: Playbook::Props::Enum,
                   values: %w[lg sm xs],
                   default: "sm"
+      prop :timezone, default: "America/New_York"
 
       def classname
         generate_classname("pb_date_kit")
@@ -33,7 +34,7 @@ module Playbook
     private
 
       def pb_date_time
-        Playbook::PbKit::PbDateTime.new(date)
+        Playbook::PbKit::PbDateTime.new(date, timezone)
       end
     end
   end

--- a/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
+++ b/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
@@ -12,6 +12,13 @@
 <br>
 
 <%= pb_rails("date", props: {
-  date: "2012-08-02T15:49:29Z",
+  date: DateTime.now,
+  timezone: "Asia/Tokyo"
+}) %>
+
+<br>
+
+<%= pb_rails("date", props: {
+  date: Date.new(2010, 11, 12),
   size: "xs"
 }) %>

--- a/app/pb_kits/playbook/pb_date/docs/_date_timezone.html.erb
+++ b/app/pb_kits/playbook/pb_date/docs/_date_timezone.html.erb
@@ -1,0 +1,51 @@
+<%= pb_rails("caption", props: { text: "East Coast (Default)"}) %>
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "America/New_York"
+}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "West Coast"}) %>
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "America/Los_Angeles"
+}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "Toyko, Japan"}) %>
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "Asia/Tokyo"
+}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "Anti-pattern example"}) %>
+
+<%= pb_rails("date", props: {
+  date: Date.today,
+  timezone: "Australia/Sydney"
+}) %>
+<%= pb_rails("body", props: { text: "Date.today ignores Timezone"}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "DateTime respects Timezone"}) %>
+
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "Australia/Sydney"
+}) %>
+
+<%= pb_rails("body", props: { text: "'.now' in Australia is tomorrow (if you're EST after 10am)"}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "String Dates"}) %>
+<%= pb_rails("date", props: {
+  date: "2012-08-02T00:49:29Z",
+}) %>
+
+<%= pb_rails("body", props: { text: "Defaults to UTC, then changes due to EST Timezone."}) %>

--- a/app/pb_kits/playbook/pb_date/docs/_date_timezone.md
+++ b/app/pb_kits/playbook/pb_date/docs/_date_timezone.md
@@ -1,0 +1,6 @@
+Depending on the data you send to the `date` prop you might have unexpected results due to ruby `Date` and `DateTime` classes.
+
+Don't care about timezones? Use `Date`.
+
+If you need a date that recognizes a timezone, especially when paired with the [Time kit](/kits/time), leverage `DateTime`.
+

--- a/app/pb_kits/playbook/pb_date/docs/_description.md
+++ b/app/pb_kits/playbook/pb_date/docs/_description.md
@@ -1,1 +1,3 @@
 Use to display the date. Year will not display if it is the current year.
+
+`DateTime` defaults to the "America/New_York" timezone. `Date` ignores timezone.

--- a/app/pb_kits/playbook/pb_date/docs/example.yml
+++ b/app/pb_kits/playbook/pb_date/docs/example.yml
@@ -2,6 +2,7 @@ examples:
   
   rails:
   - date_default: Default
+  - date_timezone: Timezones
   
   
   react:

--- a/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -17,7 +17,7 @@
       @include pb_body_light;
     }
 
-    > input:first-child {
+    input {
       @include pb_textarea_light;
       @include pb_title_4;
       overflow: hidden;
@@ -38,7 +38,7 @@
         @include pb_body_light_dark;
       }
 
-      > input:first-child {
+      input {
         @include pb_textarea_dark;
         @include pb_title_4;
         @include pb_title_dark;
@@ -54,7 +54,7 @@
 
     &.error {
       .text_input_wrapper {
-        > input:first-child {
+        input {
           border-color: $error_dark;
         }
       }
@@ -66,7 +66,7 @@
       [class*=pb_body_kit] {
         margin-top: $space_xs / 2;
       }
-      > input:first-child {
+      input {
         border-color: $error;
       }
     }

--- a/spec/pb_kits/playbook/kits/date_spec.rb
+++ b/spec/pb_kits/playbook/kits/date_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Playbook::PbDate::Date do
   it { is_expected.to define_partial }
 
   it { is_expected.to define_prop(:date) }
+  it { is_expected.to define_prop(:timezone) }
   it do
     is_expected.to define_enum_prop(:size)
                    .with_default("sm")


### PR DESCRIPTION
#### Screens
<img width="700" alt="input-selector" src="https://user-images.githubusercontent.com/4315934/91349284-78371d80-e7bb-11ea-87a0-05188addeed1.png">

#### Breaking Changes
I don't believe so. The selector is quite specific.

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/NUX-1347

#### How to test this
I'm not quite sure actually.

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
