### PR TITLE
Fixes genrator error

### DIFF
--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "sassc-rails"
+require "slim-rails"
 
 module Playbook
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Reopened after reverting. We need to confirm this is not affecting Nitro. For example, slim rails is not used in Nitro so requiring it here might have unexpected problems.

#### Screens

![body](https://user-images.githubusercontent.com/20051541/102920004-db7a4900-4457-11eb-92f2-df4cf2f0a22a.png)


#### Breaking Changes

fixes broken generator kit from [this darkmode pr](https://github.com/powerhome/playbook/pull/1238/files#)

#### Runway Ticket URL

[NUXE-378](https://nitro.powerhrg.com/runway/backlog_items/NUXE-378)

#### How to test this

Run the kit generator command, possibly check dark-mode on some kits?
