### PR TITLE
[CMPN-18] Allow all HTML options on input in PbToggle Rails kit.

### DIFF
--- a/app/pb_kits/playbook/pb_toggle/docs/_toggle_options.html.erb
+++ b/app/pb_kits/playbook/pb_toggle/docs/_toggle_options.html.erb
@@ -1,0 +1,10 @@
+<%= pb_rails("toggle" , props: {
+  text: "Toggle with Options",
+  input_options: {
+    id: "toggle-id",
+    name: "toggle-name",
+    value: "toggle-value",
+    class: "toggle-class",
+    checked: true
+  }
+}) %>

--- a/app/pb_kits/playbook/pb_toggle/docs/example.yml
+++ b/app/pb_kits/playbook/pb_toggle/docs/example.yml
@@ -5,6 +5,7 @@ examples:
   - toggle_name: Name and Value
   - toggle_custom: Custom checkbox input
   - toggle_custom_radio: Custom radio inputs
+  - toggle_options: Toggle w/ Options
 
   react:
   - toggle_default: Default State

--- a/app/pb_kits/playbook/pb_toggle/toggle.rb
+++ b/app/pb_kits/playbook/pb_toggle/toggle.rb
@@ -11,6 +11,9 @@ module Playbook
 
       partial "pb_toggle/toggle"
 
+      prop :input_options, type: Playbook::Props::Hash,
+                           default: {}
+
       prop :checked, type: Playbook::Props::Boolean,
                      default: false
       prop :name
@@ -24,7 +27,7 @@ module Playbook
       end
 
       def input
-        check_box_tag(name, value, checked)
+        check_box_tag(name, value, checked, input_options)
       end
 
     private

--- a/spec/pb_kits/playbook/kits/toggle_spec.rb
+++ b/spec/pb_kits/playbook/kits/toggle_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Playbook::PbToggle::Toggle do
   it { is_expected.to define_boolean_prop(:checked).with_default(false) }
   it { is_expected.to define_prop(:name) }
   it { is_expected.to define_prop(:value) }
+  it { is_expected.to define_hash_prop(:input_options).with_default({}) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do


### PR DESCRIPTION
#### Screens

<img width="1462" alt="Screen Shot 2020-09-21 at 4 36 45 PM" src="https://user-images.githubusercontent.com/64423490/93818669-a710aa00-fc28-11ea-950e-5e9431917d3d.png">

<img width="638" alt="Screen Shot 2020-09-21 at 4 38 03 PM" src="https://user-images.githubusercontent.com/64423490/93818822-d9220c00-fc28-11ea-9499-f293ca0cf3fb.png">


#### Breaking Changes

No. This PR adds the input_options prop to the toggle kit so PlayBook users can pass every single kind of HTML element option to the input element. This PR does not remove any props as to not break any existing usages of the toggle kit.

Read this [RFC](https://github.com/powerhome/rfcs/blob/master/0052-playbook-html-attribute-standards.md) for more details.

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/CMPN-18)

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `depreciation`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*

