### PR TITLE
Resolve type error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
           cpus: '4.0'
           memory: 8G
         reservations:
-          cpus: '2.0'
+          cpus: 2.0
           memory: 2G
     env_file:
       - '.env.docker'


### PR DESCRIPTION
#### Screens

<img width="741" alt="Screen Shot 2020-09-21 at 2 29 03 PM" src="https://user-images.githubusercontent.com/51907753/93806318-fe0d8380-fc16-11ea-801b-f6ff30f4d200.png">

I could not run `make install` nor `make start` without running into this error. I tried restarting docker.

I updated my local Docker version last week.

@garettarrowood asked me to open this PR and run it by you.

---

This fixed my local issue starting docker in Playbook.