### PR TITLE
Fix Image kit rounded prop warning

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_image/_image.jsx
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.jsx
@@ -46,7 +46,7 @@ const Image = (props: ImageProps) => {
           className={classes}
           data-src={url}
           id={id}
-          rounded={rounded}
+          rounded={+rounded}
           src={url}
       />
     </div>


### PR DESCRIPTION
#### Screens

<img width="861" alt="Screen Shot 2021-02-02 at 11 33 14 AM" src="https://user-images.githubusercontent.com/2293844/106639336-7af82480-654a-11eb-87ec-fe5f5117b741.png">

#### Breaking Changes

No

#### Runway Ticket URL

N/A

#### How to test this

1. View http://playbook.powerapp.cloud/kits/image/react
2. Open inspector and ensure the error above does not occur

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
