### PR TITLE
[NUXE-308] Set Overflow to be Auto on the Card Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.scss
@@ -3,6 +3,7 @@
 
 [class^=pb_card_kit] {
   @include pb_card;
+  overflow: auto;
 
   &[class*=_selected] {
     @include pb_card_selected;
@@ -26,7 +27,7 @@
     flex-basis: auto;
     min-height: 1px;
     border: 0;
-    border-radius: $pb_card_header_border_radius $pb_card_header_border_radius 0px 0px;  
+    border-radius: $pb_card_header_border_radius $pb_card_header_border_radius 0px 0px;
     @each $color_name, $color_value in $pb_card_header_colors {
       &[class*=_#{$color_name}] {
         @include pb_card_header_color($color_value);
@@ -41,7 +42,7 @@
     min-height: 1px;
     border: 0;
   }
-  
+
   @each $name, $shadow in $box_shadows {
     &[class*=_#{$name}] {
       box-shadow: $shadow;


### PR DESCRIPTION
#### Screens

<img width="429" alt="Screen Shot 2021-01-07 at 1 06 27 PM" src="https://user-images.githubusercontent.com/64423298/103927979-2e573000-50e9-11eb-9d08-566625749f34.png">

#### Breaking Changes
No
#### Runway Ticket URL

[Runway URL](https://nitro.powerhrg.com/runway/backlog_items/NUXE-380)

#### How to test this

No testing

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
