### PR TITLE
Added status colors to the distribution bar

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.scss
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.scss
@@ -1,7 +1,7 @@
 @import "../tokens/colors";
 
 [class^=pb_distribution_bar] {
-  $bar_colors: map-values($data_colors);
+  $bar_colors: map-merge($data_colors, $status_colors);
   $small_bar: 8px;
   $large_bar: 36px;
   display: flex;
@@ -10,8 +10,8 @@
   .pb_distribution_width {
     height: 100%;
     display: inline-block;
-    @each $name, $color in $data_colors {
-      &:nth-child(#{length($data_colors)}n+#{index(($data_colors), ($name $color))}) {
+    @each $name, $color in $bar_colors {
+      &:nth-child(#{length($bar_colors)}n+#{index(($bar_colors), ($name $color))}) {
         background-color: $color;
       }
       &.color_#{$name} {

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.html.erb
@@ -1,4 +1,4 @@
 <%= pb_rails("distribution_bar", props: {
   widths: [4,5,3],
-  colors: ["data_7", "data_1", "data_6"]
+  colors: ["data_7", "data_1", "neutral"]
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.jsx
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.jsx
@@ -6,7 +6,7 @@ const DistributionBarCustomColors = (props) => {
     <React.Fragment>
       <div>
         <DistributionBar
-            colors={['data_7', 'data_1', 'data_6']}
+            colors={['data_7', 'data_1', 'neutral']}
             widths={[4, 5, 3]}
             {...props}
         />

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.md
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/docs/_distribution_bar_custom_colors.md
@@ -1,1 +1,1 @@
-You can customize the order of the colors you would like to use by using the `colors` prop. Only the data colors will work for Playbook charts. See the [design page](/visual_guidelines) for reference.
+You can customize the order of the colors you would like to use by using the `colors` prop. Only the data and status colors will work for Playbook charts. See the [design page](/visual_guidelines) for reference.


### PR DESCRIPTION
#### Screens
![image](https://user-images.githubusercontent.com/863031/107711186-d7ff8300-6c8c-11eb-9d3b-b55d104ad6cb.png)


#### Breaking Changes

No

#### Runway Ticket URL

NA

#### How to test this

See the docs under custom colors. The last option `Neutral` is new
