### PR TITLE
 Add `zIndex` as a global prop

### DIFF
--- a/playbook/app/pb_kits/playbook/_playbook.scss
+++ b/playbook/app/pb_kits/playbook/_playbook.scss
@@ -90,3 +90,4 @@
 @import 'pb_weekday_stacked/weekday_stacked';
 @import './utilities/spacing';
 @import './utilities/max_width';
+@import './utilities/positioning';

--- a/playbook/app/pb_kits/playbook/utilities/_positioning.scss
+++ b/playbook/app/pb_kits/playbook/utilities/_positioning.scss
@@ -1,0 +1,30 @@
+.z_index_1 {
+  z-index: 100;
+}
+.z_index_2 {
+  z-index: 200;
+}
+.z_index_3 {
+  z-index: 300;
+}
+.z_index_4 {
+  z-index: 400;
+}
+.z_index_5 {
+  z-index: 500;
+}
+.z_index_6 {
+  z-index: 600;
+}
+.z_index_7 {
+  z-index: 700;
+}
+.z_index_8 {
+  z-index: 800;
+}
+.z_index_9 {
+  z-index: 900;
+}
+.z_index_10 {
+  z-index: 1000;
+}

--- a/playbook/app/pb_kits/playbook/utilities/globalProps.js
+++ b/playbook/app/pb_kits/playbook/utilities/globalProps.js
@@ -41,14 +41,20 @@ const darkProps = ({ dark }) => {
 
 const maxWidthProps = ({ maxWidth }) => {
   let css = ''
-  css += maxWidth  ? `max_width_${maxWidth } ` : ''
+  css += maxWidth ? `max_width_${maxWidth } ` : ''
+  return css
+}
+
+const zIndexProps = ({ zIndex }) => {
+  let css = ''
+  css += zIndex ? `z_index_${zIndex } ` : ''
   return css
 }
 
 // All Exported as a single function
 export const globalProps = (props, defaultProps = {}) => {
   const allProps = { ...props, ...defaultProps }
-  return spacingProps(allProps) + darkProps(allProps) + maxWidthProps(allProps)
+  return spacingProps(allProps) + darkProps(allProps) + maxWidthProps(allProps) + zIndexProps(allProps)
 }
 
 export const deprecatedProps = (kit, props = []) => {

--- a/playbook/app/views/playbook/pages/visual_guidelines.html.erb
+++ b/playbook/app/views/playbook/pages/visual_guidelines.html.erb
@@ -5,7 +5,7 @@
           <%= pb_rails("title", props: { classname: "dark", margin_bottom: "lg", text: "Our Visual Langauge", tag: "h1", size: 1 }) %>
           <%= pb_rails("body", props: {
             classname: "dark",
-            text: "This page outlines the guiding principles that inform Playbook Design System's past, present, and future development.  
+            text: "This page outlines the guiding principles that inform Playbook Design System's past, present, and future development.
             These core concepts are the basis upon which every higher order design element is built.  Some of these principles have been abstracted into sass variables listed below."
           }) %>
         </div>
@@ -15,6 +15,7 @@
   <%= pb_rails("background", props: { classname: "token-wrapper", background_color: "light", padding: "xl" }) do %>
       <%= render "playbook/pages/visual_guidelines_partials/colors.html.slim" %>
       <%= render "playbook/pages/visual_guidelines_partials/max_width.html.slim" %>
+      <%= render "playbook/pages/visual_guidelines_partials/positioning.html.slim" %>
       <%= render "playbook/pages/visual_guidelines_partials/spacing.html.slim" %>
   <% end %>
 

--- a/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
+++ b/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
@@ -12,9 +12,9 @@ scss class="myClass":
   $width: 33%;
   $position: absolute;
 
-  div.one1 { height: $height; width: $width; position: $position; }
-  div.two2 { height: $height; width: $width; margin-left: 50px; position: $position; }
-  div.three3 { height: $height; width: $width; margin-left: 100px; position: $position; }
+  div.one { height: $height; width: $width; position: $position; }
+  div.two { height: $height; width: $width; margin-left: 50px; position: $position; }
+  div.three { height: $height; width: $width; margin-left: 100px; position: $position; }
   div.four { height: $height; width: $width; margin-left: 150px; position: $position; }
   div.five { height: $height; width: $width; margin-left: 200px; position: $position; }
   div.six { height: $height; width: $width; margin-left: 250px; position: $position; }
@@ -25,17 +25,17 @@ scss class="myClass":
 
   div.z-index-example code { position: $position; right: 10px; bottom: 5px; }
 
-= pb_rails("card", props: { classname: "one1 z-index-example", max_width: "lg", z_index: "10" }) do
+= pb_rails("card", props: { classname: "one z-index-example", max_width: "lg", z_index: "10" }) do
   code z_index_10
 br
 br
 br
-= pb_rails("card", props: { classname: "two2 z-index-example",  max_width: "lg", z_index: "9" }) do
+= pb_rails("card", props: { classname: "two z-index-example",  max_width: "lg", z_index: "9" }) do
   code z_index_9
 br
 br
 br
-= pb_rails("card", props: { classname: "three3 z-index-example",  max_width: "lg", z_index: "8" }) do
+= pb_rails("card", props: { classname: "three z-index-example",  max_width: "lg", z_index: "8" }) do
   code z_index_8
 br
 br

--- a/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
+++ b/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
@@ -9,26 +9,70 @@ br
 
 scss class="myClass":
   $height: 100px;
-  $width: 70%;
+  $width: 33%;
   $position: absolute;
-  div.two { background: #C1CDD6; height: $height; width: $width; position: $position; margin-left: 50px; }
-  div.one { background: #FFFFFF; height: $height; width: $width; position: $position;}
-  div.three { background: #919EAB; height: $height; width: $width; margin-left: 100px; position: $position; }
+
+  div.one1 { height: $height; width: $width; position: $position; }
+  div.two2 { height: $height; width: $width; margin-left: 50px; position: $position; }
+  div.three3 { height: $height; width: $width; margin-left: 100px; position: $position; }
+  div.four { height: $height; width: $width; margin-left: 150px; position: $position; }
+  div.five { height: $height; width: $width; margin-left: 200px; position: $position; }
+  div.six { height: $height; width: $width; margin-left: 250px; position: $position; }
+  div.seven { height: $height; width: $width; margin-left: 300px; position: $position; }
+  div.eight { height: $height; width: $width; margin-left: 350px; position: $position; }
+  div.nine { height: $height; width: $width; margin-left: 400px; position: $position; }
+  div.ten { height: $height; width: $width; margin-left: 450px; position: $position; }
+
   div.z-index-example code { position: $position; right: 10px; bottom: 5px; }
 
-
-= pb_rails("card", props: { classname: "one z-index-example", max_width: "lg", z_index: "10" }) do
+= pb_rails("card", props: { classname: "one1 z-index-example", max_width: "lg", z_index: "10" }) do
   code z_index_10
 br
 br
 br
-= pb_rails("card", props: { classname: "two z-index-example",  max_width: "lg", z_index: "9" }) do
+= pb_rails("card", props: { classname: "two2 z-index-example",  max_width: "lg", z_index: "9" }) do
   code z_index_9
 br
 br
 br
-= pb_rails("card", props: { classname: "three z-index-example",  max_width: "lg", z_index: "8" }) do
+= pb_rails("card", props: { classname: "three3 z-index-example",  max_width: "lg", z_index: "8" }) do
   code z_index_8
+br
+br
+br
+= pb_rails("card", props: { classname: "four z-index-example", max_width: "lg", z_index: "7" }) do
+  code z_index_7
+br
+br
+br
+= pb_rails("card", props: { classname: "five z-index-example",  max_width: "lg", z_index: "6" }) do
+  code z_index_6
+br
+br
+br
+= pb_rails("card", props: { classname: "six z-index-example",  max_width: "lg", z_index: "5" }) do
+  code z_index_5
+br
+br
+br
+= pb_rails("card", props: { classname: "seven z-index-example", max_width: "lg", z_index: "4" }) do
+  code z_index_4
+br
+br
+br
+= pb_rails("card", props: { classname: "eight z-index-example",  max_width: "lg", z_index: "3" }) do
+  code z_index_3
+br
+br
+br
+= pb_rails("card", props: { classname: "nine z-index-example",  max_width: "lg", z_index: "2" }) do
+  code z_index_2
+br
+br
+br
+= pb_rails("card", props: { classname: "ten z-index-example",  max_width: "lg", z_index: "1" }) do
+  code z_index_1
+br
 br
 br
 br

--- a/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
+++ b/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
@@ -1,0 +1,35 @@
+br
+= pb_rails("title", props: { text: title, tag: "h4", size: 4 })
+
+- if defined?(usage) && usage.present?
+  = pb_rails("body", props: {"tag": "p"})
+    usage
+
+br
+
+scss class="myClass":
+  $height: 100px;
+  $width: 70%;
+  $position: absolute;
+  div.two { background: #C1CDD6; height: $height; width: $width; position: $position; margin-left: 50px; }
+  div.one { background: #FFFFFF; height: $height; width: $width; position: $position;}
+  div.three { background: #919EAB; height: $height; width: $width; margin-left: 100px; position: $position; }
+  div.z-index-example code { position: $position; right: 10px; bottom: 5px; }
+
+
+= pb_rails("card", props: { classname: "one z-index-example", max_width: "lg", z_index: "10" }) do
+  code z_index_10
+br
+br
+br
+= pb_rails("card", props: { classname: "two z-index-example",  max_width: "lg", z_index: "9" }) do
+  code z_index_9
+br
+br
+br
+= pb_rails("card", props: { classname: "three z-index-example",  max_width: "lg", z_index: "8" }) do
+  code z_index_8
+br
+br
+br
+br

--- a/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
+++ b/playbook/app/views/playbook/pages/visual_guidelines_partials/_pb_doc_positioning.html.slim
@@ -26,52 +26,52 @@ scss class="myClass":
   div.z-index-example code { position: $position; right: 10px; bottom: 5px; }
 
 = pb_rails("card", props: { classname: "one z-index-example", max_width: "lg", z_index: "10" }) do
-  code z_index_10
+  code z_index: "10"
 br
 br
 br
 = pb_rails("card", props: { classname: "two z-index-example",  max_width: "lg", z_index: "9" }) do
-  code z_index_9
+  code z_index: "9"
 br
 br
 br
 = pb_rails("card", props: { classname: "three z-index-example",  max_width: "lg", z_index: "8" }) do
-  code z_index_8
+  code z_index: "8"
 br
 br
 br
 = pb_rails("card", props: { classname: "four z-index-example", max_width: "lg", z_index: "7" }) do
-  code z_index_7
+  code z_index: "7"
 br
 br
 br
 = pb_rails("card", props: { classname: "five z-index-example",  max_width: "lg", z_index: "6" }) do
-  code z_index_6
+  code z_index: "6"
 br
 br
 br
 = pb_rails("card", props: { classname: "six z-index-example",  max_width: "lg", z_index: "5" }) do
-  code z_index_5
+  code z_index: "5"
 br
 br
 br
 = pb_rails("card", props: { classname: "seven z-index-example", max_width: "lg", z_index: "4" }) do
-  code z_index_4
+  code z_index: "4"
 br
 br
 br
 = pb_rails("card", props: { classname: "eight z-index-example",  max_width: "lg", z_index: "3" }) do
-  code z_index_3
+  code z_index: "3"
 br
 br
 br
 = pb_rails("card", props: { classname: "nine z-index-example",  max_width: "lg", z_index: "2" }) do
-  code z_index_2
+  code z_index: "2"
 br
 br
 br
 = pb_rails("card", props: { classname: "ten z-index-example",  max_width: "lg", z_index: "1" }) do
-  code z_index_1
+  code z_index: "1"
 br
 br
 br

--- a/playbook/app/views/playbook/pages/visual_guidelines_partials/_positioning.html.slim
+++ b/playbook/app/views/playbook/pages/visual_guidelines_partials/_positioning.html.slim
@@ -1,0 +1,16 @@
+= pb_rails("title", props: { margin_top: "xl", text: "Positioning", tag: "h1", size: 1 })
+
+br
+= render :partial => "playbook/pages/visual_guidelines_partials/pb_doc_positioning",
+    locals:{ title: "Positioning Options",
+    usage: "Used for building Kits: Use the z-index prop when you want to stack elements.",
+    sizes:[{name:"One",variable:"z_index_1"},
+      {name:"Two",variable:"z_index_2"},
+      {name:"Three",variable:"z_index_3"},
+      {name:"Four",variable:"z_index_4"},
+      {name:"Five",variable:"z_index_5"},
+      {name:"Six",variable:"z_index_6"},
+      {name:"Seven",variable:"z_index_7"},
+      {name:"Eight",variable:"z_index_8"},
+      {name:"Nine",variable:"z_index_9"},
+      {name:"Ten",variable:"z_index_10"},]}

--- a/playbook/lib/playbook/props.rb
+++ b/playbook/lib/playbook/props.rb
@@ -57,6 +57,16 @@ module Playbook
       end.compact.join(" ")
     end
 
+    def z_index_props
+      selected_index_props = z_index_options.keys.select { |sk| try(sk) }
+      return nil unless selected_index_props.present?
+
+      selected_index_props.map do |k|
+        index_value = send(k)
+        "z_index_#{index_value}" if z_index_values.include? index_value
+      end.compact.join(" ")
+    end
+
     def generate_classname(*name_parts, separator: "_")
       [
         name_parts.compact.join(separator),
@@ -64,6 +74,7 @@ module Playbook
         spacing_props,
         dark_props,
         max_width_props,
+        z_index_props,
       ].compact.join(" ")
     end
 
@@ -99,6 +110,7 @@ module Playbook
       prop :padding_x
       prop :padding_y
       prop :dark, type: Playbook::Props::Boolean, default: false
+      prop :z_index
     end
 
     def spacing_options
@@ -128,6 +140,16 @@ module Playbook
 
     def max_width_values
       %w[sm md lg xl]
+    end
+
+    def z_index_options
+      {
+        z_index: "z-index",
+      }
+    end
+
+    def z_index_values
+      %w[1 2 3 4 5 6 7 8 9 10]
     end
 
     def spacing_values


### PR DESCRIPTION
#### Screens

<img width="1652" alt="Screen Shot 2021-02-05 at 1 47 25 PM" src="https://user-images.githubusercontent.com/64423298/107075959-d2033100-67b8-11eb-9546-f10b81d23a7a.png">

#### Breaking Changes
No 
#### Runway Ticket URL

[Runway URL](https://nitro.powerhrg.com/runway/backlog_items/NUXE-82)

#### How to test this

No testing

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
