### PR TITLE
Add name prop to typeahead with pills options

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -40,6 +40,7 @@ module Playbook
           id: id,
           isMulti: true,
           label: label,
+          name: name,
           options: options,
           placeholder: placeholder,
         }


### PR DESCRIPTION
#### Screens
<img width="600" alt="missing-prop" src="https://user-images.githubusercontent.com/4315934/107971477-48f6b180-6f91-11eb-83dc-af925301fb83.png">
Above: The name prop is missing...

#### Breaking Changes

No, bug fix.

#### Runway Ticket URL

[NUXE-489](https://nitro.powerhrg.com/runway/backlog_items/NUXE-489)

#### How to test this
Add name to kit.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
