### PR TITLE
Pill Kit double line fix

### DIFF
--- a/app/pb_kits/playbook/pb_pill/_pill.scss
+++ b/app/pb_kits/playbook/pb_pill/_pill.scss
@@ -12,6 +12,7 @@ $pb_pill_height: 22px;
   padding: 0 $space-sm/1.8;
   height: $pb_pill_height;
   border-radius: $pb_pill_height/2;
+  white-space: nowrap;
 
   @each $color_name, $color_value in $status_color_text {
     &[class*=_#{$color_name}]  {


### PR DESCRIPTION
#### Screens

**Before:**
<img width="460" alt="Screen Shot 2020-10-14 at 11 46 35 AM" src="https://user-images.githubusercontent.com/53874143/96013198-fce50600-0e12-11eb-8d46-34bf8fcdffc9.png">

**New:**
<img width="462" alt="Screen Shot 2020-10-14 at 11 46 12 AM" src="https://user-images.githubusercontent.com/53874143/96013223-03737d80-0e13-11eb-92b6-7e926a0fdbf2.png">

#### Breaking Changes

No, style fix to prevent the pill text from breaking into two lines.

#### Runway Ticket URL

[NUXE-104](https://nitro.powerhrg.com/runway/backlog_items/NUXE-104)

#### How to test this

Set the browser to a smaller size that would enforce the break. Saw the pill text was breaking. Applied the `white-space: nowrap` and retested to make sure the pill text did not break. Images above.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
