### PR TITLE
[CHMN-35] Add yellow as option to progress simple kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.jsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.jsx
@@ -14,7 +14,7 @@ type ProgressSimpleProps = {
   muted: boolean,
   percent: string,
   value: number,
-  variant?: "default" | "positive" | "negative",
+  variant?: "default" | "positive" | "negative" | "warning",
   width: string,
 }
 

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.scss
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.scss
@@ -33,6 +33,11 @@ $pb_progress_simple_height: 4px;
         background: $error;
       }
     }
+    &[class*=_warning] {
+      .progress_simple_value {
+        background: $warning;
+      }
+    }
 
   [class^=progress_simple_value] {
     width: 0%;

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.html.erb
@@ -2,8 +2,13 @@
 
 <br>
 
-<%= pb_rails("progress_simple", props: { percent: 90, variant: "positive" }) %>
+<%= pb_rails("progress_simple", props: { percent: 80, variant: "positive" }) %>
 
 <br>
 
 <%= pb_rails("progress_simple", props: { percent: 10, variant: "negative" }) %>
+
+<br>
+
+<%= pb_rails("progress_simple", props: { percent: 40, variant: "warning" }) %>
+

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.html.erb
@@ -2,7 +2,7 @@
 
 <br>
 
-<%= pb_rails("progress_simple", props: { percent: 80, variant: "positive" }) %>
+<%= pb_rails("progress_simple", props: { percent: 90, variant: "positive" }) %>
 
 <br>
 

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.jsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.jsx
@@ -9,7 +9,7 @@ const ProgressSimpleVariants = () => {
       <br />
 
       <ProgressSimple
-          percent={90}
+          percent={80}
           variant="positive"
       />
 
@@ -18,6 +18,13 @@ const ProgressSimpleVariants = () => {
       <ProgressSimple
           percent={10}
           variant="negative"
+      />
+
+      <br />
+
+      <ProgressSimple
+          percent={40}
+          variant="warning"
       />
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.jsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.jsx
@@ -9,7 +9,7 @@ const ProgressSimpleVariants = () => {
       <br />
 
       <ProgressSimple
-          percent={80}
+          percent={90}
           variant="positive"
       />
 

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.md
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_progress_simple_variants.md
@@ -1,1 +1,1 @@
-Progress Simple can pass colors - primary, green and red. Variants names are `default`, `positive`, and `negative` respectively.
+Progress Simple can pass colors - primary, green, red, and yellow. Variants names are `default`, `positive`, `negative`, and `warning`, respectively.

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/progress_simple.rb
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/progress_simple.rb
@@ -18,7 +18,7 @@ module Playbook
       # could this possibly be [sm, md, lg]?
       prop :width, default: "100%"
       prop :variant, type: Playbook::Props::Enum,
-                     values: %w[default positive negative],
+                     values: %w[default positive negative warning],
                      default: "default"
 
       def number_value

--- a/playbook/spec/pb_kits/playbook/kits/progress_simple_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/progress_simple_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Playbook::PbProgressSimple::ProgressSimple do
   it { is_expected.to define_prop(:percent).of_type(Playbook::Props::Percentage) }
   it { is_expected.to define_prop(:width) }
   it { is_expected.to define_enum_prop(:variant)
-    .with_values("default", "positive", "negative")
+    .with_values("default", "positive", "negative", "warning")
     .with_default("default") }
 
   describe "#classname" do
@@ -27,6 +27,7 @@ RSpec.describe Playbook::PbProgressSimple::ProgressSimple do
       expect(subject.new(variant: "default").classname).to eq "pb_progress_simple_kit_left"
       expect(subject.new(variant: "positive").classname).to eq "pb_progress_simple_kit_positive_left"
       expect(subject.new(variant: "negative").classname).to eq "pb_progress_simple_kit_negative_left"
+      expect(subject.new(variant: "warning").classname).to eq "pb_progress_simple_kit_warning_left"
     end
   end
 


### PR DESCRIPTION
#### Screens

RAILS

<img width="1308" alt=" " src="https://user-images.githubusercontent.com/51907753/108896706-40caf180-75e3-11eb-86d7-479132520a07.png">

REACT

<img width="1372" alt="Screen Shot 2021-02-23 at 2 26 19 PM" src="https://user-images.githubusercontent.com/51907753/108896743-4b858680-75e3-11eb-8946-5e58c417b7ac.png">


#### Breaking Changes

None -- only additive changes.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/CHMN-35

#### How to test this

The easiest way is to go to the Progress Simple docs and look at the "Variants" example.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
