### PR TITLE
[NUX-1347] - Reduce input css specificity

### DIFF
--- a/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -17,7 +17,7 @@
       @include pb_body_light;
     }
 
-    > input:first-child {
+    input {
       @include pb_textarea_light;
       @include pb_title_4;
       overflow: hidden;
@@ -38,7 +38,7 @@
         @include pb_body_light_dark;
       }
 
-      > input:first-child {
+      input {
         @include pb_textarea_dark;
         @include pb_title_4;
         @include pb_title_dark;
@@ -54,7 +54,7 @@
 
     &.error {
       .text_input_wrapper {
-        > input:first-child {
+        input {
           border-color: $error_dark;
         }
       }
@@ -66,7 +66,7 @@
       [class*=pb_body_kit] {
         margin-top: $space_xs / 2;
       }
-      > input:first-child {
+      input {
         border-color: $error;
       }
     }


### PR DESCRIPTION
#### Screens
<img width="700" alt="input-selector" src="https://user-images.githubusercontent.com/4315934/91349284-78371d80-e7bb-11ea-87a0-05188addeed1.png">

#### Breaking Changes
I don't believe so. The selector is quite specific.

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/NUX-1347

#### How to test this
I'm not quite sure actually.

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
