### PR TITLE
Forward refs within Text Input, Radio, & Select React kits

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_radio/_radio.jsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/_radio.jsx
@@ -23,7 +23,7 @@ type RadioProps = {
   onChange: (Boolean)=>void,
 }
 
-const Radio = forwardRef(({
+const Radio = ({
   aria = {},
   children,
   className,
@@ -71,6 +71,6 @@ const Radio = forwardRef(({
       />
     </label>
   )
-})
+}
 
-export default Radio
+export default forwardRef(Radio)

--- a/playbook/app/pb_kits/playbook/pb_radio/_radio.jsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/_radio.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 /*eslint-disable react/no-multi-comp, flowtype/space-before-type-colon */
 
-import React from 'react'
+import React, { forwardRef } from 'react'
 import Body from '../pb_body/_body.jsx'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
@@ -23,7 +23,7 @@ type RadioProps = {
   onChange: (Boolean)=>void,
 }
 
-const Radio = ({
+const Radio = forwardRef(({
   aria = {},
   children,
   className,
@@ -37,7 +37,7 @@ const Radio = ({
   value = 'radio_text',
   onChange = () => {},
   ...props
-}: RadioProps) => {
+}: RadioProps, ref) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const classes = classnames(buildCss('pb_radio_kit'), { error }, { dark }, globalProps(props), className)
@@ -57,6 +57,7 @@ const Radio = ({
             id={id}
             name={name}
             onChange={onChange}
+            ref={ref}
             text={text}
             type="radio"
             value={value}
@@ -70,6 +71,6 @@ const Radio = ({
       />
     </label>
   )
-}
+})
 
 export default Radio

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_default.jsx
@@ -2,12 +2,15 @@ import React from 'react'
 import { Radio } from '../../'
 
 const RadioDefault = () => {
+  const ref = React.createRef()
+
   return (
     <div>
       <Radio
           defaultChecked
           label="Power"
           name="Group2"
+          ref={ref}
           value="Power"
       />
       <br />

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/index.js
@@ -1,2 +1,3 @@
 export { default as RadioDefault } from './_radio_default.jsx'
 export { default as RadioCustom } from './_radio_custom.jsx'
+export { default as RadioError } from './_radio_error.jsx'

--- a/playbook/app/pb_kits/playbook/pb_radio/radio.test.js
+++ b/playbook/app/pb_kits/playbook/pb_radio/radio.test.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import Radio from './_radio'
+
+const testId = 'radio1',
+  kitClass = 'pb_radio_kit'
+
+test('returns namespaced class name', () => {
+  render(
+    <Radio
+        data={{ testid: testId }}
+        defaultChecked
+        label="Power"
+        name="Group2"
+        value="Power"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(kitClass)
+})
+
+test('returns dark class name', () => {
+  render(
+    <Radio
+        data={{ testid: testId }}
+        dark
+        defaultChecked
+        label="Power"
+        name="Group2"
+        value="Power"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} dark`)
+})
+
+test('returns error class name', () => {
+  render(
+    <Radio
+        data={{ testid: testId }}
+        defaultChecked
+        error
+        label="Power"
+        name="Group2"
+        value="Power"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} error`)
+})
+
+test('returns dark + error class name', () => {
+  render(
+    <Radio
+        dark
+        data={{ testid: testId }}
+        defaultChecked
+        error
+        label="Power"
+        name="Group2"
+        value="Power"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} dark error`)
+})

--- a/playbook/app/pb_kits/playbook/pb_radio/radio.test.js
+++ b/playbook/app/pb_kits/playbook/pb_radio/radio.test.js
@@ -24,8 +24,8 @@ test('returns namespaced class name', () => {
 test('returns dark class name', () => {
   render(
     <Radio
-        data={{ testid: testId }}
         dark
+        data={{ testid: testId }}
         defaultChecked
         label="Power"
         name="Group2"

--- a/playbook/app/pb_kits/playbook/pb_select/_select.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.jsx
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React from 'react'
+import React, { forwardRef } from 'react'
 import classnames from 'classnames'
 import {
   Body,
@@ -69,7 +69,7 @@ const Select = ({
   required = false,
   value,
   ...props
-}: SelectProps) => {
+}: SelectProps, ref: React.ElementRef<"select">) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const optionsList = createOptions(options)
@@ -107,6 +107,7 @@ const Select = ({
               multiple={multiple}
               name={name}
               onChange={onChange}
+              ref={ref}
               required={required}
               value={value}
           >
@@ -132,4 +133,4 @@ const Select = ({
   )
 }
 
-export default Select
+export default forwardRef(Select)

--- a/playbook/app/pb_kits/playbook/pb_select/select.test.js
+++ b/playbook/app/pb_kits/playbook/pb_select/select.test.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import Select from './_select'
+
+const testId = 'select1',
+  kitClass = 'pb_select'
+
+const options = [
+  {
+    value: '1',
+    text: 'Burgers',
+  },
+  {
+    value: '2',
+    text: 'Pizza',
+  },
+  {
+    value: '3',
+    text: 'Tacos',
+  },
+]
+
+test('returns namespaced class name', () => {
+  render(
+    <Select
+        data={{ testid: testId }}
+        label="Favorite Food"
+        name="food"
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(kitClass)
+})
+
+test('returns dark class name', () => {
+  render(
+    <Select
+        dark
+        data={{ testid: testId }}
+        label="Favorite Food"
+        name="food"
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} dark`)
+})

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -1,5 +1,5 @@
 /* @flow */
-import React from 'react'
+import React, { forwardRef } from 'react'
 import classnames from 'classnames'
 import { Body, Caption } from '../'
 import { globalProps } from '../utilities/globalProps.js'
@@ -27,7 +27,10 @@ type TextInputProps = {
   children: Node,
 }
 
-const TextInput = (props: TextInputProps) => {
+const TextInput = (
+  props: TextInputProps,
+  ref: React.ElementRef<"input">
+) => {
   const {
     aria = {},
     className,
@@ -42,7 +45,7 @@ const TextInput = (props: TextInputProps) => {
     placeholder,
     required,
     type = 'text',
-    value,
+    value = '',
     children = null,
   } = props
 
@@ -78,6 +81,7 @@ const TextInput = (props: TextInputProps) => {
               name={name}
               onChange={onChange}
               placeholder={placeholder}
+              ref={ref}
               required={required}
               type={type}
               value={value}
@@ -94,4 +98,4 @@ const TextInput = (props: TextInputProps) => {
   )
 }
 
-export default TextInput
+export default forwardRef(TextInput)

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_description.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_description.md
@@ -1,1 +1,2 @@
-Area where user can enter small amount of text. Commonly used in forms.
+Area where user can enter small amount of text. Commonly used in forms.<br/>
+<strong>Note:</strong> This kit does not handle form validation logic.

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_custom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_custom.jsx
@@ -1,7 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { TextInput } from '../../'
 
 const TextInputCustom = () => {
+  const [name, setName] = useState('')
+  const handleUpdateName = ({ target }) => {
+    setName(target.value)
+  }
   return (
     <div>
       <TextInput
@@ -9,8 +13,10 @@ const TextInputCustom = () => {
       >
         <input
             name="custom-name"
+            onChange={handleUpdateName}
             placeholder="custom-placeholder"
             type="text"
+            value={name}
         />
       </TextInput>
     </div>

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
@@ -6,7 +6,7 @@ import {
 } from '../../'
 
 const TextInputDefault = () => {
-  const handleOnChangeFirstName = ({target}) => {
+  const handleOnChangeFirstName = ({ target }) => {
     setFirstName(target.value)
   }
   const ref = React.createRef()

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
@@ -1,75 +1,71 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   Caption,
   TextInput,
   Title,
 } from '../../'
 
-class TextInputDefault extends React.Component {
-  state = {
-    firstName: '',
+const TextInputDefault = () => {
+  const handleOnChangeFirstName = ({target}) => {
+    setFirstName(target.value)
   }
+  const ref = React.createRef()
 
-  render() {
-    const handleOnChange = ({ target }) => this.setState({ firstName: target.value })
+  const [firstName, setFirstName] = useState('')
 
-    const {
-      firstName,
-    } = this.state
+  return (
+    <div>
+      <TextInput
+          aria={{ label: 'hello' }}
+          data={{ say: 'hi', yell: 'go' }}
+          id="unique-id"
+          label="First Name"
+          placeholder="Enter first name"
+          value="Tim Wenhold"
+      />
+      <TextInput
+          label="Last Name"
+          placeholder="Enter last name"
+      />
+      <TextInput
+          label="Phone Number"
+          placeholder="Enter phone number"
+          type="phone"
+      />
+      <TextInput
+          label="Email Address"
+          placeholder="Enter email address"
+          type="email"
+      />
+      <TextInput
+          label="Zip Code"
+          placeholder="Enter zip code"
+          type="number"
+      />
 
-    return (
-      <div>
-        <TextInput
-            aria={{ label: 'hello' }}
-            data={{ say: 'hi', yell: 'go' }}
-            id="unique-id"
-            label="First Name"
-            placeholder="Enter first name"
-            value="Timothy Wenhold"
-        />
-        <TextInput
-            label="Last Name"
-            placeholder="Enter last name"
-        />
-        <TextInput
-            label="Phone Number"
-            placeholder="Enter phone number"
-            type="phone"
-        />
-        <TextInput
-            label="Email Address"
-            placeholder="Enter email address"
-            type="email"
-        />
-        <TextInput
-            label="Zip Code"
-            placeholder="Enter zip code"
-            type="number"
-        />
+      <br />
+      <br />
 
-        <br />
-        <br />
+      <Title>{'Event Handler Props'}</Title>
 
-        <Title>{'Event Handler Props'}</Title>
+      <br />
+      <Caption>{'onChange'}</Caption>
 
-        <br />
-        <Caption>{'onChange'}</Caption>
+      <br />
 
-        <br />
+      <TextInput
+          label="First Name"
+          onChange={handleOnChangeFirstName}
+          placeholder="Enter first name"
+          ref={ref}
+          value={firstName}
+      />
 
-        <TextInput
-            label="First Name"
-            onChange={handleOnChange}
-            placeholder="Enter first name"
-            value={firstName}
-        />
-
-        <If condition={firstName !== ''}>
-          {`First name is: ${firstName}`}
-        </If>
-      </div>
-    )
-  }
+      <If condition={firstName !== ''}>
+        {`First name is: ${firstName}`}
+      </If>
+    </div>
+  )
 }
 
 export default TextInputDefault

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
@@ -12,6 +12,18 @@ const TextInputDefault = () => {
   const ref = React.createRef()
 
   const [firstName, setFirstName] = useState('')
+  const [formFields, setFormFields] = useState({
+    firstName: 'Jane',
+    lastName: 'Doe',
+    phone: '8888888888',
+    email: 'jane@doe.com',
+    zip: 55555,
+  })
+
+  const handleOnChangeFormField =  ({ target }) => {
+    const { name, value } = target
+    setFormFields({ ...formFields, [name]: value })
+  }
 
   return (
     <div>
@@ -20,27 +32,41 @@ const TextInputDefault = () => {
           data={{ say: 'hi', yell: 'go' }}
           id="unique-id"
           label="First Name"
+          name="firstName"
+          onChange={handleOnChangeFormField}
           placeholder="Enter first name"
-          value="Tim Wenhold"
+          value={formFields.firstName}
       />
       <TextInput
           label="Last Name"
+          name="lastName"
+          onChange={handleOnChangeFormField}
           placeholder="Enter last name"
+          value={formFields.lastName}
       />
       <TextInput
           label="Phone Number"
+          name="phone"
+          onChange={handleOnChangeFormField}
           placeholder="Enter phone number"
           type="phone"
+          value={formFields.phone}
       />
       <TextInput
           label="Email Address"
+          name="email"
+          onChange={handleOnChangeFormField}
           placeholder="Enter email address"
           type="email"
+          value={formFields.email}
       />
       <TextInput
           label="Zip Code"
+          name="zip"
+          onChange={handleOnChangeFormField}
           placeholder="Enter zip code"
           type="number"
+          value={formFields.zip}
       />
 
       <br />

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.jsx
@@ -1,17 +1,25 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   TextInput,
 } from '../..'
 
-const TextInputError = () => (
-  <div>
-    <TextInput
-        error="Please enter a valid email address"
-        label="Email Address"
-        placeholder="Enter email address"
-        type="email"
-    />
-  </div>
-)
+const TextInputError = () => {
+  const [email, setEmail] = useState('')
 
+  const handleUpdateEmail = ({ target }) => {
+    setEmail(target.value)
+  }
+  return (
+    <div>
+      <TextInput
+          error="Please enter a valid email address"
+          label="Email Address"
+          onChange={handleUpdateEmail}
+          placeholder="Enter email address"
+          type="email"
+          value={email}
+      />
+    </div>
+  )
+}
 export default TextInputError

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.test.js
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.test.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import TextInput from './_text_input'
+
+const testId = 'text-input1',
+  kitClass = 'pb_text_input_kit'
+
+test('returns namespaced class name', () => {
+  render(
+    <TextInput
+        data={{ testid: testId }}
+        label="First Name"
+        placeholder="Enter first name"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(kitClass)
+})
+
+test('returns additional class name', () => {
+  render(
+    <TextInput
+        className="additional_class"
+        data={{ testid: testId }}
+        label="First Name"
+        placeholder="Enter first name"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} additional_class`)
+})
+
+test('returns additional class name', () => {
+  render(
+    <TextInput
+        dark
+        data={{ testid: testId }}
+        label="First Name"
+        placeholder="Enter first name"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} dark`)
+})
+
+test('returns additional class name', () => {
+  render(
+    <TextInput
+        data={{ testid: testId }}
+        error="Please enter a valid email"
+        label="First Name"
+        placeholder="Enter first name"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} error`)
+})
+
+test('returns additional class name', () => {
+  render(
+    <TextInput
+        dark
+        data={{ testid: testId }}
+        error="Please enter a valid email"
+        label="First Name"
+        placeholder="Enter first name"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} dark error`)
+})

--- a/playbook/app/pb_kits/playbook/pb_textarea/_textarea.jsx
+++ b/playbook/app/pb_kits/playbook/pb_textarea/_textarea.jsx
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React from 'react'
+import React, { forwardRef } from 'react'
 import classnames from 'classnames'
 import { Body, Caption } from '../'
 import type { InputCallback } from '../types.js'
@@ -9,7 +9,6 @@ import { globalProps } from '../utilities/globalProps.js'
 type TextareaProps = {
   className?: string,
   children?: array<React.ReactChild>,
-  data?: string,
   disabled?: boolean,
   error?: string,
   id?: string,
@@ -39,7 +38,7 @@ const Textarea = ({
   rows = 4,
   value,
   ...props
-}: TextareaProps) => {
+}: TextareaProps, ref: React.ElementRef<"textarea">) => {
   const errorClass = error ? 'error' : null
   const resizeClass = `resize_${resize}`
   const classes = classnames('pb_textarea_kit', errorClass, resizeClass, globalProps(props), className)
@@ -53,15 +52,16 @@ const Textarea = ({
         {children}
         <Else />
         <textarea
-            {...props}
             className="pb_textarea_kit"
             disabled={disabled}
             name={name}
             onChange={onChange}
             placeholder={placeholder}
+            ref={ref}
             required={required}
             rows={rows}
             value={value}
+            {...props}
         />
         <If condition={error}>
           <Body
@@ -74,4 +74,4 @@ const Textarea = ({
   )
 }
 
-export default Textarea
+export default forwardRef(Textarea)


### PR DESCRIPTION
1. Adds `React.forwardRef` implementation to Text Input React kit 
2. Adds basic test coverage (matching Rails kit) to Text Input kit

#### Screens

N/A

#### Breaking Changes

none

#### Runway Ticket URL

- Forward Ref: https://nitro.powerhrg.com/runway/backlog_items/NUXE-303
- Test Coverage: https://nitro.powerhrg.com/runway/backlog_items/NUXE-326

#### How to test this

- See Playbook website #1 example for `ref` prop. 
- Ensure that no JavaScript errors occur in website example 
- Ensure CI goes green + `yarn run test` locally

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
