### PR TITLE
[NUX-639] - Time Kit Redesign / Update

### DIFF
--- a/app/pb_kits/playbook/pb_time/_time.html.erb
+++ b/app/pb_kits/playbook/pb_time/_time.html.erb
@@ -2,7 +2,7 @@
     id: object.id,
     data: object.data,
     class: object.classname) do %>
-  <% if object.size == "lg" %>
+  <% if object.size == "md" %>
     <% if object.show_icon %>
       <%= pb_rails("body", props: { color: "light", tag: "span"}) do %>
         <%= pb_rails("icon", props: { icon: "clock", fixed_width: true, size: "lg" }) %>

--- a/app/pb_kits/playbook/pb_time/_time.html.erb
+++ b/app/pb_kits/playbook/pb_time/_time.html.erb
@@ -2,6 +2,11 @@
     id: object.id,
     data: object.data,
     class: object.classname) do %>
+    <%
+      # convert deprecated prop values
+      object.size = "sm" if object.size == "xs"
+      object.size = "md" if object.size == "lg"
+    %>
   <% if object.size == "md" %>
     <% if object.show_icon %>
       <%= pb_rails("body", props: { color: "light", tag: "span"}) do %>

--- a/app/pb_kits/playbook/pb_time/_time.html.erb
+++ b/app/pb_kits/playbook/pb_time/_time.html.erb
@@ -4,10 +4,11 @@
     class: object.classname) do %>
     <%
       # convert deprecated prop values
-      object.size = "sm" if object.size == "xs"
-      object.size = "md" if object.size == "lg"
+      size = object.size
+      size = "sm" if object.size == "xs"
+      size = "md" if object.size == "lg"
     %>
-  <% if object.size == "md" %>
+  <% if size == "md" %>
     <% if object.show_icon %>
       <%= pb_rails("body", props: { color: "light", tag: "span"}) do %>
         <%= pb_rails("icon", props: { icon: "clock", fixed_width: true, size: "lg" }) %>

--- a/app/pb_kits/playbook/pb_time/_time.html.erb
+++ b/app/pb_kits/playbook/pb_time/_time.html.erb
@@ -3,31 +3,31 @@
     data: object.data,
     class: object.classname) do %>
   <% if object.size == "lg" %>
-    <%= pb_rails("title", props: { tag: "span", text: object.format_time_string, size: 3 }) %>
-    <%= content_tag(:span) do %>
+    <% if object.show_icon %>
+      <%= pb_rails("body", props: { color: "light", tag: "span"}) do %>
+        <%= pb_rails("icon", props: { icon: "clock", fixed_width: true, size: "lg" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("caption", props: { tag: "span", text: object.format_time_string, size: "lg" }) %>
+    <% if object.show_timezone %>
       <%= content_tag(:span, class: "pb_time_timezone") do %>
         <%= object.pb_date_time.to_timezone.upcase %>
       <% end %>
     <% end %>
-  <% elsif object.size == "sm" %>
-    <%= pb_rails("body", props: { tag: "span", text: object.format_time_string }) do %>
-      <%= pb_rails("icon", props: { icon: "clock", fixed_width: true }) %>
-      <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
-        <%= content_tag(:span) do %>
-          <%= object.format_time_string %>
-          <%= content_tag(:span, class: "pb_time_timezone") do %>
-            <%= object.pb_date_time.to_timezone.upcase %>
-          <% end %>
-        <% end %>
+  <% else %>
+    <% if object.show_icon %>
+      <%= pb_rails("body", props: { color: "light", tag: "span"}) do %>
+        <%= pb_rails("icon", props: { icon: "clock", fixed_width: true }) %>
       <% end %>
     <% end %>
-  <% else %>
-    <%= pb_rails("body", props: { tag: "span", text: object.format_time_string }) do %>
+    <%= pb_rails("body", props: { color: "light", tag: "span", text: object.format_time_string }) do %>
       <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
         <%= content_tag(:span) do %>
           <%= object.format_time_string %>
-          <%= content_tag(:span, class: "pb_time_timezone") do %>
-            <%= object.pb_date_time.to_timezone.upcase %>
+          <% if object.show_timezone %>
+            <%= content_tag(:span, class: "pb_time_timezone") do %>
+              <%= object.pb_date_time.to_timezone.upcase %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/pb_kits/playbook/pb_time/_time.jsx
+++ b/app/pb_kits/playbook/pb_time/_time.jsx
@@ -17,7 +17,7 @@ type TimeProps = {
   dark?: boolean,
   id?: string,
   showIcon?: boolean,
-  size?: 'lg' | 'sm',
+  size?: 'md' | 'sm',
   timeZone?: string,
 }
 
@@ -42,14 +42,14 @@ const Time = (props: TimeProps) => {
             <Icon
                 fixedWidth
                 icon="clock"
-                size={size === 'lg' ? 'lg' : 'sm'}
+                size={size === 'md' ? 'lg' : 'sm'}
             />
           </Body>
           {' '}
         </If>
         <time dateTime={date}>
           <span>
-            <If condition={size !== 'lg'}>
+            <If condition={size !== 'md'}>
               <Body
                   color="light"
                   tag="span"

--- a/app/pb_kits/playbook/pb_time/_time.jsx
+++ b/app/pb_kits/playbook/pb_time/_time.jsx
@@ -7,20 +7,22 @@ import DateTime from '../pb_kit/dateTime.js'
 import { buildCss } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
 
-import { Body, Icon, Title  } from '../'
+import { Body, Caption, Icon } from '../'
 
 type TimeProps = {
   align?: 'left' | 'center' | 'right',
   className?: string | array<string>,
   data?: string,
   date: string,
+  dark?: boolean,
   id?: string,
-  size?: 'lg' | 'sm' | 'xs',
+  showIcon?: boolean,
+  size?: 'lg' | 'sm',
   timeZone?: string,
 }
 
 const Time = (props: TimeProps) => {
-  const { align, className, date, size, timeZone } = props
+  const { align, className, date, showIcon, size, timeZone } = props
   const classes = classnames(
     className,
     buildCss('pb_time_kit', align, size),
@@ -32,23 +34,30 @@ const Time = (props: TimeProps) => {
   return (
     <div className={classes}>
       <span className="pb_body_kit">
-        <If condition={size === 'sm'}>
-          <Icon
-              fixedWidth
-              icon="clock"
-          />
+        <If condition={showIcon}>
+          <Body
+              color="light"
+              tag="span"
+          >
+            <Icon
+                fixedWidth
+                icon="clock"
+                size={size === 'lg' ? 'lg' : 'sm'}
+            />
+          </Body>
           {' '}
         </If>
         <time dateTime={date}>
           <span>
             <If condition={size !== 'lg'}>
               <Body
+                  color="light"
                   tag="span"
                   text={dateTimestamp.toTimeWithMeridian()}
               />
               <Else />
-              <Title
-                  size={3}
+              <Caption
+                  size="lg"
                   tag="span"
                   text={dateTimestamp.toTimeWithMeridian()}
               />

--- a/app/pb_kits/playbook/pb_time/_time.scss
+++ b/app/pb_kits/playbook/pb_time/_time.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  &[class*=_lg] {
+  &[class*=_md] {
     [class^=pb_caption_kit] {
       color: $text_lt_default;
       letter-spacing: $lspace_tight;

--- a/app/pb_kits/playbook/pb_time/_time.scss
+++ b/app/pb_kits/playbook/pb_time/_time.scss
@@ -2,9 +2,11 @@
 @import "../tokens/typography";
 @import "../pb_icon/icon";
 @import "../pb_body/body";
-@import "../pb_title/title";
+@import "../pb_caption/caption";
 
 [class^=pb_time_kit] {
+  letter-spacing: $lspace_looser;
+  text-transform: uppercase;
   &[class*=_center]  {
     text-align: center;
   }
@@ -18,9 +20,8 @@
   }
 
   [class^=pb_time_timezone] {
-    font-size: $font-small;
-    font-weight: $regular;
-    color: $text-lt-light;
+    color: $text_lt_light;
+    font-weight: $bold;
 
     &::before {
       content: " ";
@@ -28,17 +29,24 @@
   }
 
   &[class*=_lg] {
+    [class^=pb_caption_kit] {
+      color: $text_lt_default;
+      letter-spacing: $lspace_tight;
+      text-transform: capitalize;
+    }
     [class^=pb_time_timezone] {
+      color: $text_lt_light;
       font-size: $font-large !important;
-      color: $text-lt-light;
+      font-weight: $regular;
+      letter-spacing: $lspace_tight;
     }
   }
 
   &.dark {
-    & > * [class^=pb_title_kit] {
+    [class^=pb_caption_kit] {
       color: $text_dk_default;
     }
-    & > * [class^=pb_body_kit] {
+    [class^=pb_body_kit] {
       color: $text_dk_light;
     }
   }

--- a/app/pb_kits/playbook/pb_time/docs/_time_align.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_align.html.erb
@@ -1,0 +1,18 @@
+<%= pb_rails("time", props: {
+  time: DateTime.now,
+  align: "left"
+}) %>
+
+<br>
+
+<%= pb_rails("time", props: {
+  time: Time.now,
+  align: "center"
+}) %>
+
+<br>
+
+<%= pb_rails("time", props: {
+  time: Time.now,
+  align: "right"
+}) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_align.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_align.jsx
@@ -6,19 +6,19 @@ const TimeAlign = () => {
     <div>
       <Time
           date={new Date()}
-          size="lg"
+          size="md"
       />
       <br />
       <Time
           align="center"
           date={new Date()}
-          size="lg"
+          size="md"
       />
       <br />
       <Time
           align="right"
           date={new Date()}
-          size="lg"
+          size="md"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_time/docs/_time_dark.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_dark.html.erb
@@ -36,7 +36,7 @@
  <%= pb_rails("time", props: {
   dark: true,
   time: Time.now,
-  size: "lg",
+  size: "md",
 }) %>
 
 <br>
@@ -46,7 +46,7 @@
   show_timezone: true,
   time: DateTime.now,
   timezone: "America/New_York",
-  size: "lg",
+  size: "md",
 }) %>
 
 <br>
@@ -56,7 +56,7 @@
   show_timezone: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
-  size: "lg",
+  size: "md",
 }) %>
 
 <br>
@@ -65,6 +65,6 @@
   dark: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
-  size: "lg",
+  size: "md",
   timezone: "America/New_York",
 }) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_dark.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_dark.html.erb
@@ -1,18 +1,21 @@
 <%= pb_rails("time", props: {
-  time: Time.now,
+  dark: true,
+  time: Time.now
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
+  dark: true,
   show_timezone: true,
   time: DateTime.now,
-  timezone: "America/Chicago"
+  timezone: "America/Chicago",
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
+  dark: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
 }) %>
@@ -20,16 +23,18 @@
 <br>
 
 <%= pb_rails("time", props: {
+  dark: true,
   show_timezone: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
-  timezone: "America/Chicago"
+  timezone: "America/Chicago",
 }) %>
 
  <br>
  <br>
 
  <%= pb_rails("time", props: {
+  dark: true,
   time: Time.now,
   size: "lg",
 }) %>
@@ -37,6 +42,8 @@
 <br>
 
 <%= pb_rails("time", props: {
+  dark: true,
+  show_timezone: true,
   time: DateTime.now,
   timezone: "America/New_York",
   size: "lg",
@@ -45,6 +52,8 @@
 <br>
 
 <%= pb_rails("time", props: {
+  dark: true,
+  show_timezone: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
   size: "lg",
@@ -53,6 +62,7 @@
 <br>
 
 <%= pb_rails("time", props: {
+  dark: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
   size: "lg",

--- a/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_dark.jsx
@@ -12,7 +12,7 @@ const TimeDark = () => {
       <Time
           dark
           date={new Date()}
-          size="lg"
+          size="md"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_time/docs/_time_default.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_default.html.erb
@@ -31,30 +31,32 @@
 
  <%= pb_rails("time", props: {
   time: Time.now,
-  size: "lg",
+  size: "md",
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
+  show_timezone: true,
+  size: "md",
   time: DateTime.now,
   timezone: "America/New_York",
-  size: "lg",
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  time: "2012-08-02T15:49:29Z",
   show_icon: true,
-  size: "lg",
+  size: "md",
+  time: "2012-08-02T15:49:29Z",
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  time: "2012-08-02T15:49:29Z",
   show_icon: true,
-  size: "lg",
+  show_timezone: true,
+  size: "md",
+  time: "2012-08-02T15:49:29Z",
   timezone: "America/New_York",
 }) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
@@ -27,25 +27,25 @@ const TimeDefault = () => {
       <br />
       <Time
           date={new Date()}
-          size="lg"
+          size="md"
       />
       <br />
       <Time
           date={new Date()}
-          size="lg"
+          size="md"
           timeZone="America/New_York"
       />
       <br />
       <Time
           date={new Date()}
           showIcon
-          size="lg"
+          size="md"
       />
       <br />
       <Time
           date={new Date()}
           showIcon
-          size="lg"
+          size="md"
           timeZone="America/New_York"
       />
     </div>

--- a/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_default.jsx
@@ -5,19 +5,48 @@ const TimeDefault = () => {
   return (
     <div>
       <Time
+          date={new Date().getTime()}
+      />
+      <br />
+      <Time
+          date={new Date()}
+          timeZone="America/New_York"
+      />
+      <br />
+      <Time
+          date={new Date().getTime()}
+          showIcon
+      />
+      <br />
+      <Time
+          date={new Date()}
+          showIcon
+          timeZone="America/New_York"
+      />
+      <br />
+      <br />
+      <Time
+          date={new Date()}
+          size="lg"
+      />
+      <br />
+      <Time
           date={new Date()}
           size="lg"
           timeZone="America/New_York"
       />
       <br />
       <Time
-          date={new Date().getTime()}
-          size="sm"
+          date={new Date()}
+          showIcon
+          size="lg"
       />
       <br />
       <Time
-          date="2012-08-02T09:49:29Z"
-          size="xs"
+          date={new Date()}
+          showIcon
+          size="lg"
+          timeZone="America/New_York"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_time/docs/_time_sizes.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_sizes.html.erb
@@ -7,5 +7,5 @@
 
 <%= pb_rails("time", props: {
   time: Time.now,
-  size: "lg"
+  size: "md"
 }) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_sizes.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_sizes.html.erb
@@ -1,0 +1,11 @@
+<%= pb_rails("time", props: {
+  time: DateTime.now,
+  size: "sm"
+}) %>
+
+<br>
+
+<%= pb_rails("time", props: {
+  time: Time.now,
+  size: "lg"
+}) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_sizes.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_sizes.jsx
@@ -10,7 +10,7 @@ const TimeSizes = () => {
       <br />
       <Time
           date={new Date()}
-          size="lg"
+          size="md"
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_time/docs/_time_sizes.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_sizes.jsx
@@ -1,16 +1,14 @@
 import React from 'react'
 import Time from '../_time.jsx'
 
-const TimeDark = () => {
+const TimeSizes = () => {
   return (
     <div>
       <Time
-          dark
           date={new Date()}
       />
       <br />
       <Time
-          dark
           date={new Date()}
           size="lg"
       />
@@ -18,4 +16,4 @@ const TimeDark = () => {
   )
 }
 
-export default TimeDark
+export default TimeSizes

--- a/app/pb_kits/playbook/pb_time/docs/_time_sizes.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_sizes.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import Time from '../_time.jsx'
 
 const TimeSizes = () => {
   return (
-    <div>
+    <Fragment>
       <Time
           date={new Date()}
       />
@@ -12,7 +12,7 @@ const TimeSizes = () => {
           date={new Date()}
           size="md"
       />
-    </div>
+    </Fragment>
   )
 }
 

--- a/app/pb_kits/playbook/pb_time/docs/_time_timestamp.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timestamp.html.erb
@@ -11,6 +11,7 @@
 <br>
 
 <%= pb_rails("time", props: {
+  show_timezone: true,
   time: DateTime.now,
-  timezone: "America/Chicago"
+  timezone: "America/Chicago",
 }) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_timestamp.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timestamp.jsx
@@ -15,13 +15,6 @@ const TimeStamp = () => {
           date={new Date().getTime()}
           size="sm"
       />
-
-      <br />
-
-      <Time
-          date="2012-08-02T15:49:29Z"
-          size="sm"
-      />
     </div>
   )
 }

--- a/app/pb_kits/playbook/pb_time/docs/_time_timezone.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timezone.html.erb
@@ -1,0 +1,42 @@
+<h4>East Coast</h4>
+<%= pb_rails("time", props: {
+  show_timezone: true,
+  time: Time.now,
+  timezone: "America/New_York"
+}) %>
+
+<br>
+
+<h4>Central</h4>
+<%= pb_rails("time", props: {
+  show_timezone: true,
+  time: Time.now,
+  timezone: "America/Chicago"
+}) %>
+
+<br>
+
+<h4>Mountain</h4>
+<%= pb_rails("time", props: {
+  show_timezone: true,
+  time: Time.now,
+  timezone: "America/Denver"
+}) %>
+
+<br>
+
+<h4>West Coast</h4>
+ <%= pb_rails("time", props: {
+  show_timezone: true,
+  time: Time.now,
+  timezone: "America/Los_Angeles"
+}) %>
+
+<br>
+
+<h4>Toyko, Japan</h4>
+<%= pb_rails("time", props: {
+  show_timezone: true,
+  time: Time.now,
+  timezone: "Asia/Tokyo",
+}) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_timezone.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timezone.jsx
@@ -13,42 +13,40 @@ const TimeTimeZone = () => {
     <div>
       <h4>{'East Coast'}</h4>
       <Time
-          date={new Date().toLocaleString('en-US', { timeZone: zones.east })}
+          date={new Date()}
           size="lg"
           timeZone={zones.east}
       />
+
       <br />
-      <br />
+
       <h4>{'Central'}</h4>
       <Time
-          date={new Date().toLocaleString('en-US', { timeZone: zones.central })}
-          size="sm"
+          date={new Date()}
           timeZone={zones.central}
       />
+
       <br />
-      <br />
+
       <h4>{'Mountain'}</h4>
       <Time
-          date={new Date().toLocaleString('en-US', { timeZone: zones.mountain })}
-          size="sm"
+          date={new Date()}
           timeZone={zones.mountain}
       />
 
       <br />
-      <br />
+
       <h4>{'West Coast'}</h4>
       <Time
-          date={new Date().toLocaleString('en-US', { timeZone: zones.west })}
-          size="sm"
+          date={new Date()}
           timeZone={zones.west}
       />
 
       <br />
-      <br />
+
       <h4>{'Tokyo, Japan'}</h4>
       <Time
-          date={new Date('2012-08-02T09:49:29Z').toLocaleString('en-US', { timeZone: zones.asia })}
-          size="sm"
+          date={new Date()}
           timeZone={zones.asia}
       />
 

--- a/app/pb_kits/playbook/pb_time/docs/_time_timezone.jsx
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timezone.jsx
@@ -14,7 +14,7 @@ const TimeTimeZone = () => {
       <h4>{'East Coast'}</h4>
       <Time
           date={new Date()}
-          size="lg"
+          size="md"
           timeZone={zones.east}
       />
 

--- a/app/pb_kits/playbook/pb_time/docs/example.yml
+++ b/app/pb_kits/playbook/pb_time/docs/example.yml
@@ -1,11 +1,16 @@
 examples:
 
   rails:
-  - time_default: Sizes
+  - time_default: Default
+  - time_sizes: Sizes
   - time_timestamp: Timestamp Values
+  - time_timezone: Handling Timezones
+  - time_align: Alignment
+  - time_dark: Dark
 
   react:
-  - time_default: Sizes
+  - time_default: Default
+  - time_sizes: Sizes
   - time_timestamp: Timestamp Values
   - time_timezone: Handling Timezones
   - time_align: Alignment

--- a/app/pb_kits/playbook/pb_time/docs/index.js
+++ b/app/pb_kits/playbook/pb_time/docs/index.js
@@ -1,4 +1,5 @@
 export { default as TimeDefault } from './_time_default.jsx'
+export { default as TimeSizes } from './_time_sizes.jsx'
 export { default as TimeTimestamp } from './_time_timestamp.jsx'
 export { default as TimeAlign } from './_time_align.jsx'
 export { default as TimeDark } from './_time_dark.jsx'

--- a/app/pb_kits/playbook/pb_time/time.rb
+++ b/app/pb_kits/playbook/pb_time/time.rb
@@ -9,12 +9,19 @@ module Playbook
 
       prop :time, required: true
       prop :size, type: Playbook::Props::Enum,
-                  values: %w[lg sm xs],
+                  values: %w[lg sm],
                   default: "sm"
+      prop :align, type: Playbook::Props::Enum,
+                   values: %w[left center right],
+                   default: "left"
       prop :timezone, default: "America/New_York"
+      prop :show_icon, type: Playbook::Props::Boolean,
+                       default: false
+      prop :show_timezone, type: Playbook::Props::Boolean,
+                           default: false
 
       def classname
-        generate_classname("pb_time_kit", size)
+        generate_classname("pb_time_kit", align, size)
       end
 
       def format_time_string

--- a/app/pb_kits/playbook/pb_time/time.rb
+++ b/app/pb_kits/playbook/pb_time/time.rb
@@ -9,7 +9,7 @@ module Playbook
 
       prop :time, required: true
       prop :size, type: Playbook::Props::Enum,
-                  values: %w[lg md sm xs],
+                  values: %w[xs sm md lg],
                   default: "sm"
       prop :align, type: Playbook::Props::Enum,
                    values: %w[left center right],
@@ -25,7 +25,7 @@ module Playbook
         mutated_size = size
         mutated_size = "sm" if mutated_size == "xs"
         mutated_size = "md" if mutated_size == "lg"
-        # end
+
         generate_classname("pb_time_kit", align, mutated_size)
       end
 

--- a/app/pb_kits/playbook/pb_time/time.rb
+++ b/app/pb_kits/playbook/pb_time/time.rb
@@ -9,7 +9,7 @@ module Playbook
 
       prop :time, required: true
       prop :size, type: Playbook::Props::Enum,
-                  values: %w[md sm],
+                  values: %w[lg md sm xs],
                   default: "sm"
       prop :align, type: Playbook::Props::Enum,
                    values: %w[left center right],
@@ -21,7 +21,12 @@ module Playbook
                            default: false
 
       def classname
-        generate_classname("pb_time_kit", align, size)
+        # convert deprecated prop values
+        mutated_size = size
+        mutated_size = "sm" if mutated_size == "xs"
+        mutated_size = "md" if mutated_size == "lg"
+        # end
+        generate_classname("pb_time_kit", align, mutated_size)
       end
 
       def format_time_string

--- a/app/pb_kits/playbook/pb_time/time.rb
+++ b/app/pb_kits/playbook/pb_time/time.rb
@@ -9,7 +9,7 @@ module Playbook
 
       prop :time, required: true
       prop :size, type: Playbook::Props::Enum,
-                  values: %w[lg sm],
+                  values: %w[md sm],
                   default: "sm"
       prop :align, type: Playbook::Props::Enum,
                    values: %w[left center right],

--- a/app/pb_kits/playbook/tokens/_typography.scss
+++ b/app/pb_kits/playbook/tokens/_typography.scss
@@ -39,9 +39,9 @@ $heading_4: $font_base;
 
 
 // Letter Spacing
-$lspace_tightest:         _.1em;
-$lspace_tighter:          _.07em;
-$lspace_tight:            _.03em;
+$lspace_tightest:         -.1em;
+$lspace_tighter:          -.07em;
+$lspace_tight:            -.03em;
 $lspace_normal:           0;
 $lspace_loose:            .03em;
 $lspace_looser:           .07em;

--- a/spec/pb_kits/playbook/kits/time_spec.rb
+++ b/spec/pb_kits/playbook/kits/time_spec.rb
@@ -6,20 +6,30 @@ RSpec.describe Playbook::PbTime::Time do
   subject { Playbook::PbTime::Time }
 
   it { is_expected.to define_partial }
+  it { is_expected.to define_prop(:show_timezone).with_default(false) }
+  it { is_expected.to define_prop(:dark).with_default(false) }
   it { is_expected.to define_prop(:time) }
   it { is_expected.to define_prop(:timezone).with_default("America/New_York") }
   it do
+    is_expected.to define_enum_prop(:align)
+      .with_default("left")
+      .with_values("left", "center", "right")
+  end
+  it do
     is_expected.to define_enum_prop(:size)
       .with_default("sm")
-      .with_values("lg", "sm", "xs")
+      .with_values("lg", "sm")
   end
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       required_props = { time: Time.now }
 
-      expect(subject.new(required_props).classname).to eq "pb_time_kit_sm"
-      expect(subject.new(required_props.merge(size: "lg")).classname).to eq "pb_time_kit_lg"
+      expect(subject.new(required_props).classname).to eq "pb_time_kit_left_sm"
+      expect(subject.new(required_props.merge(size: "lg")).classname).to eq "pb_time_kit_left_lg"
+      expect(subject.new(required_props.merge(align: "center")).classname).to eq "pb_time_kit_center_sm"
+      expect(subject.new(required_props.merge(size: "lg", align: "right")).classname).to eq "pb_time_kit_right_lg"
+      expect(subject.new(required_props.merge(dark: true)).classname).to eq "pb_time_kit_left_sm dark"
     end
   end
 end

--- a/spec/pb_kits/playbook/kits/time_spec.rb
+++ b/spec/pb_kits/playbook/kits/time_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Playbook::PbTime::Time do
   it do
     is_expected.to define_enum_prop(:size)
       .with_default("sm")
-      .with_values("md", "sm")
+      .with_values("lg","md", "sm", "xs")
   end
 
   describe "#classname" do

--- a/spec/pb_kits/playbook/kits/time_spec.rb
+++ b/spec/pb_kits/playbook/kits/time_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Playbook::PbTime::Time do
   it do
     is_expected.to define_enum_prop(:size)
       .with_default("sm")
-      .with_values("lg", "sm")
+      .with_values("md", "sm")
   end
 
   describe "#classname" do
@@ -26,9 +26,9 @@ RSpec.describe Playbook::PbTime::Time do
       required_props = { time: Time.now }
 
       expect(subject.new(required_props).classname).to eq "pb_time_kit_left_sm"
-      expect(subject.new(required_props.merge(size: "lg")).classname).to eq "pb_time_kit_left_lg"
+      expect(subject.new(required_props.merge(size: "md")).classname).to eq "pb_time_kit_left_md"
       expect(subject.new(required_props.merge(align: "center")).classname).to eq "pb_time_kit_center_sm"
-      expect(subject.new(required_props.merge(size: "lg", align: "right")).classname).to eq "pb_time_kit_right_lg"
+      expect(subject.new(required_props.merge(size: "md", align: "right")).classname).to eq "pb_time_kit_right_md"
       expect(subject.new(required_props.merge(dark: true)).classname).to eq "pb_time_kit_left_sm dark"
     end
   end


### PR DESCRIPTION
#### Screens
<img width="700" alt="time-1" src="https://user-images.githubusercontent.com/4315934/92607093-0d411880-f28a-11ea-801f-ac0da6626ed3.png">

<img width="700" alt="time-2" src="https://user-images.githubusercontent.com/4315934/92607120-1631ea00-f28a-11ea-9001-04d29fd70403.png">

#### Breaking Changes

**React** - No, there is no reference to the `<Time />` component in Nitro.

**Rails** - Yes, there are 14 references to `<%= pb_rails("time") %>`.

- "Lg" size is not used in any kits.
- "Sm" is referenced and has an icon if that's the case. Therefore we need to add the `show_icon` prop to those instances.
- "Xs" references needs to be changed to "sm"


#### Runway Ticket URL
[https://nitro.powerhrg.com/runway/backlog_items/NUX-639](https://nitro.powerhrg.com/runway/backlog_items/NUX-639)

#### How to test this
- Check Implementation in Playbook
- Testing in Playground
- Specs Updated

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `depreciation`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
