### PR TITLE
Add React tests for Button, Button Toolbar, Circle Icon Button

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/_button.jsx
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import classnames from 'classnames'
+import { buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
 
 import Icon from '../pb_icon/_icon.jsx'
@@ -13,6 +14,7 @@ type ButtonPropTypes = {
   },
   children?: array<React.ReactChild>,
   className?: string | array<string>,
+  data?: object,
   disabled?: boolean,
   fixedWidth?: boolean,
   fullWidth?: boolean,
@@ -69,6 +71,7 @@ const Button = (props: ButtonPropTypes) => {
   const {
     children,
     className,
+    data = {},
     disabled,
     icon = null,
     id,
@@ -82,6 +85,7 @@ const Button = (props: ButtonPropTypes) => {
   } = props
 
   const buttonAria = buttonAriaProps(props)
+  const dataProps = buildDataProps(data)
   const css = classnames(
     buttonClassName(props),
     globalProps(props),
@@ -111,6 +115,7 @@ const Button = (props: ButtonPropTypes) => {
     <If condition={link !== null}>
       <a
           {...buttonAria}
+          {...dataProps}
           className={css}
           href={link}
           id={id}
@@ -122,6 +127,7 @@ const Button = (props: ButtonPropTypes) => {
       <Else />
       <button
           {...buttonAria}
+          {...dataProps}
           className={css}
           disabled={disabled}
           id={id}

--- a/playbook/app/pb_kits/playbook/pb_button/button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button/button.test.js
@@ -21,7 +21,7 @@ test('passes type, text, and value props to button', () => {
     </>
   )
 
-  const kit      = screen.getByTestId('primary-test')
+  const kit = screen.getByTestId('primary-test')
   const content  = screen.getByText(text)
 
   expect(kit).toHaveClass('pb_button_kit_primary_inline_enabled')
@@ -41,7 +41,7 @@ test('adds link to button', () => {
     />
   )
 
-  const kit      = screen.getByTestId('link-test')
+  const kit = screen.getByTestId('link-test')
 
   expect(kit).toHaveAttribute('href', link)
 })
@@ -54,7 +54,7 @@ test('button with secondary variant', () => {
     />
   )
 
-  const kit      = screen.getByTestId('variant-test')
+  const kit = screen.getByTestId('variant-test')
 
   expect(kit).toHaveClass('pb_button_kit_secondary_inline_enabled')
   expect(kit).toHaveAttribute('type', 'button')
@@ -68,7 +68,7 @@ test('disable prop', () => {
     />
   )
 
-  const kit      = screen.getByTestId('disable-test')
+  const kit = screen.getByTestId('disable-test')
 
   expect(kit).toBeDisabled()
 })

--- a/playbook/app/pb_kits/playbook/pb_button/button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button/button.test.js
@@ -4,32 +4,69 @@ import { render, screen } from '../utilities/test-utils'
 
 import Button from './_button'
 
+// Primary Test Variables
 const htmlType = 'submit',
-  link = 'https://www.google.com',
   text = 'Button Text',
   value = '1234'
 
-test('loads the given image url and name', () => {
+// const link = 'https://www.google.com'
+
+test('passes type, text, and value props to button', () => {
   render(
-    <Button
-        data={{ testid: 'primary-test' }}
-        htmlType={htmlType}
-        link={link}
-        text={text}
-        value={value}
-    />
+    <>
+      <Button
+          data={{ testid: 'primary-test' }}
+          htmlType={htmlType}
+          text={text}
+          value={value}
+      />
+      {/* <Button
+          data={{ testid: 'link-test' }}
+          link={link}
+      />
+      <Button
+          data={{ testid: 'variant-test' }}
+          variant="secondary"
+      /> */}
+    </>
   )
 
   const kit      = screen.getByTestId('primary-test')
+  const content  = screen.getByText(text)
 
   expect(kit).toHaveClass('pb_button_kit_primary_inline_enabled')
   expect(kit).toHaveAttribute('type', htmlType)
-  expect(kit).toHaveAttribute('href', link)
   expect(kit).toHaveAttribute('value', value)
+  expect(content).toHaveTextContent(text)
+
+  // const kit2      = screen.getByTestId('link-test')
+
+  // expect(kit2).toHaveAttribute('href', link)
+
+  // const kit3      = screen.getByTestId('variant-test')
+
+  // expect(kit3).toHaveClass('pb_button_kit_secondary_inline_enabled')
+  // expect(kit3).toHaveAttribute('type', 'button')
+})
+
+// Link Test Variables
+const link = 'https://www.google.com'
+
+test('adds link to button', () => {
+  render(
+    <Button
+        data={{ testid: 'link-test' }}
+        link={link}
+    />
+  )
+
+  const kit      = screen.getByTestId('link-test')
+
+  expect(kit).toHaveAttribute('href', link)
   // expect(kit).tagName('A')
 })
 
-test('loads the given image url and name', () => {
+test('button with secondary variant', () => {
   render(
     <Button
         data={{ testid: 'variant-test' }}
@@ -41,4 +78,17 @@ test('loads the given image url and name', () => {
 
   expect(kit).toHaveClass('pb_button_kit_secondary_inline_enabled')
   expect(kit).toHaveAttribute('type', 'button')
+})
+
+test('disable prop', () => {
+  render(
+    <Button
+        data={{ testid: 'disable-test' }}
+        disable
+    />
+  )
+
+  const kit      = screen.getByTestId('disable-test')
+
+  expect(kit).toBeDisabled()
 })

--- a/playbook/app/pb_kits/playbook/pb_button/button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button/button.test.js
@@ -1,6 +1,6 @@
 
 import React from 'react'
-import { fireEvent, render, screen, waitFor } from '../utilities/test-utils'
+import { appendAlert, fireEvent, render, screen, waitFor } from '../utilities/test-utils'
 
 import Button from './_button'
 
@@ -8,8 +8,6 @@ import Button from './_button'
 const htmlType = 'submit',
   text = 'Button Text',
   value = '1234'
-
-// const link = 'https://www.google.com'
 
 test('passes type, text, and value props to button', () => {
   render(
@@ -20,14 +18,6 @@ test('passes type, text, and value props to button', () => {
           text={text}
           value={value}
       />
-      {/* <Button
-          data={{ testid: 'link-test' }}
-          link={link}
-      />
-      <Button
-          data={{ testid: 'variant-test' }}
-          variant="secondary"
-      /> */}
     </>
   )
 
@@ -38,15 +28,6 @@ test('passes type, text, and value props to button', () => {
   expect(kit).toHaveAttribute('type', htmlType)
   expect(kit).toHaveAttribute('value', value)
   expect(content).toHaveTextContent(text)
-
-  // const kit2      = screen.getByTestId('link-test')
-
-  // expect(kit2).toHaveAttribute('href', link)
-
-  // const kit3      = screen.getByTestId('variant-test')
-
-  // expect(kit3).toHaveClass('pb_button_kit_secondary_inline_enabled')
-  // expect(kit3).toHaveAttribute('type', 'button')
 })
 
 // Link Test Variables
@@ -63,7 +44,6 @@ test('adds link to button', () => {
   const kit      = screen.getByTestId('link-test')
 
   expect(kit).toHaveAttribute('href', link)
-  // expect(kit).tagName('A')
 })
 
 test('button with secondary variant', () => {
@@ -93,19 +73,30 @@ test('disable prop', () => {
   expect(kit).toBeDisabled()
 })
 
+// const appendAlert = (message) => {
+//   const textNode = document.createTextNode(message)
+//   document.querySelector('body').appendChild(textNode)
+// }
+
 test('click event', async () => {
   render(
     <Button
         data={{ testid: 'click-test' }}
-        onClick={() => alert('clicked button!')}
+        // onClick={() => {
+        //     document.querySelector('body')
+        //             .appendChild(document.createElement('div')
+        //             .appendChild(document.createTextNode('clicked button!')))
+        //   }
+        // }
+        onClick={() => appendAlert('clicked button!')}
     />
   )
 
-  const kit      = screen.getByTestId('click-test')
+  const kit = screen.getByTestId('click-test')
 
   fireEvent.click(kit)
 
-  await waitFor(() => screen.getByRole('alert'))
+  await waitFor(() => screen.getByText('clicked button!'))
 
-  expect(screen.getByRole('alert')).toHaveTextContent('clicked button!')
+  expect(screen.getByText('clicked button!')).toBeInTheDocument()
 })

--- a/playbook/app/pb_kits/playbook/pb_button/button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button/button.test.js
@@ -1,0 +1,44 @@
+
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import Button from './_button'
+
+const htmlType = 'submit',
+  link = 'https://www.google.com',
+  text = 'Button Text',
+  value = '1234'
+
+test('loads the given image url and name', () => {
+  render(
+    <Button
+        data={{ testid: 'primary-test' }}
+        htmlType={htmlType}
+        link={link}
+        text={text}
+        value={value}
+    />
+  )
+
+  const kit      = screen.getByTestId('primary-test')
+
+  expect(kit).toHaveClass('pb_button_kit_primary_inline_enabled')
+  expect(kit).toHaveAttribute('type', htmlType)
+  expect(kit).toHaveAttribute('href', link)
+  expect(kit).toHaveAttribute('value', value)
+  // expect(kit).tagName('A')
+})
+
+test('loads the given image url and name', () => {
+  render(
+    <Button
+        data={{ testid: 'variant-test' }}
+        variant="secondary"
+    />
+  )
+
+  const kit      = screen.getByTestId('variant-test')
+
+  expect(kit).toHaveClass('pb_button_kit_secondary_inline_enabled')
+  expect(kit).toHaveAttribute('type', 'button')
+})

--- a/playbook/app/pb_kits/playbook/pb_button/button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button/button.test.js
@@ -73,21 +73,10 @@ test('disable prop', () => {
   expect(kit).toBeDisabled()
 })
 
-// const appendAlert = (message) => {
-//   const textNode = document.createTextNode(message)
-//   document.querySelector('body').appendChild(textNode)
-// }
-
 test('click event', async () => {
   render(
     <Button
         data={{ testid: 'click-test' }}
-        // onClick={() => {
-        //     document.querySelector('body')
-        //             .appendChild(document.createElement('div')
-        //             .appendChild(document.createTextNode('clicked button!')))
-        //   }
-        // }
         onClick={() => appendAlert('clicked button!')}
     />
   )

--- a/playbook/app/pb_kits/playbook/pb_button/button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button/button.test.js
@@ -1,6 +1,6 @@
 
 import React from 'react'
-import { render, screen } from '../utilities/test-utils'
+import { fireEvent, render, screen, waitFor } from '../utilities/test-utils'
 
 import Button from './_button'
 
@@ -84,11 +84,28 @@ test('disable prop', () => {
   render(
     <Button
         data={{ testid: 'disable-test' }}
-        disable
+        disabled
     />
   )
 
   const kit      = screen.getByTestId('disable-test')
 
   expect(kit).toBeDisabled()
+})
+
+test('click event', async () => {
+  render(
+    <Button
+        data={{ testid: 'click-test' }}
+        onClick={() => alert('clicked button!')}
+    />
+  )
+
+  const kit      = screen.getByTestId('click-test')
+
+  fireEvent.click(kit)
+
+  await waitFor(() => screen.getByRole('alert'))
+
+  expect(screen.getByRole('alert')).toHaveTextContent('clicked button!')
 })

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.jsx
@@ -1,47 +1,35 @@
 import React from 'react'
 import { Button } from '../../'
 
-const htmlType = 'submit',
-  link = 'https://www.google.com',
-  text = 'Button Text',
-  value = '1234'
-
 const ButtonDefault = (props) => (
-  // <div>
-  //   <Button
-  //       marginRight="xl"
-  //       onClick={() => alert('button clicked!')}
-  //       text="Button Primary"
-  //       {...props}
-  //   />
-  //   {' '}
-  //   <Button
-  //       onClick={() => alert('button clicked!')}
-  //       text="Button Secondary"
-  //       variant="secondary"
-  //       {...props}
-  //   />
-  //   {' '}
-  //   <Button
-  //       onClick={() => alert('button clicked!')}
-  //       text="Button Link"
-  //       variant="link"
-  //       {...props}
-  //   />
-  //   <Button
-  //       disabled
-  //       onClick={() => alert('button clicked!')}
-  //       text="Button Disabled"
-  //       {...props}
-  //   />
-  // </div>
-  <Button
-      data={{ testid: 'primary-test' }}
-      htmlType={htmlType}
-      // link={link}
-      text={text}
-      value={value}
-  />
+  <div>
+    <Button
+        marginRight="xl"
+        onClick={() => alert('button clicked!')}
+        text="Button Primary"
+        {...props}
+    />
+    {' '}
+    <Button
+        onClick={() => alert('button clicked!')}
+        text="Button Secondary"
+        variant="secondary"
+        {...props}
+    />
+    {' '}
+    <Button
+        onClick={() => alert('button clicked!')}
+        text="Button Link"
+        variant="link"
+        {...props}
+    />
+    <Button
+        disabled
+        onClick={() => alert('button clicked!')}
+        text="Button Disabled"
+        {...props}
+    />
+  </div>
 )
 
 export default ButtonDefault

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.jsx
@@ -1,36 +1,47 @@
 import React from 'react'
 import { Button } from '../../'
 
-const ButtonDefault = (props) => (
-  <div>
-    <Button
-        marginRight="xl"
-        onClick={() => alert('button clicked!')}
-        text="Button Primary"
-        {...props}
-    />
-    {' '}
-    <Button
-        onClick={() => alert('button clicked!')}
-        text="Button Secondary"
-        variant="secondary"
-        {...props}
-    />
-    {' '}
-    <Button
-        onClick={() => alert('button clicked!')}
-        text="Button Link"
-        variant="link"
-        {...props}
-    />
-    <Button
-        disabled
-        onClick={() => alert('button clicked!')}
-        text="Button Disabled"
-        {...props}
-    />
-  </div>
+const htmlType = 'submit',
+  link = 'https://www.google.com',
+  text = 'Button Text',
+  value = '1234'
 
+const ButtonDefault = (props) => (
+  // <div>
+  //   <Button
+  //       marginRight="xl"
+  //       onClick={() => alert('button clicked!')}
+  //       text="Button Primary"
+  //       {...props}
+  //   />
+  //   {' '}
+  //   <Button
+  //       onClick={() => alert('button clicked!')}
+  //       text="Button Secondary"
+  //       variant="secondary"
+  //       {...props}
+  //   />
+  //   {' '}
+  //   <Button
+  //       onClick={() => alert('button clicked!')}
+  //       text="Button Link"
+  //       variant="link"
+  //       {...props}
+  //   />
+  //   <Button
+  //       disabled
+  //       onClick={() => alert('button clicked!')}
+  //       text="Button Disabled"
+  //       {...props}
+  //   />
+  // </div>
+  <Button
+      data={{ testid: 'primary-test' }}
+      htmlType={htmlType}
+      // link={link}
+      text={text}
+      value={value}
+  />
 )
 
 export default ButtonDefault

--- a/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.test.js
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import { render, screen } from '../utilities/test-utils'
 

--- a/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.test.js
@@ -1,0 +1,60 @@
+
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import { Button, ButtonToolbar } from '../'
+
+test('default test', () => {
+  render(
+    <ButtonToolbar
+        data={{ testid: 'default-test' }}
+    >
+      <Button
+          data={{ testid: 'child-button' }}
+          text="Test"
+      />
+      {/* <Button
+          text="Edit"
+      />
+      <Button
+          text="Copy"
+      />
+      <Button
+          text="Cut"
+      /> */}
+    </ButtonToolbar>
+  )
+
+  const kit   = screen.getByTestId('default-test')
+  const child = screen.getByTestId('child-button')
+  // const content  = screen.getByText(text)
+
+  expect(kit).toHaveClass('pb_button_toolbar_kit_horizontal_primary')
+  expect(kit).toContainElement(child)
+  expect(child).toHaveClass('pb_button_kit_primary_inline_enabled')
+  // expect(kit).toHaveAttribute('type', htmlType)
+  // expect(kit).toHaveAttribute('value', value)
+  // expect(content).toHaveTextContent(text)
+})
+
+test('variant and orientation props', () => {
+  render(
+    <ButtonToolbar
+        data={{ testid: 'second-test' }}
+        orientation="vertical"
+        variant="secondary"
+    >
+      <Button
+          data={{ testid: 'child-button' }}
+          text="Create"
+          variant="secondary"
+      />
+    </ButtonToolbar>
+  )
+
+  const kit   = screen.getByTestId('second-test')
+  const child = screen.getByTestId('child-button')
+
+  expect(kit).toHaveClass('pb_button_toolbar_kit_vertical_secondary')
+  expect(child).toHaveClass('pb_button_kit_secondary_inline_enabled')
+})

--- a/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.test.js
+++ b/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.test.js
@@ -13,28 +13,15 @@ test('default test', () => {
           data={{ testid: 'child-button' }}
           text="Test"
       />
-      {/* <Button
-          text="Edit"
-      />
-      <Button
-          text="Copy"
-      />
-      <Button
-          text="Cut"
-      /> */}
     </ButtonToolbar>
   )
 
   const kit   = screen.getByTestId('default-test')
   const child = screen.getByTestId('child-button')
-  // const content  = screen.getByText(text)
 
   expect(kit).toHaveClass('pb_button_toolbar_kit_horizontal_primary')
   expect(kit).toContainElement(child)
   expect(child).toHaveClass('pb_button_kit_primary_inline_enabled')
-  // expect(kit).toHaveAttribute('type', htmlType)
-  // expect(kit).toHaveAttribute('value', value)
-  // expect(content).toHaveTextContent(text)
 })
 
 test('variant and orientation props', () => {

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -1,6 +1,6 @@
 
 import React from 'react'
-import { render, screen } from '../utilities/test-utils'
+import { appendAlert, fireEvent, render, screen, waitFor } from '../utilities/test-utils'
 
 import CircleIconButton from './_circle_icon_button'
 
@@ -8,13 +8,28 @@ test('default test', () => {
   render(
     <CircleIconButton
         data={{ testid: 'default-test' }}
+        icon="plus"
     />
   )
 
-  const kit   = screen.getByTestId('default-test')
+  const kit = screen.getByTestId('default-test')
 
   expect(kit).toHaveClass('pb_circle_icon_button_kit')
-  // expect(kit).toHaveAttribute('type', htmlType)
-  // expect(kit).toHaveAttribute('value', value)
-  // expect(content).toHaveTextContent(text)
 })
+
+// test('click event', async () => {
+//   render(
+//     <CircleIconButton
+//         data={{ testid: 'click-test' }}
+//         onClick={() => appendAlert('clicked button!')}
+//     />
+//   )
+
+//   const kit = screen.getByTestId('click-test')
+
+//   fireEvent.click(kit)
+
+//   await waitFor(() => screen.getByText('clicked button!'))
+
+//   expect(screen.getByText('clicked button!')).toBeInTheDocument()
+// })

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import { render, screen } from '../utilities/test-utils'
 

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -1,0 +1,20 @@
+
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import CircleIconButton from './_circle_icon_button'
+
+test('default test', () => {
+  render(
+    <CircleIconButton
+        data={{ testid: 'default-test' }}
+    />
+  )
+
+  const kit   = screen.getByTestId('default-test')
+
+  expect(kit).toHaveClass('pb_circle_icon_button_kit')
+  // expect(kit).toHaveAttribute('type', htmlType)
+  // expect(kit).toHaveAttribute('value', value)
+  // expect(content).toHaveTextContent(text)
+})

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -1,6 +1,6 @@
 
 import React from 'react'
-import { appendAlert, fireEvent, render, screen, waitFor } from '../utilities/test-utils'
+import { render, screen } from '../utilities/test-utils'
 
 import CircleIconButton from './_circle_icon_button'
 
@@ -16,20 +16,3 @@ test('default test', () => {
 
   expect(kit).toHaveClass('pb_circle_icon_button_kit')
 })
-
-// test('click event', async () => {
-//   render(
-//     <CircleIconButton
-//         data={{ testid: 'click-test' }}
-//         onClick={() => appendAlert('clicked button!')}
-//     />
-//   )
-
-//   const kit = screen.getByTestId('click-test')
-
-//   fireEvent.click(kit)
-
-//   await waitFor(() => screen.getByText('clicked button!'))
-
-//   expect(screen.getByText('clicked button!')).toBeInTheDocument()
-// })

--- a/playbook/app/pb_kits/playbook/utilities/test-utils.js
+++ b/playbook/app/pb_kits/playbook/utilities/test-utils.js
@@ -40,12 +40,6 @@ export const ensureAccessible = async (Kit, props = {}, newProps = {}) => {
   expect(await axe(html)).toHaveNoViolations()
 }
 
-// export const appendAlert = (message) => {
-//   const alertWrapper = document.createElement('div')
-//   const textNode = document.createTextNode(message)
-//   const alertNode = alertWrapper.appendChild(textNode)
-//   document.querySelector('body').appendChild(alertNode)
-// }
 export const appendAlert = (message) => {
   const alertNode = document.createElement('div')
   alertNode.innerHTML = message

--- a/playbook/app/pb_kits/playbook/utilities/test-utils.js
+++ b/playbook/app/pb_kits/playbook/utilities/test-utils.js
@@ -39,3 +39,15 @@ export const ensureAccessible = async (Kit, props = {}, newProps = {}) => {
   const html = render()
   expect(await axe(html)).toHaveNoViolations()
 }
+
+// export const appendAlert = (message) => {
+//   const alertWrapper = document.createElement('div')
+//   const textNode = document.createTextNode(message)
+//   const alertNode = alertWrapper.appendChild(textNode)
+//   document.querySelector('body').appendChild(alertNode)
+// }
+export const appendAlert = (message) => {
+  const alertNode = document.createElement('div')
+  alertNode.innerHTML = message
+  document.querySelector('body').appendChild(alertNode)
+}


### PR DESCRIPTION
#### What does this PR do?

1. Adds React tests for Button, Button Toolbar, and Circle Icon Button kits.
2. Adds a test utility method that can be used to test click functionality.

#### Breaking Changes

n/a

#### Runway Ticket URL

[Link to Runway Story](https://nitro.powerhrg.com/runway/backlog_items/NUXE-325)

#### How to test this

Pull locally and run `docker-compose run web yarn test`

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
