### PR TITLE
Don't issue new certs for review envs

### DIFF
--- a/config/deploy/production/values.yaml
+++ b/config/deploy/production/values.yaml
@@ -1,1 +1,2 @@
-{}
+ingress:
+  issueCerts: true

--- a/config/deploy/prs/values.yaml
+++ b/config/deploy/prs/values.yaml
@@ -1,1 +1,2 @@
-{}
+ingress:
+  issueCerts: false # Certificate is issued once per cluster in the playbook-prs namespace

--- a/config/deploy/staging/values.yaml
+++ b/config/deploy/staging/values.yaml
@@ -1,1 +1,2 @@
-{}
+ingress:
+  issueCerts: true

--- a/config/deploy/templates/ingress.yaml.erb
+++ b/config/deploy/templates/ingress.yaml.erb
@@ -7,7 +7,9 @@ metadata:
     app: playbook
   annotations:
     kubernetes.io/ingress.class: nginx
+    <% if ingress["issueCert"] %>
     cert-manager.io/cluster-issuer: production-certs
+    <% end %>
     <% if environment == 'production' %>
     nginx.ingress.kubernetes.io/whitelist-source-range: '0.0.0.0/0'
     <% end %>


### PR DESCRIPTION
Each APP cluster has a wildcard cert issued for playbook-prs which is provisioned into each review namespace. This avoids having to issue a new cert for each review environment, which results in regular notifications of cert expiry for these discarded certs.
