### PR TITLE
[BOP-726] Add safe navigator to address home's without addresses

### DIFF
--- a/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -38,7 +38,7 @@ module Playbook
       end
 
       def address_house_style
-        "#{address.titleize} #{separator} #{house_style}"
+        "#{address&.titleize} #{separator} #{house_style}"
       end
 
       def address_house_style2


### PR DESCRIPTION
#### Screens
No visual changes.

#### Breaking Changes

No.

#### Runway Ticket URL

[BOP-726](https://nitro.powerhrg.com/runway/backlog_items/BOP-726)

#### How to test this
No changes should be visible. Errors in Nitro becomes subdued.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
