### PR TITLE
Better error messages, and more test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Playbook is the first design system built for both Rails & React interfaces. Ins
 
 ## Getting started
 
-1. Run `make install`
-1. Run `make start`
+1. Run `make it`
 1. Install overcommit hooks `bin/overcommit`
 1. open [http://localhost:8089](http://localhost:8089)
 

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -124,7 +124,7 @@ module Playbook
 
       def prop(name, type: Playbook::Props::String, **options)
         @props ||= {}
-        @props[name] = type.new(**options)
+        @props[name] = type.new(options.merge(name: name))
 
         define_method(name) { prop(name) }
       end

--- a/app/pb_kits/playbook/props.rb
+++ b/app/pb_kits/playbook/props.rb
@@ -124,7 +124,7 @@ module Playbook
 
       def prop(name, type: Playbook::Props::String, **options)
         @props ||= {}
-        @props[name] = type.new(options.merge(name: name))
+        @props[name] = type.new(options.merge(name: name, kit: self))
 
         define_method(name) { prop(name) }
       end

--- a/app/pb_kits/playbook/props/base.rb
+++ b/app/pb_kits/playbook/props/base.rb
@@ -5,12 +5,13 @@ module Playbook
     class Error < StandardError; end
 
     class Base
-      attr_reader :default, :required
+      attr_reader :default, :required, :name, :kit
 
-      def initialize(default: nil, required: false, name:)
+      def initialize(default: nil, required: false, name:, kit:)
         @default = default
         @required = required
         @name = name
+        @kit = kit
       end
 
       def value(value)
@@ -18,10 +19,10 @@ module Playbook
       end
 
       def validate!(input_value)
-        raise(Playbook::Props::Error, "Prop '#{@name}' of type #{inspect.class} is required and needs to be provided a value") if required && input_value.nil?
+        raise(Playbook::Props::Error, "#{kit} prop '#{name}' of type #{inspect.class} is required and needs a value") if required && input_value.nil?
 
         validate(value(input_value)) ||
-          raise(Playbook::Props::Error, "Invalid value of '#{input_value.inspect}' for prop '#{@name}' of type #{inspect.class}")
+          raise(Playbook::Props::Error, "#{kit} has invalid value of '#{input_value.inspect}' for prop '#{name}' of type #{inspect.class}")
       end
 
       def validate(_value)

--- a/app/pb_kits/playbook/props/base.rb
+++ b/app/pb_kits/playbook/props/base.rb
@@ -7,9 +7,10 @@ module Playbook
     class Base
       attr_reader :default, :required
 
-      def initialize(default: nil, required: false)
+      def initialize(default: nil, required: false, name:)
         @default = default
         @required = required
+        @name = name
       end
 
       def value(value)
@@ -17,10 +18,10 @@ module Playbook
       end
 
       def validate!(input_value)
-        raise(Playbook::Props::Error, "#{inspect} is a required prop and needs to be provided a value") if required && input_value.nil?
+        raise(Playbook::Props::Error, "Prop '#{@name}' of type #{inspect.class} is required and needs to be provided a value") if required && input_value.nil?
 
         validate(value(input_value)) ||
-          raise(Playbook::Props::Error, "Invalid value (#{input_value.inspect}) for prop (#{inspect})")
+          raise(Playbook::Props::Error, "Invalid value of '#{input_value.inspect}' for prop '#{@name}' of type #{inspect.class}")
       end
 
       def validate(_value)

--- a/spec/pb_kits/playbook/props/array_spec.rb
+++ b/spec/pb_kits/playbook/props/array_spec.rb
@@ -3,23 +3,23 @@
 RSpec.describe Playbook::Props::Array do
   describe "#validate" do
     it "returns true given an empty array", :aggregate_failures do
-      expect(Playbook::Props::Array.new(name: :array_prop).validate([])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([])).to eq true
     end
 
     it "returns true given an array with things in it", :aggregate_failures do
-      expect(Playbook::Props::Array.new(name: :array_prop).validate([true])).to eq true
-      expect(Playbook::Props::Array.new(name: :array_prop).validate([:false])).to eq true
-      expect(Playbook::Props::Array.new(name: :array_prop).validate([7, nil, 81])).to eq true
-      expect(Playbook::Props::Array.new(name: :array_prop).validate(["foo", "bar", 8, {}, []])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([true])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([:false])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([7, nil, 81])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(["foo", "bar", 8, {}, []])).to eq true
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::Array.new(name: :array_prop).validate("true")).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop).validate(:false)).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop).validate(1)).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop).validate({})).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop).validate(6.5)).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop).validate(nil)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate("true")).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(:false)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(1)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate({})).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(6.5)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/array_spec.rb
+++ b/spec/pb_kits/playbook/props/array_spec.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::Array do
+  subject { Playbook::Props::Array.new(name: :array_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given an empty array", :aggregate_failures do
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([])).to eq true
+      expect(subject.validate([])).to eq true
     end
 
     it "returns true given an array with things in it", :aggregate_failures do
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([true])).to eq true
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([:false])).to eq true
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate([7, nil, 81])).to eq true
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(["foo", "bar", 8, {}, []])).to eq true
+      expect(subject.validate([true])).to eq true
+      expect(subject.validate([:false])).to eq true
+      expect(subject.validate([7, nil, 81])).to eq true
+      expect(subject.validate(["foo", "bar", 8, {}, []])).to eq true
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate("true")).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(:false)).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(1)).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate({})).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(6.5)).to eq false
-      expect(Playbook::Props::Array.new(name: :array_prop, kit: Class.new).validate(nil)).to eq false
+      expect(subject.validate("true")).to eq false
+      expect(subject.validate(:false)).to eq false
+      expect(subject.validate(1)).to eq false
+      expect(subject.validate({})).to eq false
+      expect(subject.validate(6.5)).to eq false
+      expect(subject.validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/array_spec.rb
+++ b/spec/pb_kits/playbook/props/array_spec.rb
@@ -3,23 +3,23 @@
 RSpec.describe Playbook::Props::Array do
   describe "#validate" do
     it "returns true given an empty array", :aggregate_failures do
-      expect(Playbook::Props::Array.new.validate([])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop).validate([])).to eq true
     end
 
     it "returns true given an array with things in it", :aggregate_failures do
-      expect(Playbook::Props::Array.new.validate([true])).to eq true
-      expect(Playbook::Props::Array.new.validate([:false])).to eq true
-      expect(Playbook::Props::Array.new.validate([7, nil, 81])).to eq true
-      expect(Playbook::Props::Array.new.validate(["foo", "bar", 8, {}, []])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop).validate([true])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop).validate([:false])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop).validate([7, nil, 81])).to eq true
+      expect(Playbook::Props::Array.new(name: :array_prop).validate(["foo", "bar", 8, {}, []])).to eq true
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::Array.new.validate("true")).to eq false
-      expect(Playbook::Props::Array.new.validate(:false)).to eq false
-      expect(Playbook::Props::Array.new.validate(1)).to eq false
-      expect(Playbook::Props::Array.new.validate({})).to eq false
-      expect(Playbook::Props::Array.new.validate(6.5)).to eq false
-      expect(Playbook::Props::Array.new.validate(nil)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop).validate("true")).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop).validate(:false)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop).validate(1)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop).validate({})).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop).validate(6.5)).to eq false
+      expect(Playbook::Props::Array.new(name: :array_prop).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/base_spec.rb
+++ b/spec/pb_kits/playbook/props/base_spec.rb
@@ -7,23 +7,24 @@ RSpec.describe Playbook::Props::Base do
         def validate(_value); true; end
       end
 
-      expect(truthy_validation_class.new(name: :test_prop).validate!(nil)).to eq true
+      expect(truthy_validation_class.new(name: :test_prop, kit: truthy_validation_class).validate!(nil)).to eq true
     end
 
     it "returns true when child class does not contain custom validation" do
       no_validation_class = Class.new(Playbook::Props::Base)
 
-      expect(no_validation_class.new(name: :test_prop).validate!(nil)).to eq true
+      expect(no_validation_class.new(name: :test_prop, kit: no_validation_class).validate!(nil)).to eq true
     end
 
     it "raises error when child class fails validation" do
       falsy_validation_class = Class.new(Playbook::Props::Base) do
         def validate(_value); false; end
       end
+      FalsyValidationClass = falsy_validation_class
 
-      expect { falsy_validation_class.new(name: :test_prop).validate!("wrong_value") }.to(
+      expect { FalsyValidationClass.new(name: :test_prop, kit: falsy_validation_class).validate!("wrong_value") }.to(
         raise_error(Playbook::Props::Error,
-          /Invalid value of '"wrong_value"' for prop 'test_prop'/
+          /FalsyValidationClass has invalid value of '"wrong_value"' for prop 'test_prop'/
         )
       )
     end

--- a/spec/pb_kits/playbook/props/base_spec.rb
+++ b/spec/pb_kits/playbook/props/base_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Playbook::Props::Base do
         def validate(_value); true; end
       end
 
-      expect(truthy_validation_class.new.validate!(nil)).to eq true
+      expect(truthy_validation_class.new(name: :test_prop).validate!(nil)).to eq true
     end
 
     it "returns true when child class does not contain custom validation" do
       no_validation_class = Class.new(Playbook::Props::Base)
 
-      expect(no_validation_class.new.validate!(nil)).to eq true
+      expect(no_validation_class.new(name: :test_prop).validate!(nil)).to eq true
     end
 
     it "raises error when child class fails validation" do
@@ -21,8 +21,10 @@ RSpec.describe Playbook::Props::Base do
         def validate(_value); false; end
       end
 
-      expect { falsy_validation_class.new.validate!(nil) }.to(
-        raise_error(Playbook::Props::Error)
+      expect { falsy_validation_class.new(name: :test_prop).validate!("wrong_value") }.to(
+        raise_error(Playbook::Props::Error,
+          /Invalid value of '"wrong_value"' for prop 'test_prop'/
+        )
       )
     end
   end

--- a/spec/pb_kits/playbook/props/boolean_spec.rb
+++ b/spec/pb_kits/playbook/props/boolean_spec.rb
@@ -3,20 +3,20 @@
 RSpec.describe Playbook::Props::Boolean do
   describe "#validate" do
     it "returns true given true" do
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(true)).to eq true
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(true)).to eq true
     end
 
     it "returns true given false" do
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(false)).to eq true
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(false)).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate("true")).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(:false)).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(1)).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate({})).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate([])).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(nil)).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate("true")).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(:false)).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(1)).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate({})).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate([])).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/boolean_spec.rb
+++ b/spec/pb_kits/playbook/props/boolean_spec.rb
@@ -3,20 +3,20 @@
 RSpec.describe Playbook::Props::Boolean do
   describe "#validate" do
     it "returns true given true" do
-      expect(Playbook::Props::Boolean.new.validate(true)).to eq true
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(true)).to eq true
     end
 
     it "returns true given false" do
-      expect(Playbook::Props::Boolean.new.validate(false)).to eq true
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(false)).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Boolean.new.validate("true")).to eq false
-      expect(Playbook::Props::Boolean.new.validate(:false)).to eq false
-      expect(Playbook::Props::Boolean.new.validate(1)).to eq false
-      expect(Playbook::Props::Boolean.new.validate({})).to eq false
-      expect(Playbook::Props::Boolean.new.validate([])).to eq false
-      expect(Playbook::Props::Boolean.new.validate(nil)).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate("true")).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(:false)).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(1)).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate({})).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate([])).to eq false
+      expect(Playbook::Props::Boolean.new(name: :boolean_prop).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/boolean_spec.rb
+++ b/spec/pb_kits/playbook/props/boolean_spec.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::Boolean do
+  subject { Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given true" do
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(true)).to eq true
+      expect(subject.validate(true)).to eq true
     end
 
     it "returns true given false" do
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(false)).to eq true
+      expect(subject.validate(false)).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate("true")).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(:false)).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(1)).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate({})).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate([])).to eq false
-      expect(Playbook::Props::Boolean.new(name: :boolean_prop, kit: Class.new).validate(nil)).to eq false
+      expect(subject.validate("true")).to eq false
+      expect(subject.validate(:false)).to eq false
+      expect(subject.validate(1)).to eq false
+      expect(subject.validate({})).to eq false
+      expect(subject.validate([])).to eq false
+      expect(subject.validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/date_spec.rb
+++ b/spec/pb_kits/playbook/props/date_spec.rb
@@ -3,16 +3,16 @@
 RSpec.describe Playbook::Props::Date do
   describe "#validate" do
     it "returns true given a Ruby:Date", :aggregate_failures do
-      expect(Playbook::Props::Date.new(name: :date_prop).validate(Date.new(2020, 03, 02))).to eq true
+      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(Date.new(2020, 03, 02))).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Date.new(name: :date_prop).validate("foo")).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop).validate(true)).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop).validate(:foo)).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop).validate(1)).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop).validate([])).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop).validate(nil)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate("foo")).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(true)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(:foo)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(1)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate([])).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/date_spec.rb
+++ b/spec/pb_kits/playbook/props/date_spec.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::Date do
+  subject { Playbook::Props::Date.new(name: :date_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given a Ruby:Date", :aggregate_failures do
-      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(Date.new(2020, 03, 02))).to eq true
+      expect(subject.validate(Date.new(2020, 03, 02))).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate("foo")).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(true)).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(:foo)).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(1)).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate([])).to eq false
-      expect(Playbook::Props::Date.new(name: :date_prop, kit: Class.new).validate(nil)).to eq false
+      expect(subject.validate("foo")).to eq false
+      expect(subject.validate(true)).to eq false
+      expect(subject.validate(:foo)).to eq false
+      expect(subject.validate(1)).to eq false
+      expect(subject.validate([])).to eq false
+      expect(subject.validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/date_spec.rb
+++ b/spec/pb_kits/playbook/props/date_spec.rb
@@ -3,16 +3,16 @@
 RSpec.describe Playbook::Props::Date do
   describe "#validate" do
     it "returns true given a Ruby:Date", :aggregate_failures do
-      expect(Playbook::Props::Date.new.validate(Date.new(2020, 03, 02))).to eq true
+      expect(Playbook::Props::Date.new(name: :date_prop).validate(Date.new(2020, 03, 02))).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Date.new.validate("foo")).to eq false
-      expect(Playbook::Props::Date.new.validate(true)).to eq false
-      expect(Playbook::Props::Date.new.validate(:foo)).to eq false
-      expect(Playbook::Props::Date.new.validate(1)).to eq false
-      expect(Playbook::Props::Date.new.validate([])).to eq false
-      expect(Playbook::Props::Date.new.validate(nil)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop).validate("foo")).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop).validate(true)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop).validate(:foo)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop).validate(1)).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop).validate([])).to eq false
+      expect(Playbook::Props::Date.new(name: :date_prop).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/enum_spec.rb
+++ b/spec/pb_kits/playbook/props/enum_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Playbook::Props::Enum do
   describe "#validate" do
     it "returns true given value supplied upon initialization", :aggregate_failures do
-      enum = Playbook::Props::Enum.new(values: [1, "two", :three], name: :enum_prop)
+      enum = Playbook::Props::Enum.new(values: [1, "two", :three], name: :enum_prop, kit: Class.new)
 
       expect(enum.validate(1)).to eq true
       expect(enum.validate("two")).to eq true
@@ -11,7 +11,7 @@ RSpec.describe Playbook::Props::Enum do
     end
 
     it "returns false given anything else", :aggregate_failures do
-      enum = Playbook::Props::Enum.new(values: [], name: :enum_prop)
+      enum = Playbook::Props::Enum.new(values: [], name: :enum_prop, kit: Class.new)
 
       expect(enum.validate(true)).to eq false
       expect(enum.validate(:foo)).to eq false

--- a/spec/pb_kits/playbook/props/enum_spec.rb
+++ b/spec/pb_kits/playbook/props/enum_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Playbook::Props::Enum do
   describe "#validate" do
     it "returns true given value supplied upon initialization", :aggregate_failures do
-      enum = Playbook::Props::Enum.new(values: [1, "two", :three])
+      enum = Playbook::Props::Enum.new(values: [1, "two", :three], name: :enum_prop)
 
       expect(enum.validate(1)).to eq true
       expect(enum.validate("two")).to eq true
@@ -11,7 +11,7 @@ RSpec.describe Playbook::Props::Enum do
     end
 
     it "returns false given anything else", :aggregate_failures do
-      enum = Playbook::Props::Enum.new(values: [])
+      enum = Playbook::Props::Enum.new(values: [], name: :enum_prop)
 
       expect(enum.validate(true)).to eq false
       expect(enum.validate(:foo)).to eq false

--- a/spec/pb_kits/playbook/props/hash_array_spec.rb
+++ b/spec/pb_kits/playbook/props/hash_array_spec.rb
@@ -3,35 +3,35 @@
 RSpec.describe Playbook::Props::HashArray do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new.validate([{}])).to eq true
-      expect(Playbook::Props::HashArray.new.validate([{a: 1}])).to eq true
-      expect(Playbook::Props::HashArray.new.validate([{"asdf": nil, foo: false}])).to eq true
-      expect(Playbook::Props::HashArray.new.validate([])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{a: 1}])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{"asdf": nil, foo: false}])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([])).to eq true
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new.validate("true")).to eq false
-      expect(Playbook::Props::HashArray.new.validate(:false)).to eq false
-      expect(Playbook::Props::HashArray.new.validate(1)).to eq false
-      expect(Playbook::Props::HashArray.new.validate({})).to eq false
-      expect(Playbook::Props::HashArray.new.validate(6.5)).to eq false
-      expect(Playbook::Props::HashArray.new.validate(nil)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate("true")).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(:false)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(1)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate({})).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(6.5)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(nil)).to eq false
     end
 
     it "returns false given an array that does not contain hashes", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new.validate([true])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([:false])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([[]])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([6.5])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([nil])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([true])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([:false])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([[]])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([6.5])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([nil])).to eq false
     end
 
     it "returns false given an array that doesn't only contain hashes", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new.validate([{}, true])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([8, {}])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([{}, :foo])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([{}, 6.5])).to eq false
-      expect(Playbook::Props::HashArray.new.validate([nil, {}])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}, true])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([8, {}])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}, :foo])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}, 6.5])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([nil, {}])).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/hash_array_spec.rb
+++ b/spec/pb_kits/playbook/props/hash_array_spec.rb
@@ -3,35 +3,35 @@
 RSpec.describe Playbook::Props::HashArray do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}])).to eq true
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{a: 1}])).to eq true
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{"asdf": nil, foo: false}])).to eq true
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{a: 1}])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{"asdf": nil, foo: false}])).to eq true
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([])).to eq true
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate("true")).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(:false)).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(1)).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate({})).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(6.5)).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate(nil)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate("true")).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(:false)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(1)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate({})).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(6.5)).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(nil)).to eq false
     end
 
     it "returns false given an array that does not contain hashes", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([true])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([:false])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([[]])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([6.5])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([nil])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([true])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([:false])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([[]])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([6.5])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([nil])).to eq false
     end
 
     it "returns false given an array that doesn't only contain hashes", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}, true])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([8, {}])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}, :foo])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([{}, 6.5])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop).validate([nil, {}])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}, true])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([8, {}])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}, :foo])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}, 6.5])).to eq false
+      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([nil, {}])).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/hash_array_spec.rb
+++ b/spec/pb_kits/playbook/props/hash_array_spec.rb
@@ -1,37 +1,39 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::HashArray do
+  subject { Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}])).to eq true
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{a: 1}])).to eq true
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{"asdf": nil, foo: false}])).to eq true
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([])).to eq true
+      expect(subject.validate([{}])).to eq true
+      expect(subject.validate([{a: 1}])).to eq true
+      expect(subject.validate([{"asdf": nil, foo: false}])).to eq true
+      expect(subject.validate([])).to eq true
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate("true")).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(:false)).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(1)).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate({})).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(6.5)).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate(nil)).to eq false
+      expect(subject.validate("true")).to eq false
+      expect(subject.validate(:false)).to eq false
+      expect(subject.validate(1)).to eq false
+      expect(subject.validate({})).to eq false
+      expect(subject.validate(6.5)).to eq false
+      expect(subject.validate(nil)).to eq false
     end
 
     it "returns false given an array that does not contain hashes", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([true])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([:false])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([[]])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([6.5])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([nil])).to eq false
+      expect(subject.validate([true])).to eq false
+      expect(subject.validate([:false])).to eq false
+      expect(subject.validate([[]])).to eq false
+      expect(subject.validate([6.5])).to eq false
+      expect(subject.validate([nil])).to eq false
     end
 
     it "returns false given an array that doesn't only contain hashes", :aggregate_failures do
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}, true])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([8, {}])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}, :foo])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([{}, 6.5])).to eq false
-      expect(Playbook::Props::HashArray.new(name: :hash_array_prop, kit: Class.new).validate([nil, {}])).to eq false
+      expect(subject.validate([{}, true])).to eq false
+      expect(subject.validate([8, {}])).to eq false
+      expect(subject.validate([{}, :foo])).to eq false
+      expect(subject.validate([{}, 6.5])).to eq false
+      expect(subject.validate([nil, {}])).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/hash_spec.rb
+++ b/spec/pb_kits/playbook/props/hash_spec.rb
@@ -3,18 +3,18 @@
 RSpec.describe Playbook::Props::Hash do
   describe "#validate" do
     it "returns true given a Ruby Hash", :aggregate_failures do
-      expect(Playbook::Props::Hash.new.validate({})).to eq true
-      expect(Playbook::Props::Hash.new.validate(a: 1)).to eq true
-      expect(Playbook::Props::Hash.new.validate("foo" => :bar)).to eq true
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate({})).to eq true
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(a: 1)).to eq true
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate("foo" => :bar)).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Hash.new.validate("foo")).to eq false
-      expect(Playbook::Props::Hash.new.validate(true)).to eq false
-      expect(Playbook::Props::Hash.new.validate(:foo)).to eq false
-      expect(Playbook::Props::Hash.new.validate(1)).to eq false
-      expect(Playbook::Props::Hash.new.validate([])).to eq false
-      expect(Playbook::Props::Hash.new.validate(nil)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate("foo")).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(true)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(:foo)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(1)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate([])).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/hash_spec.rb
+++ b/spec/pb_kits/playbook/props/hash_spec.rb
@@ -3,18 +3,18 @@
 RSpec.describe Playbook::Props::Hash do
   describe "#validate" do
     it "returns true given a Ruby Hash", :aggregate_failures do
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate({})).to eq true
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(a: 1)).to eq true
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate("foo" => :bar)).to eq true
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate({})).to eq true
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(a: 1)).to eq true
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate("foo" => :bar)).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate("foo")).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(true)).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(:foo)).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(1)).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate([])).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop).validate(nil)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate("foo")).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(true)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(:foo)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(1)).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate([])).to eq false
+      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/hash_spec.rb
+++ b/spec/pb_kits/playbook/props/hash_spec.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::Hash do
+  subject { Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given a Ruby Hash", :aggregate_failures do
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate({})).to eq true
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(a: 1)).to eq true
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate("foo" => :bar)).to eq true
+      expect(subject.validate({})).to eq true
+      expect(subject.validate(a: 1)).to eq true
+      expect(subject.validate("foo" => :bar)).to eq true
     end
 
     it "returns false given anything else", :aggregate_failures do
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate("foo")).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(true)).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(:foo)).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(1)).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate([])).to eq false
-      expect(Playbook::Props::Hash.new(name: :hash_prop, kit: Class.new).validate(nil)).to eq false
+      expect(subject.validate("foo")).to eq false
+      expect(subject.validate(true)).to eq false
+      expect(subject.validate(:foo)).to eq false
+      expect(subject.validate(1)).to eq false
+      expect(subject.validate([])).to eq false
+      expect(subject.validate(nil)).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/number_array_spec.rb
+++ b/spec/pb_kits/playbook/props/number_array_spec.rb
@@ -3,36 +3,36 @@
 RSpec.describe Playbook::Props::NumberArray do
   describe "#validate" do
     it "returns true given a valid input" do
-      expect(Playbook::Props::NumberArray.new.validate([45, 67])).to eq true
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([45, 67])).to eq true
     end
 
     it "returns false given an empty array" do
-      expect(Playbook::Props::NumberArray.new.validate([])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([])).to eq false
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new.validate("true")).to eq false
-      expect(Playbook::Props::NumberArray.new.validate(:false)).to eq false
-      expect(Playbook::Props::NumberArray.new.validate(1)).to eq false
-      expect(Playbook::Props::NumberArray.new.validate({})).to eq false
-      expect(Playbook::Props::NumberArray.new.validate(6.5)).to eq false
-      expect(Playbook::Props::NumberArray.new.validate(nil)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate("true")).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(:false)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(1)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate({})).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(6.5)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(nil)).to eq false
     end
 
     it "returns false given an array that does not contain integers", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new.validate([true])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([:false])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([{}])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([6.5])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([nil])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([true])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([:false])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([{}])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([6.5])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([nil])).to eq false
     end
 
     it "returns false given an array that doesn't only contain integers", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new.validate([7, true])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([8, :false])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([{}, 9])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([1, 3, 5, 6.5])).to eq false
-      expect(Playbook::Props::NumberArray.new.validate([nil, 0, 65])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([7, true])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([8, :false])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([{}, 9])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([1, 3, 5, 6.5])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([nil, 0, 65])).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/number_array_spec.rb
+++ b/spec/pb_kits/playbook/props/number_array_spec.rb
@@ -3,36 +3,36 @@
 RSpec.describe Playbook::Props::NumberArray do
   describe "#validate" do
     it "returns true given a valid input" do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([45, 67])).to eq true
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([45, 67])).to eq true
     end
 
     it "returns false given an empty array" do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([])).to eq false
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate("true")).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(:false)).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(1)).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate({})).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(6.5)).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate(nil)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate("true")).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(:false)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(1)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate({})).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(6.5)).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(nil)).to eq false
     end
 
     it "returns false given an array that does not contain integers", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([true])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([:false])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([{}])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([6.5])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([nil])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([true])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([:false])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([{}])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([6.5])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([nil])).to eq false
     end
 
     it "returns false given an array that doesn't only contain integers", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([7, true])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([8, :false])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([{}, 9])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([1, 3, 5, 6.5])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop).validate([nil, 0, 65])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([7, true])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([8, :false])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([{}, 9])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([1, 3, 5, 6.5])).to eq false
+      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([nil, 0, 65])).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/number_array_spec.rb
+++ b/spec/pb_kits/playbook/props/number_array_spec.rb
@@ -1,38 +1,40 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::NumberArray do
+  subject { Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given a valid input" do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([45, 67])).to eq true
+      expect(subject.validate([45, 67])).to eq true
     end
 
     it "returns false given an empty array" do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([])).to eq false
+      expect(subject.validate([])).to eq false
     end
 
     it "returns false given anything something besides an array", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate("true")).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(:false)).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(1)).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate({})).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(6.5)).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate(nil)).to eq false
+      expect(subject.validate("true")).to eq false
+      expect(subject.validate(:false)).to eq false
+      expect(subject.validate(1)).to eq false
+      expect(subject.validate({})).to eq false
+      expect(subject.validate(6.5)).to eq false
+      expect(subject.validate(nil)).to eq false
     end
 
     it "returns false given an array that does not contain integers", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([true])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([:false])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([{}])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([6.5])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([nil])).to eq false
+      expect(subject.validate([true])).to eq false
+      expect(subject.validate([:false])).to eq false
+      expect(subject.validate([{}])).to eq false
+      expect(subject.validate([6.5])).to eq false
+      expect(subject.validate([nil])).to eq false
     end
 
     it "returns false given an array that doesn't only contain integers", :aggregate_failures do
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([7, true])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([8, :false])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([{}, 9])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([1, 3, 5, 6.5])).to eq false
-      expect(Playbook::Props::NumberArray.new(name: :number_array_prop, kit: Class.new).validate([nil, 0, 65])).to eq false
+      expect(subject.validate([7, true])).to eq false
+      expect(subject.validate([8, :false])).to eq false
+      expect(subject.validate([{}, 9])).to eq false
+      expect(subject.validate([1, 3, 5, 6.5])).to eq false
+      expect(subject.validate([nil, 0, 65])).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/number_spec.rb
+++ b/spec/pb_kits/playbook/props/number_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::Number do
+  subject { Playbook::Props::Number.new(name: :number_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate(45)).to eq true
-      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate(nil)).to eq true
+      expect(subject.validate(45)).to eq true
+      expect(subject.validate(nil)).to eq true
     end
 
     it "returns false given anything besides a number", :aggregate_failures do
-      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate("true")).to eq false
-      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate(:false)).to eq false
-      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate("a")).to eq false
-      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate({})).to eq false
+      expect(subject.validate("true")).to eq false
+      expect(subject.validate(:false)).to eq false
+      expect(subject.validate("a")).to eq false
+      expect(subject.validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/number_spec.rb
+++ b/spec/pb_kits/playbook/props/number_spec.rb
@@ -3,15 +3,15 @@
 RSpec.describe Playbook::Props::Number do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Number.new.validate(45)).to eq true
-      expect(Playbook::Props::Number.new.validate(nil)).to eq true
+      expect(Playbook::Props::Number.new(name: :number_prop).validate(45)).to eq true
+      expect(Playbook::Props::Number.new(name: :number_prop).validate(nil)).to eq true
     end
 
     it "returns false given anything besides a number", :aggregate_failures do
-      expect(Playbook::Props::Number.new.validate("true")).to eq false
-      expect(Playbook::Props::Number.new.validate(:false)).to eq false
-      expect(Playbook::Props::Number.new.validate("a")).to eq false
-      expect(Playbook::Props::Number.new.validate({})).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop).validate("true")).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop).validate(:false)).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop).validate("a")).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop).validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/number_spec.rb
+++ b/spec/pb_kits/playbook/props/number_spec.rb
@@ -3,15 +3,15 @@
 RSpec.describe Playbook::Props::Number do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Number.new(name: :number_prop).validate(45)).to eq true
-      expect(Playbook::Props::Number.new(name: :number_prop).validate(nil)).to eq true
+      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate(45)).to eq true
+      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate(nil)).to eq true
     end
 
     it "returns false given anything besides a number", :aggregate_failures do
-      expect(Playbook::Props::Number.new(name: :number_prop).validate("true")).to eq false
-      expect(Playbook::Props::Number.new(name: :number_prop).validate(:false)).to eq false
-      expect(Playbook::Props::Number.new(name: :number_prop).validate("a")).to eq false
-      expect(Playbook::Props::Number.new(name: :number_prop).validate({})).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate("true")).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate(:false)).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate("a")).to eq false
+      expect(Playbook::Props::Number.new(name: :number_prop, kit: Class.new).validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/numeric_spec.rb
+++ b/spec/pb_kits/playbook/props/numeric_spec.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::Numeric do
+  subject { Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(nil)).to eq true
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(12)).to eq true
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(12.3)).to eq true
+      expect(subject.validate(nil)).to eq true
+      expect(subject.validate(12)).to eq true
+      expect(subject.validate(12.3)).to eq true
     end
 
     it "returns false given anything besides a integer or float", :aggregate_failures do
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate("seventy")).to eq false
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(:seventy)).to eq false
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate("70")).to eq false
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate({})).to eq false
+      expect(subject.validate("seventy")).to eq false
+      expect(subject.validate(:seventy)).to eq false
+      expect(subject.validate("70")).to eq false
+      expect(subject.validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/numeric_spec.rb
+++ b/spec/pb_kits/playbook/props/numeric_spec.rb
@@ -3,16 +3,16 @@
 RSpec.describe Playbook::Props::Numeric do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Numeric.new.validate(nil)).to eq true
-      expect(Playbook::Props::Numeric.new.validate(12)).to eq true
-      expect(Playbook::Props::Numeric.new.validate(12.3)).to eq true
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(nil)).to eq true
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(12)).to eq true
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(12.3)).to eq true
     end
 
     it "returns false given anything besides a integer or float", :aggregate_failures do
-      expect(Playbook::Props::Numeric.new.validate("seventy")).to eq false
-      expect(Playbook::Props::Numeric.new.validate(:seventy)).to eq false
-      expect(Playbook::Props::Numeric.new.validate("70")).to eq false
-      expect(Playbook::Props::Numeric.new.validate({})).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate("seventy")).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(:seventy)).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate("70")).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/numeric_spec.rb
+++ b/spec/pb_kits/playbook/props/numeric_spec.rb
@@ -3,16 +3,16 @@
 RSpec.describe Playbook::Props::Numeric do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(nil)).to eq true
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(12)).to eq true
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(12.3)).to eq true
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(nil)).to eq true
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(12)).to eq true
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(12.3)).to eq true
     end
 
     it "returns false given anything besides a integer or float", :aggregate_failures do
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate("seventy")).to eq false
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate(:seventy)).to eq false
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate("70")).to eq false
-      expect(Playbook::Props::Numeric.new(name: :numeric_prop).validate({})).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate("seventy")).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate(:seventy)).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate("70")).to eq false
+      expect(Playbook::Props::Numeric.new(name: :numeric_prop, kit: Class.new).validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/percentage_spec.rb
+++ b/spec/pb_kits/playbook/props/percentage_spec.rb
@@ -3,30 +3,30 @@
 RSpec.describe Playbook::Props::Percentage do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new.validate(45)).to eq true
-      expect(Playbook::Props::Percentage.new.validate(45.5)).to eq true
-      expect(Playbook::Props::Percentage.new.validate(0.0)).to eq true
-      expect(Playbook::Props::Percentage.new.validate(100)).to eq true
-      expect(Playbook::Props::Percentage.new.validate(nil)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(45)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(45.5)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(0.0)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(100)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(nil)).to eq true
     end
 
     it "returns false given anything less than 0", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new.validate(-1)).to eq false
-      expect(Playbook::Props::Percentage.new.validate(-1.1)).to eq false
-      expect(Playbook::Props::Percentage.new.validate(-100)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(-1)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(-1.1)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(-100)).to eq false
     end
 
     it "returns false given anything greater than 100", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new.validate(101)).to eq false
-      expect(Playbook::Props::Percentage.new.validate(100.1)).to eq false
-      expect(Playbook::Props::Percentage.new.validate(100000)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(101)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(100.1)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(100000)).to eq false
     end
 
     it "returns false given anything that is not numeric", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new.validate(true)).to eq false
-      expect(Playbook::Props::Percentage.new.validate(:false)).to eq false
-      expect(Playbook::Props::Percentage.new.validate("a")).to eq false
-      expect(Playbook::Props::Percentage.new.validate({})).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(true)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(:false)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate("a")).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/percentage_spec.rb
+++ b/spec/pb_kits/playbook/props/percentage_spec.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
 RSpec.describe Playbook::Props::Percentage do
+  subject { Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new) }
+
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(45)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(45.5)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(0.0)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(100)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(nil)).to eq true
+      expect(subject.validate(45)).to eq true
+      expect(subject.validate(45.5)).to eq true
+      expect(subject.validate(0.0)).to eq true
+      expect(subject.validate(100)).to eq true
+      expect(subject.validate(nil)).to eq true
     end
 
     it "returns false given anything less than 0", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(-1)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(-1.1)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(-100)).to eq false
+      expect(subject.validate(-1)).to eq false
+      expect(subject.validate(-1.1)).to eq false
+      expect(subject.validate(-100)).to eq false
     end
 
     it "returns false given anything greater than 100", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(101)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(100.1)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(100000)).to eq false
+      expect(subject.validate(101)).to eq false
+      expect(subject.validate(100.1)).to eq false
+      expect(subject.validate(100000)).to eq false
     end
 
     it "returns false given anything that is not numeric", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(true)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(:false)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate("a")).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate({})).to eq false
+      expect(subject.validate(true)).to eq false
+      expect(subject.validate(:false)).to eq false
+      expect(subject.validate("a")).to eq false
+      expect(subject.validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props/percentage_spec.rb
+++ b/spec/pb_kits/playbook/props/percentage_spec.rb
@@ -3,30 +3,30 @@
 RSpec.describe Playbook::Props::Percentage do
   describe "#validate" do
     it "returns true given a valid input", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(45)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(45.5)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(0.0)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(100)).to eq true
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(nil)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(45)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(45.5)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(0.0)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(100)).to eq true
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(nil)).to eq true
     end
 
     it "returns false given anything less than 0", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(-1)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(-1.1)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(-100)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(-1)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(-1.1)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(-100)).to eq false
     end
 
     it "returns false given anything greater than 100", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(101)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(100.1)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(100000)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(101)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(100.1)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(100000)).to eq false
     end
 
     it "returns false given anything that is not numeric", :aggregate_failures do
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(true)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate(:false)).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate("a")).to eq false
-      expect(Playbook::Props::Percentage.new(name: :percentage_prop).validate({})).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(true)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate(:false)).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate("a")).to eq false
+      expect(Playbook::Props::Percentage.new(name: :percentage_prop, kit: Class.new).validate({})).to eq false
     end
   end
 end

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -176,7 +176,10 @@ RSpec.describe Playbook::Props do
     it { is_expected.to define_string_prop(:required_prop).that_is_required }
 
     it "raises error when not given a value" do
-      expect { subject.new({}) }.to raise_error(Playbook::Props::Error)
+      expect { subject.new({}) }.to raise_error(
+        Playbook::Props::Error,
+        /Prop 'required_prop' of type String is required and needs to be provided a value/
+      )
     end
 
     it "does not raise error when given a value" do

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -166,11 +166,11 @@ RSpec.describe Playbook::Props do
 
   describe "required props" do
     subject do
-      Class.new do
+      Object.const_set("TestClassForRequiredProps", Class.new do
         include Playbook::Props
 
         prop :required_prop, required: true
-      end
+      end)
     end
 
     it { is_expected.to define_string_prop(:required_prop).that_is_required }
@@ -178,7 +178,7 @@ RSpec.describe Playbook::Props do
     it "raises error when not given a value" do
       expect { subject.new({}) }.to raise_error(
         Playbook::Props::Error,
-        /Prop 'required_prop' of type String is required and needs to be provided a value/
+        /TestClassForRequiredProps prop 'required_prop' of type String is required and needs a value/
       )
     end
 

--- a/spec/pb_kits/playbook/props_spec.rb
+++ b/spec/pb_kits/playbook/props_spec.rb
@@ -12,6 +12,21 @@ RSpec.describe Playbook::Props do
     it { is_expected.to define_hash_prop(:data).with_default({}) }
     it { is_expected.to define_prop(:classname) }
     it { is_expected.to define_hash_prop(:aria).with_default({}) }
+    it { is_expected.to define_prop(:margin) }
+    it { is_expected.to define_prop(:margin_bottom) }
+    it { is_expected.to define_prop(:margin_left) }
+    it { is_expected.to define_prop(:margin_right) }
+    it { is_expected.to define_prop(:margin_top) }
+    it { is_expected.to define_prop(:margin_x) }
+    it { is_expected.to define_prop(:margin_y) }
+    it { is_expected.to define_prop(:padding) }
+    it { is_expected.to define_prop(:padding_bottom) }
+    it { is_expected.to define_prop(:padding_left) }
+    it { is_expected.to define_prop(:padding_right) }
+    it { is_expected.to define_prop(:padding_top) }
+    it { is_expected.to define_prop(:padding_x) }
+    it { is_expected.to define_prop(:padding_y) }
+    it { is_expected.to define_boolean_prop(:dark).with_default(false) }
 
     describe "can be overwritten with custom values" do
       it "#id" do
@@ -34,6 +49,11 @@ RSpec.describe Playbook::Props do
         expect(instance.aria).to eq(bar: :baz)
       end
 
+      it "#dark" do
+        instance = subject.new(dark: true)
+        expect(instance.dark).to eq(true)
+      end
+
       describe "#children" do
         it "allows to be passed as prop" do
           block = -> { 42 }
@@ -53,7 +73,14 @@ RSpec.describe Playbook::Props do
 
     describe ".props" do
       it "returns collection of available properties" do
-        expect(subject.props).to include(:id, :data, :classname, :aria)
+        expect(subject.props).to include(
+          :id, :data, :classname, :aria, :children,
+          :margin, :margin_bottom, :margin_left,
+          :margin_right, :margin_top, :margin_x, :margin_y,
+          :padding, :padding_bottom, :padding_left,
+          :padding_right, :padding_top, :padding_x, :padding_y,
+          :dark
+        )
       end
     end
 


### PR DESCRIPTION
#### Screens

See added tests and updated error messages. Specifically the additions to `props_spec.rb` and `props/base_spec.rb`. The other changes in prop type tests are simply to keep them working.

#### Breaking Changes

No breaking changes.

#### Runway Ticket URL

[CMPN-143](https://nitro.powerhrg.com/runway/backlog_items/CMPN-143)

#### Other

Consider merging with the next major release if you like. Should be a nice developer experience enhancement.

#### How to test this

1. Make sure milano envs loads normally. (It does)
2. After it's merged, see the error become more informative locally and caught in sentry. [Here is an example of what the error message looked like before this change](https://sentry.io/organizations/power-home-remodeling-group/issues/1918768597/?query=is%3Aunresolved+%22required+prop+and+needs+to+be+provided+a+value%22&statsPeriod=14d) .  

```
#<Playbook::Props::String:0x000000001129fa48 @default=nil, @required=true> is a required prop and needs to be provided a value
```

And after:

```
PbExampleKit prop 'necessary_prop' of type String is required and needs a value
```
and
```
PbExampleKit has invalid value of '"wrong_value"' for prop 'test_prop' of type Boolean
```

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `depreciation`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two. (See the tests that expose the error message.)
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
