### PR TITLE
Display numeric zero in StatsValue Kit

### DIFF
--- a/app/pb_kits/playbook/pb_stat_value/_stat_value.jsx
+++ b/app/pb_kits/playbook/pb_stat_value/_stat_value.jsx
@@ -21,11 +21,11 @@ const StatValue = (props: StatValueProps) => {
   } = props
 
   const displayValue = function(value) {
-    if (value) {
+    if (value || value === 0) {
       return (
         <Title
             size={1}
-            text={value}
+            text={`${value}`}
         />
       )
     }

--- a/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_default.jsx
+++ b/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_default.jsx
@@ -3,7 +3,12 @@ import { StatValue } from '../../'
 
 const StatValueDefault = () => {
   return (
-    <StatValue value={1048} />
+    <>
+      <StatValue value={1048} />
+      <br />
+      <br />
+      <StatValue value={0} />
+    </>
   )
 }
 


### PR DESCRIPTION
When we pass a numeric `0` to the `value` prop of the `StatsValue` kit  (i.e. `<StatValue value={0} />`) in React, the value is not being displayed. This PR is to fix this issue.

#### Screens

Before
![image](https://user-images.githubusercontent.com/938522/93128200-82a35380-f6a5-11ea-9c50-37ccb2ccb87f.png)

After
<img width="886" alt="image" src="https://user-images.githubusercontent.com/938522/93128155-728b7400-f6a5-11ea-9c23-d4068df0714f.png">

#### Breaking Changes

No.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NOVA-596

#### How to test this

I've added an example of that usage into the documentation. Thus, it can be tested asserting that the 0 value is being shown.

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `depreciation`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [X] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
