### PR TITLE
[NUXE-272] Fixed background kit Rails image bug

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_background/_background.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_background/_background.html.erb
@@ -4,7 +4,7 @@
       data: object.data,
       id: object.id,
       class: object.classname,
-      style: `background-image: url(#{object.image_url});`
+      style: "background-image: url('#{object.image_url}');"
   ) do %>
     <%= capture(&object.children) %>
   <% end %>

--- a/playbook/app/views/playbook/pages/home.html.erb
+++ b/playbook/app/views/playbook/pages/home.html.erb
@@ -1,5 +1,5 @@
 <div class="landing-page">
-  <%= pb_rails("background", props: { background_color:"dark", padding: "xl" }) do %>
+  <%= pb_rails("background", props: { image_url: image_url("landing-background.svg"), padding: "xl" }) do %>
     <%= pb_rails("flex", props: { classname: "flex-container hero-inner-wrapper", horizontal: "center", wrap: true } ) do %>
       <div class="flex-item">
         <%= image_tag("landing-image.svg", class: "pb-hero-image") %>


### PR DESCRIPTION
#### What does this PR do?

1. Fixes rails background kit image bug.
2. Reintroduces hero background svg to landing page.

#### Screens

![code_snippet](https://p-a6FbDk.t4.n0.cdn.getcloudapp.com/items/4guJpLK6/background_string_interpolation.png?v=050f41e566605d74057a640d63723a8e)

#### Breaking Changes

n/a

#### Runway Ticket URL

[Link to Runway Story](https://nitro.powerhrg.com/runway/backlog_items/NUXE-272)

#### How to test this

Double check that the Rails background kit is pulling in an image in the doc examples (last example on page).

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
