### PR TITLE
Add data, aria, & name props to RichTextEditor

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/card.rb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.rb
@@ -27,14 +27,13 @@ module Playbook
 
       def body_padding
         if padding.present?
-           ""
+          ""
         else
           "p_md"
         end
       end
 
     private
-
 
       def selected_class
         selected ? "selected" : "deselected"

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.jsx
@@ -5,11 +5,15 @@ import classnames from 'classnames'
 import useFocus from './useFocus.js'
 import Trix from 'trix'
 import { globalProps } from '../utilities/globalProps.js'
+import { buildAriaProps, buildDataProps } from '../utilities/props'
 
 type RichTextEditorProps = {
+  aria?: object,
   className?: string,
+  data?: object,
   focus?: boolean,
   id?: string,
+  name?: string,
   onChange: (string) => void,
   placeholder?: string,
   simple?: boolean,
@@ -20,9 +24,12 @@ type RichTextEditorProps = {
 
 const RichTextEditor = (props: RichTextEditorProps) => {
   const {
+    aria = {},
     className,
+    data = {},
     focus = false,
     id,
+    name,
     onChange,
     placeholder,
     simple = false,
@@ -31,6 +38,8 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     value = '',
   } = props
   const trixRef = useRef()
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
 
   useEffect(() => {
     Trix.config.textAttributes.inlineCode = {
@@ -98,6 +107,8 @@ const RichTextEditor = (props: RichTextEditorProps) => {
 
   return (
     <div
+        {...ariaProps}
+        {...dataProps}
         className={classnames(
         RichTextEditorClass,
         SimpleClass,
@@ -108,11 +119,13 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     >
       <input
           id={id}
+          name={name}
           type="hidden"
           value={value}
       />
       <trix-editor
           input={id}
+          name={name}
           placeholder={placeholder}
           ref={trixRef}
       />

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_attributes.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_attributes.html.erb
@@ -1,0 +1,5 @@
+<%= pb_rails("rich_text_editor", props: {
+  aria: { label: "rich-textarea" },
+  data: { key: "value", key2: "value2" },
+  name: "textarea-label",
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_attributes.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_attributes.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { RichTextEditor } from '../../'
+
+const RichTextEditorAttributes = (props) => (
+  <div>
+    <RichTextEditor
+        aria={{ label: 'rich textarea' }}
+        data={{ key: 'value', key2: 'value2' }}
+        name="name-attribute"
+        {...props}
+    />
+  </div>
+)
+
+export default RichTextEditorAttributes

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/example.yml
@@ -3,6 +3,7 @@ examples:
   rails:
   - rich_text_editor_default: Default
   - rich_text_editor_simple: Simple
+  - rich_text_editor_attributes: Attributes
   - rich_text_editor_focus: Focus
   - rich_text_editor_sticky: Sticky
   - rich_text_editor_templates: Templates
@@ -11,6 +12,7 @@ examples:
   react:
   - rich_text_editor_default: Default
   - rich_text_editor_simple: Simple
+  - rich_text_editor_attributes: Attributes
   - rich_text_editor_focus: Focus
   - rich_text_editor_sticky: Sticky
   - rich_text_editor_templates: Templates

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/index.js
@@ -1,5 +1,6 @@
 export { default as RichTextEditorDefault } from './_rich_text_editor_default.jsx'
 export { default as RichTextEditorSimple } from './_rich_text_editor_simple.jsx'
+export { default as RichTextEditorAttributes } from './_rich_text_editor_attributes.jsx'
 export { default as RichTextEditorFocus } from './_rich_text_editor_focus.jsx'
 export { default as RichTextEditorSticky } from './_rich_text_editor_sticky.jsx'
 export { default as RichTextEditorTemplates } from './_rich_text_editor_templates.jsx'

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/rich_text_editor.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/rich_text_editor.html.erb
@@ -1,1 +1,5 @@
-<%= react_component('RichTextEditor', object.rich_text_options) %>
+<%= react_component('RichTextEditor',
+  object.rich_text_options,
+  aria: object.aria,
+  data: object.data
+) %>

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/rich_text_editor.test.js
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/rich_text_editor.test.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import RichTextEditor from './_rich_text_editor'
+
+const testId = 'richtext-input1',
+  kitClass = 'pb_rich_text_editor_kit'
+
+test('returns namespaced class name', () => {
+  render(
+    <RichTextEditor data={{ testid: testId }} />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(kitClass)
+})
+
+test('returns "Simple" namespaced class name via prop', () => {
+  render(
+    <RichTextEditor
+        data={{ testid: testId }}
+        simple
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} simple`)
+})
+
+test('returns "Focus" namespaced class name via prop', () => {
+  render(
+    <RichTextEditor
+        data={{ testid: testId }}
+        focus
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} focus-editor-targets`)
+})
+
+test('returns "Sticky" namespaced class name via prop', () => {
+  render(
+    <RichTextEditor
+        data={{ testid: testId }}
+        sticky
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} sticky`)
+})
+
+test('returns "Dark" class name', () => {
+  render(
+    <RichTextEditor
+        dark
+        data={{ testid: testId }}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} dark`)
+})


### PR DESCRIPTION
#### Screens
<img width="600" alt="richtext-attributes" src="https://user-images.githubusercontent.com/4315934/107279401-c2dce700-6a35-11eb-969a-33b7a113cc7f.png">


#### Breaking Changes

No - This add additional props with optional props.

#### Runway Ticket URL

[NUXE-447](https://nitro.powerhrg.com/runway/backlog_items/NUXE-447)

#### How to test this

Has tests, attributes in new example as well.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
