### PR TITLE
[NUXE-158] Section separator dark mode (WIP)

### DIFF
--- a/app/pb_kits/playbook/pb_section_separator/_section_separator.jsx
+++ b/app/pb_kits/playbook/pb_section_separator/_section_separator.jsx
@@ -20,17 +20,15 @@ const SectionSeparator = (props: SectionSeparatorProps) => {
   const {
     aria = {},
     className,
-    dark = false,
     data = {},
     id,
     orientation = 'horizontal',
     text,
     variant = 'card',
   } = props
-  const themeStyle = dark === true ? '_dark' : ''
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const classes = classnames(buildCss('pb_section_separator_kit', variant, orientation, themeStyle), globalProps(props), className)
+  const classes = classnames(buildCss('pb_section_separator_kit', variant, orientation), globalProps(props), className)
 
   return (
 

--- a/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
+++ b/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
@@ -1,10 +1,18 @@
 @import "../tokens/colors";
 @import "../tokens/spacing";
 @import "../pb_caption/caption";
+@import "../pb_card/card";
+@import "./section_separator_mixin";
 
-$section_colors: (
+$section_colors_light: (
   background:   $bg_light,
-  card:   $card_light,
+  card:         $card_light,
+);
+
+$section_colors_dark: (
+  background:   $bg_dark,
+  card:         $card_dark,
+//  card:         #282342,
 );
 
 [class^=pb_section_separator_kit] {
@@ -13,7 +21,7 @@ $section_colors: (
   align-items: center;
   position: relative;
 
-  @each $color_name, $color_value in $section_colors {
+  @each $color_name, $color_value in $section_colors_light {
     &[class*=_#{$color_name}] {
       span {
         display: inline-block;
@@ -26,14 +34,7 @@ $section_colors: (
   }
  
   &::after {
-    content: "";
-    height: 1px;
-    width: 100%;
-    background: $border_light;
-    position: absolute;
-    top: 50%;
-    left: 0;
-    z-index: 0;
+    @include section_separator_horizontal(false);
   }
 
   &[class*=_horizontal] {
@@ -41,47 +42,31 @@ $section_colors: (
   }
   &[class*=_vertical] {
     &::after {
-      content: "";
-      height: 100%;
-      width: 1px;
-      margin-left: $space_xs;
-      margin-right: $space_xs;
-      background: $border_light;
-      position: initial;
-      z-index: 0;
+      @include section_separator_vertical(false);
     }
   }
   
-  &[class*=_dark] {
+  // Dark =========================
+  
+  &.dark {
     &::after {
-      content: "";
-      height: 1px;
-      width: 100%;
-      background: $border_dark;
-      position: absolute;
-      top: 50%;
-      left: 0;
-      z-index: 0;
+      @include section_separator_horizontal(true);
     }
-    &[class*=_background] {
-      span {
-        display: inline-block;
-        padding: 0 $space_xs;
-        background: $bg_dark;
-        position: relative;
-        z-index: 1;
+
+    @each $color_name, $color_value in $section_colors_dark {
+      &[class*=_#{$color_name}] {
+        span {
+          display: inline-block;
+          padding: 0 $space_xs;
+          background: #{$color_value};
+          position: relative;
+          z-index: 1;
+        }
       }
     }
     &[class*=_vertical] {
       &::after {
-        content: "";
-        height: 100%;
-        width: 1px;
-        margin-left: $space_xs;
-        margin-right: $space_xs;
-        background: $border_dark;
-        position: initial;
-        z-index: 0;
+        @include section_separator_vertical(true);
       }
     }
   }

--- a/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
+++ b/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
@@ -1,7 +1,6 @@
 @import "../tokens/colors";
 @import "../tokens/spacing";
-@import "../pb_caption/caption";
-@import "../pb_card/card";
+@import "../tokens/opacity";
 @import "./section_separator_mixin";
 
 $section_colors_light: (
@@ -11,8 +10,7 @@ $section_colors_light: (
 
 $section_colors_dark: (
   background:   $bg_dark,
-  card:         $card_dark,
-//  card:         #282342,
+  card:         tint($bg_dark,10),
 );
 
 [class^=pb_section_separator_kit] {
@@ -20,7 +18,6 @@ $section_colors_dark: (
   justify-content: center;
   align-items: center;
   position: relative;
-
   @each $color_name, $color_value in $section_colors_light {
     &[class*=_#{$color_name}] {
       span {
@@ -32,11 +29,9 @@ $section_colors_dark: (
       }
     }
   }
- 
   &::after {
     @include section_separator_horizontal(false);
   }
-
   &[class*=_horizontal] {
     justify-content: center;
   }
@@ -52,7 +47,6 @@ $section_colors_dark: (
     &::after {
       @include section_separator_horizontal(true);
     }
-
     @each $color_name, $color_value in $section_colors_dark {
       &[class*=_#{$color_name}] {
         span {

--- a/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
+++ b/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
@@ -1,0 +1,32 @@
+@import "../tokens/colors";
+@import "../tokens/spacing";
+
+@mixin section_separator_vertical($dark: false) {
+    @if $dark == false {
+        background: $border_light;
+    } @else {
+        background: $border_dark;
+    }
+    content: "";
+    height: 100%;
+    width: 1px;
+    margin-left: $space_xs;
+    margin-right: $space_xs;
+    position: initial;
+    z-index: 0;
+}
+
+@mixin section_separator_horizontal($dark: false) {
+    @if $dark == false {
+        background: $border_light;
+    } @else {
+        background: $border_dark;
+    }
+    content: "";
+    height: 1px;
+    width: 100%;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    z-index: 0;
+}

--- a/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_line.jsx
+++ b/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_line.jsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import { SectionSeparator } from '../../'
 
-const SectionSeparatorLine = () => {
+const SectionSeparatorLine = (props) => {
   return (
-    <SectionSeparator />
+    <div>
+      <SectionSeparator
+          {...props}
+      />
+    </div>
   )
 }
 

--- a/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.jsx
+++ b/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { SectionSeparator } from '../../'
 
-const SectionSeparatorText = () => {
+const SectionSeparatorText = (props) => {
   return (
     <SectionSeparator
+        {...props}
         text="Title Separator"
     />
   )

--- a/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text_background.jsx
+++ b/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text_background.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { SectionSeparator } from '../../'
 
-const SectionSeparatorTextBackground = () => {
+const SectionSeparatorTextBackground = (props) => {
   return (
     <SectionSeparator
+        {...props}
         text="Title Separator"
         variant="background"
     />

--- a/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_vertical.jsx
+++ b/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_vertical.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Flex, FlexItem, SectionSeparator } from '../../'
 
-const SectionSeparatorVertical = () => {
+const SectionSeparatorVertical = (props) => {
   return (
     <Flex
         inline="flex-container"
@@ -10,11 +10,17 @@ const SectionSeparatorVertical = () => {
       <FlexItem>
         {'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'}
       </FlexItem>
-      <SectionSeparator orientation="vertical" />
+      <SectionSeparator
+          {...props}
+          orientation="vertical"
+      />
       <FlexItem>
         {'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'}
       </FlexItem>
-      <SectionSeparator orientation="vertical" />
+      <SectionSeparator
+          {...props}
+          orientation="vertical"
+      />
       <FlexItem>
         {'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'}
       </FlexItem>

--- a/app/pb_kits/playbook/pb_section_separator/section_separator.rb
+++ b/app/pb_kits/playbook/pb_section_separator/section_separator.rb
@@ -18,7 +18,7 @@ module Playbook
                   default: false
 
       def classname
-        generate_classname("pb_section_separator_kit", variant, orientation, dark_class)
+        generate_classname("pb_section_separator_kit", variant, orientation)
       end
 
     private

--- a/spec/pb_kits/playbook/kits/section_seperator_spec.rb
+++ b/spec/pb_kits/playbook/kits/section_seperator_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Playbook::PbSectionSeparator::SectionSeparator do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_section_separator_kit_card_horizontal"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_section_separator_kit_card_horizontal additional_class"
-      expect(subject.new(variant: "background", classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_background_horizontal_dark additional_class dark"
-      expect(subject.new(orientation: "vertical", classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_card_vertical_dark additional_class dark"
-      expect(subject.new(classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_card_horizontal_dark additional_class dark"
+      expect(subject.new(variant: "background", classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_background_horizontal additional_class dark"
+      expect(subject.new(orientation: "vertical", classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_card_vertical additional_class dark"
+      expect(subject.new(classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_card_horizontal additional_class dark"
 
     end
   end


### PR DESCRIPTION
#### Screens

<img width="1022" alt="Screen Shot 2020-10-12 at 3 47 40 PM" src="https://user-images.githubusercontent.com/42459486/95784815-89bc8200-0ca2-11eb-85c6-f8753c83e1fb.png">
<img width="1024" alt="Screen Shot 2020-10-12 at 3 47 47 PM" src="https://user-images.githubusercontent.com/42459486/95784820-8cb77280-0ca2-11eb-8c03-bde02af80a4d.png">

#### Breaking Changes

No breaking changes. This PR consist of taking dark_class off of classname and other css changes.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-158

#### How to test this

Test this by making the page dark and checking that it looks like how it's supposed to.
https://pr1146.playbook.beta.gm.powerapp.cloud/kits/section_separator/react

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
