### PR TITLE
Add deprecation back

### DIFF
--- a/playbook/lib/playbook/props/base.rb
+++ b/playbook/lib/playbook/props/base.rb
@@ -5,10 +5,11 @@ module Playbook
     class Error < StandardError; end
 
     class Base
-      attr_reader :default, :required, :name, :kit
+      attr_reader :default, :deprecated, :required, :name, :kit
 
-      def initialize(default: nil, required: false, name:, kit:)
+      def initialize(default: nil, deprecated: false, required: false, name:, kit:)
         @default = default
+        @deprecated = deprecated
         @required = required
         @name = name
         @kit = kit
@@ -19,6 +20,8 @@ module Playbook
       end
 
       def validate!(input_value)
+        warn("#{kit} Kit: The prop '#{name}' is deprecated and will be removed in a future release!") if deprecated #TODO: add some color for pop
+
         raise(Playbook::Props::Error, "#{kit} prop '#{name}' of type #{inspect.class} is required and needs a value") if required && input_value.nil?
 
         validate(value(input_value)) ||
@@ -27,6 +30,19 @@ module Playbook
 
       def validate(_value)
         true
+      end
+
+    private
+
+      def warn(message)
+        log("Prop Warning: #{message}")
+      end
+
+      def log(message)
+        logger = ActiveSupport::Logger.new(STDOUT)
+        log_formatter = ::Logger::Formatter.new
+        @logger ||= ActiveSupport::TaggedLogging.new(logger)
+        @logger.log(0, message)
       end
     end
   end


### PR DESCRIPTION
Adds the ruby work from https://github.com/powerhome/playbook/pull/1203 back. It was removed by accident during `7.7.0` or some time after. 