### PR TITLE
fixup dark mode select truncation

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -66,6 +66,10 @@
       background: $focus_input_dark;
       box-shadow: inset 0 -11px 20px rgba($white, 0.05);
       text-shadow: 0 0 0 $text_dk_default;
+      padding-right: $space_xl;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       @media (hover:hover) {
         &:hover, &:active, &:focus {
           background-color: tint($focus_input_dark, 5%);


### PR DESCRIPTION
#### Screens

![image](https://user-images.githubusercontent.com/863031/107699815-37a16280-6c7c-11eb-82ab-9c94ddab6109.png)

#### Breaking Changes

NO

#### Runway Ticket URL

NA

#### How to test this
Switch to dark mode and shrink the select till truncation appears on the select