### PR TITLE
Bug Fix - Swap show_timezone to be false by default

### DIFF
--- a/app/pb_kits/playbook/pb_time/docs/_time_dark.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_dark.html.erb
@@ -1,5 +1,6 @@
 <%= pb_rails("time", props: {
   dark: true,
+  show_timezone: false,
   time: Time.now
 }) %>
 
@@ -7,7 +8,6 @@
 
 <%= pb_rails("time", props: {
   dark: true,
-  show_timezone: true,
   time: DateTime.now,
   timezone: "America/Chicago",
 }) %>
@@ -16,15 +16,15 @@
 
 <%= pb_rails("time", props: {
   dark: true,
-  time: "2012-08-02T15:49:29Z",
   show_icon: true,
+  show_timezone: false,
+  time: "2012-08-02T15:49:29Z",
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
   dark: true,
-  show_timezone: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
   timezone: "America/Chicago",
@@ -35,15 +35,15 @@
 
  <%= pb_rails("time", props: {
   dark: true,
-  time: Time.now,
+  show_timezone: false,
   size: "md",
+  time: Time.now,
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
   dark: true,
-  show_timezone: true,
   time: DateTime.now,
   timezone: "America/New_York",
   size: "md",
@@ -53,9 +53,9 @@
 
 <%= pb_rails("time", props: {
   dark: true,
-  show_timezone: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
+  show_timezone: false,
   size: "md",
 }) %>
 

--- a/app/pb_kits/playbook/pb_time/docs/_time_default.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_default.html.erb
@@ -1,11 +1,11 @@
 <%= pb_rails("time", props: {
+  show_timezone: false,
   time: Time.now,
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  show_timezone: true,
   time: DateTime.now,
   timezone: "America/Chicago"
 }) %>
@@ -15,12 +15,12 @@
 <%= pb_rails("time", props: {
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
+  show_timezone: false,
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  show_timezone: true,
   time: "2012-08-02T15:49:29Z",
   show_icon: true,
   timezone: "America/Chicago"
@@ -32,12 +32,12 @@
  <%= pb_rails("time", props: {
   time: Time.now,
   size: "md",
+  show_timezone: false,
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  show_timezone: true,
   size: "md",
   time: DateTime.now,
   timezone: "America/New_York",
@@ -48,6 +48,7 @@
 <%= pb_rails("time", props: {
   show_icon: true,
   size: "md",
+  show_timezone: false,
   time: "2012-08-02T15:49:29Z",
 }) %>
 
@@ -55,7 +56,6 @@
 
 <%= pb_rails("time", props: {
   show_icon: true,
-  show_timezone: true,
   size: "md",
   time: "2012-08-02T15:49:29Z",
   timezone: "America/New_York",

--- a/app/pb_kits/playbook/pb_time/docs/_time_timestamp.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timestamp.html.erb
@@ -1,17 +1,18 @@
 <%= pb_rails("time", props: {
+  show_timezone: false,
   time: "2012-08-02T15:49:29Z"
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
+  show_timezone: false,
   time: DateTime.now
 }) %>
 
 <br>
 
 <%= pb_rails("time", props: {
-  show_timezone: true,
   time: DateTime.now,
   timezone: "America/Chicago",
 }) %>

--- a/app/pb_kits/playbook/pb_time/docs/_time_timezone.html.erb
+++ b/app/pb_kits/playbook/pb_time/docs/_time_timezone.html.erb
@@ -1,6 +1,5 @@
 <h4>East Coast</h4>
 <%= pb_rails("time", props: {
-  show_timezone: true,
   time: Time.now,
   timezone: "America/New_York"
 }) %>
@@ -9,7 +8,6 @@
 
 <h4>Central</h4>
 <%= pb_rails("time", props: {
-  show_timezone: true,
   time: Time.now,
   timezone: "America/Chicago"
 }) %>
@@ -18,7 +16,6 @@
 
 <h4>Mountain</h4>
 <%= pb_rails("time", props: {
-  show_timezone: true,
   time: Time.now,
   timezone: "America/Denver"
 }) %>
@@ -27,7 +24,6 @@
 
 <h4>West Coast</h4>
  <%= pb_rails("time", props: {
-  show_timezone: true,
   time: Time.now,
   timezone: "America/Los_Angeles"
 }) %>
@@ -36,7 +32,6 @@
 
 <h4>Toyko, Japan</h4>
 <%= pb_rails("time", props: {
-  show_timezone: true,
   time: Time.now,
   timezone: "Asia/Tokyo",
 }) %>

--- a/app/pb_kits/playbook/pb_time/time.rb
+++ b/app/pb_kits/playbook/pb_time/time.rb
@@ -18,7 +18,7 @@ module Playbook
       prop :show_icon, type: Playbook::Props::Boolean,
                        default: false
       prop :show_timezone, type: Playbook::Props::Boolean,
-                           default: false
+                           default: true
 
       def classname
         # convert deprecated prop values


### PR DESCRIPTION
**Note**: 1 Logic Change - Other changes are just the documentation.

Logic swap here:
https://github.com/powerhome/playbook/compare/hotfix/timezone-show?expand=1#diff-956141a959c897010749a84f9ce34bf7R21

#### Screens

<img width="350" alt="timezone-fix" src="https://user-images.githubusercontent.com/4315934/93249105-2bfe4e00-f767-11ea-95cc-e9535baeba43.png">

#### Breaking Changes

No - This is a fix to adopt a previous behavior.

#### Runway Ticket URL

Bug Fix

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `depreciation`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
