### PR TITLE
Remove unused methods from Playbook api

### DIFF
--- a/playbook/lib/playbook.rb
+++ b/playbook/lib/playbook.rb
@@ -10,22 +10,6 @@ module Playbook
   class ConflictingPropsError < StandardError; end
   class MissingPropError < StandardError; end
 
-  # @return [Boolean] indication of whether the request is a web view within Nitro Mobile
-  def self.web_page_within_mobile_app?(request)
-    request.user_agent.try(:downcase) =~ /^nitro/
-  end
-
-  # @return [String] the digest value for assets managed by the asset pipeline
-  def self.assets_digest
-    @assets_digest ||= begin
-      if ActionView::Base.respond_to?(:asset_manifest) # Rails 4
-        Digest::MD5.hexdigest(ActionView::Base.assets_manifest.assets.values.sort.join)
-      elsif Rails.configuration.assets.digests.present? # Rails 3
-        Digest::MD5.hexdigest(Rails.configuration.assets.digests.try(:values).sort.join)
-      end
-    end
-  end
-
   class << self
     def webpacker
       @webpacker ||= ::Webpacker::Instance.new(


### PR DESCRIPTION
Removes methods from the Playbook API which are not used.

#### Screens

No UI change

#### Breaking Changes

 No breaking changes

#### Runway Ticket URL

There's no Runway ticket, this work tracks back to the proposition of [RFC 0056](https://github.com/powerhome/rfcs/blob/master/0056-playbook-project-organization.md).

#### How to test this

Smoke testing the deployed playbook-docs

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
