### PR TITLE
[NUXE-260] SAMPLE PAGE - Image aspect ratio on News View

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_image/_image.scss
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.scss
@@ -11,7 +11,6 @@ $image-sizes: (
 
 [class^=pb_image_kit] {
   position: relative;
-  max-width: -webkit-fill-available;
 
   @each $name, $size in $image-sizes {
     &[class*=_#{$name}] {

--- a/playbook/app/pb_kits/playbook/pb_image/_image.scss
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.scss
@@ -11,6 +11,7 @@ $image-sizes: (
 
 [class^=pb_image_kit] {
   position: relative;
+  max-width: -webkit-fill-available;
 
   @each $name, $size in $image-sizes {
     &[class*=_#{$name}] {
@@ -37,5 +38,6 @@ $image-sizes: (
       -webkit-filter: blur(0);
       filter: blur(0);
     }
+
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_image/_image.scss
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.scss
@@ -37,6 +37,5 @@ $image-sizes: (
       -webkit-filter: blur(0);
       filter: blur(0);
     }
-
   }
 }

--- a/playbook/app/views/playbook/samples/news_magazine/index.html.erb
+++ b/playbook/app/views/playbook/samples/news_magazine/index.html.erb
@@ -1,13 +1,3 @@
-<%= javascript_tag do %>
-
-  window.addEventListener('DOMContentLoaded', (event) => {
-    document.querySelectorAll(".pb_image_kit").forEach(function(element) {
-      element.style.width = "100%";
-      element.style.height = "200px";
-    })
-  })
-<% end %>
-
 <%= pb_rails("layout", props: { position: "left", size: "sm", collapse: "md", layout: "collection_detail", dark: false }) do %>
   <%= pb_rails("layout/sidebar") do %>
     <%= pb_rails("card", props: { padding: "none" }) do %>
@@ -41,7 +31,7 @@
                 <%= pb_rails("caption", props: { text: "Planet Money", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1561414927-6d86591d0c4f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80"}) %>
+                <%= pb_rails("image", props: { classname:"image_size", url: "https://images.unsplash.com/photo-1561414927-6d86591d0c4f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80"}) %>
                 <%= pb_rails("title", props: { text: "Where’d the Money Go, and Other Questions", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
@@ -64,7 +54,7 @@
                 <%= pb_rails("caption", props: { text: "World", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1500202352583-7b2fc394ed15?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" }) %>
+                <%= pb_rails("image", props: { classname:"image_size", url: "https://images.unsplash.com/photo-1500202352583-7b2fc394ed15?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" }) %>
                 <%= pb_rails("title", props: { text: "U.K. Willing To Admit 3 Million If China Adopts Security Law", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
@@ -87,7 +77,7 @@
                 <%= pb_rails("caption", props: { text: "Books", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1551269901-5c5e14c25df7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" }) %>
+                <%= pb_rails("image", props: { classname:"image_size", url: "https://images.unsplash.com/photo-1551269901-5c5e14c25df7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" }) %>
                 <%= pb_rails("title", props: { text: "Opinion: Harry Potter's Magic Fades When His Creator Tweets", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
@@ -110,7 +100,7 @@
                 <%= pb_rails("caption", props: { text: "National", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1352&q=80" }) %>
+                <%= pb_rails("image", props: { classname:"image_size", url: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1352&q=80" }) %>
                 <%= pb_rails("title", props: { text: "1st U.S. Woman To Walk In Space Dives To Deepest Point In Ocean", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
@@ -133,7 +123,7 @@
                 <%= pb_rails("caption", props: { text: "Books, News, and Features", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1550751827-4bd374c3f58b?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80" }) %>
+                <%= pb_rails("image", props: { classname:"image_size", url: "https://images.unsplash.com/photo-1550751827-4bd374c3f58b?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80" }) %>
                 <%= pb_rails("title", props: { text: "Publishers Sue Internet Archive For Mass Copyright Infringement", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
@@ -156,7 +146,7 @@
                 <%= pb_rails("caption", props: { text: "Science", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1558677949-260173506bbf?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1267&q=80" }) %>
+                <%= pb_rails("image", props: { classname:"image_size", url: "https://images.unsplash.com/photo-1558677949-260173506bbf?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1267&q=80" }) %>
                 <%= pb_rails("title", props: { text: "New Book Argues Migration Isn’t A Crisis — It’s The Solution", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
@@ -175,3 +165,10 @@
     <!-- END SCIENCE CARD -->
     <% end %>
 <% end %>
+
+<style>
+.image_size {
+    width:100%;
+    height:200px;
+    }
+</style>

--- a/playbook/app/views/playbook/samples/news_magazine/index.html.erb
+++ b/playbook/app/views/playbook/samples/news_magazine/index.html.erb
@@ -20,19 +20,19 @@
                     <%= pb_rails("nav/item", props: { text: "Analysis", link: "#" }) %>
                 <% end %>
             <%= pb_rails("nav/item", props: { text: "World", link: "#" }) %>
-        <% end %>    
-    <% end %>  
+        <% end %>
+    <% end %>
     <% end %>
 
-    <%= pb_rails("layout/body") do %> 
+    <%= pb_rails("layout/body") do %>
     <!-- START PLANET MONEY CARD -->
         <%= pb_rails("card", props: { padding: "none", header: true}) do %>
             <%= pb_rails("card/card_header", props: { padding: "sm" }) do %>
                 <%= pb_rails("caption", props: { text: "Planet Money", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://djenjyj46f9j9.cloudfront.net/items/292f0C2i3f2z2f2A0P0n/Screen%20Shot%202020-07-09%20at%201.23.31%20PM.png?X-CloudApp-Visitor-Id=3399053&v=ed16c3c4" }) %>
-                <%= pb_rails("title", props: { text: "Where’d the Money Go, and Other Questions", tag: "h4", size: 4, padding: "sm", variant: "link" }) %> 
+                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1561414927-6d86591d0c4f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80"}) %>
+                <%= pb_rails("title", props: { text: "Where’d the Money Go, and Other Questions", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
                     <%= pb_rails("body", props: {classname: "flex-item", margin_right: "md" }) do %>
@@ -54,8 +54,8 @@
                 <%= pb_rails("caption", props: { text: "World", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://djenjyj46f9j9.cloudfront.net/items/0n07340O0c3R0V0L1V0P/Screen%20Shot%202020-07-09%20at%201.41.26%20PM.png?X-CloudApp-Visitor-Id=3399053&v=b532b3f0" }) %>
-                <%= pb_rails("title", props: { text: "U.K. Willing To Admit 3 Million If China Adopts Security Law", tag: "h4", size: 4, padding: "sm", variant: "link" }) %> 
+                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1500202352583-7b2fc394ed15?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" }) %>
+                <%= pb_rails("title", props: { text: "U.K. Willing To Admit 3 Million If China Adopts Security Law", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
                     <%= pb_rails("body", props: {classname: "flex-item", margin_right: "md" }) do %>
@@ -77,8 +77,8 @@
                 <%= pb_rails("caption", props: { text: "Books", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://djenjyj46f9j9.cloudfront.net/items/1j2k1g3f2H2W2f1v3225/Screen%20Shot%202020-07-09%20at%201.42.32%20PM.png?X-CloudApp-Visitor-Id=3399053&v=2ab46cb6" }) %>
-                <%= pb_rails("title", props: { text: "Opinion: Harry Potter's Magic Fades When His Creator Tweets", tag: "h4", size: 4, padding: "sm", variant: "link" }) %> 
+                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1551269901-5c5e14c25df7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" }) %>
+                <%= pb_rails("title", props: { text: "Opinion: Harry Potter's Magic Fades When His Creator Tweets", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
                     <%= pb_rails("body", props: {classname: "flex-item", margin_right: "md" }) do %>
@@ -100,8 +100,8 @@
                 <%= pb_rails("caption", props: { text: "National", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://djenjyj46f9j9.cloudfront.net/items/2j0G2k3I0f3W3a2c2q3o/Screen%20Shot%202020-07-09%20at%201.43.40%20PM.png?X-CloudApp-Visitor-Id=3399053&v=d2667a0b" }) %>
-                <%= pb_rails("title", props: { text: "1st U.S. Woman To Walk In Space Dives To Deepest Point In Ocean", tag: "h4", size: 4, padding: "sm", variant: "link" }) %> 
+                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1352&q=80" }) %>
+                <%= pb_rails("title", props: { text: "1st U.S. Woman To Walk In Space Dives To Deepest Point In Ocean", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
                     <%= pb_rails("body", props: {classname: "flex-item", margin_right: "md" }) do %>
@@ -123,8 +123,8 @@
                 <%= pb_rails("caption", props: { text: "Books, News, and Features", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://djenjyj46f9j9.cloudfront.net/items/0m353s3A3I3B0w3N3W2U/Screen%20Shot%202020-07-09%20at%201.44.30%20PM.png?X-CloudApp-Visitor-Id=3399053&v=5b24787c" }) %>
-                <%= pb_rails("title", props: { text: "Publishers Sue Internet Archive For Mass Copyright Infringement", tag: "h4", size: 4, padding: "sm", variant: "link" }) %> 
+                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1550751827-4bd374c3f58b?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80" }) %>
+                <%= pb_rails("title", props: { text: "Publishers Sue Internet Archive For Mass Copyright Infringement", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
                     <%= pb_rails("body", props: {classname: "flex-item", margin_right: "md" }) do %>
@@ -146,8 +146,8 @@
                 <%= pb_rails("caption", props: { text: "Science", dark: true }) %>
             <% end %>
             <%= pb_rails("card/card_body", props: { padding: "none" }) do %>
-                <%= pb_rails("image", props: { url: "https://djenjyj46f9j9.cloudfront.net/items/0n1b1V1F4614343t3547/Screen%20Shot%202020-07-09%20at%201.45.26%20PM.png?X-CloudApp-Visitor-Id=3399053&v=a3cc4d20" }) %>
-                <%= pb_rails("title", props: { text: "New Book Argues Migration Isn’t A Crisis — It’s The Solution", tag: "h4", size: 4, padding: "sm", variant: "link" }) %> 
+                <%= pb_rails("image", props: { url: "https://images.unsplash.com/photo-1558677949-260173506bbf?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1267&q=80" }) %>
+                <%= pb_rails("title", props: { text: "New Book Argues Migration Isn’t A Crisis — It’s The Solution", tag: "h4", size: 4, padding: "sm", variant: "link" }) %>
                 <%= pb_rails("section_separator") %>
                 <%= pb_rails("flex", props: { padding: "sm", wrap: true }) do %>
                     <%= pb_rails("body", props: {classname: "flex-item", margin_right: "md" }) do %>

--- a/playbook/app/views/playbook/samples/news_magazine/index.html.erb
+++ b/playbook/app/views/playbook/samples/news_magazine/index.html.erb
@@ -8,7 +8,7 @@
   })
 <% end %>
 
-<%= pb_rails("layout", props: {position: "left", size: "sm", collapse: "md", layout: "collection_detail" }) do %>
+<%= pb_rails("layout", props: { position: "left", size: "sm", collapse: "md", layout: "collection_detail", dark: false }) do %>
   <%= pb_rails("layout/sidebar") do %>
     <%= pb_rails("card", props: { padding: "none" }) do %>
     <%= pb_rails("caption", props: { text: "News Stories", size: 'lg', margin: "md" }) %>
@@ -175,5 +175,3 @@
     <!-- END SCIENCE CARD -->
     <% end %>
 <% end %>
-
-

--- a/playbook/app/views/playbook/samples/news_magazine/index.html.erb
+++ b/playbook/app/views/playbook/samples/news_magazine/index.html.erb
@@ -1,3 +1,13 @@
+<%= javascript_tag do %>
+
+  window.addEventListener('DOMContentLoaded', (event) => {
+    document.querySelectorAll(".pb_image_kit").forEach(function(element) {
+      element.style.width = "100%";
+      element.style.height = "200px";
+    })
+  })
+<% end %>
+
 <%= pb_rails("layout", props: {position: "left", size: "sm", collapse: "md", layout: "collection_detail" }) do %>
   <%= pb_rails("layout/sidebar") do %>
     <%= pb_rails("card", props: { padding: "none" }) do %>

--- a/playbook/app/views/playbook/samples/news_magazine/index.jsx
+++ b/playbook/app/views/playbook/samples/news_magazine/index.jsx
@@ -1,372 +1,380 @@
 import React from 'react'
 import { Caption, Card, Flex, FlexItem, IconValue, Image, Layout, Nav, NavItem, SectionSeparator, Title } from '../../../../pb_kits/playbook'
 
-const NewsMagazine = () => (
-  <div>
+const NewsMagazine = () => {
+  window.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[class*="pb_image_kit"]').forEach((element) => {
+      element.style.width = '100%'
+      element.style.height = '200px'
+    })
+  })
 
-    <Layout
-        layout="collection_detail"
-        padding="lg"
-    >
-      <Card padding="none">
-        <Caption
-            padding="md"
-            size="lg"
-            text="News Stories"
-        />
-        <SectionSeparator />
-        {
-          <Nav
-              link="#"
-              marginTop="sm"
-              orientation="vertical"
-          >
-            <NavItem
+  return (
+    <div>
+      <Layout
+          layout="collection_detail"
+          padding="lg"
+      >
+        <Card padding="none">
+          <Caption
+              padding="md"
+              size="lg"
+              text="News Stories"
+          />
+          <SectionSeparator />
+          {
+            <Nav
                 link="#"
-                text="All News"
-            />
-            <NavItem
-                link="#"
-                text="Top Stories"
-            />
-            <NavItem
-                active
-                link="#"
-                text="National"
-            />
-            <Nav variant="subtle">
+                marginTop="sm"
+                orientation="vertical"
+            >
+              <NavItem
+                  link="#"
+                  text="All News"
+              />
+              <NavItem
+                  link="#"
+                  text="Top Stories"
+              />
               <NavItem
                   active
                   link="#"
-                  text="All"
+                  text="National"
               />
+              <Nav variant="subtle">
+                <NavItem
+                    active
+                    link="#"
+                    text="All"
+                />
+                <NavItem
+                    link="#"
+                    text="Planet Money"
+                />
+                <NavItem
+                    link="#"
+                    text="Books"
+                />
+                <NavItem
+                    link="#"
+                    text="Books, News, and Features"
+                />
+                <NavItem
+                    link="#"
+                    text="Science"
+                />
+                <NavItem
+                    link="#"
+                    text="Politics"
+                />
+                <NavItem
+                    link="#"
+                    text="National Security"
+                />
+                <NavItem
+                    link="#"
+                    text="Environment"
+                />
+                <NavItem
+                    link="#"
+                    text="Shots - Health News"
+                />
+                <NavItem
+                    link="#"
+                    text="Analysis"
+                />
+              </Nav>
               <NavItem
                   link="#"
-                  text="Planet Money"
-              />
-              <NavItem
-                  link="#"
-                  text="Books"
-              />
-              <NavItem
-                  link="#"
-                  text="Books, News, and Features"
-              />
-              <NavItem
-                  link="#"
-                  text="Science"
-              />
-              <NavItem
-                  link="#"
-                  text="Politics"
-              />
-              <NavItem
-                  link="#"
-                  text="National Security"
-              />
-              <NavItem
-                  link="#"
-                  text="Environment"
-              />
-              <NavItem
-                  link="#"
-                  text="Shots - Health News"
-              />
-              <NavItem
-                  link="#"
-                  text="Analysis"
+                  text="Files"
               />
             </Nav>
-            <NavItem
-                link="#"
-                text="Files"
-            />
-          </Nav>
-        }
-      </Card>
+          }
+        </Card>
 
-      <Layout.Body>
-        {/* START PLANET MONEY */}
-        <Card padding="none">
-          <Card.Header>
-            <Caption
-                dark
-                text="Planet Money"
-            />
-          </Card.Header>
-          <Card.Body padding="none">
-            <Image url="https://images.unsplash.com/photo-1561414927-6d86591d0c4f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80" />
-            <Title
-                paddingLeft="sm"
-                paddingTop="sm"
-                size={4}
-                tag="h4"
-                text="Where’d the Money Go, and Other Questions"
-            />
-            <SectionSeparator paddingY="sm" />
-            <Flex
-                orientation="row"
-                paddingBottom="sm"
-                paddingX="sm"
-                wrap
-            >
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="share-alt"
-                    text="391"
-                  /> }
-              </FlexItem>
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="eye"
-                    text="2,039"
-                  /> }
-              </FlexItem>
-              <FlexItem>
-                { <IconValue
-                    icon="comments"
-                    text="89"
-                  /> }
-              </FlexItem>
-            </Flex>
-          </Card.Body>
-        </Card>
-        {/* END PLANET MONEY */}
-        {/* START WORLD CARD */}
-        <Card padding="none">
-          <Card.Header categoryColor={2}>
-            <Caption
-                dark
-                text="World"
-            />
-          </Card.Header>
-          <Card.Body padding="none">
-            <Image url="https://images.unsplash.com/photo-1500202352583-7b2fc394ed15?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" />
-            <Title
-                paddingLeft="sm"
-                paddingTop="sm"
-                size={4}
-                tag="h4"
-                text="U.K. Willing To Admit 3 Million If China Adopts Security Law"
-            />
-            <SectionSeparator paddingY="sm" />
-            <Flex
-                orientation="row"
-                paddingBottom="sm"
-                paddingX="sm"
-                wrap
-            >
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="share-alt"
-                    text="304"
-                  /> }
-              </FlexItem>
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="eye"
-                    text="5,032"
-                  /> }
-              </FlexItem>
-              <FlexItem>
-                { <IconValue
-                    icon="comments"
-                    text="102"
-                  /> }
-              </FlexItem>
-            </Flex>
-          </Card.Body>
-        </Card>
-        {/* END WORLD CARD */}
-        {/* START BOOKS CARD */}
-        <Card padding="none">
-          <Card.Header categoryColor={3}>
-            <Caption
-                dark
-                text="Books"
-            />
-          </Card.Header>
-          <Card.Body padding="none">
-            <Image url="https://images.unsplash.com/photo-1551269901-5c5e14c25df7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" />
-            <Title
-                paddingLeft="sm"
-                paddingTop="sm"
-                size={4}
-                tag="h4"
-                text="Opinion: Harry Potter's Magic Fades When His Creator Tweets"
-            />
-            <SectionSeparator paddingY="sm" />
-            <Flex
-                orientation="row"
-                paddingBottom="sm"
-                paddingX="sm"
-                wrap
-            >
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="share-alt"
-                    text="201"
-                  /> }
-              </FlexItem>
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="eye"
-                    text="890"
-                  /> }
-              </FlexItem>
-              <FlexItem>
-                { <IconValue
-                    icon="comments"
-                    text="2"
-                  /> }
-              </FlexItem>
-            </Flex>
-          </Card.Body>
-        </Card>
-        {/* END BOOKS CARD */}
-        {/* START NATIONAL CARD */}
-        <Card padding="none">
-          <Card.Header categoryColor={4}>
-            <Caption
-                dark
-                text="National"
-            />
-          </Card.Header>
-          <Card.Body padding="none">
-            <Image url="https://images.unsplash.com/photo-1451187580459-43490279c0fa?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1352&q=80" />
-            <Title
-                paddingTop="sm"
-                paddingX="sm"
-                size={4}
-                tag="h4"
-                text="1st U.S. Woman To Walk In Space Dives To Deepest Point In Ocean"
-            />
-            <SectionSeparator paddingY="sm" />
-            <Flex
-                orientation="row"
-                paddingBottom="sm"
-                paddingX="sm"
-                wrap
-            >
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="share-alt"
-                    text="245"
-                  /> }
-              </FlexItem>
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="eye"
-                    text="10,302"
-                  /> }
-              </FlexItem>
-              <FlexItem>
-                { <IconValue
-                    icon="comments"
-                    text="89"
-                  /> }
-              </FlexItem>
-            </Flex>
-          </Card.Body>
-        </Card>
-        {/* END NATIONAL CARD */}
-        {/* START BOOKS, NEWS, AND FEATURES CARD */}
-        <Card padding="none">
-          <Card.Header categoryColor={5}>
-            <Caption
-                dark
-                text="Books, News, and Features"
-            />
-          </Card.Header>
-          <Card.Body padding="none">
-            <Image url="https://images.unsplash.com/photo-1550751827-4bd374c3f58b?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80" />
-            <Title
-                paddingLeft="sm"
-                paddingTop="sm"
-                size={4}
-                tag="h4"
-                text="Publishers Sue Internet Archive For Mass Copyright Infringement"
-            />
-            <SectionSeparator paddingY="sm" />
-            <Flex
-                orientation="row"
-                paddingBottom="sm"
-                paddingX="sm"
-                wrap
-            >
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="share-alt"
-                    text="84"
-                  /> }
-              </FlexItem>
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="eye"
-                    text="5,592"
-                  /> }
-              </FlexItem>
-              <FlexItem>
-                { <IconValue
-                    icon="comments"
-                    text="104"
-                  /> }
-              </FlexItem>
-            </Flex>
-          </Card.Body>
-        </Card>
-        {/* END BOOKS, NEWS, AND FEATURES CARD */}
-        {/* START SCIENCE CARD */}
-        <Card padding="none">
-          <Card.Header categoryColor={6}>
-            <Caption
-                dark
-                text="Science"
-            />
-          </Card.Header>
-          <Card.Body padding="none">
-            <Image url="https://images.unsplash.com/photo-1558677949-260173506bbf?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1267&q=80" />
-            <Title
-                paddingLeft="sm"
-                paddingTop="sm"
-                size={4}
-                tag="h4"
-                text="New Book Argues Migration Isn’t A Crisis — It’s The Solution"
-            />
-            <SectionSeparator paddingY="sm" />
-            <Flex
-                orientation="row"
-                paddingBottom="sm"
-                paddingX="sm"
-                wrap
-            >
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="share-alt"
-                    text="54"
-                  /> }
-              </FlexItem>
-              <FlexItem paddingRight="sm">
-                { <IconValue
-                    icon="eye"
-                    text="3,982"
-                  /> }
-              </FlexItem>
-              <FlexItem>
-                { <IconValue
-                    icon="comments"
-                    text="12"
-                  /> }
-              </FlexItem>
-            </Flex>
-          </Card.Body>
-        </Card>
-        {/* END SCIENCE CARD */}
+        <Layout.Body>
+          {/* START PLANET MONEY */}
+          <Card padding="none">
+            <Card.Header>
+              <Caption
+                  dark
+                  text="Planet Money"
+              />
+            </Card.Header>
+            <Card.Body padding="none">
+              <Image url="https://images.unsplash.com/photo-1561414927-6d86591d0c4f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80" />
+              <Title
+                  paddingLeft="sm"
+                  paddingTop="sm"
+                  size={4}
+                  tag="h4"
+                  text="Where’d the Money Go, and Other Questions"
+              />
+              <SectionSeparator paddingY="sm" />
+              <Flex
+                  orientation="row"
+                  paddingBottom="sm"
+                  paddingX="sm"
+                  wrap
+              >
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="share-alt"
+                      text="391"
+                    /> }
+                </FlexItem>
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="eye"
+                      text="2,039"
+                    /> }
+                </FlexItem>
+                <FlexItem>
+                  { <IconValue
+                      icon="comments"
+                      text="89"
+                    /> }
+                </FlexItem>
+              </Flex>
+            </Card.Body>
+          </Card>
+          {/* END PLANET MONEY */}
+          {/* START WORLD CARD */}
+          <Card padding="none">
+            <Card.Header categoryColor={2}>
+              <Caption
+                  dark
+                  text="World"
+              />
+            </Card.Header>
+            <Card.Body padding="none">
+              <Image url="https://images.unsplash.com/photo-1500202352583-7b2fc394ed15?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" />
+              <Title
+                  paddingLeft="sm"
+                  paddingTop="sm"
+                  size={4}
+                  tag="h4"
+                  text="U.K. Willing To Admit 3 Million If China Adopts Security Law"
+              />
+              <SectionSeparator paddingY="sm" />
+              <Flex
+                  orientation="row"
+                  paddingBottom="sm"
+                  paddingX="sm"
+                  wrap
+              >
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="share-alt"
+                      text="304"
+                    /> }
+                </FlexItem>
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="eye"
+                      text="5,032"
+                    /> }
+                </FlexItem>
+                <FlexItem>
+                  { <IconValue
+                      icon="comments"
+                      text="102"
+                    /> }
+                </FlexItem>
+              </Flex>
+            </Card.Body>
+          </Card>
+          {/* END WORLD CARD */}
+          {/* START BOOKS CARD */}
+          <Card padding="none">
+            <Card.Header categoryColor={3}>
+              <Caption
+                  dark
+                  text="Books"
+              />
+            </Card.Header>
+            <Card.Body padding="none">
+              <Image url="https://images.unsplash.com/photo-1551269901-5c5e14c25df7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" />
+              <Title
+                  paddingLeft="sm"
+                  paddingTop="sm"
+                  size={4}
+                  tag="h4"
+                  text="Opinion: Harry Potter's Magic Fades When His Creator Tweets"
+              />
+              <SectionSeparator paddingY="sm" />
+              <Flex
+                  orientation="row"
+                  paddingBottom="sm"
+                  paddingX="sm"
+                  wrap
+              >
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="share-alt"
+                      text="201"
+                    /> }
+                </FlexItem>
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="eye"
+                      text="890"
+                    /> }
+                </FlexItem>
+                <FlexItem>
+                  { <IconValue
+                      icon="comments"
+                      text="2"
+                    /> }
+                </FlexItem>
+              </Flex>
+            </Card.Body>
+          </Card>
+          {/* END BOOKS CARD */}
+          {/* START NATIONAL CARD */}
+          <Card padding="none">
+            <Card.Header categoryColor={4}>
+              <Caption
+                  dark
+                  text="National"
+              />
+            </Card.Header>
+            <Card.Body padding="none">
+              <Image url="https://images.unsplash.com/photo-1451187580459-43490279c0fa?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1352&q=80" />
+              <Title
+                  paddingTop="sm"
+                  paddingX="sm"
+                  size={4}
+                  tag="h4"
+                  text="1st U.S. Woman To Walk In Space Dives To Deepest Point In Ocean"
+              />
+              <SectionSeparator paddingY="sm" />
+              <Flex
+                  orientation="row"
+                  paddingBottom="sm"
+                  paddingX="sm"
+                  wrap
+              >
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="share-alt"
+                      text="245"
+                    /> }
+                </FlexItem>
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="eye"
+                      text="10,302"
+                    /> }
+                </FlexItem>
+                <FlexItem>
+                  { <IconValue
+                      icon="comments"
+                      text="89"
+                    /> }
+                </FlexItem>
+              </Flex>
+            </Card.Body>
+          </Card>
+          {/* END NATIONAL CARD */}
+          {/* START BOOKS, NEWS, AND FEATURES CARD */}
+          <Card padding="none">
+            <Card.Header categoryColor={5}>
+              <Caption
+                  dark
+                  text="Books, News, and Features"
+              />
+            </Card.Header>
+            <Card.Body padding="none">
+              <Image url="https://images.unsplash.com/photo-1550751827-4bd374c3f58b?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80" />
+              <Title
+                  paddingLeft="sm"
+                  paddingTop="sm"
+                  size={4}
+                  tag="h4"
+                  text="Publishers Sue Internet Archive For Mass Copyright Infringement"
+              />
+              <SectionSeparator paddingY="sm" />
+              <Flex
+                  orientation="row"
+                  paddingBottom="sm"
+                  paddingX="sm"
+                  wrap
+              >
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="share-alt"
+                      text="84"
+                    /> }
+                </FlexItem>
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="eye"
+                      text="5,592"
+                    /> }
+                </FlexItem>
+                <FlexItem>
+                  { <IconValue
+                      icon="comments"
+                      text="104"
+                    /> }
+                </FlexItem>
+              </Flex>
+            </Card.Body>
+          </Card>
+          {/* END BOOKS, NEWS, AND FEATURES CARD */}
+          {/* START SCIENCE CARD */}
+          <Card padding="none">
+            <Card.Header categoryColor={6}>
+              <Caption
+                  dark
+                  text="Science"
+              />
+            </Card.Header>
+            <Card.Body padding="none">
+              <Image url="https://images.unsplash.com/photo-1558677949-260173506bbf?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1267&q=80" />
+              <Title
+                  paddingLeft="sm"
+                  paddingTop="sm"
+                  size={4}
+                  tag="h4"
+                  text="New Book Argues Migration Isn’t A Crisis — It’s The Solution"
+              />
+              <SectionSeparator paddingY="sm" />
+              <Flex
+                  orientation="row"
+                  paddingBottom="sm"
+                  paddingX="sm"
+                  wrap
+              >
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="share-alt"
+                      text="54"
+                    /> }
+                </FlexItem>
+                <FlexItem paddingRight="sm">
+                  { <IconValue
+                      icon="eye"
+                      text="3,982"
+                    /> }
+                </FlexItem>
+                <FlexItem>
+                  { <IconValue
+                      icon="comments"
+                      text="12"
+                    /> }
+                </FlexItem>
+              </Flex>
+            </Card.Body>
+          </Card>
+          {/* END SCIENCE CARD */}
 
-      </Layout.Body>
+        </Layout.Body>
 
-    </Layout>
+      </Layout>
+    </div>
+  )
+}
 
-  </div>
-)
 export default NewsMagazine

--- a/playbook/app/views/playbook/samples/news_magazine/index.jsx
+++ b/playbook/app/views/playbook/samples/news_magazine/index.jsx
@@ -141,7 +141,7 @@ const NewsMagazine = () => {
           {/* END PLANET MONEY */}
           {/* START WORLD CARD */}
           <Card padding="none">
-            <Card.Header categoryColor={2}>
+            <Card.Header headerColor="category_2">
               <Caption
                   dark
                   text="World"
@@ -187,7 +187,7 @@ const NewsMagazine = () => {
           {/* END WORLD CARD */}
           {/* START BOOKS CARD */}
           <Card padding="none">
-            <Card.Header categoryColor={3}>
+            <Card.Header headerColor="category_3">
               <Caption
                   dark
                   text="Books"
@@ -233,7 +233,7 @@ const NewsMagazine = () => {
           {/* END BOOKS CARD */}
           {/* START NATIONAL CARD */}
           <Card padding="none">
-            <Card.Header categoryColor={4}>
+            <Card.Header headerColor="category_4">
               <Caption
                   dark
                   text="National"
@@ -279,7 +279,7 @@ const NewsMagazine = () => {
           {/* END NATIONAL CARD */}
           {/* START BOOKS, NEWS, AND FEATURES CARD */}
           <Card padding="none">
-            <Card.Header categoryColor={5}>
+            <Card.Header headerColor="category_5">
               <Caption
                   dark
                   text="Books, News, and Features"
@@ -325,7 +325,7 @@ const NewsMagazine = () => {
           {/* END BOOKS, NEWS, AND FEATURES CARD */}
           {/* START SCIENCE CARD */}
           <Card padding="none">
-            <Card.Header categoryColor={6}>
+            <Card.Header headerColor="category_6">
               <Caption
                   dark
                   text="Science"

--- a/playbook/app/views/playbook/samples/news_magazine/index.jsx
+++ b/playbook/app/views/playbook/samples/news_magazine/index.jsx
@@ -95,7 +95,7 @@ const NewsMagazine = () => (
             />
           </Card.Header>
           <Card.Body padding="none">
-            <Image url="https://djenjyj46f9j9.cloudfront.net/items/292f0C2i3f2z2f2A0P0n/Screen%20Shot%202020-07-09%20at%201.23.31%20PM.png?X-CloudApp-Visitor-Id=3399053&v=ed16c3c4" />
+            <Image url="https://images.unsplash.com/photo-1561414927-6d86591d0c4f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1266&q=80" />
             <Title
                 paddingLeft="sm"
                 paddingTop="sm"
@@ -141,7 +141,7 @@ const NewsMagazine = () => (
             />
           </Card.Header>
           <Card.Body padding="none">
-            <Image url="https://djenjyj46f9j9.cloudfront.net/items/0n07340O0c3R0V0L1V0P/Screen%20Shot%202020-07-09%20at%201.41.26%20PM.png?X-CloudApp-Visitor-Id=3399053&v=b532b3f0" />
+            <Image url="https://images.unsplash.com/photo-1500202352583-7b2fc394ed15?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" />
             <Title
                 paddingLeft="sm"
                 paddingTop="sm"
@@ -187,7 +187,7 @@ const NewsMagazine = () => (
             />
           </Card.Header>
           <Card.Body padding="none">
-            <Image url="https://djenjyj46f9j9.cloudfront.net/items/1j2k1g3f2H2W2f1v3225/Screen%20Shot%202020-07-09%20at%201.42.32%20PM.png?X-CloudApp-Visitor-Id=3399053&v=2ab46cb6" />
+            <Image url="https://images.unsplash.com/photo-1551269901-5c5e14c25df7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80" />
             <Title
                 paddingLeft="sm"
                 paddingTop="sm"
@@ -233,7 +233,7 @@ const NewsMagazine = () => (
             />
           </Card.Header>
           <Card.Body padding="none">
-            <Image url="https://djenjyj46f9j9.cloudfront.net/items/2j0G2k3I0f3W3a2c2q3o/Screen%20Shot%202020-07-09%20at%201.43.40%20PM.png?X-CloudApp-Visitor-Id=3399053&v=d2667a0b" />
+            <Image url="https://images.unsplash.com/photo-1451187580459-43490279c0fa?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1352&q=80" />
             <Title
                 paddingTop="sm"
                 paddingX="sm"
@@ -279,7 +279,7 @@ const NewsMagazine = () => (
             />
           </Card.Header>
           <Card.Body padding="none">
-            <Image url="https://djenjyj46f9j9.cloudfront.net/items/0m353s3A3I3B0w3N3W2U/Screen%20Shot%202020-07-09%20at%201.44.30%20PM.png?X-CloudApp-Visitor-Id=3399053&v=5b24787c" />
+            <Image url="https://images.unsplash.com/photo-1550751827-4bd374c3f58b?ixlib=rb-1.2.1&auto=format&fit=crop&w=1350&q=80" />
             <Title
                 paddingLeft="sm"
                 paddingTop="sm"
@@ -325,7 +325,7 @@ const NewsMagazine = () => (
             />
           </Card.Header>
           <Card.Body padding="none">
-            <Image url="https://djenjyj46f9j9.cloudfront.net/items/0n1b1V1F4614343t3547/Screen%20Shot%202020-07-09%20at%201.45.26%20PM.png?X-CloudApp-Visitor-Id=3399053&v=a3cc4d20" />
+            <Image url="https://images.unsplash.com/photo-1558677949-260173506bbf?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1267&q=80" />
             <Title
                 paddingLeft="sm"
                 paddingTop="sm"


### PR DESCRIPTION
#### Screens
**Rails**
![Screen Shot 2020-11-18 at 10 15 54 AM](https://user-images.githubusercontent.com/64423490/99549022-3d422180-2987-11eb-8a7e-fc4c1a4321c8.png)

**React**
<img width="1779" alt="Screen Shot 2020-11-18 at 10 28 52 AM" src="https://user-images.githubusercontent.com/64423775/99550649-f05f4a80-2988-11eb-9a11-38974c19cdad.png">



#### Breaking Changes

No, we are fixing issues on the sample news magazine with Javascript.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-260

#### How to test this

Go into samples and select the news magazine example. Make sure to see the page loading with images and that the images fit the card body.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
