### PR TITLE
Add default pre-selected options to Typeahead with Pills

### DIFF
--- a/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
+++ b/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
@@ -60,7 +60,16 @@ const Typeahead = (props: Props) => {
 
   const Tag = props.async ? AsyncSelect : Select
 
-  const handleOnChange = (data, { action }) => {
+  const handleOnChange = (data, { action, option, removedValue }) => {
+    if (action === 'select-option') {
+      if (selectProps.onMultiValueClick) selectProps.onMultiValueClick(option)
+      const multiValueClearEvent = new CustomEvent('pb-typeahead-kit-result-option-select', { detail: option })
+      document.dispatchEvent(multiValueClearEvent)
+    }
+    if (action === 'remove-value' || action === 'pop-value') {
+      const multiValueRemoveEvent = new CustomEvent('pb-typeahead-kit-result-option-remove', { detail: removedValue })
+      document.dispatchEvent(multiValueRemoveEvent)
+    }
     if (action === 'clear') {
       const multiValueClearEvent = new CustomEvent('pb-typeahead-kit-result-clear')
       document.dispatchEvent(multiValueClearEvent)

--- a/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
+++ b/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
@@ -6,6 +6,7 @@ import AsyncSelect from 'react-select/async'
 import { get } from 'lodash'
 
 import Control from './components/Control'
+import ClearIndicator from './components/ClearIndicator'
 import IndicatorsContainer from './components/IndicatorsContainer'
 import MenuList from './components/MenuList'
 import MultiValue from './components/MultiValue'
@@ -40,6 +41,7 @@ const Typeahead = (props: Props) => {
     defaultOptions: true,
     components: {
       Control,
+      ClearIndicator,
       IndicatorsContainer,
       IndicatorSeparator: null,
       MenuList,

--- a/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
+++ b/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
@@ -50,6 +50,7 @@ const Typeahead = (props: Props) => {
       Placeholder,
       ValueContainer,
     },
+    id: 'react-select-input',
     isClearable: true,
     isSearchable: true,
     name,
@@ -63,15 +64,15 @@ const Typeahead = (props: Props) => {
   const handleOnChange = (data, { action, option, removedValue }) => {
     if (action === 'select-option') {
       if (selectProps.onMultiValueClick) selectProps.onMultiValueClick(option)
-      const multiValueClearEvent = new CustomEvent('pb-typeahead-kit-result-option-select', { detail: option })
+      const multiValueClearEvent = new CustomEvent(`pb-typeahead-kit-${selectProps.id}-result-option-select`, { detail: option })
       document.dispatchEvent(multiValueClearEvent)
     }
     if (action === 'remove-value' || action === 'pop-value') {
-      const multiValueRemoveEvent = new CustomEvent('pb-typeahead-kit-result-option-remove', { detail: removedValue })
+      const multiValueRemoveEvent = new CustomEvent(`pb-typeahead-kit-${selectProps.id}-result-option-remove`, { detail: removedValue })
       document.dispatchEvent(multiValueRemoveEvent)
     }
     if (action === 'clear') {
-      const multiValueClearEvent = new CustomEvent('pb-typeahead-kit-result-clear')
+      const multiValueClearEvent = new CustomEvent(`pb-typeahead-kit-${selectProps.id}-result-clear`)
       document.dispatchEvent(multiValueClearEvent)
     }
   }

--- a/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.jsx
+++ b/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.jsx
@@ -1,0 +1,19 @@
+/* @flow */
+
+import React, { useEffect } from 'react'
+import { components } from 'react-select'
+
+const ClearContainer = (props: any) => {
+  useEffect(() => {
+    document.addEventListener('pb-typeahead-kit:clear', props.clearValue)
+  }, true)
+
+  return (
+    <components.ClearIndicator
+        className="clear_indicator"
+        {...props}
+    />
+  )
+}
+
+export default ClearContainer

--- a/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.jsx
+++ b/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.jsx
@@ -4,8 +4,9 @@ import React, { useEffect } from 'react'
 import { components } from 'react-select'
 
 const ClearContainer = (props: any) => {
+  const { selectProps, clearValue } = props
   useEffect(() => {
-    document.addEventListener('pb-typeahead-kit:clear', props.clearValue)
+    document.addEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, clearValue)
   }, true)
 
   return (

--- a/app/pb_kits/playbook/pb_typeahead/components/MultiValue.jsx
+++ b/app/pb_kits/playbook/pb_typeahead/components/MultiValue.jsx
@@ -13,24 +13,17 @@ type Props = {
 }
 
 const MultiValue = (props: Props) => {
-  const {
-    data,
-    removeProps,
-    selectProps,
-  } = props
+  const { removeProps } = props
+  const { imageUrl, label } = props.data
 
-  const { imageUrl, label } = data
-
-  const handleOnMultiValueRemove = () => {
-    const multiValueRemoveEvent = new CustomEvent('pb-typeahead-kit-result-option-remove', { detail: data })
-    document.dispatchEvent(multiValueRemoveEvent)
+  const formPillProps = {
+    marginRight: 'xs',
+    name: label,
   }
 
-  const handleOnClick = () => {
-    if (selectProps.onMultiValueClick) selectProps.onMultiValueClick(data)
-    handleOnMultiValueRemove()
-    removeProps.onClick()
-  }
+  if (typeof imageUrl === 'string') formPillProps.avatarUrl = imageUrl
+
+  const handleOnClick = removeProps.onClick
 
   return (
     <components.MultiValueContainer

--- a/app/pb_kits/playbook/pb_typeahead/components/Option.jsx
+++ b/app/pb_kits/playbook/pb_typeahead/components/Option.jsx
@@ -13,14 +13,9 @@ const Option = (props: any) => {
     label,
   } = props.data
 
-  const handleOptionClicked = () => {
-    const resultSelectedEvent = new CustomEvent('pb-typeahead-kit-result-option-select', { detail: props.data })
-    document.dispatchEvent(resultSelectedEvent)
-  }
-
   return (
     <components.Option {...props}>
-      <div onClick={handleOptionClicked}>
+      <div>
         <Choose>
           <When condition={imageUrl}>
             <User

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
@@ -9,6 +9,8 @@
 
 <%= pb_rails("typeahead", props: { default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
 
+<%= pb_rails("button", props: {id: "clear-pills", text: "Clear All Options", variant: "secondary"}) %>
+
 <!-- This section is an example of the available JavaScript event hooks -->
 <%= javascript_tag defer: "defer" do %>
   document.addEventListener("pb-typeahead-kit-result-option-select", function(event) {
@@ -21,5 +23,9 @@
   })
   document.addEventListener("pb-typeahead-kit-result-clear", function() {
     console.log('All options cleared')
+  })
+
+  document.querySelector('#clear-pills').addEventListener('click', function() {
+    document.dispatchEvent(new CustomEvent('pb-typeahead-kit:clear'))
   })
 <% end %>

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
@@ -7,7 +7,7 @@
   ]
 %>
 
-<%= pb_rails("typeahead", props: { options: options, label: "Colors", name: :foo, pills: true }) %>
+<%= pb_rails("typeahead", props: { default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
 
 <!-- This section is an example of the available JavaScript event hooks -->
 <%= javascript_tag defer: "defer" do %>

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
@@ -7,25 +7,25 @@
   ]
 %>
 
-<%= pb_rails("typeahead", props: { default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
+<%= pb_rails("typeahead", props: { id: "typeahead-pills-example1", default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
 
 <%= pb_rails("button", props: {id: "clear-pills", text: "Clear All Options", variant: "secondary"}) %>
 
 <!-- This section is an example of the available JavaScript event hooks -->
 <%= javascript_tag defer: "defer" do %>
-  document.addEventListener("pb-typeahead-kit-result-option-select", function(event) {
+  document.addEventListener("pb-typeahead-kit-typeahead-pills-example1-result-option-select", function(event) {
     console.log('Option selected')
     console.dir(event.detail)
   })
-  document.addEventListener("pb-typeahead-kit-result-option-remove", function(event) {
+  document.addEventListener("pb-typeahead-kit-typeahead-pills-example1-result-option-remove", function(event) {
     console.log('Option removed')
     console.dir(event.detail)
   })
-  document.addEventListener("pb-typeahead-kit-result-clear", function() {
+  document.addEventListener("pb-typeahead-kit-typeahead-pills-example1-result-clear", function() {
     console.log('All options cleared')
   })
 
   document.querySelector('#clear-pills').addEventListener('click', function() {
-    document.dispatchEvent(new CustomEvent('pb-typeahead-kit:clear'))
+    document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example1:clear'))
   })
 <% end %>

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
@@ -1,6 +1,12 @@
 Typeahead kit is data-driven. The minimum default fields are `label` and `value`.
 
-`{ label: "Foo", value: "bar" }`
+This is an example of an option: `{ label: 'Windows', value: '#FFA500' }`
+
+#### Rails: Default Options
+
+You can also pass `default_options` which will populate the initial pill selections:
+
+`default_options: [{ label: 'Windows', value: '#FFA500' }]`
 
 #### Rails: Subscribing to JS Events
 `pb-typeahead-kit-result-option-select` event to perform custom work when an option is clicked.

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
@@ -12,3 +12,6 @@ You can also pass `default_options` which will populate the initial pill selecti
 `pb-typeahead-kit-result-option-select` event to perform custom work when an option is clicked.
 `pb-typeahead-kit-result-option-remove` event to perform custom work when a pill is clicked.
 `pb-typeahead-kit-result-option-clear` event to perform custom work when all pills are removed upon clicking the X.
+
+#### Rails: Publishing JS Events
+`pb-typeahead-kit:clear` event to clear all options.

--- a/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
+++ b/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
@@ -9,9 +9,16 @@ You can also pass `default_options` which will populate the initial pill selecti
 `default_options: [{ label: 'Windows', value: '#FFA500' }]`
 
 #### Rails: Subscribing to JS Events
-`pb-typeahead-kit-result-option-select` event to perform custom work when an option is clicked.
-`pb-typeahead-kit-result-option-remove` event to perform custom work when a pill is clicked.
-`pb-typeahead-kit-result-option-clear` event to perform custom work when all pills are removed upon clicking the X.
+
+JavaScript events are triggered based on actions you take within the kit such as selection, removal and clearing.
+This kit utilizes a default `id` prop named `react-select-input`. It is **highly advised** to send your own unique `id` prop when using this kit to ensure these events do not unintentionally affect other instances of the kit in the same view. The examples below will use the unique `id` prop named `typeahead-pills-example1`:
+
+`pb-typeahead-kit-typeahead-pills-example1-result-option-select` event to perform custom work when an option is clicked.
+`pb-typeahead-kit-typeahead-pills-example1-result-option-remove` event to perform custom work when a pill is clicked.
+`pb-typeahead-kit-typeahead-pills-example1-result-option-clear` event to perform custom work when all pills are removed upon clicking the X.
 
 #### Rails: Publishing JS Events
-`pb-typeahead-kit:clear` event to clear all options.
+
+The same rule regarding the `id` prop applies to publishing JS events. The examples below will use the unique `id` prop named `typeahead-pills-example1`:
+
+`pb-typeahead-kit-typeahead-pills-example1:clear` event to clear all options.

--- a/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -7,6 +7,7 @@ module Playbook
 
       prop :async, type: Playbook::Props::Boolean,
                     default: false
+      prop :default_options, type: Playbook::Props::HashArray, default: []
       prop :label
       prop :load_options
       prop :name
@@ -35,6 +36,7 @@ module Playbook
 
       def typeahead_with_pills_options
         base_options = {
+          defaultValue: default_options,
           isMulti: true,
           label: label,
           options: options,

--- a/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -8,6 +8,7 @@ module Playbook
       prop :async, type: Playbook::Props::Boolean,
                     default: false
       prop :default_options, type: Playbook::Props::HashArray, default: []
+      prop :id
       prop :label
       prop :load_options
       prop :name
@@ -37,6 +38,7 @@ module Playbook
       def typeahead_with_pills_options
         base_options = {
           defaultValue: default_options,
+          id: id,
           isMulti: true,
           label: label,
           options: options,

--- a/spec/pb_kits/playbook/pb_typeahead/typeahead_spec.rb
+++ b/spec/pb_kits/playbook/pb_typeahead/typeahead_spec.rb
@@ -17,4 +17,32 @@ RSpec.describe Playbook::PbTypeahead::Typeahead do
   it { is_expected.to define_prop(:placeholder) }
   it { is_expected.to define_prop(:search_term_minimum_length).with_default(3) }
   it { is_expected.to define_prop(:search_debounce_timeout).with_default(250) }
+
+  describe "#typeahead_with_pills_options" do
+    before(:each) do
+      @expected_options = [{ label: 'Windows', value: '1' }]
+      @expected_label = "Label Here"
+      @expected_placeholder = "Placeholder Here"
+    end
+
+    it "returns base props", :aggregate_failures do
+      base_example = subject.new(label: @expected_label, options: @expected_options, placeholder: @expected_placeholder)
+      expect(base_example.typeahead_with_pills_options[:defaultValue]).to match_array([])
+      expect(base_example.typeahead_with_pills_options[:isMulti]).to eq(true)
+      expect(base_example.typeahead_with_pills_options[:options]).to match_array(@expected_options)
+      expect(base_example.typeahead_with_pills_options[:label]).to eq(@expected_label)
+      expect(base_example.typeahead_with_pills_options[:placeholder]).to eq(@expected_placeholder)
+    end
+
+    it "returns props with default_options", :aggregate_failures do
+      default_options_example = subject.new(default_options: @expected_options, label: @expected_label, options: @expected_options, placeholder: @expected_placeholder)
+      expect(default_options_example.typeahead_with_pills_options[:defaultValue]).to match_array(@expected_options)
+      expect(default_options_example.typeahead_with_pills_options[:options]).to match_array(@expected_options)
+    end
+    it "returns props with load_options", :aggregate_failures do
+      default_options_example = subject.new(async: true, load_options: 'foo', label: @expected_label, options: @expected_options, placeholder: @expected_placeholder)
+      expect(default_options_example.typeahead_with_pills_options[:async]).to be(true)
+      expect(default_options_example.typeahead_with_pills_options[:loadOptions]).to eq('foo')
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -8861,7 +8861,7 @@ react-popper@^2.1.0:
 
 react-select@3.0.8:
   version "3.0.8"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#1c002f04997401a11bede0852fea0807c6aebe41"
   integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
   dependencies:
     "@babel/runtime" "^7.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3399,7 +3399,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5230,7 +5230,7 @@ import-local@2.0.0, import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6238,11 +6238,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6251,32 +6246,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -6312,11 +6285,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.template@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
#### Prerequisites

https://github.com/powerhome/playbook/pull/1172

#### Screens

<img width="1419" alt="Screen Shot 2020-10-29 at 1 31 45 PM" src="https://user-images.githubusercontent.com/2293844/97616927-25f8bf80-19eb-11eb-96c7-d5a416557ed6.png">
<img width="1415" alt="Screen Shot 2020-10-29 at 1 32 27 PM" src="https://user-images.githubusercontent.com/2293844/97616966-33ae4500-19eb-11eb-9bc3-50a554ebf15f.png">



#### Breaking Changes

No

#### Runway Ticket URL

N/A

#### How to test this

View the Playbook doc example for testing. Ensure that the default "Windows" pill shows for the first Typeahead with Pills example.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
