### PR TITLE
[NUXE-367] Fix typeahead cursor position (REACT)

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
@@ -100,7 +100,16 @@
       }
       &_value_container {
         flex-grow: 1;
+        position: relative;
       }
+    }
+    .placeholder {
+      position: absolute;
+      margin-right: 2px;
+      margin-left: 2px;
+      top: 50%;
+      transform: translateY(-50%);
+      box-sizing: border-box;
     }
   }
 }

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "sassc-rails"
+require "slim-rails"
 
 module Playbook
   class Engine < ::Rails::Engine

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require "sassc-rails"
-require "slim-rails"
 
 module Playbook
   class Engine < ::Rails::Engine


### PR DESCRIPTION
#### Screens
<img width="964" alt="Screen Shot 2021-01-06 at 10 05 58 AM" src="https://user-images.githubusercontent.com/64423298/103783603-efe94480-5006-11eb-92cd-09b142e8f54f.png">

#### Breaking Changes
No 

#### Runway Ticket URL
[Runway URL](https://nitro.powerhrg.com/runway/backlog_items/NUXE-367)

#### How to test this

No tests

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
