### PR TITLE
[NUXE-332] Input Margin Update

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -1,13 +1,10 @@
 /* @flow */
-import React from 'react'
-import classnames from 'classnames'
-import { Body, Caption } from '../'
-import { globalProps } from '../utilities/globalProps.js'
+import React from "react"
+import classnames from "classnames"
+import { Body, Caption } from "../"
+import { globalProps } from "../utilities/globalProps.js"
 
-import {
-  buildAriaProps,
-  buildDataProps,
-} from '../utilities/props'
+import { buildAriaProps, buildDataProps } from "../utilities/props"
 
 type TextInputProps = {
   aria?: object,
@@ -43,7 +40,7 @@ const TextInput = (props: TextInputProps) => {
     onChange = () => {},
     placeholder,
     required,
-    type = 'text',
+    type = "text",
     value,
     children = null,
   } = props
@@ -51,45 +48,36 @@ const TextInput = (props: TextInputProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const css = classnames([
-    'pb_text_input_kit',
-    error ? 'error' : null,
-    globalProps(props),
+    "pb_text_input_kit",
+    error ? "error" : null,
+    globalProps({
+      ...props,
+      marginBottom: props.marginBottom || props.margin || "sm",
+    }),
     className,
-    props.margin || props.marginBottom ? null : 'default_mb_sm',
   ])
 
   return (
-    <div
-        {...ariaProps}
-        {...dataProps}
-        className={css}
-    >
-      <Caption
-          className="pb_text_input_kit_label"
-          dark={dark}
-          text={label}
-      />
-      <div className="text_input_wrapper">
+    <div {...ariaProps} {...dataProps} className={css}>
+      <Caption className='pb_text_input_kit_label' dark={dark} text={label} />
+      <div className='text_input_wrapper'>
         <If condition={children}>
           {children}
           <Else />
           <input
-              {...props}
-              className="text_input"
-              disabled={disabled}
-              id={id}
-              name={name}
-              onChange={onChange}
-              placeholder={placeholder}
-              required={required}
-              type={type}
-              value={value}
+            {...props}
+            className='text_input'
+            disabled={disabled}
+            id={id}
+            name={name}
+            onChange={onChange}
+            placeholder={placeholder}
+            required={required}
+            type={type}
+            value={value}
           />
           <If condition={error}>
-            <Body
-                status="negative"
-                text={error}
-            />
+            <Body status='negative' text={error} />
           </If>
         </If>
       </div>

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -17,8 +17,10 @@ type TextInputProps = {
   disabled?: boolean,
   error?: string,
   id?: string,
-  name: string,
   label: string,
+  margin: string,
+  marginBottom: string,
+  name: string,
   onChange: (String) => void,
   placeholder: string,
   required?: boolean,
@@ -36,8 +38,8 @@ const TextInput = (props: TextInputProps) => {
     disabled,
     error,
     id,
-    name,
     label,
+    name,
     onChange = () => {},
     placeholder,
     required,
@@ -53,6 +55,7 @@ const TextInput = (props: TextInputProps) => {
     error ? 'error' : null,
     globalProps(props),
     className,
+    props.margin || props.marginBottom ? null : 'default_mb_sm',
   ])
 
   return (

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -1,10 +1,10 @@
 /* @flow */
-import React from "react"
-import classnames from "classnames"
-import { Body, Caption } from "../"
-import { globalProps } from "../utilities/globalProps.js"
+import React from 'react'
+import classnames from 'classnames'
+import { Body, Caption } from '../'
+import { globalProps } from '../utilities/globalProps.js'
 
-import { buildAriaProps, buildDataProps } from "../utilities/props"
+import { buildAriaProps, buildDataProps } from '../utilities/props'
 
 type TextInputProps = {
   aria?: object,
@@ -40,7 +40,7 @@ const TextInput = (props: TextInputProps) => {
     onChange = () => {},
     placeholder,
     required,
-    type = "text",
+    type = 'text',
     value,
     children = null,
   } = props
@@ -48,36 +48,47 @@ const TextInput = (props: TextInputProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const css = classnames([
-    "pb_text_input_kit",
-    error ? "error" : null,
+    'pb_text_input_kit',
+    error ? 'error' : null,
     globalProps({
       ...props,
-      marginBottom: props.marginBottom || props.margin || "sm",
+      marginBottom: props.marginBottom || props.margin || 'sm',
     }),
     className,
   ])
 
   return (
-    <div {...ariaProps} {...dataProps} className={css}>
-      <Caption className='pb_text_input_kit_label' dark={dark} text={label} />
-      <div className='text_input_wrapper'>
+    <div
+        {...ariaProps}
+        {...dataProps}
+        className={css}
+    >
+      <Caption
+          className="pb_text_input_kit_label"
+          dark={dark}
+          text={label}
+      />
+      <div className="text_input_wrapper">
         <If condition={children}>
           {children}
           <Else />
           <input
-            {...props}
-            className='text_input'
-            disabled={disabled}
-            id={id}
-            name={name}
-            onChange={onChange}
-            placeholder={placeholder}
-            required={required}
-            type={type}
-            value={value}
+              {...props}
+              className="text_input"
+              disabled={disabled}
+              id={id}
+              name={name}
+              onChange={onChange}
+              placeholder={placeholder}
+              required={required}
+              type={type}
+              value={value}
           />
           <If condition={error}>
-            <Body status='negative' text={error} />
+            <Body
+                status="negative"
+                text={error}
+            />
           </If>
         </If>
       </div>

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -34,10 +34,6 @@
     }
   }
 
-  &.default_mb_sm {
-    margin-bottom: $space_sm;
-  }
-
   &.dark {
     .text_input_wrapper {
       margin-bottom: 1rem;

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -10,7 +10,6 @@
   }
 
   .text_input_wrapper {
-    margin-bottom: $space_sm;
     display: block;
 
     input::placeholder,
@@ -33,6 +32,10 @@
       -webkit-box-shadow: 0 0 0px 1000px $focus_input_light inset;
       transition: background-color 5000s ease-in-out 0s;
     }
+  }
+
+  &.default_mb_sm {
+    margin-bottom: $space_sm;
   }
 
   &.dark {

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
@@ -4,7 +4,7 @@
   value: "Timothy Wenhold",
   data: { say: "hi", yell: "go" },
   aria: { something: "hello"},
-  id: "unique_id"
+  id: "unique_id",
 }) %>
 
 <%= pb_rails("text_input", props: {

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
@@ -4,7 +4,7 @@
   value: "Timothy Wenhold",
   data: { say: "hi", yell: "go" },
   aria: { something: "hello"},
-  id: "unique_id",
+  id: "unique_id"
 }) %>
 
 <%= pb_rails("text_input", props: {

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -23,7 +23,7 @@ module Playbook
       prop :value
 
       def classname
-        generate_classname("pb_text_input_kit") + error_class
+        generate_classname("pb_text_input_kit") + default_mb_sm + error_class
       end
 
       def validation_message
@@ -44,6 +44,11 @@ module Playbook
 
       def error_class
         error ? " error" : ""
+      end
+
+      def default_mb_sm
+        classname = generate_classname("pb_text_input_kit")
+        classname.include?("m_") || classname.include?("mb_") ? "" : " default_mb_sm"
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -23,7 +23,7 @@ module Playbook
       prop :value
 
       def classname
-        generate_classname("pb_text_input_kit") + default_mb_sm + error_class
+        generate_classname("pb_text_input_kit") + error_class
       end
 
       def validation_message
@@ -44,11 +44,6 @@ module Playbook
 
       def error_class
         error ? " error" : ""
-      end
-
-      def default_mb_sm
-        classname = generate_classname("pb_text_input_kit")
-        classname.include?("m_") || classname.include?("mb_") ? "" : " default_mb_sm"
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -23,7 +23,7 @@ module Playbook
       prop :value
 
       def classname
-        generate_classname("pb_text_input_kit") + error_class
+        generate_classname("pb_text_input_kit", text_input_margin_bottom, separator: " ") + error_class
       end
 
       def validation_message
@@ -38,6 +38,10 @@ module Playbook
         fields = {}
         fields[:message] = validation_message unless validation_message.blank?
         fields
+      end
+
+      def text_input_margin_bottom
+        margin.present? || margin_bottom.present? ? "" : "mb_sm"
       end
 
     private

--- a/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe Playbook::PbTextInput::TextInput do
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
-      expect(subject.new({}).classname).to eq "pb_text_input_kit default_mb_sm"
-      expect(subject.new(margin_bottom: "lg").classname).to eq "pb_text_input_kit mb_lg"
-      expect(subject.new(margin: "lg").classname).to eq "pb_text_input_kit m_lg"
-      expect(subject.new(classname: "additional_class").classname).to eq "pb_text_input_kit additional_class default_mb_sm"
-      expect(subject.new({dark:true}).classname).to eq "pb_text_input_kit dark default_mb_sm"
-      expect(subject.new({error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit default_mb_sm error"
-      expect(subject.new({dark: true, error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit dark default_mb_sm error"
+      expect(subject.new({}).classname).to eq "pb_text_input_kit mb_sm"
+      expect(subject.new(margin_bottom: "lg").classname).to eq "pb_text_input_kit  mb_lg"
+      expect(subject.new(margin: "lg").classname).to eq "pb_text_input_kit  m_lg"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_text_input_kit mb_sm additional_class"
+      expect(subject.new({dark:true}).classname).to eq "pb_text_input_kit mb_sm dark"
+      expect(subject.new({error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit mb_sm error"
+      expect(subject.new({dark: true, error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit mb_sm dark error"
     end
   end
 end

--- a/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
@@ -18,11 +18,13 @@ RSpec.describe Playbook::PbTextInput::TextInput do
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
-      expect(subject.new({}).classname).to eq "pb_text_input_kit"
-      expect(subject.new(classname: "additional_class").classname).to eq "pb_text_input_kit additional_class"
-      expect(subject.new({dark:true}).classname).to eq "pb_text_input_kit dark"
-      expect(subject.new({error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit error"
-      expect(subject.new({dark: true, error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit dark error"
+      expect(subject.new({}).classname).to eq "pb_text_input_kit default_mb_sm"
+      expect(subject.new(margin_bottom: "lg").classname).to eq "pb_text_input_kit mb_lg"
+      expect(subject.new(margin: "lg").classname).to eq "pb_text_input_kit m_lg"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_text_input_kit additional_class default_mb_sm"
+      expect(subject.new({dark:true}).classname).to eq "pb_text_input_kit dark default_mb_sm"
+      expect(subject.new({error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit default_mb_sm error"
+      expect(subject.new({dark: true, error: "Please enter a valid email"}).classname).to eq "pb_text_input_kit dark default_mb_sm error"
     end
   end
 end


### PR DESCRIPTION
#### Breaking Changes

No. The default `margin small` was removed from the `text_input_wrapper`, but added to the `pb_caption_kit` (by default). Visually, any existing implementations of the text input kit will remain the same. 

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-332

#### How to test this

The text input kit should have a small margin on the bottom by default. When a user specifies either `margin-bottom` or `margin` prop, the default `margin-bottom` is overridden.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
