### PR TITLE
[CMPN-379] Add Error State to Selectable Card

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.html.erb
@@ -24,7 +24,7 @@
             <% end %>
           <% end %>
           <div class="separator"></div>
-          <%= pb_rails("card/card_body", props: { padding: "sm" }) do %>
+          <%= pb_rails("card/card_body", props: { padding: "sm", status: object.status }) do %>
             <% if object.children.nil? %>
               <%= pb_rails("body", props: { text: object.text }) %>
             <% else %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.jsx
@@ -23,6 +23,7 @@ type SelectableCardProps = {
   dark?: boolean,
   data: object,
   disabled?: boolean,
+  error?: boolean,
   icon?: boolean,
   id?: string,
   inputId?: string,
@@ -42,6 +43,7 @@ const SelectableCard = ({
   dark = false,
   data = {},
   disabled = false,
+  error = false,
   icon = false,
   inputId = null,
   multi = true,
@@ -58,9 +60,11 @@ const SelectableCard = ({
   const classes = classnames(buildCss('pb_selectable_card_kit',
     { 'checked': checked,
       'disabled': disabled,
-      'enabled': !disabled }),
-  dark ? 'dark' : '',
-  className
+      'enabled': !disabled
+    }),
+    { error },
+    dark ? 'dark' : '',
+    className
   )
 
   const displayIcon = () => {
@@ -132,6 +136,7 @@ const SelectableCard = ({
                 <Card.Body
                     dark={dark}
                     padding="sm"
+                    status={error ? 'negative' : null}
                 >
                   {text || children}
                 </Card.Body>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.jsx
@@ -58,13 +58,14 @@ const SelectableCard = ({
   const dataProps = buildDataProps(data)
 
   const classes = classnames(buildCss('pb_selectable_card_kit',
-    { 'checked': checked,
+    {
+      'checked': checked,
       'disabled': disabled,
-      'enabled': !disabled
+      'enabled': !disabled,
     }),
-    { error },
-    dark ? 'dark' : '',
-    className
+  { error },
+  dark ? 'dark' : '',
+  className
   )
 
   const displayIcon = () => {

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -14,7 +14,6 @@ $pb_selectable_card_border: 2px;
   display: block;
   margin-bottom: 0;
 
-
   > label {
     > .buffer {
       display: inherit;
@@ -114,6 +113,16 @@ $pb_selectable_card_border: 2px;
     .separator {
       background: $bg_dark;
     }
+
+    &.error {
+      > label {
+        border-color: $error_dark;
+      }
+      .separator{
+        background: $error_dark;
+        width: 2px;
+      }
+    }
   }
 
   .separator {
@@ -126,5 +135,15 @@ $pb_selectable_card_border: 2px;
     margin-top: -1px;
     margin-bottom: -1px;
     background: $border_light;
+  }
+
+  &.error {
+    > label {
+      border-color: $error;
+    }
+    .separator {
+      background: $error;
+      width: 2px;
+    }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.html.erb
@@ -1,0 +1,36 @@
+<%= pb_rails("title", props: {
+  size: 3,
+  text: "What sports do you like?"
+}) %>
+
+<br />
+
+<%= pb_rails("selectable_card", props: {
+  error: true,
+  input_id: "football",
+  name: "football",
+  value: "football",
+  variant: "display_input"
+}) do %>
+  Football
+<% end %>
+
+<%= pb_rails("selectable_card", props: {
+  error: true,
+  input_id: "basketball",
+  name: "basketball",
+  value: "basketball",
+  variant: "display_input"
+}) do %>
+  Basketball
+<% end %>
+
+<%= pb_rails("selectable_card", props: {
+  error: true,
+  input_id: "baseball",
+  name: "baseball",
+  value: "baseball",
+  variant: "display_input"
+}) do %>
+  Baseball
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.jsx
@@ -1,10 +1,10 @@
-import React, {useState} from 'react'
+import React, { useState } from 'react'
 import { Body, SelectableCard, Title } from '../..'
 
 const SelectableCardError = (props) => {
-      const [football, setFootball] = useState(false)
-      const [basketball, setBasketball] = useState(false)
-      const [baseball, setBaseball] = useState(false)
+  const [football, setFootball] = useState(false)
+  const [basketball, setBasketball] = useState(false)
+  const [baseball, setBaseball] = useState(false)
 
   return (
     <div>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.jsx
@@ -1,0 +1,61 @@
+import React, {useState} from 'react'
+import { Body, SelectableCard, Title } from '../..'
+
+const SelectableCardError = (props) => {
+      const [football, setFootball] = useState(false)
+      const [basketball, setBasketball] = useState(false)
+      const [baseball, setBaseball] = useState(false)
+
+  return (
+    <div>
+      <Title
+          dark
+          size={3}
+          text="What sports do you like?"
+      />
+      <br />
+      <SelectableCard
+          {...props}
+          checked={football}
+          dark
+          error
+          inputId="football"
+          name="football"
+          onChange={() => setFootball(!football)}
+          value="football"
+          variant="displayInput"
+      >
+        <Body dark>{'Football'}</Body>
+      </SelectableCard>
+
+      <SelectableCard
+          {...props}
+          checked={basketball}
+          dark
+          error
+          inputId="basketball"
+          name="basketball"
+          onChange={() => setBasketball(!basketball)}
+          value="basketball"
+          variant="displayInput"
+      >
+        <Body dark>{'Basketball'}</Body>
+      </SelectableCard>
+
+      <SelectableCard
+          {...props}
+          checked={baseball}
+          dark
+          error
+          inputId="baseball"
+          name="baseball"
+          onChange={() => setBaseball(!baseball)}
+          value="baseball"
+          variant="displayInput"
+      >
+        <Body dark>{'Baseball'}</Body>
+      </SelectableCard>
+    </div>
+  )
+}
+export default SelectableCardError

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/docs/_selectable_card_error.jsx
@@ -9,7 +9,7 @@ const SelectableCardError = (props) => {
   return (
     <div>
       <Title
-          dark
+          {...props}
           size={3}
           text="What sports do you like?"
       />
@@ -17,7 +17,6 @@ const SelectableCardError = (props) => {
       <SelectableCard
           {...props}
           checked={football}
-          dark
           error
           inputId="football"
           name="football"
@@ -25,13 +24,12 @@ const SelectableCardError = (props) => {
           value="football"
           variant="displayInput"
       >
-        <Body dark>{'Football'}</Body>
+        <Body {...props}>{'Football'}</Body>
       </SelectableCard>
 
       <SelectableCard
           {...props}
           checked={basketball}
-          dark
           error
           inputId="basketball"
           name="basketball"
@@ -39,13 +37,12 @@ const SelectableCardError = (props) => {
           value="basketball"
           variant="displayInput"
       >
-        <Body dark>{'Basketball'}</Body>
+        <Body {...props}>{'Basketball'}</Body>
       </SelectableCard>
 
       <SelectableCard
           {...props}
           checked={baseball}
-          dark
           error
           inputId="baseball"
           name="baseball"
@@ -53,7 +50,7 @@ const SelectableCardError = (props) => {
           value="baseball"
           variant="displayInput"
       >
-        <Body dark>{'Baseball'}</Body>
+        <Body {...props}>{'Baseball'}</Body>
       </SelectableCard>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/docs/example.yml
@@ -7,6 +7,7 @@ examples:
   - selectable_card_options: With Options
   - selectable_card_image: Image Example
   - selectable_card_input: Input Variant
+  - selectable_card_error: With Errors
 
 
   react:
@@ -15,3 +16,4 @@ examples:
   - selectable_card_block: Block
   - selectable_card_image: Image Example
   - selectable_card_input: Input Variant
+  - selectable_card_error: With Errors

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/docs/index.js
@@ -1,5 +1,6 @@
 export { default as SelectableCardDefault } from './_selectable_card_default.jsx'
 export { default as SelectableCardSingleSelect } from './_selectable_card_single_select.jsx'
 export { default as SelectableCardBlock } from './_selectable_card_block.jsx'
+export { default as SelectableCardError } from './_selectable_card_error.jsx'
 export { default as SelectableCardImage } from './_selectable_card_image.jsx'
 export { default as SelectableCardInput } from './_selectable_card_input.jsx'

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.rb
@@ -11,6 +11,8 @@ module Playbook
                      default: false
       prop :disabled, type: Playbook::Props::Boolean,
                       default: false
+      prop :error, type: Playbook::Props::Boolean,
+                   default: false
       prop :icon, type: Playbook::Props::Boolean,
                   default: false
       prop :multi, type: Playbook::Props::Boolean,
@@ -27,7 +29,7 @@ module Playbook
 
       def classname
         [
-          generate_classname_without_spacing("pb_selectable_card_kit", checked_class, enable_disabled_class),
+          generate_classname_without_spacing("pb_selectable_card_kit", checked_class, enable_disabled_class) + error_class,
           dark_props,
         ].compact.join(" ")
       end
@@ -63,6 +65,10 @@ module Playbook
         disabled ? "disabled" : ""
       end
 
+      def status
+        error ? "negative" : nil
+      end
+
     private
 
       def checked_class
@@ -71,6 +77,10 @@ module Playbook
 
       def enable_disabled_class
         disabled ? "disabled" : "enabled"
+      end
+
+      def error_class
+        error ? " error" : ""
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.rb
@@ -29,7 +29,8 @@ module Playbook
 
       def classname
         [
-          generate_classname_without_spacing("pb_selectable_card_kit", checked_class, enable_disabled_class) + error_class,
+          generate_classname_without_spacing("pb_selectable_card_kit", checked_class, enable_disabled_class),
+          error_class,
           dark_props,
         ].compact.join(" ")
       end
@@ -80,7 +81,7 @@ module Playbook
       end
 
       def error_class
-        error ? " error" : ""
+        error ? "error" : nil
       end
     end
   end


### PR DESCRIPTION
#### Screens

![Screen Shot 2021-02-04 at 9 24 29 AM](https://user-images.githubusercontent.com/64423775/106906309-08fb1900-66cb-11eb-8536-e157c576405e.png)
![Screen Shot 2021-02-04 at 9 25 19 AM](https://user-images.githubusercontent.com/64423775/106906311-08fb1900-66cb-11eb-9876-6ecdaeeb9490.png)
![Screen Shot 2021-02-04 at 9 24 46 AM](https://user-images.githubusercontent.com/64423775/106906312-08fb1900-66cb-11eb-86d7-49fcfaf45e2b.png)
![Screen Shot 2021-02-04 at 9 25 31 AM](https://user-images.githubusercontent.com/64423775/106906313-0993af80-66cb-11eb-82fc-31c70a0b98a1.png)

#### Breaking Changes
This is not a breaking change. This PR simply adds an example variant to Selectable Card kit that displays what an error state would look like in both Rails and React (also included dark mode.)

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/CMPN-379

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
