### PR TITLE
Fix form kit view context

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
@@ -13,8 +13,8 @@
   ]
 %>
 
-<%= pb_rails("form", props: {
-    form_system_options: { scope: :example, method: :get, url: "" },
+<%= pb_rails("form/form_with", props: {
+    scope: :example, method: :get, url: "",
     validate: true
   }) do |form| %>
   <%= form.text_field :example_text_field, props: { label: true, required: true } %>

--- a/playbook/app/pb_kits/playbook/pb_form/form.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/form.html.erb
@@ -1,7 +1,0 @@
-<%=
-  pb_rails("form/#{form_system}", props: {
-    options: form_system_options,
-    children: children,
-    validate: validate
-  })
-%>

--- a/playbook/app/pb_kits/playbook/pb_form/form.rb
+++ b/playbook/app/pb_kits/playbook/pb_form/form.rb
@@ -19,8 +19,17 @@ module Playbook
         end
       end
 
-      def render_in(view_context, &_block)
-        super(view_context, &nil)
+      def render_in(view_context, &block)
+        form_kit.render_in(view_context, &block)
+      end
+
+    private
+
+      def form_kit
+        @form_system ||= begin
+          ::Playbook::KitResolver.resolve("form/#{form_system}")
+                                 .new(options: form_system_options, validate: validate, children: children)
+        end
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_form/form_builder.rb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_builder.rb
@@ -21,7 +21,7 @@ module Playbook
         prepend(DatePickerField)
 
         def actions(&block)
-          @template.render_component ActionArea.new(submit_default_value: submit_default_value), &block
+          @template.render_component ActionArea.new(submit_default_value: submit_default_value, children: block)
         end
       end
     end

--- a/playbook/app/pb_kits/playbook/pb_form/form_builder/action_area.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_builder/action_area.html.erb
@@ -1,3 +1,3 @@
 <ol class="pb-form-actions">
-    <%= content %>
+  <%= instance_exec(self, &children) %>
 </ol>

--- a/playbook/app/pb_kits/playbook/pb_form/form_with.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_with.html.erb
@@ -1,18 +1,11 @@
-<%= form_with(id: id,
-              aria: aria,
-              class: classname,
-              data: data,
-              builder: form_builder,
-              **options) do |form| %>
-  <% instance_exec form, &children %>
+<%= form_with(form_options, &method(:render_form)) %>
 
-  <% if validate %>
-    <% content_for :pb_js do %>
-      <%= javascript_tag do %>
-        window.addEventListener('DOMContentLoaded', function() {
-          PbFormValidation.start()
-        })
-      <% end %>
+<% if validate %>
+  <% content_for :pb_js do %>
+    <%= javascript_tag do %>
+      window.addEventListener('DOMContentLoaded', function() {
+        PbFormValidation.start()
+      })
     <% end %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_form/form_with.rb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_with.rb
@@ -14,16 +14,23 @@ module Playbook
         prop(:data).merge("pb-form-validation" => validate)
       end
 
-      def options
-        { url: "" }.merge(Hash(prop(:options)))
+      def form_options
+        {
+          url: "",
+          id: id,
+          aria: aria,
+          class: classname,
+          data: data,
+          builder: ::Playbook::PbForm::FormWith::FormBuilder,
+        }.merge(options)
+      end
+
+      def render_form(builder)
+        view_context.capture(builder, &children)
       end
 
       def classname
         [generate_classname("pb-form"), options[:class]].join(" ")
-      end
-
-      def form_builder
-        ::Playbook::PbForm::FormWith::FormBuilder
       end
 
       def render_in(view_context, &_block)


### PR DESCRIPTION
#### Screens

Each playbook kit runs in its own view context, with a block that carries a context in itself. The way the form is setup, the context in which the block code is executed is ran within the kit context, not the same context it was created. This PR fixes this issue and simplify the form kit setup.
