### PR TITLE
[NUXE-315] UX - KIT DEV - Remove extra Margin from selectable cards

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -12,6 +12,7 @@ $pb_selectable_card_border: 2px;
 
 [class^=pb_selectable_card_kit] {
   display: block;
+  margin-bottom: 0;
 
   label {
     @include pb_card;

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "sassc-rails"
+require "slim-rails"
 
 module Playbook
   class Engine < ::Rails::Engine

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require "sassc-rails"
-require "slim-rails"
 
 module Playbook
   class Engine < ::Rails::Engine


### PR DESCRIPTION
#### Screens

<img width="581" alt="Screen Shot 2021-01-05 at 3 16 44 PM" src="https://user-images.githubusercontent.com/64423298/103694494-0b057700-4f69-11eb-926c-b5670d5d9f16.png">

#### Breaking Changes
No 

#### Runway Ticket URL

[Runway URL](https://nitro.powerhrg.com/runway/backlog_items/NUXE-315)

#### How to test this

No tests

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
