### PR TITLE
Adds truncation for select kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -12,6 +12,11 @@
     cursor: pointer;
     box-shadow: inset 0 -11px 20px rgba($primary, 0.05);
     padding-right: $space_xl;
+    color: transparent !important;
+    text-shadow: 0 0 0 $text_lt_default;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     @media (hover:hover) {
       &:hover, &:active, &:focus {
         background-color: $focus_input_light;
@@ -20,8 +25,6 @@
     &:disabled ~ .pb_select_kit_caret {
       opacity: 0.5;
     }
-    color: transparent !important;
-    text-shadow: 0 0 0 $text_lt_default;
   }
   option {
     color: $text_lt_default;
@@ -62,12 +65,12 @@
       @include pb_title_dark;
       background: $focus_input_dark;
       box-shadow: inset 0 -11px 20px rgba($white, 0.05);
+      text-shadow: 0 0 0 $text_dk_default;
       @media (hover:hover) {
         &:hover, &:active, &:focus {
           background-color: tint($focus_input_dark, 5%);
         }
       }
-      text-shadow: 0 0 0 $text_dk_default;
     }
     .pb_select_kit_caret {
       color: $white;
@@ -82,5 +85,4 @@
       }
     }
   }
-
 }


### PR DESCRIPTION
#### Screens

![image](https://user-images.githubusercontent.com/863031/105073301-7e6cb580-5a4c-11eb-90ab-c018484203ce.png)


#### Breaking Changes

No

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-432

#### How to test this

You can add CSS to select to make it smaller than the content.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
