### PR TITLE
Improve consistency of the react filter kit sort icon to match rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_filter/Filter/SortMenu.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/Filter/SortMenu.jsx
@@ -27,7 +27,6 @@ const renderOptions = (options: SortOptions, value: SortValue[], handleChange: (
     return (
       <ListItem key={`option-${next.name}-${next.dir}`}>
         <Button
-            icon={directionIcon(next.dir)}
             onClick={partial(handleChange, next)}
             text={` ${label}`}
             variant="link"
@@ -60,11 +59,11 @@ const SortMenu = ({ dark, options, value, onChange }: SortMenuProps) => {
     >
       {map(value, ({ dir, name }) => (
         <span key={`current-sort-${name}-${dir}`}>
+          {` ${options[name]}`}
           <Icon
               dark={dark}
               icon={directionIcon(dir)}
           />
-          {` ${options[name]}`}
         </span>
       ))}
     </Button>


### PR DESCRIPTION
#### Screens
## Move sort icon to the right of the text and remove icons from drop down on React
![Screen Shot 2020-12-14 at 1 11 47 PM](https://user-images.githubusercontent.com/63466080/102232813-92f1e700-3ebd-11eb-9c33-8f7d2db65e07.png)

#### Breaking Changes

No

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-299

#### How to test this

Sort menu on React of look the same as the Rails implementation. Icon on the right of the sort button and no icons in the drop down. 

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
