### PR TITLE
Add Object-fit: cover to Image Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_image/_image.scss
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.scss
@@ -11,6 +11,7 @@ $image-sizes: (
 
 [class^=pb_image_kit] {
   position: relative;
+  object-fit: cover;
 
   @each $name, $size in $image-sizes {
     &[class*=_#{$name}] {


### PR DESCRIPTION
#### Screens

<img width="225" alt="Screen Shot 2021-01-12 at 12 22 54 PM" src="https://user-images.githubusercontent.com/64423298/104349710-435d0600-54d1-11eb-9386-b73e4e5be264.png">

#### Breaking Changes

No

#### Runway Ticket URL

[Runway URL](https://nitro.powerhrg.com/runway/backlog_items/NUXE-396)

#### How to test this
No testing

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
