### PR TITLE
Online Status Accessibility Improvements

### DIFF
--- a/playbook/app/pb_kits/playbook/data/menu.yml
+++ b/playbook/app/pb_kits/playbook/data/menu.yml
@@ -47,7 +47,6 @@ kits:
   - multiple_users
   - multiple_users_stacked
   - nav
-  - online_status
   - tags:
     - badge
     - hashtag

--- a/playbook/app/pb_kits/playbook/pb_online_status/_online_status.jsx
+++ b/playbook/app/pb_kits/playbook/pb_online_status/_online_status.jsx
@@ -23,6 +23,8 @@ const OnlineStatus = (props: OnlineStatusProps) => {
     status = 'offline',
   } = props
 
+  aria.label = status
+
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const classes = classnames(buildCss('pb_online_status_kit', status), globalProps(props), className)

--- a/playbook/app/pb_kits/playbook/pb_online_status/online_status.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_online_status/online_status.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag(:div,
-    aria: object.aria,
+    aria: object.aria.merge!(label: object.status),
     class: object.classname,
     data: object.data,
     id: object.id) do %>


### PR DESCRIPTION
#### What does this PR do?

1. Adds an `aria-label` to the Online Status kit matching it's status prop (i.e. online, offline, away)
2. Removes Online Status kit from `menu.yml` (no longer visible in the docs)

#### Screens

No visual changes

#### Breaking Changes

No

#### Runway Ticket URL

[Story 1](https://nitro.powerhrg.com/runway/backlog_items/NUXE-529)
[Story 2](https://nitro.powerhrg.com/runway/backlog_items/NUXE-499)

#### How to test this

Check the `aria-label` on the Avatar kit's online status (both React and Rails).  Confirm that the Online Status kit no longer appears in the docs.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
