### PR TITLE
Specifying Node Version for Github Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Node.js 12.x
         uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '12.20.0'
 
       - name: Produce Test Coverage Data
         run: |


### PR DESCRIPTION
This fixes the CI errors we were encountering by having the Node version too loose.