### PR TITLE
[NUXE-23] - Fix tooltip with CSS

### DIFF
--- a/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
+++ b/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
@@ -57,7 +57,7 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
       z-index: $z_9;
       margin-bottom: $space_sm;
       background-color: $white;
-      padding: $space_xs $space_sm $space_xs $space_sm;
+      padding: $space_xs $space_sm;
       box-shadow: $shadow_deeper;
       border-radius: $border_rad_light;
 
@@ -92,9 +92,9 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
 
   &[x-placement="right"] {
     box-shadow: -8px 0 28px 0 $tooltip_shadow;
-    margin: 0 0 0 16px;
+    margin: 0 0 0 $space_sm;
     .arrow {
-      left: -8px;
+      left: -#{$space_xs};
       margin-bottom: 0;
       transform: rotate(90deg);
     }
@@ -104,8 +104,8 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
   }
 
   &[x-placement="bottom"] {
-    box-shadow: 0 0 28px 0 $tooltip_shadow;
-    margin: 16px 0 0 0;
+    box-shadow: 0 -12px 28px 0 $tooltip_shadow;
+    margin: $space_sm 0 0 0;
     .arrow {
       top: -18px;
       margin-bottom: 0;
@@ -118,7 +118,7 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
 
   &[x-placement="left"] {
     box-shadow: 8px 0 28px 0 $tooltip_shadow;
-    margin: 0 16px 0 0;
+    margin: 0 $space_sm 0 0;
     .arrow {
       margin-bottom: 0;
       right: -18px;

--- a/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
+++ b/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
@@ -1,6 +1,8 @@
 @import "../tokens/positioning";
 @import "../tokens/colors";
 
+$tooltip_shadow: rgba(60, 106, 172, 0.18);
+
 @keyframes fadeIn {
   from {
     opacity: 0;
@@ -86,55 +88,44 @@
 }
 
 // Right
-[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="right"] {
-  box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
-  margin: 0 0 0 16px;
-  .arrow {
-    left: -8px;
-    margin-bottom: 0;
-    transform: rotate(90deg);
-  }
-  &.flipped {
-    box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
+[class^="pb_tooltip_kit"] .tooltip_tooltip {
+
+  &[x-placement="right"] {
+    box-shadow: -8px 0 28px 0 $tooltip_shadow;
     margin: 0 0 0 16px;
     .arrow {
-      transform: rotate(270deg);
+      left: -8px;
+      margin-bottom: 0;
+      transform: rotate(90deg);
+    }
+    &.flipped .arrow {
+        transform: rotate(270deg);
     }
   }
-}
 
-// Bottom
-[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="bottom"] {
-  box-shadow: 0 0 28px 0 rgba(60, 106, 172, 0.18);
-  margin: 16px 0 0 0;
-  .arrow {
-    top: -18px;
-    margin-bottom: 0;
-    transform: rotate(180deg);
-  }
-  &.flipped{
-    box-shadow: 0 0 28px 0 rgba(60, 106, 172, 0.18);
+  &[x-placement="bottom"] {
+    box-shadow: 0 0 28px 0 $tooltip_shadow;
     margin: 16px 0 0 0;
     .arrow {
+      top: -18px;
+      margin-bottom: 0;
+      transform: rotate(180deg);
+    }
+    &.flipped .arrow {
       transform: rotate(0deg);
     }
   }
-}
 
-// Left
-[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="left"] {
-  box-shadow: 8px 0 28px 0 rgba(60, 106, 172, 0.18);
-  margin: 0 16px 0 0;
-  .arrow {
-    margin-bottom: 0;
-    right: -18px;
-    left: auto;
-    transform: rotate(270deg);
-  }
-  &.flipped {
-    box-shadow: 8px 0 28px 0 rgba(60, 106, 172, 0.18);
+  &[x-placement="left"] {
+    box-shadow: 8px 0 28px 0 $tooltip_shadow;
     margin: 0 16px 0 0;
     .arrow {
+      margin-bottom: 0;
+      right: -18px;
+      left: auto;
+      transform: rotate(270deg);
+    }
+    &.flipped .arrow {
       transform: rotate(90deg);
     }
   }

--- a/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
+++ b/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
@@ -38,17 +38,6 @@
       }
     }
 
-    &.react {
-      .arrow {
-        top: 78%;
-      }
-      &.flipped {
-        .arrow {
-          top: -8%;
-        }
-      }
-    }
-
     .arrow {
       content: " ";
       position: absolute;
@@ -82,10 +71,6 @@
     .tooltip_tooltip{
       color: $white;
       background-color: rgba($black, $opacity_9);
-
-
-      &.show {
-      }
       .arrow {
         border-color: $black transparent transparent transparent;
         opacity: $opacity_9;
@@ -100,6 +85,75 @@
   }
 }
 
-.tooltip_tooltip.top {
-  padding: ($space_xs - 3px) 0;
+// Right
+[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="right"] {
+  box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
+  margin: 0 0 0 16px;
+  .arrow {
+    left: -8px;
+    margin-bottom: 0;
+    transform: rotate(90deg);
+  }
+  &.flipped {
+    box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
+    margin: 0 0 0 16px;
+    .arrow {
+      transform: rotate(270deg);
+    }
+  }
+}
+
+// Left
+[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="left"] {
+  box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
+  margin: 0 0 0 16px;
+  .arrow {
+    left: -8px;
+    margin-bottom: 0;
+    transform: rotate(90deg);
+  }
+  &.flipped {
+    box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
+    margin: 0 0 0 16px;
+    .arrow {
+      transform: rotate(270deg);
+    }
+  }
+}
+
+// Bottom
+[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="bottom"] {
+  box-shadow: 0 0 28px 0 rgba(60, 106, 172, 0.18);
+  margin: 16px 0 0 0;
+  .arrow {
+    top: -18px;
+    margin-bottom: 0;
+    transform: rotate(180deg);
+  }
+  &.flipped{
+    box-shadow: 0 0 28px 0 rgba(60, 106, 172, 0.18);
+    margin: 16px 0 0 0;
+    .arrow {
+      transform: rotate(0deg);
+    }
+  }
+}
+
+// Left
+[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="left"] {
+  box-shadow: 8px 0 28px 0 rgba(60, 106, 172, 0.18);
+  margin: 0 16px 0 0;
+  .arrow {
+    margin-bottom: 0;
+    right: -18px;
+    left: auto;
+    transform: rotate(270deg);
+  }
+  &.flipped {
+    box-shadow: 8px 0 28px 0 rgba(60, 106, 172, 0.18);
+    margin: 0 16px 0 0;
+    .arrow {
+      transform: rotate(90deg);
+    }
+  }
 }

--- a/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
+++ b/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
@@ -33,8 +33,8 @@
     &.flipped {
       margin-top: 15px;
       .arrow {
-        top: -35%;
         border-color: transparent transparent $white transparent;
+        transform: rotate(180deg);
       }
     }
 
@@ -87,24 +87,6 @@
 
 // Right
 [class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="right"] {
-  box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
-  margin: 0 0 0 16px;
-  .arrow {
-    left: -8px;
-    margin-bottom: 0;
-    transform: rotate(90deg);
-  }
-  &.flipped {
-    box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
-    margin: 0 0 0 16px;
-    .arrow {
-      transform: rotate(270deg);
-    }
-  }
-}
-
-// Left
-[class^="pb_tooltip_kit"] .tooltip_tooltip[x-placement="left"] {
   box-shadow: -8px 0 28px 0 rgba(60, 106, 172, 0.18);
   margin: 0 0 0 16px;
   .arrow {

--- a/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_default.html.erb
+++ b/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_default.html.erb
@@ -1,10 +1,46 @@
-<span id='regular-tooltip-2'>Hover over me.</span>
+<%= pb_rails("flex", props: { horizontal: "center", orientation: "column" }) do %>
+  <%= pb_rails("flex/flex_item") do %>
+    <span id='regular-tooltip-1'>Hover here (Top)</span>
 
-<%= pb_rails("tooltip", props: {
-  trigger_element_id: "regular-tooltip-2",
-  tooltip_id: "tooltip-2",
-  position: 'top',
-  dark: true,
-}) do %>
-    Whoa. I'm a tooltip.
+    <%= pb_rails("tooltip", props: {
+      trigger_element_id: "regular-tooltip-1",
+      tooltip_id: "tooltip-1",
+      position: 'top'
+    }) do %>
+        Whoa. I'm a tooltip.
+    <% end %>
+  <% end %>
+
+  <%= pb_rails("flex/flex_item", props: {margin_top: "md"}) do %>
+    <span id='regular-tooltip-2'>Hover here (Bottom)</span>
+    <%= pb_rails("tooltip", props: {
+      trigger_element_id: "regular-tooltip-2",
+      tooltip_id: "tooltip-2",
+      position: 'bottom'
+    }) do %>
+        Whoa. I'm a tooltip.
+    <% end %>
+  <% end %>
+
+  <%= pb_rails("flex/flex_item", props: {margin_top: "md"}) do %>
+    <span id='regular-tooltip-3'>Hover here (Right)</span>
+    <%= pb_rails("tooltip", props: {
+      trigger_element_id: "regular-tooltip-3",
+      tooltip_id: "tooltip-3",
+      position: 'right'
+    }) do %>
+        Whoa. I'm a tooltip.
+    <% end %>
+  <% end %>
+
+  <%= pb_rails("flex/flex_item", props: {margin_top: "md"}) do %>
+    <span id='regular-tooltip-4'>Hover here (Left)</span>
+    <%= pb_rails("tooltip", props: {
+      trigger_element_id: "regular-tooltip-4",
+      tooltip_id: "tooltip-4",
+      position: 'left'
+    }) do %>
+        Whoa. I'm a tooltip.
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_white.html.erb
+++ b/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_white.html.erb
@@ -1,8 +1,8 @@
-<span id='regular-tooltip-1'>I am a white tooltip.</span>
+<span id='regular-tooltip-5'>I am a white tooltip.</span>
 
 <%= pb_rails("tooltip", props: {
-  trigger_element_id: "regular-tooltip-1",
-  tooltip_id: "tooltip-1",
+  trigger_element_id: "regular-tooltip-5",
+  tooltip_id: "tooltip-5",
   position: 'top'
 }) do %>
     Whoa. I'm a white tooltip.

--- a/app/pb_kits/playbook/pb_tooltip/tooltip.rb
+++ b/app/pb_kits/playbook/pb_tooltip/tooltip.rb
@@ -10,7 +10,7 @@ module Playbook
       prop :trigger_element_id
       prop :tooltip_id
       prop :dark, type: Playbook::Props::Boolean,
-                          default: false
+                  default: false
 
       def classname
         generate_classname("pb_tooltip_kit", dark_class)
@@ -25,7 +25,8 @@ module Playbook
         )
       end
 
-      private
+    private
+
       def dark_class
         dark ? "dark" : nil
       end


### PR DESCRIPTION
#### Screens
<img width="391" alt="tooltip-top" src="https://user-images.githubusercontent.com/4315934/96473621-42854280-1208-11eb-9b6e-9f09a2aec04e.png">

<img width="420" alt="tooltip-bottom" src="https://user-images.githubusercontent.com/4315934/96473603-3c8f6180-1208-11eb-9d4c-bfe018677cc2.png">

<img width="420" alt="tooltip-left" src="https://user-images.githubusercontent.com/4315934/96473615-41541580-1208-11eb-873e-41d3514bc358.png">

<img width="420" alt="tooltip-right" src="https://user-images.githubusercontent.com/4315934/96473619-41ecac00-1208-11eb-8116-2079346dd43b.png">

#### Breaking Changes

No - These are CSS updates.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-23

#### How to test this

Hover

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
