### PR TITLE
[NUXE-349] Update gauge examples using overflow in flex item

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_flex/_flex_item.jsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex_item.jsx
@@ -10,19 +10,21 @@ type FlexItemPropTypes = {
   shrink: boolean,
   flex: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 'none',
   className: string,
+  overflow?: "auto" | "hidden" | "initial" | "inherit" | "scroll" | "visible",
 }
 
 const FlexItem = (props: FlexItemPropTypes) => {
-  const { children, className, fixedSize, grow, shrink, flex } = props
+  const { children, className, fixedSize, grow, overflow = null, shrink, flex } = props
   const growClass = grow === true ? 'grow' : ''
   const flexClass = flex !== 'none' ? `flex_${flex}` : ''
+  const overflowClass = overflow ? `overflow_${overflow}` : ''
   const shrinkClass = shrink === true ? 'shrink' : ''
   const fixedStyle =
     fixedSize !== undefined ? { flexBasis: `${fixedSize}` } : null
 
   return (
     <div
-        className={classnames(buildCss('pb_flex_item_kit', growClass, shrinkClass, flexClass), globalProps(props), className)}
+        className={classnames(buildCss('pb_flex_item_kit', growClass, shrinkClass, flexClass), overflowClass, globalProps(props), className)}
         style={fixedStyle}
     >
       {children}

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex_item.scss
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex_item.scss
@@ -12,6 +12,15 @@
     flex-shrink: 1;
   }
 
+
+  $overflow_values: auto, hidden, inherit, initial, scroll, visible;
+
+  @each $value in $overflow_values {
+    &.overflow_#{$value} {
+      overflow: #{$value}
+    }
+  }
+
   @for $i from 0 through 12 {
     &[class*=_flex_#{$i}]{
       flex: $i;

--- a/playbook/app/pb_kits/playbook/pb_flex/flex_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_flex/flex_item.rb
@@ -15,9 +15,12 @@ module Playbook
       prop :flex, type: Playbook::Props::Enum,
                   values: %w[0 1 2 3 4 5 6 7 8 9 10 11 12 none],
                   default: "none"
+      prop :overflow, type: Playbook::Props::Enum,
+                      values: %w[auto hidden inherit initial scroll visible] + [nil],
+                      default: nil
 
       def classname
-        generate_classname("pb_flex_item_kit", fixed_size_class, grow_class, shrink_class, flex_class)
+        generate_classname("pb_flex_item_kit", fixed_size_class, grow_class, shrink_class, flex_class) + overflow_class
       end
 
       def style_value
@@ -32,6 +35,10 @@ module Playbook
 
       def grow_class
         grow ? "grow" : nil
+      end
+
+      def overflow_class
+        overflow  ? " overflow_#{overflow}" : ""
       end
 
       def shrink_class

--- a/playbook/app/pb_kits/playbook/pb_flex/flex_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_flex/flex_item.rb
@@ -38,7 +38,7 @@ module Playbook
       end
 
       def overflow_class
-        overflow  ? " overflow_#{overflow}" : ""
+        overflow ? " overflow_#{overflow}" : ""
       end
 
       def shrink_class

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
@@ -1,26 +1,32 @@
+<style>
+  .hideOverflow {
+    overflow: hidden;
+  }
+</style>
+
 <%= pb_rails("flex", props: {wrap: true}) do %>
-  <div style="flex-basis:400px; overflow:hidden">
+  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "400px", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing4",
         chart_data: [{ name: "Point 1", value: 100 }],
       }) %>
-  </div>
-  <div style="flex-basis:300px; overflow:hidden">
+  <% end %>
+  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "300px", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing3",
         chart_data: [{ name: "Point 2", value: 75 }],
       }) %>
-  </div>
-  <div style="flex-basis:200px; overflow:hidden">
+  <% end %>
+  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "200px", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing2",
         chart_data: [{ name: "Point 3", value: 50 }],
       }) %>
-  </div>
-  <div style="flex-basis:125px; overflow:hidden">
+  <% end %>
+  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "125px", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing1",
         chart_data: [{ name: "Point 4", value: 25 }],
       }) %>
-  </div>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
@@ -5,25 +5,25 @@
 </style>
 
 <%= pb_rails("flex", props: {wrap: true}) do %>
-  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "400px", shrink: true }) do %>
+  <%= pb_rails("flex/flex_item", props: {fixed_size: "400px", overflow: "hidden", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing4",
         chart_data: [{ name: "Point 1", value: 100 }],
       }) %>
   <% end %>
-  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "300px", shrink: true }) do %>
+  <%= pb_rails("flex/flex_item", props: {fixed_size: "300px", overflow: "hidden", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing3",
         chart_data: [{ name: "Point 2", value: 75 }],
       }) %>
   <% end %>
-  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "200px", shrink: true }) do %>
+  <%= pb_rails("flex/flex_item", props: {fixed_size: "200px", overflow: "hidden", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing2",
         chart_data: [{ name: "Point 3", value: 50 }],
       }) %>
   <% end %>
-  <%= pb_rails("flex/flex_item", props: {classname: "hideOverflow", fixed_size: "125px", shrink: true }) do %>
+  <%= pb_rails("flex/flex_item", props: {fixed_size: "125px", overflow: "hidden", shrink: true }) do %>
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing1",
         chart_data: [{ name: "Point 4", value: 25 }],

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
@@ -1,9 +1,3 @@
-<style>
-  .hideOverflow {
-    overflow: hidden;
-  }
-</style>
-
 <%= pb_rails("flex", props: {wrap: true}) do %>
   <%= pb_rails("flex/flex_item", props: {fixed_size: "400px", overflow: "hidden", shrink: true }) do %>
       <%= pb_rails("gauge", props: {

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.html.erb
@@ -1,26 +1,26 @@
 <%= pb_rails("flex", props: {wrap: true}) do %>
-  <%= pb_rails("flex/flex_item", props: {fixed_size: "400px"}) do %>
+  <div style="flex-basis:400px; overflow:hidden">
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing4",
         chart_data: [{ name: "Point 1", value: 100 }],
       }) %>
-  <% end %>
-  <%= pb_rails("flex/flex_item", props: {fixed_size: "300px"}) do %>
+  </div>
+  <div style="flex-basis:300px; overflow:hidden">
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing3",
         chart_data: [{ name: "Point 2", value: 75 }],
       }) %>
-  <% end %>
-  <%= pb_rails("flex/flex_item", props: {fixed_size: "200px"}) do %>
+  </div>
+  <div style="flex-basis:200px; overflow:hidden">
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing2",
         chart_data: [{ name: "Point 3", value: 50 }],
       }) %>
-  <% end %>
-  <%= pb_rails("flex/flex_item", props: {fixed_size: "125px"}) do %>
+  </div>
+  <div style="flex-basis:125px; overflow:hidden">
       <%= pb_rails("gauge", props: {
         id: "gauge-sizing1",
         chart_data: [{ name: "Point 4", value: 25 }],
       }) %>
-  <% end %>
+  </div>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.jsx
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Flex, FlexItem, Gauge } from '../../'
+import { Flex, Gauge } from '../../'
 
 const GaugeSizing = (props) => (
   <div>
@@ -7,18 +7,15 @@ const GaugeSizing = (props) => (
         wrap
         {...props}
     >
-      <FlexItem
-          fixedSize="400px"
-          {...props}
-      >
+      <div style={{ overflow: 'hidden', flexBasis: '400px' }}>
         <Gauge
             chartData={[ { name: 'Point 1', value: 100 } ]}
             id="gauge-sizing4"
             {...props}
         />
-      </FlexItem>
-      <FlexItem
-          fixedSize="300px"
+      </div>
+      <div
+          style={{ overflow: 'hidden', flexBasis: '300px' }}
           {...props}
       >
         <Gauge
@@ -26,9 +23,9 @@ const GaugeSizing = (props) => (
             id="gauge-sizing3"
             {...props}
         />
-      </FlexItem>
-      <FlexItem
-          fixedSize="200px"
+      </div>
+      <div
+          style={{ overflow: 'hidden', flexBasis: '200px' }}
           {...props}
       >
         <Gauge
@@ -36,14 +33,17 @@ const GaugeSizing = (props) => (
             id="gauge-sizing2"
             {...props}
         />
-      </FlexItem>
-      <FlexItem fixedSize="125px">
+      </div>
+      <div
+          style={{ overflow: 'hidden', flexBasis: '125px' }}
+          {...props}
+      >
         <Gauge
             chartData={[ { name: 'Point 4', value: 25 } ]}
             id="gauge-sizing1"
             {...props}
         />
-      </FlexItem>
+      </div>
     </Flex>
   </div>
 )

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.jsx
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.jsx
@@ -55,18 +55,6 @@ const GaugeSizing = (props) => (
             {...props}
         />
       </FlexItem>
-      <FlexItem
-          fixedSize="300px"
-          shrink
-          {...props}
-      >
-        <Gauge
-            chartData={[ { name: 'Point 2', value: 75 } ]}
-            id="gauge-sizing5"
-            {...props}
-        />
-        {'No "overflow: hidden", doesn\'t respond well to shrinking screen.'}
-      </FlexItem>
     </Flex>
   </div>
 )

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.jsx
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Flex, Gauge } from '../../'
+import { Flex, FlexItem, Gauge } from '../../'
 
 const GaugeSizing = (props) => (
   <div>
@@ -7,15 +7,22 @@ const GaugeSizing = (props) => (
         wrap
         {...props}
     >
-      <div style={{ overflow: 'hidden', flexBasis: '400px' }}>
+      <FlexItem
+          fixedSize="400px"
+          overflow="hidden"
+          shrink
+          {...props}
+      >
         <Gauge
             chartData={[ { name: 'Point 1', value: 100 } ]}
             id="gauge-sizing4"
             {...props}
         />
-      </div>
-      <div
-          style={{ overflow: 'hidden', flexBasis: '300px' }}
+      </FlexItem>
+      <FlexItem
+          fixedSize="300px"
+          overflow="hidden"
+          shrink
           {...props}
       >
         <Gauge
@@ -23,9 +30,11 @@ const GaugeSizing = (props) => (
             id="gauge-sizing3"
             {...props}
         />
-      </div>
-      <div
-          style={{ overflow: 'hidden', flexBasis: '200px' }}
+      </FlexItem>
+      <FlexItem
+          fixedSize="200px"
+          overflow="hidden"
+          shrink
           {...props}
       >
         <Gauge
@@ -33,9 +42,11 @@ const GaugeSizing = (props) => (
             id="gauge-sizing2"
             {...props}
         />
-      </div>
-      <div
-          style={{ overflow: 'hidden', flexBasis: '125px' }}
+      </FlexItem>
+      <FlexItem
+          fixedSize="125px"
+          overflow="hidden"
+          shrink
           {...props}
       >
         <Gauge
@@ -43,7 +54,19 @@ const GaugeSizing = (props) => (
             id="gauge-sizing1"
             {...props}
         />
-      </div>
+      </FlexItem>
+      <FlexItem
+          fixedSize="300px"
+          shrink
+          {...props}
+      >
+        <Gauge
+            chartData={[ { name: 'Point 2', value: 75 } ]}
+            id="gauge-sizing5"
+            {...props}
+        />
+        {'No "overflow: hidden", doesn\'t respond well to shrinking screen.'}
+      </FlexItem>
     </Flex>
   </div>
 )

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.md
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_sizing.md
@@ -1,1 +1,2 @@
 ### Gauge resizes dynamically to fit whatever element it's placed within.
+#### Note: set `overflow` to hidden on the parent element when nesting gauges inside of a flex items to best respond to shrinking screens.

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/example.yml
@@ -1,12 +1,12 @@
 examples:
 
   rails:
-  - gauge_default: Default
-  - gauge_disable_animation: Disable Animation
-  - gauge_title: Title
-  - gauge_units: Units
-  - gauge_full_circle: Full Circle
-  - gauge_min_max: Min Max Labels
+  # - gauge_default: Default
+  # - gauge_disable_animation: Disable Animation
+  # - gauge_title: Title
+  # - gauge_units: Units
+  # - gauge_full_circle: Full Circle
+  # - gauge_min_max: Min Max Labels
   - gauge_sizing: Sizing
   - gauge_height: Height
 

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/example.yml
@@ -1,12 +1,12 @@
 examples:
 
   rails:
-  # - gauge_default: Default
-  # - gauge_disable_animation: Disable Animation
-  # - gauge_title: Title
-  # - gauge_units: Units
-  # - gauge_full_circle: Full Circle
-  # - gauge_min_max: Min Max Labels
+  - gauge_default: Default
+  - gauge_disable_animation: Disable Animation
+  - gauge_title: Title
+  - gauge_units: Units
+  - gauge_full_circle: Full Circle
+  - gauge_min_max: Min Max Labels
   - gauge_sizing: Sizing
   - gauge_height: Height
 

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/example.yml
@@ -1,5 +1,5 @@
 examples:
-  
+
   rails:
   - gauge_default: Default
   - gauge_disable_animation: Disable Animation
@@ -9,16 +9,15 @@ examples:
   - gauge_min_max: Min Max Labels
   - gauge_sizing: Sizing
   - gauge_height: Height
-  
-  
+
+
   react:
   - gauge_default: Default
   - gauge_disable_animation: Disable Animation
-  - gauge_title: Title 
+  - gauge_title: Title
   - gauge_units: Units
   - gauge_full_circle: Full Circle
   - gauge_min_max: Min Max Labels
   - gauge_sizing: Sizing
   - gauge_height: Height
   - gauge_live_data: Live Data
-  

--- a/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Playbook::PbFlex::FlexItem do
   it { is_expected.to define_enum_prop(:flex)
                       .with_default("none")
                       .with_values("0","1","2","3","4","5","6","7","8","9","10","11","12","none") }
+  it { is_expected.to define_enum_prop(:overflow)
+                      .with_default(nil)
+                      .with_values("auto","hidden", "initial", "inherit", "scroll", "visible", nil) }
   it { is_expected.to define_boolean_prop(:shrink).with_default(false) }
   it { is_expected.to define_boolean_prop(:grow).with_default(false) }
   it { is_expected.to define_string_prop(:fixed_size)}
@@ -20,6 +23,7 @@ RSpec.describe Playbook::PbFlex::FlexItem do
       expect(subject.new(shrink: true).classname).to eq "pb_flex_item_kit_shrink"
       expect(subject.new(flex: "1").classname).to eq "pb_flex_item_kit_flex_1"
       expect(subject.new(fixed_size: "250px").classname).to eq "pb_flex_item_kit_fixed_size"
+      expect(subject.new(overflow: "hidden").classname).to eq "pb_flex_item_kit overflow_hidden"
     end
   end
 

--- a/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Playbook::PbFlex::FlexItem do
                       .with_values("0","1","2","3","4","5","6","7","8","9","10","11","12","none") }
   it { is_expected.to define_enum_prop(:overflow)
                       .with_default(nil)
-                      .with_values("auto","hidden", "initial", "inherit", "scroll", "visible", nil) }
+                      .with_values("auto", "hidden", "initial", "inherit", "scroll", "visible", nil) }
   it { is_expected.to define_boolean_prop(:shrink).with_default(false) }
   it { is_expected.to define_boolean_prop(:grow).with_default(false) }
   it { is_expected.to define_string_prop(:fixed_size)}


### PR DESCRIPTION
Charts were not behaving correctly when nested inside of a flex item. The best remedy seemed to be adding "overflow: true" to the flex item, so that it would shrink its width and not keep the width of its child, when the screen was made smaller. This allows the highcharts javascript to detect the change in size and redraw the chart appropriately.

To accomplish this, the FlexItem kit has a new prop of `overflow` which takes any of the available values for overflow as a string, and by default does nothing.

#### Screens

https://user-images.githubusercontent.com/28073714/106659743-24501200-656d-11eb-8953-866ca50ba10b.mov


#### Breaking Changes

No - prop added that by default has no effect

#### Runway Ticket URL

[NUXE-349](https://nitro.powerhrg.com/runway/backlog_items/NUXE-349)

#### How to test this

Check docs at 
/kits/gauge/rails
/kits/gauge/react

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
