### PR TITLE
Reintroduce missing kit description markdown

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_docs/kit_example.rb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_example.rb
@@ -21,7 +21,7 @@ module Playbook
       end
 
       def description
-        @description ||= read_kit_file(kit, "_#{example_key}.md")
+        @description ||= read_kit_file("_#{example_key}.md")
       end
 
       def highlighter


### PR DESCRIPTION
#### Screens

![before](https://p-a6FbDk.t4.n0.cdn.getcloudapp.com/items/Qwu9d5W1/98a79875-cf29-4551-941a-3269bab93373.jpg?source=client&v=07b04de96af1e63164b40228d5326c98)
Before...
![after](https://p-a6FbDk.t4.n0.cdn.getcloudapp.com/items/ApuRD9KX/b1d57b37-0f35-424f-9c47-850ba49caeab.jpg?source=client&v=7b1e401836b54ded0eab14495d05c4ae)
After...

#### Breaking Changes

n/a

#### Runway Ticket URL

[Link to Runway Story](https://nitro.powerhrg.com/runway/backlog_items/NUXE-515)

#### How to test this

Double check Milano deploy to see if markdown is displaying.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
