### PR TITLE
Fixed Distribution Bar Cuttoff + added custom color props

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.jsx
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.jsx
@@ -6,6 +6,7 @@ import { globalProps } from '../utilities/globalProps.js'
 
 type DistributionBarProps = {
   className?: string,
+  colors: array,
   data?: string,
   id?: string,
   size?: "lg" | "sm",
@@ -18,13 +19,13 @@ const normalizeCharacters = (widths) => {
   })
 }
 
-const barValues = (normalizedValues) => {
+const barValues = (normalizedValues, colors) => {
   const arrSum = (value) => value.reduce((a, b) => a + b, 0)
   const widthSum = arrSum(normalizedValues)
   return normalizedValues.map((value, i) => {
     return (
       <div
-          className="pb_distribution_width"
+          className={classnames('pb_distribution_width', colors[i] ? `color_${colors[i]}` : '')}
           key={i}
           style={{ width: `${(value * 100) / widthSum}%` }}
       />
@@ -33,12 +34,16 @@ const barValues = (normalizedValues) => {
 }
 
 const DistributionBar = (props: DistributionBarProps) => {
-  const { size = 'lg', widths = [1] } = props
+  const {
+    size = 'lg',
+    widths = [1],
+    colors = [],
+  } = props
   const normalizedValues = normalizeCharacters(widths)
 
   return (
     <div className={classnames(`pb_distribution_bar_${size}`, globalProps(props))}>
-      {barValues(normalizedValues)}
+      {barValues(normalizedValues, colors)}
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.scss
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.scss
@@ -5,21 +5,26 @@
   $small_bar: 8px;
   $large_bar: 36px;
   display: flex;
+  border-radius: $large_bar;
+  overflow: auto;
   .pb_distribution_width {
     height: 100%;
     display: inline-block;
-    @for $i from 1 through length($bar_colors) {
-      &:nth-child(#{length($bar_colors)}n+#{$i}) {
-        background-color: nth($bar_colors, $i);
+    @each $name, $color in $data_colors {
+      &:nth-child(#{length($data_colors)}n+#{index(($data_colors), ($name $color))}) {
+        background-color: $color;
+      }
+      &.color_#{$name} {
+        background-color: $color !important;
       }
     }
     &:first-child {
-      border-top-left-radius: 18px;
-      border-bottom-left-radius: 18px;
+      border-top-left-radius: $large_bar;
+      border-bottom-left-radius: $large_bar;
     }
     &:last-child {
-      border-top-right-radius: 18px;
-      border-bottom-right-radius: 18px;
+      border-top-right-radius: $large_bar;
+      border-bottom-right-radius: $large_bar;
     }
   }
   &[class*=_sm] {

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.rb
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.rb
@@ -11,7 +11,9 @@ module Playbook
                   values: %w[lg sm],
                   default: "lg"
       prop :widths, type: Playbook::Props::NumberArray,
-                    default: [1]
+                  default: [1]
+      prop :colors, type: Playbook::Props::Array,
+                  default: []
 
       def classname
         generate_classname("pb_distribution_bar", size)
@@ -27,6 +29,7 @@ module Playbook
         {
           size: size,
           widths: widths,
+          colors: colors,
         }
       end
     end

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.html.erb
@@ -1,0 +1,4 @@
+<%= pb_rails("distribution_bar", props: {
+  widths: [4,5,3],
+  colors: ["data_7", "data_1", "data_6"]
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.jsx
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import DistributionBar from '../_distribution_bar.jsx'
+
+const DistributionBarCustomColors = (props) => {
+  return (
+    <React.Fragment>
+      <div>
+        <DistributionBar
+            colors={['data_7', 'data_1', 'data_6']}
+            widths={[4, 5, 3]}
+            {...props}
+        />
+      </div>
+    </React.Fragment>
+  )
+}
+
+export default DistributionBarCustomColors

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.md
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.md
@@ -1,0 +1,1 @@
+You can customize the order of the colors you would like to use by using the `colors` prop. Only the data colors will work for Playbook charts. See the [design page](/visual_guidelines) for reference.

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/example.yml
@@ -2,8 +2,10 @@ examples:
   
   rails:
   - distribution_bar_default: Default
+  - distribution_bar_custom_colors: Custom Colors
   
   
   react:
   - distribution_bar_default: Default
+  - distribution_bar_custom_colors: Custom Colors
   

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/index.js
@@ -1,1 +1,2 @@
 export { default as DistributionBarDefault } from './_distribution_bar_default.jsx'
+export { default as DistributionBarCustomColors } from './_distribution_bar_custom_colors.jsx'

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -12,6 +12,11 @@
     cursor: pointer;
     box-shadow: inset 0 -11px 20px rgba($primary, 0.05);
     padding-right: $space_xl;
+    color: transparent !important;
+    text-shadow: 0 0 0 $text_lt_default;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     @media (hover:hover) {
       &:hover, &:active, &:focus {
         background-color: $focus_input_light;
@@ -20,8 +25,6 @@
     &:disabled ~ .pb_select_kit_caret {
       opacity: 0.5;
     }
-    color: transparent !important;
-    text-shadow: 0 0 0 $text_lt_default;
   }
   option {
     color: $text_lt_default;
@@ -62,12 +65,12 @@
       @include pb_title_dark;
       background: $focus_input_dark;
       box-shadow: inset 0 -11px 20px rgba($white, 0.05);
+      text-shadow: 0 0 0 $text_dk_default;
       @media (hover:hover) {
         &:hover, &:active, &:focus {
           background-color: tint($focus_input_dark, 5%);
         }
       }
-      text-shadow: 0 0 0 $text_dk_default;
     }
     .pb_select_kit_caret {
       color: $white;
@@ -82,5 +85,4 @@
       }
     }
   }
-
 }


### PR DESCRIPTION
#### Screens

![image](https://user-images.githubusercontent.com/863031/105090663-4e311100-5a64-11eb-932d-05e539f0fdd5.png)


#### Breaking Changes

No

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-414
https://nitro.powerhrg.com/runway/backlog_items/NUXE-415

#### How to test this

1. You can add just 1 data and see that the bar is still rounded
2. You can add color props to customize colors.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
