### PR TITLE
Fix tooltip - Center Arrows

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
@@ -46,7 +46,7 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
       content: " ";
       position: absolute;
       top: 100%;
-      left: 50%;
+      left: calc(50% - 10px);
       border-color: $white transparent transparent transparent;
       border-style: solid;
       border-width: 10px;
@@ -95,9 +95,10 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
     box-shadow: -8px 0 28px 0 $tooltip_shadow;
     margin: 0 0 0 $space_sm;
     .arrow {
-      left: -#{$space_xs};
-      top: $arrow_vertical_offset;
+      left: -18px;
+      right: auto;
       margin-bottom: 0;
+      top: $arrow_vertical_offset;
       transform: rotate(90deg);
     }
     &.flipped .arrow {


### PR DESCRIPTION
#### Screens

<img width="247" alt="Screen Shot 2021-02-23 at 12 28 08 PM" src="https://user-images.githubusercontent.com/9784112/108883398-63550e80-75d3-11eb-8987-08508a70b5b4.png">
<img width="386" alt="Screen Shot 2021-02-23 at 12 28 14 PM" src="https://user-images.githubusercontent.com/9784112/108883423-66e89580-75d3-11eb-8025-0a5bffbb5fbe.png">


#### Breaking Changes

No

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-453

#### How to test this

Check If the tooltip is centered

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
