### PR TITLE
Add image alt attributes as props to avatar kits

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar/_avatar.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/_avatar.jsx
@@ -15,6 +15,7 @@ type AvatarProps = {
   data?: object,
   dark?: boolean,
   id?: string,
+  imageAlt?: string,
   imageUrl: string,
   name: string,
   size?: "md" | "lg" | "sm" | "xl" | "xs",
@@ -27,7 +28,18 @@ const firstTwoInitials = (name) =>
     .substring(0, 2)
 
 const Avatar = (props: AvatarProps) => {
-  const { aria = {}, className, data = {}, name = null, id = '', imageUrl, size = 'md', status = null, dark = false } = props
+  const {
+    aria = {},
+    className,
+    data = {},
+    name = null,
+    id = '',
+    imageAlt = '',
+    imageUrl,
+    size = 'md',
+    status = null,
+    dark = false,
+  } = props
   const dataProps = buildDataProps(data)
   const ariaProps = buildAriaProps(aria)
   const classes = classnames(
@@ -55,7 +67,7 @@ const Avatar = (props: AvatarProps) => {
       >
         <If condition={imageUrl && !error}>
           <Image
-              alt={name}
+              alt={imageAlt}
               onError={handleError}
               url={imageUrl}
           />

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
@@ -4,7 +4,7 @@
     class: object.classname,
     aria: object.aria) do %>
   <%= content_tag(:div, data: { initials: object.initials }, class: "avatar_wrapper") do %>
-    <%= pb_rails("image", props: { url: object.image_url, on_error: object.handle_img_error }) if object.image_url.present? %>
+    <%= pb_rails("image", props: { alt: object.image_alt, url: object.image_url, on_error: object.handle_img_error }) if object.image_url.present? %>
   <% end %>
   <%= pb_rails("online_status", props: object.online_status_props) if object.status %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
@@ -3,8 +3,11 @@
 module Playbook
   module PbAvatar
     class Avatar < Playbook::KitBase
-      prop :image_url
-      prop :name, default: ""
+      prop :image_url, type: Playbook::Props::String
+      prop :image_alt, type: Playbook::Props::String,
+                       default: ""
+      prop :name, type: Playbook::Props::String,
+                  default: ""
       prop :size, type: Playbook::Props::Enum,
                   values: %w[xs sm md base lg xl],
                   default: "md"

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.html.erb
@@ -1,6 +1,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "xs",
+    image_alt: "Terry Johnson Standing",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "online"
   }) %>
@@ -10,6 +11,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
+    image_alt: "Terry Johnson Standing",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "away"
   }) %>
@@ -19,6 +21,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "md",
+    image_alt: "Terry Johnson Standing",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "offline"
   }) %>
@@ -28,6 +31,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "lg",
+    image_alt: "Terry Johnson Standing",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "online"
   }) %>
@@ -37,6 +41,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "xl",
+    image_alt: "Terry Johnson Standing",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "away"
   }) %>

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.jsx
@@ -5,6 +5,7 @@ const AvatarDefault = (props) => {
   return (
     <div>
       <Avatar
+          imageAlt="Terry Johnson Standing"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="xs"
@@ -13,6 +14,7 @@ const AvatarDefault = (props) => {
       />
       <br />
       <Avatar
+          imageAlt="Terry Johnson Standing"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="sm"
@@ -21,6 +23,7 @@ const AvatarDefault = (props) => {
       />
       <br />
       <Avatar
+          imageAlt="Terry Johnson Standing"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="md"
@@ -29,6 +32,7 @@ const AvatarDefault = (props) => {
       />
       <br />
       <Avatar
+          imageAlt="Terry Johnson Standing"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="lg"
@@ -37,6 +41,7 @@ const AvatarDefault = (props) => {
       />
       <br />
       <Avatar
+          imageAlt="Terry Johnson Standing"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="xl"

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_status.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_status.html.erb
@@ -1,6 +1,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
+    image_alt: "Terry Johnson Status",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg"
   }) %>
 
@@ -9,6 +10,7 @@
   <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
+    image_alt: "Terry Johnson Online",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "online"
   }) %>
@@ -18,6 +20,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
+    image_alt: "Terry Johnson Away",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "away"
   }) %>
@@ -27,6 +30,7 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "sm",
+    image_alt: "Terry Johnson Offline",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "offline"
   }) %>

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_status.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_status.jsx
@@ -5,6 +5,7 @@ const AvatarStatus = (props) => {
   return (
     <>
       <Avatar
+          imageAlt="Terry Johnson Status"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="sm"
@@ -14,6 +15,7 @@ const AvatarStatus = (props) => {
       <br />
 
       <Avatar
+          imageAlt="Terry Johnson Online"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="sm"
@@ -24,6 +26,7 @@ const AvatarStatus = (props) => {
       <br />
 
       <Avatar
+          imageAlt="Terry Johnson Away"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="sm"
@@ -34,6 +37,7 @@ const AvatarStatus = (props) => {
       <br />
 
       <Avatar
+          imageAlt="Terry Johnson Offline"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="sm"

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.jsx
@@ -15,6 +15,7 @@ import { globalProps } from '../utilities/globalProps.js'
 type AvatarActionButtonProps = {
   action?: string,
   aria: Object,
+  linkAriaLabel?: string,
   className?: string,
   dark?: boolean,
   data?: Object,
@@ -32,6 +33,7 @@ const AvatarActionButton = (props: AvatarActionButtonProps) => {
   const {
     action = 'add',
     aria = {},
+    linkAriaLabel,
     className,
     dark = false,
     data = {},
@@ -69,6 +71,7 @@ const AvatarActionButton = (props: AvatarActionButtonProps) => {
         id={id}
     >
       <a
+          aria-label={linkAriaLabel}
           href={linkUrl}
           onClick={onClick}
       >

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.jsx
@@ -19,6 +19,7 @@ type AvatarActionButtonProps = {
   dark?: boolean,
   data?: Object,
   id?: string,
+  imageAlt?: string,
   imageUrl?: string,
   linkUrl?: string,
   name?: string,
@@ -35,6 +36,7 @@ const AvatarActionButton = (props: AvatarActionButtonProps) => {
     dark = false,
     data = {},
     id,
+    imageAlt = '',
     imageUrl,
     linkUrl,
     name,
@@ -71,6 +73,7 @@ const AvatarActionButton = (props: AvatarActionButtonProps) => {
           onClick={onClick}
       >
         <Avatar
+            imageAlt={imageAlt}
             imageUrl={imageUrl}
             name={name}
             size={size}

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.html.erb
@@ -14,7 +14,7 @@
         <% end %>
     <% end %>
 
-    <%= link_to object.link_url, id: object.tooltip_id do %>
+    <%= link_to object.link_url, id: object.tooltip_id, 'aria-label': object.link_aria_label do %>
       <%= pb_rails("avatar", props: {
         dark: object.dark,
         name: object.name,

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.html.erb
@@ -19,6 +19,7 @@
         dark: object.dark,
         name: object.name,
         size: object.size,
+        image_alt: object.image_alt,
         image_url: object.image_url,
         class: "avatar_action"
       }) %>

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.rb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.rb
@@ -5,6 +5,7 @@ module Playbook
     class AvatarActionButton < Playbook::KitBase
       prop :action, type: Playbook::Props::String,
                     default: "add"
+      prop :image_alt, type: Playbook::Props::String
       prop :image_url, type: Playbook::Props::String
       prop :link_url, type: Playbook::Props::String, default: "#"
       prop :tooltip_text, type: Playbook::Props::String

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.rb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.rb
@@ -5,6 +5,7 @@ module Playbook
     class AvatarActionButton < Playbook::KitBase
       prop :action, type: Playbook::Props::String,
                     default: "add"
+      prop :link_aria_label, type: Playbook::Props::String
       prop :image_alt, type: Playbook::Props::String
       prop :image_url, type: Playbook::Props::String
       prop :link_url, type: Playbook::Props::String, default: "#"

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.html.erb
@@ -2,12 +2,14 @@
   
   <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
+      image_alt: "Add Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
       action: "add",
   }) %>
 
   <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
+      image_alt: "Remove Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
       action: "remove",
   }) %>

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.html.erb
@@ -1,6 +1,7 @@
 <div class="pb--doc-demo-row">
   
   <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Add Sophia Carden",
       name: "Sophia Carden",
       image_alt: "Add Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
@@ -8,6 +9,7 @@
   }) %>
 
   <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Remove Sophia Carden",
       name: "Sophia Carden",
       image_alt: "Remove Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.jsx
@@ -5,12 +5,14 @@ const AvatarActionButtonActions = (props) => (
   <div className="pb--doc-demo-row">
     <AvatarActionButton
         action="add"
+        imageAlt="Add Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         name="Sophia Carden"
         {...props}
     />
     <AvatarActionButton
         action="remove"
+        imageAlt="Remove Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         name="Sophia Carden"
         {...props}

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_actions.jsx
@@ -7,6 +7,7 @@ const AvatarActionButtonActions = (props) => (
         action="add"
         imageAlt="Add Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Add Sophia Carden"
         name="Sophia Carden"
         {...props}
     />
@@ -14,6 +15,7 @@ const AvatarActionButtonActions = (props) => (
         action="remove"
         imageAlt="Remove Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Remove Sophia Carden"
         name="Sophia Carden"
         {...props}
     />

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.html.erb
@@ -2,6 +2,7 @@
 
   <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
+      image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg"
   }) %>
 

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.html.erb
@@ -1,6 +1,7 @@
 <div class="pb--doc-demo-row">
 
   <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Sophia Carden",
       name: "Sophia Carden",
       image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg"

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.jsx
@@ -4,6 +4,7 @@ import { AvatarActionButton } from '../../'
 const AvatarActionButtonDefault = (props) => (
   <div className="pb--doc-demo-row">
     <AvatarActionButton
+        imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         name="Sophia Carden"
         {...props}

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_default.jsx
@@ -6,6 +6,7 @@ const AvatarActionButtonDefault = (props) => (
     <AvatarActionButton
         imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Sophia Carden"
         name="Sophia Carden"
         {...props}
     />

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_on_click.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_on_click.jsx
@@ -4,6 +4,7 @@ import { AvatarActionButton } from '../../'
 const AvatarActionButtonOnClick = (props) => (
   <div className="pb--doc-demo-row">
     <AvatarActionButton
+        imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         linkUrl="https://www.google.com"
         name="Sophia Carden"

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_on_click.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_on_click.jsx
@@ -6,6 +6,7 @@ const AvatarActionButtonOnClick = (props) => (
     <AvatarActionButton
         imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Alert Sophia Carden"
         linkUrl="https://www.google.com"
         name="Sophia Carden"
         onClick={() => alert('clicked!')}

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_onclick.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_onclick.html.erb
@@ -1,6 +1,7 @@
 <div class="pb--doc-demo-row">
   
   <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Alert Sophia Carden",
       name: "Sophia Carden",
       id: "clickable",
       link_url: "http://www.google.com",

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_onclick.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_onclick.html.erb
@@ -4,6 +4,7 @@
       name: "Sophia Carden",
       id: "clickable",
       link_url: "http://www.google.com",
+      image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
   }) %>
 

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.html.erb
@@ -2,24 +2,28 @@
   
   <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
+      image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
       placement: "bottom_left"
   }) %>
 
   <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
+      image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
       placement: "bottom_right"
   }) %>
 
     <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
+      image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
       placement: "top_left"
   }) %>
 
     <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
+      image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
       placement: "top_right"
   }) %>

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.html.erb
@@ -1,6 +1,7 @@
 <div class="pb--doc-demo-row">
   
   <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Sophia Carden",
       name: "Sophia Carden",
       image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
@@ -8,6 +9,7 @@
   }) %>
 
   <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Sophia Carden",
       name: "Sophia Carden",
       image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
@@ -15,6 +17,7 @@
   }) %>
 
     <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Sophia Carden",
       name: "Sophia Carden",
       image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
@@ -22,6 +25,7 @@
   }) %>
 
     <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Sophia Carden",
       name: "Sophia Carden",
       image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.jsx
@@ -6,6 +6,7 @@ const AvatarActionButtonPlacement = (props) => (
     <AvatarActionButton
         imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Sophia Carden"
         name="Sophia Carden"
         placement="bottom_left"
         {...props}
@@ -13,6 +14,7 @@ const AvatarActionButtonPlacement = (props) => (
     <AvatarActionButton
         imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Sophia Carden"
         name="Sophia Carden"
         placement="bottom_right"
         {...props}
@@ -20,6 +22,7 @@ const AvatarActionButtonPlacement = (props) => (
     <AvatarActionButton
         imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Sophia Carden"
         name="Sophia Carden"
         placement="top_left"
         {...props}
@@ -27,6 +30,7 @@ const AvatarActionButtonPlacement = (props) => (
     <AvatarActionButton
         imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
+        linkAriaLabel="Sophia Carden"
         name="Sophia Carden"
         placement="top_right"
         {...props}

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_placement.jsx
@@ -4,24 +4,28 @@ import { AvatarActionButton } from '../../'
 const AvatarActionButtonPlacement = (props) => (
   <div className="pb--doc-demo-row">
     <AvatarActionButton
+        imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         name="Sophia Carden"
         placement="bottom_left"
         {...props}
     />
     <AvatarActionButton
+        imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         name="Sophia Carden"
         placement="bottom_right"
         {...props}
     />
     <AvatarActionButton
+        imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         name="Sophia Carden"
         placement="top_left"
         {...props}
     />
     <AvatarActionButton
+        imageAlt="Sophia Carden"
         imageUrl="https://randomuser.me/api/portraits/women/8.jpg"
         name="Sophia Carden"
         placement="top_right"

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_tooltip.html.erb
@@ -3,6 +3,7 @@
   <%= pb_rails("avatar_action_button", props: {
       name: "Sophia Carden",
       link_url: "http://www.google.com",
+      image_alt: "Sophia Carden",
       image_url: "https://randomuser.me/api/portraits/women/8.jpg",
       tooltip_text: "Tooltip Text",
       tooltip_id: "avatar_1",

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/docs/_avatar_action_button_tooltip.html.erb
@@ -1,6 +1,7 @@
 <div class="pb--doc-demo-row">
   
   <%= pb_rails("avatar_action_button", props: {
+      link_aria_label: "Sophia Carden",
       name: "Sophia Carden",
       link_url: "http://www.google.com",
       image_alt: "Sophia Carden",

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/pb_avatar_action_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/pb_avatar_action_button.test.js
@@ -14,15 +14,18 @@ test('loads the given image url and name', () => {
         data={{ testid: testId }}
         imageAlt={imageAlt}
         imageUrl={imageUrl}
+        linkAriaLabel={name}
         name={name}
     />
   )
 
   const kit      = screen.getByTestId(testId)
   const image    = screen.getByAltText(imageAlt)
+  const link     = kit.children[0]
 
   expect(kit).toHaveClass('pb_avatar_action_button_kit_add_bottom_left_md')
   expect(image).toHaveAttribute('data-src', imageUrl)
   expect(image).toHaveAttribute('src', imageUrl)
   expect(image).toHaveAttribute('alt', imageAlt)
+  expect(link).toHaveAttribute('aria-label', name)
 })

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/pb_avatar_action_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/pb_avatar_action_button.test.js
@@ -1,16 +1,16 @@
 import React from 'react'
 import { render, screen } from '../utilities/test-utils'
 
-import Avatar from './_avatar'
+import AvatarActionButton from './_avatar_action_button'
 
-const imageUrl = 'https://randomuser.me/api/portraits/men/44.jpg',
-  testId = 'tjohnson',
-  name = 'Terry Johnson',
-  imageAlt = 'Terry Johnson Standing'
+const imageUrl = 'https://randomuser.me/api/portraits/women/8.jpg',
+  testId = 'scarden',
+  name = 'Sophia Carden',
+  imageAlt = 'Sophia Carden Profile'
 
 test('loads the given image url and name', () => {
   render(
-    <Avatar
+    <AvatarActionButton
         data={{ testid: testId }}
         imageAlt={imageAlt}
         imageUrl={imageUrl}
@@ -20,10 +20,8 @@ test('loads the given image url and name', () => {
 
   const kit      = screen.getByTestId(testId)
   const image    = screen.getByAltText(imageAlt)
-  const initials = name.split(/\s/)[0].substr(0, 1) + name.split(/\s/)[1].substr(0, 1)
 
-  expect(kit).toHaveClass('pb_avatar_kit_md')
-  expect(kit).toHaveAttribute('data-initials', initials)
+  expect(kit).toHaveClass('pb_avatar_action_button_kit_add_bottom_left_md')
   expect(image).toHaveAttribute('data-src', imageUrl)
   expect(image).toHaveAttribute('src', imageUrl)
   expect(image).toHaveAttribute('alt', imageAlt)

--- a/playbook/spec/pb_kits/playbook/kits/avatar_action_button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/avatar_action_button_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Playbook::PbAvatarActionButton::AvatarActionButton do
 
   it { is_expected.to define_prop(:action)
                   .with_default("add") }
+  it { is_expected.to define_prop(:image_alt) }
   it { is_expected.to define_prop(:image_url) }
   it { is_expected.to define_prop(:link_url) }
   it { is_expected.to define_prop(:tooltip_text) }

--- a/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Playbook::PbAvatar::Avatar do
 
   it { is_expected.to define_prop(:status) }
   it { is_expected.to define_prop(:image_url) }
+  it { is_expected.to define_prop(:image_alt) }
   it { is_expected.to define_prop(:name)
                       .with_default("") }
   it { is_expected.to define_enum_prop(:size)


### PR DESCRIPTION
#### Screens
<img width="500" alt="avatar-alt1" src="https://user-images.githubusercontent.com/4315934/109988608-7740f480-7ce6-11eb-91e7-378a510baf45.png">

<img width="500" alt="avatar-alt2" src="https://user-images.githubusercontent.com/4315934/109988614-790ab800-7ce6-11eb-9221-47b8b36d1356.png">

<img width="500" alt="aria-label" src="https://user-images.githubusercontent.com/4315934/110140241-a6249c80-7db2-11eb-902b-5c2c492ef07a.png">

#### Breaking Changes

No - Added prop and it's variable and has a default

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-491

#### How to test this

Add image alt prop and check render. Tests added.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.

