### PR TITLE
[NUXE-80] - Add 'close' option to kit, with examples

### DIFF
--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.html.erb
@@ -3,7 +3,7 @@
     id: object.id,
     data: object.data,
     class: object.classname) do %>
-    <%= pb_rails("icon", props: { icon: object.icon_value, classname: "pb_icon" }) %>
+    <%= pb_rails("icon", props: { icon: object.icon_value, classname: "pb_icon", fixed_width: true }) %>
     <%= pb_rails("title", props: { text: object.text, size: 4, classname: "pb_fixed_confirmation_toast_text" }) if object.show_text? %>
     <%= pb_rails("icon", props: { icon: "times", classname: "pb_icon" }) if object.closeable %>
 <% end %>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.html.erb
@@ -4,5 +4,6 @@
     data: object.data,
     class: object.classname) do %>
     <%= pb_rails("icon", props: { icon: object.icon_value, classname: "pb_icon" }) %>
-    <%= pb_rails("title", props: { text: object.text, size: 4, classname: "pb_fixed_confirmation_toast_text" }) if object.show_text?%>
+    <%= pb_rails("title", props: { text: object.text, size: 4, classname: "pb_fixed_confirmation_toast_text" }) if object.show_text? %>
+    <%= pb_rails("icon", props: { icon: "times", classname: "pb_icon" }) if object.closeable %>
 <% end %>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -22,7 +22,7 @@ type FixedConfirmationToastProps = {
 }
 
 const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
-  const [showToast, hideToast] = useState(true)
+  const [showToast, toggleToast] = useState(true)
   const { className, closeable = false, status = 'neutral', text } = props
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
@@ -35,7 +35,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
     <If condition={showToast}>
       <div
           className={css}
-          onClick={closeable ? () => hideToast(false) : null}
+          onClick={closeable ? () => toggleToast(false) : null}
       >
         <If condition={icon}>
           <Icon

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React from 'react'
+import React, { useState } from 'react'
 import classnames from 'classnames'
 import { Icon, Title } from '../'
 import { globalProps } from '../utilities/globalProps.js'
@@ -14,6 +14,7 @@ const iconMap = {
 
 type FixedConfirmationToastProps = {
   className?: string,
+  closeable?: false,
   data?: string,
   id?: string,
   status?: "success" | "error" | "neutral" | "tip",
@@ -21,7 +22,8 @@ type FixedConfirmationToastProps = {
 }
 
 const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
-  const { className, status = 'neutral', text } = props
+  const [showToast, hideToast] = useState(true)
+  const { className, closeable, status = 'neutral', text } = props
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
     globalProps(props),
@@ -30,20 +32,32 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const icon = iconMap[status]
 
   return (
-    <div className={css}>
-      <If condition={icon}>
-        <Icon
-            className="pb_icon"
-            fixed_width
-            icon={icon}
+    <If condition={showToast}>
+      <div
+          className={css}
+          onClick={closeable ? () => hideToast(false) : null}
+      >
+        <If condition={icon}>
+          <Icon
+              className="pb_icon"
+              fixed_width
+              icon={icon}
+          />
+        </If>
+        <Title
+            className="pb_fixed_confirmation_toast_text"
+            size={4}
+            text={text}
         />
-      </If>
-      <Title
-          className="pb_fixed_confirmation_toast_text"
-          size={4}
-          text={text}
-      />
-    </div>
+        <If condition={closeable}>
+          <Icon
+              className="pb_icon"
+              fixed_width
+              icon="times"
+          />
+        </If>
+      </div>
+    </If>
   )
 }
 

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -27,8 +27,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
     globalProps(props),
-    className,
-    { 'remove_toast': closeable }
+    className
   )
   const icon = iconMap[status]
 

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -27,7 +27,8 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
     globalProps(props),
-    className
+    className,
+    closeable && 'remove_toast'
   )
   const icon = iconMap[status]
 
@@ -40,7 +41,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
         <If condition={icon}>
           <Icon
               className="pb_icon"
-              fixed_width
+              fixedWidth
               icon={icon}
           />
         </If>
@@ -52,7 +53,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
         <If condition={closeable}>
           <Icon
               className="pb_icon"
-              fixed_width
+              fixedWidth={false}
               icon="times"
           />
         </If>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -14,7 +14,7 @@ const iconMap = {
 
 type FixedConfirmationToastProps = {
   className?: string,
-  closeable?: false,
+  closeable?: boolean,
   data?: string,
   id?: string,
   status?: "success" | "error" | "neutral" | "tip",
@@ -23,7 +23,7 @@ type FixedConfirmationToastProps = {
 
 const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const [showToast, hideToast] = useState(true)
-  const { className, closeable, status = 'neutral', text } = props
+  const { className, closeable = false, status = 'neutral', text } = props
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
     globalProps(props),

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -35,7 +35,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
     <If condition={showToast}>
       <div
           className={css}
-          onClick={closeable ? () => toggleToast(false) : null}
+          onClick={closeable && (() => toggleToast(false))}
       >
         <If condition={icon}>
           <Icon

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -28,7 +28,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
     `pb_fixed_confirmation_toast_kit_${status}`,
     globalProps(props),
     className,
-    closeable && 'remove_toast'
+    { 'remove_toast': closeable }
   )
   const icon = iconMap[status]
 

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
@@ -20,7 +20,7 @@ $confirmation_toast_colors: (
   border-radius: $border_rad_mega;
   box-shadow: $shadow_deeper;
 
-  &.close_toast {
+  &.remove_toast {
     cursor: pointer;
     .fa-times {
       opacity: 0.5;

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
@@ -20,16 +20,14 @@ $confirmation_toast_colors: (
   border-radius: $border_rad_mega;
   box-shadow: $shadow_deeper;
 
-  &.remove_toast {
+  .fa-times {
     cursor: pointer;
-    .fa-times {
-      opacity: 0.5;
-      position: relative;
-      right: -8px;
-    }
-    &:hover .fa-times {
-      opacity: 1;
-    }
+    opacity: 0.5;
+    position: relative;
+    right: -8px;
+  }
+  &:hover .fa-times {
+    opacity: 1;
   }
 
   @each $color_name, $color_value in $confirmation_toast_colors {

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
@@ -20,6 +20,18 @@ $confirmation_toast_colors: (
   border-radius: $border_rad_mega;
   box-shadow: $shadow_deeper;
 
+  &.close_toast {
+    cursor: pointer;
+    .fa-times {
+      opacity: 0.5;
+      position: relative;
+      right: -8px;
+    }
+    &:hover .fa-times {
+      opacity: 1;
+    }
+  }
+
   @each $color_name, $color_value in $confirmation_toast_colors {
     &[class*=_#{$color_name}]  {
       background: $color_value;

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_close.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_close.html.erb
@@ -8,12 +8,14 @@
 
 <%= pb_rails("fixed_confirmation_toast", props: {
   text: "Items Successfully Moved",
-  status: "success"
+  status: "success",
+  closeable: true
 })%>
 
 <br><br>
 
 <%= pb_rails("fixed_confirmation_toast", props: {
   text: "Scan to Assign Selected Items",
-  status: "neutral"
+  status: "neutral",
+  closeable: true
 })%>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_close.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_close.jsx
@@ -13,7 +13,6 @@ const FixedConfirmationToastClose = () => {
       </div>
 
       <br />
-      <br />
 
       <div>
         <FixedConfirmationToast
@@ -23,7 +22,6 @@ const FixedConfirmationToastClose = () => {
         />
       </div>
 
-      <br />
       <br />
 
       <div>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_close.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_close.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FixedConfirmationToast } from '../../'
 
-const FixedConfirmationToastDefault = () => {
+const FixedConfirmationToastClose = () => {
   return (
     <div>
       <div>
@@ -17,6 +17,7 @@ const FixedConfirmationToastDefault = () => {
 
       <div>
         <FixedConfirmationToast
+            closeable
             status="success"
             text="Items Successfully Moved"
         />
@@ -27,6 +28,7 @@ const FixedConfirmationToastDefault = () => {
 
       <div>
         <FixedConfirmationToast
+            closeable
             status="neutral"
             text="Scan to Assign Selected Items"
         />
@@ -35,4 +37,4 @@ const FixedConfirmationToastDefault = () => {
   )
 }
 
-export default FixedConfirmationToastDefault
+export default FixedConfirmationToastClose

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_default.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_default.jsx
@@ -13,7 +13,6 @@ const FixedConfirmationToastDefault = () => {
       </div>
 
       <br />
-      <br />
 
       <div>
         <FixedConfirmationToast
@@ -22,7 +21,6 @@ const FixedConfirmationToastDefault = () => {
         />
       </div>
 
-      <br />
       <br />
 
       <div>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.html.erb
@@ -1,4 +1,4 @@
 <%= pb_rails("fixed_confirmation_toast", props: {
-  text: "Scan to Assign Selected Items.\nClick X to close at any time",
+  text: "Scan to Assign Selected Items.\nClick here to generate report",
   status: "tip",
 }) %>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.jsx
@@ -6,7 +6,7 @@ const FixedConfirmationToastMultiLine = () => {
     <div>
       <FixedConfirmationToast
           status="tip"
-          text={'Scan to Assign Selected Items.\n Click X to close at any time'}
+          text={'Scan to Assign Selected Items.\n Click here to generate report'}
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.html.erb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("fixed_confirmation_toast", props: {
   dark: true,
-  text: "Scan to Assign Selected Items.\nClick X to close at any time",
+  text: "Scan to Assign Selected Items.\nClick here to generate report.",
   status: "tip",
 }) %>

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.jsx
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line_dark.jsx
@@ -7,7 +7,7 @@ const FixedConfirmationToastMultiLineDark = () => {
       <FixedConfirmationToast
           dark
           status="tip"
-          text={'Scan to Assign Selected Items.\n Click X to close at any time'}
+          text={'Scan to Assign Selected Items.\n Click here to generate report'}
       />
     </div>
   )

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
@@ -3,12 +3,14 @@ examples:
   rails:
   - fixed_confirmation_toast_default: Default
   - fixed_confirmation_toast_multi_line: Multi Line
+  - fixed_confirmation_toast_close: Click to Close
   - fixed_confirmation_toast_dark: Dark
   - fixed_confirmation_toast_multi_line_dark: Multi Line Dark
   
   react:
   - fixed_confirmation_toast_default: Default
   - fixed_confirmation_toast_multi_line: Multi Line
+  - fixed_confirmation_toast_close: Click to Close
   - fixed_confirmation_toast_dark: Dark
   - fixed_confirmation_toast_multi_line_dark: Multi Line Dark
   

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
@@ -1,4 +1,5 @@
 export { default as FixedConfirmationToastDefault } from './_fixed_confirmation_toast_default.jsx'
 export { default as FixedConfirmationToastMultiLine } from './_fixed_confirmation_toast_multi_line.jsx'
+export { default as FixedConfirmationToastClose } from './_fixed_confirmation_toast_close.jsx'
 export { default as FixedConfirmationToastDark } from './_fixed_confirmation_toast_dark.jsx'
 export { default as FixedConfirmationToastMultiLineDark } from './_fixed_confirmation_toast_multi_line_dark.jsx'

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
@@ -11,9 +11,15 @@ module Playbook
                     values: %w[success error neutral tip],
                     default: "neutral"
       prop :text, type: Playbook::Props::String
+      prop :closeable, type: Playbook::Props::Boolean,
+                       default: false
 
       def show_text?
         text.present?
+      end
+
+      def close_class
+        closeable.present? ? " remove_toast" : ""
       end
 
       def icon_value
@@ -30,7 +36,7 @@ module Playbook
       end
 
       def classname
-        generate_classname("pb_fixed_confirmation_toast_kit", status)
+        generate_classname("pb_fixed_confirmation_toast_kit", status) + close_class
       end
     end
   end

--- a/app/pb_kits/playbook/pb_fixed_confirmation_toast/index.js
+++ b/app/pb_kits/playbook/pb_fixed_confirmation_toast/index.js
@@ -1,0 +1,18 @@
+import PbEnhancedElement from '../pb_enhanced_element'
+
+export default class PbFixedConfirmationToast extends PbEnhancedElement {
+  static get selector() {
+    return '.remove_toast'
+  }
+
+  connect() {
+    this.self = this.element
+    this.self.addEventListener('click', () => {
+      this.removeToast(this.self)
+    })
+  }
+
+  removeToast(elem) {
+    elem.parentNode.removeChild(elem)
+  }
+}

--- a/app/pb_kits/playbook/vendor.js
+++ b/app/pb_kits/playbook/vendor.js
@@ -18,6 +18,9 @@ PbPopover.start()
 import PbTooltip from './pb_tooltip'
 PbTooltip.start()
 
+import PbFixedConfirmationToast from './pb_fixed_confirmation_toast'
+PbFixedConfirmationToast.start()
+
 import PbTypeahead from './pb_typeahead'
 PbTypeahead.start()
 

--- a/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
+++ b/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Playbook::PbFixedConfirmationToast::FixedConfirmationToast do
     end
   end
 
+  describe "#closeable?" do
+    it "returns true if closeable is present", :aggregate_failures do
+      expect(subject.new({}).closeable).to eq false
+      expect(subject.new(closeable: true).closeable).to eq true
+    end
+  end
+
   describe "#icon_value" do
     it "returns correct icon name", :aggregate_failures do
       expect(subject.new(status: "success").icon_value).to eq "check"
@@ -38,6 +45,7 @@ RSpec.describe Playbook::PbFixedConfirmationToast::FixedConfirmationToast do
       expect(subject.new(text: text, status: "neutral").classname).to eq "pb_fixed_confirmation_toast_kit_neutral"
       expect(subject.new(text: text, status: "tip").classname).to eq "pb_fixed_confirmation_toast_kit_tip"
       expect(subject.new(text: text, status: "tip", dark: true).classname).to eq "pb_fixed_confirmation_toast_kit_tip dark"
+      expect(subject.new(text: text, status: "tip", closeable: true).classname).to eq "pb_fixed_confirmation_toast_kit_tip remove_toast"
     end
   end
 end


### PR DESCRIPTION
#### Screens

<img width="500" alt="click-to-close" src="https://user-images.githubusercontent.com/4315934/94739152-e5a01600-0346-11eb-8a33-3678280b45fe.png">

#### Breaking Changes

No - New prop that is optional and defaults to existing state. 
_Please double check though : )_

#### Runway Ticket URL

[NUXE-80](https://nitro.powerhrg.com/runway/backlog_items/NUXE-80)

#### How to test this

Click toast examples in docs.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `depreciation`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
