### PR TITLE
Prevent Typeahead menu opening on FormPill removal

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
@@ -12,7 +12,6 @@ type FormPillProps = {
   text: string,
   name: string,
   onClick?: EventHandler,
-  onCloseMouseDown?: EventHandler,
   avatar?: boolean,
   avatarUrl?: string,
   closeProps?: {

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
@@ -12,11 +12,12 @@ type FormPillProps = {
   text: string,
   name: string,
   onClick?: EventHandler,
+  onCloseMouseDown?: EventHandler,
   avatar?: boolean,
   avatarUrl?: string,
 }
 const FormPill = (props: FormPillProps) => {
-  const { className, text, name, onClick = () => {}, avatarUrl } = props
+  const { className, text, name, onClick = () => {}, onCloseMouseDown = () => {}, avatarUrl } = props
   const css = classnames(
     `pb_form_pill_kit_${'primary'}`,
     globalProps(props),
@@ -46,6 +47,7 @@ const FormPill = (props: FormPillProps) => {
       <div
           className="pb_form_pill_close"
           onClick={onClick}
+          onMouseDown={onCloseMouseDown}
       >
         <Icon
             fixedWidth

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
@@ -15,9 +15,14 @@ type FormPillProps = {
   onCloseMouseDown?: EventHandler,
   avatar?: boolean,
   avatarUrl?: string,
+  closeProps?: {
+    onClick?: EventHandler,
+    onMouseDown?: EventHandler,
+    onTouchEnd?: EventHandler,
+  },
 }
 const FormPill = (props: FormPillProps) => {
-  const { className, text, name, onClick = () => {}, onCloseMouseDown = () => {}, avatarUrl } = props
+  const { className, text, name, onClick = () => {}, avatarUrl, closeProps = {} } = props
   const css = classnames(
     `pb_form_pill_kit_${'primary'}`,
     globalProps(props),
@@ -47,7 +52,7 @@ const FormPill = (props: FormPillProps) => {
       <div
           className="pb_form_pill_close"
           onClick={onClick}
-          onMouseDown={onCloseMouseDown}
+          {...closeProps}
       >
         <Icon
             fixedWidth

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.jsx
@@ -23,9 +23,6 @@ const MultiValue = (props: Props) => {
 
   if (typeof imageUrl === 'string') formPillProps.avatarUrl = imageUrl
 
-  const handleOnClick = removeProps.onClick
-  const handleMouseDown = (e) => e.stopPropagation()
-
   return (
     <components.MultiValueContainer
         className="text_input_multivalue_container"
@@ -34,15 +31,14 @@ const MultiValue = (props: Props) => {
       <If condition={imageUrl}>
         <FormPill
             avatarUrl={imageUrl}
+            closeProps={removeProps}
             marginRight="xs"
             name={label}
-            onClick={handleOnClick}
         />
         <Else />
         <FormPill
+            closeProps={removeProps}
             marginRight="xs"
-            onClick={handleOnClick}
-            onCloseMouseDown={handleMouseDown}
             text={label}
         />
       </If>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.jsx
@@ -24,6 +24,7 @@ const MultiValue = (props: Props) => {
   if (typeof imageUrl === 'string') formPillProps.avatarUrl = imageUrl
 
   const handleOnClick = removeProps.onClick
+  const handleMouseDown = (e) => e.stopPropagation()
 
   return (
     <components.MultiValueContainer
@@ -41,6 +42,7 @@ const MultiValue = (props: Props) => {
         <FormPill
             marginRight="xs"
             onClick={handleOnClick}
+            onCloseMouseDown={handleMouseDown}
             text={label}
         />
       </If>


### PR DESCRIPTION
The reason you don't see this behavior on the examples on the [react-select homepage](https://react-select.com/home) examples is because they spread ALL the remove props ([here](https://github.com/JedWatson/react-select/blob/5bee3f40e74c165117a6765588ae906f07ad76f9/packages/react-select/src/components/MultiValue.js#L160)) to the default value label.
One of these props is "onMouseDown", which stops the event from propagating
([defined here ](https://github.com/JedWatson/react-select/blob/500398d93b8e2924ae49f6c786259cfd40dc0405/packages/react-select/src/Select.js#L1553))

So because we were just passing down the onclick prop, the mousedown event was propagating from our multivalue implementation to the control (the text input area) and triggering the menu


My first approach was to just add `onCloseMouseDown` to FormPill and pass that separately, but I thought it looked cleaner to accept props for the close button collectively. Happy to change it back if it makes more sense to!


#### Screens
No UI changes

#### Breaking Changes
No, additive change to form pill kit
Passing values from `react-select` to form kit differently

#### Runway Ticket URL
[NUXE-417](https://nitro.powerhrg.com/runway/backlog_items/NUXE-417)
#### How to test this
Test the multiselect examples at `/kits/typeahead/react` and `/kits/typeahead/rails`
Form Pill kit can be regression tested as well at `/kits/form_pill/react`

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **URGENCY** Please select a release milestone
- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [X] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [X] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
