### PR TITLE
Fix snoggle margin, homepage hero background color

### DIFF
--- a/playbook/app/pb_kits/playbook/packs/site_styles/_landing-page.scss
+++ b/playbook/app/pb_kits/playbook/packs/site_styles/_landing-page.scss
@@ -14,6 +14,9 @@
   .hero-text-width {
     max-width: 500px;
   }
+  .homepage-hero {
+    background-color: $bg_dark;
+  }
   .kit-example {
     max-width: 800px;
     position: relative;
@@ -38,13 +41,9 @@
     position: absolute;
     left: 505px;
   }
-  @include break_at(1319px){
+  @include break_at(1342px){
     .kit-example {
       margin-top: $space_xl * 2;
-    }
-    .react-rails-text {
-      max-width: 625px;
-      margin-right: 0;
     }
   }
   // Mobile overrides

--- a/playbook/app/views/playbook/pages/home.html.erb
+++ b/playbook/app/views/playbook/pages/home.html.erb
@@ -1,5 +1,5 @@
 <div class="landing-page">
-  <%= pb_rails("background", props: { image_url: image_url("landing-background.svg"), padding: "xl" }) do %>
+  <%= pb_rails("background", props: { classname: "homepage-hero", image_url: image_url("landing-background.svg"), padding: "xl" }) do %>
     <%= pb_rails("flex", props: { classname: "flex-container hero-inner-wrapper", horizontal: "center", wrap: true } ) do %>
       <div class="flex-item">
         <%= image_tag("landing-image.svg", class: "pb-hero-image") %>


### PR DESCRIPTION
#### What does this PR do?

1. Adjusts a media query applied margin to account for the snoggle's new fixed width.
2. Adds background color `$bg_dark` to the homepage hero to make text readable when background image is slow or fails to load.

#### Screens

<img width="239" alt="hero_bg_color" src="https://p-a6FbDk.t4.n0.cdn.getcloudapp.com/items/v1u4OK4O/hero_bg_color.png?v=13e876f83d5284c5d02128e40f7c599a">
<br />
<img width="522" alt="snoggle_margin" src="https://p-a6FbDk.t4.n0.cdn.getcloudapp.com/items/qGulOAXv/snoggle_margin.png?v=113f350621b16fab8d51339d2bc48c20">


#### Breaking Changes

n/a

#### Runway Ticket URL

[Link to Runway Story](https://nitro.powerhrg.com/runway/backlog_items/NUXE-369)

#### How to test this

Checkout homepage.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
