### PR TITLE
Add timezone prop to date, expand docs

### DIFF
--- a/app/pb_kits/playbook/pb_date/date.rb
+++ b/app/pb_kits/playbook/pb_date/date.rb
@@ -13,6 +13,7 @@ module Playbook
       prop :size, type: Playbook::Props::Enum,
                   values: %w[lg sm xs],
                   default: "sm"
+      prop :timezone, default: "America/New_York"
 
       def classname
         generate_classname("pb_date_kit")
@@ -33,7 +34,7 @@ module Playbook
     private
 
       def pb_date_time
-        Playbook::PbKit::PbDateTime.new(date)
+        Playbook::PbKit::PbDateTime.new(date, timezone)
       end
     end
   end

--- a/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
+++ b/app/pb_kits/playbook/pb_date/docs/_date_default.html.erb
@@ -12,6 +12,13 @@
 <br>
 
 <%= pb_rails("date", props: {
-  date: "2012-08-02T15:49:29Z",
+  date: DateTime.now,
+  timezone: "Asia/Tokyo"
+}) %>
+
+<br>
+
+<%= pb_rails("date", props: {
+  date: Date.new(2010, 11, 12),
   size: "xs"
 }) %>

--- a/app/pb_kits/playbook/pb_date/docs/_date_timezone.html.erb
+++ b/app/pb_kits/playbook/pb_date/docs/_date_timezone.html.erb
@@ -1,0 +1,51 @@
+<%= pb_rails("caption", props: { text: "East Coast (Default)"}) %>
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "America/New_York"
+}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "West Coast"}) %>
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "America/Los_Angeles"
+}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "Toyko, Japan"}) %>
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "Asia/Tokyo"
+}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "Anti-pattern example"}) %>
+
+<%= pb_rails("date", props: {
+  date: Date.today,
+  timezone: "Australia/Sydney"
+}) %>
+<%= pb_rails("body", props: { text: "Date.today ignores Timezone"}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "DateTime respects Timezone"}) %>
+
+<%= pb_rails("date", props: {
+  date: DateTime.now,
+  timezone: "Australia/Sydney"
+}) %>
+
+<%= pb_rails("body", props: { text: "'.now' in Australia is tomorrow (if you're EST after 10am)"}) %>
+
+<br>
+
+<%= pb_rails("caption", props: { text: "String Dates"}) %>
+<%= pb_rails("date", props: {
+  date: "2012-08-02T00:49:29Z",
+}) %>
+
+<%= pb_rails("body", props: { text: "Defaults to UTC, then changes due to EST Timezone."}) %>

--- a/app/pb_kits/playbook/pb_date/docs/_date_timezone.md
+++ b/app/pb_kits/playbook/pb_date/docs/_date_timezone.md
@@ -1,0 +1,6 @@
+Depending on the data you send to the `date` prop you might have unexpected results due to ruby `Date` and `DateTime` classes.
+
+Don't care about timezones? Use `Date`.
+
+If you need a date that recognizes a timezone, especially when paired with the [Time kit](/kits/time), leverage `DateTime`.
+

--- a/app/pb_kits/playbook/pb_date/docs/_description.md
+++ b/app/pb_kits/playbook/pb_date/docs/_description.md
@@ -1,1 +1,3 @@
 Use to display the date. Year will not display if it is the current year.
+
+`DateTime` defaults to the "America/New_York" timezone. `Date` ignores timezone.

--- a/app/pb_kits/playbook/pb_date/docs/example.yml
+++ b/app/pb_kits/playbook/pb_date/docs/example.yml
@@ -2,6 +2,7 @@ examples:
   
   rails:
   - date_default: Default
+  - date_timezone: Timezones
   
   
   react:

--- a/spec/pb_kits/playbook/kits/date_spec.rb
+++ b/spec/pb_kits/playbook/kits/date_spec.rb
@@ -42,6 +42,31 @@ RSpec.describe Playbook::PbDate::Date do
     end
   end
 
+  describe "#timezones" do
+    it "displays the date respecting EST timezone" do
+      expect(subject.new(
+        date: DateTime.new(2019, 10, 19),
+        size: "lg",
+      ).lg_date).to include "OCT 18"
+    end
+
+    it "displays the date respecting Syndey Australia TZ" do
+      expect(subject.new(
+        date: DateTime.new(2019, 10, 19),
+        size: "lg",
+        timezone: "Australia/Sydney"
+      ).lg_date).to include "OCT 19"
+    end
+
+    it "displays the date respecting Syndey Australia TZ with Time" do
+      expect(subject.new(
+        date: DateTime.new(2019, 10, 19, 14, 4, 4),
+        size: "lg",
+        timezone: "Australia/Sydney"
+      ).lg_date).to include "OCT 20"
+    end
+  end
+
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       required_props = { date: Date.today }

--- a/spec/pb_kits/playbook/kits/date_spec.rb
+++ b/spec/pb_kits/playbook/kits/date_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Playbook::PbDate::Date do
   it { is_expected.to define_partial }
 
   it { is_expected.to define_prop(:date) }
+  it { is_expected.to define_prop(:timezone) }
   it do
     is_expected.to define_enum_prop(:size)
                    .with_default("sm")


### PR DESCRIPTION
The Date kit wasn't supporting Timezones. When you added a strict `Date` class it's not a concern but `DateTime` would have problems and default all days to adhere to EST timezone.

- This PR updates the method to leverage existing functionality, the kit just needed a Timezone prop.
- Also, since Dates, Time, Timezones are confusing as is, we needed to add a little more documentation around how our kits leverage those classes in RoR to render dates, times, and timezones.

#### Screens

**Updated details**
<img width="300" alt="title" src="https://user-images.githubusercontent.com/4315934/91221360-efa17a00-e6f3-11ea-904d-f898de13dd15.png">

**Default Example**
<img width="300" alt="date-default-example" src="https://user-images.githubusercontent.com/4315934/91221331-e2848b00-e6f3-11ea-976f-3ef84db3358b.png">

**Timezone Examples**
<img width="300" alt="timezone-examples" src="https://user-images.githubusercontent.com/4315934/91221222-bb2dbe00-e6f3-11ea-9650-5ca7e547feb7.png">

#### Breaking Changes

Should be ok. New timezone props is optional.

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/NUX-1370

#### How to test this
Use kit, enter various dates and timezones.

#### Checklist:

- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review
- [x] **SCREENSHOT** Please add a screen shot or two
- [x] **SPECS** Please cover your changes with specs
