### PR TITLE
Allow getOption[Label|Value] props in Typeahead

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
@@ -27,6 +27,8 @@ type Props = {
   async?: boolean,
   label?: string,
   loadOptions?: noop | string,
+  getOptionLabel?: () => any,
+  getOptionValue?: () => any,
   name?: string,
 }
 
@@ -38,7 +40,6 @@ type Props = {
 const Typeahead = (props: Props) => {
   const selectProps = {
     cacheOptions: true,
-    defaultOptions: true,
     components: {
       Control,
       ClearIndicator,
@@ -50,6 +51,7 @@ const Typeahead = (props: Props) => {
       Placeholder,
       ValueContainer,
     },
+    defaultOptions: true,
     id: 'react-select-input',
     isClearable: true,
     isSearchable: true,
@@ -58,6 +60,8 @@ const Typeahead = (props: Props) => {
   }
 
   if (typeof(props.loadOptions) === 'string') selectProps.loadOptions = get(window, props.loadOptions)
+  if (typeof(props.getOptionLabel) === 'string') selectProps.getOptionLabel = get(window, props.getOptionLabel)
+  if (typeof(props.getOptionValue) === 'string') selectProps.getOptionValue = get(window, props.getOptionValue)
 
   const Tag = props.async ? AsyncSelect : Select
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.jsx
@@ -10,7 +10,6 @@ import {
 const Option = (props: any) => {
   const {
     imageUrl,
-    label,
   } = props.data
 
   return (
@@ -21,12 +20,12 @@ const Option = (props: any) => {
             <User
                 align="left"
                 avatarUrl={imageUrl}
-                name={label}
+                name={props.label}
                 orientation="horizontal"
             />
           </When>
           <When condition={!imageUrl}>
-            {label}
+            {props.label}
           </When>
         </Choose>
       </div>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.html.erb
@@ -1,4 +1,13 @@
-<%= pb_rails("typeahead", props: { async: true, load_options: 'asyncPillsPromiseOptions', label: "Github Users", name: :foo, pills: true, placeholder: "type the name of a Github user" }) %>
+<%= pb_rails("typeahead", props: {
+  async: true,
+  get_option_label: 'getOptionLabel',
+  get_option_value: 'getOptionValue',
+  load_options: 'asyncPillsPromiseOptions',
+  label: "Github Users",
+  name: :foo,
+  pills: true,
+  placeholder: "type the name of a Github user"
+}) %>
 
 <!-- This section is an example of how to provide load_options prop for using dynamic options -->
 <%= javascript_tag defer: "defer" do %>
@@ -7,8 +16,8 @@
   const filterResults = function(results) {
     return results.items.map(function(result) {
       return {
-        label: result.login,
-        value: result.id,
+        name: result.login,
+        id: result.id,
       }
     })
   }
@@ -26,5 +35,12 @@
         resolve([])
       }
     })
+  }
+
+  window.getOptionLabel = function(option) {
+    return option.name;
+  }
+  window.getOptionValue = function(option) {
+    return option.id;
   }
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.jsx
@@ -20,8 +20,8 @@ import {
 const filterResults = (results) =>
   results.items.map((result) => {
     return {
-      label: result.login,
-      value: result.id,
+      name: result.login,
+      id: result.id,
     }
   })
 
@@ -71,6 +71,8 @@ const TypeaheadWithPillsAsync = () => {
       </If>
       <Typeahead
           async
+          getOptionLabel={(option) => option.name}
+          getOptionValue={(option) => option.id}
           isMulti
           label="Github Users"
           loadOptions={promiseOptions}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.md
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.md
@@ -4,8 +4,16 @@
 
 The prop `load_options`, when used in conjunction with `async: true` and `pills: true`, points to a JavaScript function located within the global window namespace. This function should return a `Promise` which resolves with the list of formatted options as described in prior examples above. This function is identical to the function provided to the React version of this kit. See the code example for more details.
 
-#### React: `loadOptions`
+#### React
+
+##### `loadOptions`
 
 **Additional required props: ** `async: true`
 
 [As outlined in the react-select Async docs](https://react-select.com/async), `loadOptions` expects to return a Promise that resolves resolves with the list of formatted options as described in prior examples above. See the code example for more details.
+
+##### `getOptionLabel` + `getOptionValue`
+
+If your server returns data that requires differing field names other than `label` and `value`
+
+See `react-select` docs for more information: https://react-select.com/advanced#replacing-builtins

--- a/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -8,6 +8,8 @@ module Playbook
       prop :async, type: Playbook::Props::Boolean,
                     default: false
       prop :default_options, type: Playbook::Props::HashArray, default: []
+      prop :get_option_label
+      prop :get_option_value
       prop :id
       prop :label
       prop :load_options
@@ -44,6 +46,9 @@ module Playbook
           options: options,
           placeholder: placeholder
         }
+
+        base_options.merge!({getOptionLabel: get_option_label}) if get_option_label.present?
+        base_options.merge!({getOptionValue: get_option_value}) if get_option_value.present?
 
         base_options.merge!({
           async: true,


### PR DESCRIPTION
Fixes #1242 

#### Screens

N/A

#### Breaking Changes

none

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-342

#### How to test this

See https://playbook.powerapp.cloud/kits/typeahead examples

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
