### PR TITLE
Add mobile search

### DIFF
--- a/playbook/app/pb_kits/playbook/docs_components/KitSearch.jsx
+++ b/playbook/app/pb_kits/playbook/docs_components/KitSearch.jsx
@@ -4,29 +4,37 @@ import React, { useEffect } from 'react'
 import { Typeahead } from '../'
 
 type SearchProps = {
+  classname: String,
   kits: Array,
+  id: String,
 }
 const KitSearch = (props: SearchProps) => {
-  const { kits } = props
+  const {
+    classname = 'kit-search',
+    id = 'kit-search',
+    kits,
+  } = props
 
   const handleChange = (selection) => {
     window.location = selection.value
   }
 
-  useEffect(() => {
-    window.addEventListener('keydown', (e) => {
-      if (e.ctrlKey && e.key === 'k') {
-        const kitSearch = document.querySelector('#kit-search #react-select-2-input')
-        kitSearch === document.activeElement ? kitSearch.blur() : kitSearch.focus()
-      }
+  if (id === 'kit-search') {
+    useEffect(() => {
+      window.addEventListener('keydown', (e) => {
+        if (e.ctrlKey && e.key === 'k') {
+          const kitSearch = document.querySelector('#kit-search #react-select-2-input')
+          kitSearch === document.activeElement ? kitSearch.blur() : kitSearch.focus()
+        }
+      })
     })
-  })
+  }
 
   return (
     <div>
       <Typeahead
-          className="kit-search"
-          id="kit-search"
+          className={classname}
+          id={id}
           onChange={handleChange}
           options={kits}
           placeholder="Search"

--- a/playbook/app/pb_kits/playbook/docs_components/KitSearch.jsx
+++ b/playbook/app/pb_kits/playbook/docs_components/KitSearch.jsx
@@ -10,20 +10,22 @@ type SearchProps = {
 }
 const KitSearch = (props: SearchProps) => {
   const {
-    classname = 'kit-search',
-    id = 'kit-search',
+    classname,
+    id,
     kits,
   } = props
 
   const handleChange = (selection) => {
-    window.location = selection.value
+    if (selection) {
+      window.location = selection.value
+    }
   }
 
-  if (id === 'kit-search') {
+  if (id === 'desktop-kit-search') {
     useEffect(() => {
       window.addEventListener('keydown', (e) => {
         if (e.ctrlKey && e.key === 'k') {
-          const kitSearch = document.querySelector('#kit-search #react-select-2-input')
+          const kitSearch = document.querySelector('#desktop-kit-search #react-select-2-input')
           kitSearch === document.activeElement ? kitSearch.blur() : kitSearch.focus()
         }
       })
@@ -37,7 +39,7 @@ const KitSearch = (props: SearchProps) => {
           id={id}
           onChange={handleChange}
           options={kits}
-          placeholder="Search"
+          placeholder="Search..."
       />
     </div>
   )

--- a/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
+++ b/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
@@ -10,6 +10,9 @@ $nav_breakpoint: breakpoint("lg");
 body {
   overflow-x: hidden;
   position: relative;
+  &.kits {
+    overflow-y: hidden;
+  }
 }
 
 .pb--page {
@@ -62,9 +65,6 @@ body {
     @include break_at(breakpoint("sm")) {
       .kit-search, .separator-explicit-height {
         display: none;
-      }
-      .mobile-kit-search {
-        display: block;
       }
     }
     @include break_at(375px) {
@@ -124,7 +124,6 @@ body {
         box-shadow: $shadow_deepest;
         top: 100px;
         right: 0;
-        width: auto !important;
         z-index: 1000;
       }
     }
@@ -185,7 +184,15 @@ body {
       }
     }
     &[class*=dark]{
-      border-color:$border_dark;
+      border-color: $border_dark;
+    }
+    .mobile-search-wrapper {
+      border-bottom: $border_light 1px solid;
+      display: none;
+      padding: $space_sm $space_sm $space_xs $space_sm;
+    }
+    .mobile-kit-search {
+      width: 210px;
     }
     .mobile-sidebar-pages {
       display: none;
@@ -195,11 +202,16 @@ body {
         display: block;
       }
     }
+    @include break_at(breakpoint("sm")) {
+      .mobile-search-wrapper {
+        display: block;
+      }
+    }
   }
 }
 #toggle-modes{
-    display: flex;
-    margin-right: 80px;
+  display: flex;
+  margin-right: 80px;
 }
 // Nav Tabs switch between Rails and React
 .pb--kit-type-nav {

--- a/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
+++ b/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
@@ -30,7 +30,7 @@ body {
     &.dark{
     background: tint(#0a0527, 10);
     }
-    .kit-search {
+    .desktop-kit-search {
       width: 33vw;
       max-width: 300px;
       [class*=_label] {
@@ -63,8 +63,11 @@ body {
       }
     }
     @include break_at(breakpoint("sm")) {
-      .kit-search, .separator-explicit-height {
+      .desktop-kit-search, .separator-explicit-height {
         display: none;
+      }
+      .mobile-kit-search {
+        display: block;
       }
     }
     @include break_at(375px) {
@@ -124,6 +127,7 @@ body {
         box-shadow: $shadow_deepest;
         top: 100px;
         right: 0;
+        width: auto !important;
         z-index: 1000;
       }
     }
@@ -186,24 +190,11 @@ body {
     &[class*=dark]{
       border-color: $border_dark;
     }
-    .mobile-search-wrapper {
-      border-bottom: $border_light 1px solid;
-      display: none;
-      padding: $space_sm $space_sm $space_xs $space_sm;
-    }
-    .mobile-kit-search {
-      width: 210px;
-    }
     .mobile-sidebar-pages {
       display: none;
     }
     @include break_at($nav_breakpoint) {
       .mobile-sidebar-pages {
-        display: block;
-      }
-    }
-    @include break_at(breakpoint("sm")) {
-      .mobile-search-wrapper {
         display: block;
       }
     }

--- a/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
+++ b/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
@@ -37,6 +37,9 @@ body {
         margin-bottom: 0 !important;
       }
     }
+    .mobile-kit-search {
+      display: none;
+    }
     .pb-version-tag {
       text-align: right;
       position: relative;
@@ -59,6 +62,9 @@ body {
     @include break_at(breakpoint("sm")) {
       .kit-search, .separator-explicit-height {
         display: none;
+      }
+      .mobile-kit-search {
+        display: block;
       }
     }
     @include break_at(375px) {

--- a/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
+++ b/playbook/app/pb_kits/playbook/packs/site_styles/_site-style.scss
@@ -127,6 +127,7 @@ body {
         box-shadow: $shadow_deepest;
         top: 100px;
         right: 0;
+        min-width: 200px;
         width: auto !important;
         z-index: 1000;
       }

--- a/playbook/app/views/layouts/playbook/_nav.html.erb
+++ b/playbook/app/views/layouts/playbook/_nav.html.erb
@@ -30,7 +30,7 @@
             <%= pb_rails("nav", props: { margin_right: "sm", orientation: "horizontal", variant: "subtle"}) do %>
               <%= pb_rails("nav/item", props: { active: current_page?('/visual_guidelines'), text: "Design", link: "/visual_guidelines" }) %>
               <%= pb_rails("nav/item", props: { active: action_name.include?('kit'), text: "Components", link: "/kits" }) %>
-              <%= pb_rails("nav/item", props: { active: current_page?('/samples'), text: "Samples", link: "/samples" }) %>
+              <%= pb_rails("nav/item", props: { active: action_name.include?('sample'), text: "Samples", link: "/samples" }) %>
             <% end %>
           </div>
         <% end %>

--- a/playbook/app/views/layouts/playbook/_nav.html.erb
+++ b/playbook/app/views/layouts/playbook/_nav.html.erb
@@ -17,7 +17,7 @@
         <% end %>
 
         <%= pb_rails("flex/flex_item", props: {}) do %>
-          <%= react_component("KitSearch", kits: search_list()) %>
+          <%= react_component("KitSearch", classname: "desktop-kit-search", id: "desktop-kit-search", kits: search_list()) %>
         <% end %>
       <% end %>
     <% end %>
@@ -54,6 +54,7 @@
       <% end %>
     <% end %>
   <% end %>
+  <%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
 </div>
 
 <%= pb_rails("section_separator")%>

--- a/playbook/app/views/layouts/playbook/_nav.html.erb
+++ b/playbook/app/views/layouts/playbook/_nav.html.erb
@@ -54,6 +54,9 @@
       <% end %>
     <% end %>
   <% end %>
+
+  <%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
+
 </div>
 
 <%= pb_rails("section_separator")%>

--- a/playbook/app/views/layouts/playbook/_nav.html.erb
+++ b/playbook/app/views/layouts/playbook/_nav.html.erb
@@ -54,7 +54,6 @@
       <% end %>
     <% end %>
   <% end %>
-
 </div>
 
 <%= pb_rails("section_separator")%>

--- a/playbook/app/views/layouts/playbook/_nav.html.erb
+++ b/playbook/app/views/layouts/playbook/_nav.html.erb
@@ -55,8 +55,6 @@
     <% end %>
   <% end %>
 
-  <%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
-
 </div>
 
 <%= pb_rails("section_separator")%>

--- a/playbook/app/views/layouts/playbook/_sidebar.html.erb
+++ b/playbook/app/views/layouts/playbook/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <div class="mobile-search-wrapper">
-<%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
+  <%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
 </div>
 
 <div class="mobile-sidebar-pages">

--- a/playbook/app/views/layouts/playbook/_sidebar.html.erb
+++ b/playbook/app/views/layouts/playbook/_sidebar.html.erb
@@ -1,3 +1,7 @@
+<div class="mobile-search-wrapper">
+<%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
+</div>
+
 <div class="mobile-sidebar-pages">
   <%= pb_rails("nav", props: { title: "Pages", link: "/", padding_y: "sm", variant: "subtle" }) do %>
     <%= pb_rails("nav/item", props: { active: current_page?("/getting_started"), text: "Getting Started", link: "/getting_started" }) %>

--- a/playbook/app/views/layouts/playbook/_sidebar.html.erb
+++ b/playbook/app/views/layouts/playbook/_sidebar.html.erb
@@ -3,7 +3,7 @@
     <%= pb_rails("nav/item", props: { active: current_page?("/getting_started"), text: "Getting Started", link: "/getting_started" }) %>
     <%= pb_rails("nav/item", props: { active: current_page?('/visual_guidelines'), text: "Design", link: "/visual_guidelines" }) %>
     <%= pb_rails("nav/item", props: { active: action_name.include?('kit'), text: "Components", link: "/kits" }) %>
-    <%= pb_rails("nav/item", props: { active: current_page?('/samples'), text: "Samples", link: "/samples" }) %>
+    <%= pb_rails("nav/item", props: { active: action_name.include?('sample'), text: "Samples", link: "/samples" }) %>
   <% end %>
 
   <%= pb_rails("section_separator") %>

--- a/playbook/app/views/layouts/playbook/_sidebar.html.erb
+++ b/playbook/app/views/layouts/playbook/_sidebar.html.erb
@@ -1,7 +1,3 @@
-<div class="mobile-search-wrapper">
-  <%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
-</div>
-
 <div class="mobile-sidebar-pages">
   <%= pb_rails("nav", props: { title: "Pages", link: "/", padding_y: "sm", variant: "subtle" }) do %>
     <%= pb_rails("nav/item", props: { active: current_page?("/getting_started"), text: "Getting Started", link: "/getting_started" }) %>

--- a/playbook/app/views/layouts/playbook/_sidebar.html.erb
+++ b/playbook/app/views/layouts/playbook/_sidebar.html.erb
@@ -1,8 +1,8 @@
 <div class="mobile-sidebar-pages">
   <%= pb_rails("nav", props: { title: "Pages", link: "/", padding_y: "sm", variant: "subtle" }) do %>
     <%= pb_rails("nav/item", props: { active: current_page?("/getting_started"), text: "Getting Started", link: "/getting_started" }) %>
-    <%= pb_rails("nav/item", props: { active: current_page?('/visual_guidelines'), text: "Visual Guidelines", link: "/visual_guidelines" }) %>
-    <%= pb_rails("nav/item", props: { active: action_name.include?('kit'), text: "Design Components", link: "/kits" }) %>
+    <%= pb_rails("nav/item", props: { active: current_page?('/visual_guidelines'), text: "Design", link: "/visual_guidelines" }) %>
+    <%= pb_rails("nav/item", props: { active: action_name.include?('kit'), text: "Components", link: "/kits" }) %>
     <%= pb_rails("nav/item", props: { active: current_page?('/samples'), text: "Samples", link: "/samples" }) %>
   <% end %>
 

--- a/playbook/app/views/layouts/playbook/kits.html.erb
+++ b/playbook/app/views/layouts/playbook/kits.html.erb
@@ -7,7 +7,7 @@
     <%= stylesheet_packs_with_chunks_tag 'main' %>
     <meta content="user-scalable=0, initial-scale=1.0, minimum-scale=1" name="viewport"></meta>
   </head>
-  <body>
+  <body class="kits">
     <%= render 'layouts/playbook/nav' %>
     <%= pb_rails("layout", props: {classname: "pb--page--content",variant: cookies[:dark_mode] == "true" ? 'dark' : 'light' }) do%>
       <%= render 'layouts/playbook/mobile_hamburger' %>

--- a/playbook/app/views/playbook/pages/visual_guidelines.html.erb
+++ b/playbook/app/views/playbook/pages/visual_guidelines.html.erb
@@ -2,9 +2,9 @@
   <%= pb_rails("background", props: { background_color: "dark", padding: "xl" }) do %>
     <%= pb_rails("flex", props: { classname: "header-text", orientation: "column", horizontal: "center"}) do %>
         <div>
-          <%= pb_rails("title", props: { dark: true, margin_bottom: "lg", text: "Our Visual Langauge", tag: "h1", size: 1 }) %>
+          <%= pb_rails("title", props: { classname: "dark", margin_bottom: "lg", text: "Our Visual Langauge", tag: "h1", size: 1 }) %>
           <%= pb_rails("body", props: {
-            dark: true,
+            classname: "dark",
             text: "This page outlines the guiding principles that inform Playbook Design System's past, present, and future development.  
             These core concepts are the basis upon which every higher order design element is built.  Some of these principles have 
             been abstracted into sass variables listed below."

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "sassc-rails"
+require "slim-rails"
 
 module Playbook
   class Engine < ::Rails::Engine

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require "sassc-rails"
-require "slim-rails"
 
 module Playbook
   class Engine < ::Rails::Engine


### PR DESCRIPTION
#### What does this PR do?

1. Adds search to mobile screen sizes.
2. Fixes extra scroll bar on kit pages (`body.kits { scroll-y: hidden; }`).
3. Fixes small bug in KitSearch by adding null value handling.
4. Fixes dark text issue on Visual Guidelines page.
5. Unifies top nav and side bar page links.

#### Screens

<img width="500px" src="https://p-a6FbDk.t4.n0.cdn.getcloudapp.com/items/OAuWZ5W4/32b1486d-d160-433b-8744-f2c597d67732.png?v=f5a29201110f99a6aec16cea683eef0c" />

#### Breaking Changes

n/a

#### Runway Ticket URL

[Link to Runway Story](https://nitro.powerhrg.com/runway/backlog_items/NUXE-346)

#### How to test this

Test out mobile search in Milano deploy.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
