### PR TITLE
Improve navigation overflow for mobile

### DIFF
--- a/playbook/app/pb_kits/playbook/packs/site_styles/_scaffold.scss
+++ b/playbook/app/pb_kits/playbook/packs/site_styles/_scaffold.scss
@@ -15,6 +15,7 @@
 html {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   height: 100vh;
+  overflow-x: hidden;
 }
 
 body {

--- a/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
+++ b/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
@@ -9,6 +9,7 @@ $nav_breakpoint: breakpoint("lg");
 
 body {
   overflow-x: hidden;
+  position: relative;
 }
 
 .pb--page {
@@ -111,7 +112,7 @@ body {
       @include break_at($nav_breakpoint) {
         position: absolute;
         transform-origin: 0% 0%;
-        transform: translate(100%, 0);
+        transform: translate(110%, 0);
         transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
         border-radius: $border_rad_heavier;
         box-shadow: $shadow_deepest;


### PR DESCRIPTION
#### Screens

![image](https://user-images.githubusercontent.com/863031/102244003-69d35580-3ec1-11eb-82ac-d2f7661a4d47.png)

#### Breaking Changes

Nope, style for doc site only

#### Runway Ticket URL

NA

#### How to test this

Try this out in Milano on Mobile

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
