### PR TITLE
Fix forms and action area rendering context

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form/form_builder.rb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_builder.rb
@@ -19,9 +19,11 @@ module Playbook
         prepend(CollectionSelectField)
         prepend(CheckboxField)
         prepend(DatePickerField)
+      end
 
-        def actions(&block)
-          @template.render_component ActionArea.new(submit_default_value: submit_default_value, children: block)
+      def actions
+        @template.send(:view_context).content_tag :ol, class: "pb-form-actions" do
+          yield ActionArea.new(@template, submit_default_value)
         end
       end
     end

--- a/playbook/app/pb_kits/playbook/pb_form/form_builder/action_area.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_builder/action_area.html.erb
@@ -1,3 +1,0 @@
-<ol class="pb-form-actions">
-  <%= instance_exec(self, &children) %>
-</ol>

--- a/playbook/app/pb_kits/playbook/pb_form/form_builder/action_area.rb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_builder/action_area.rb
@@ -3,21 +3,28 @@
 module Playbook
   module PbForm
     module FormBuilder
-      class ActionArea < Playbook::KitBase
-        prop :submit_default_value, type: Playbook::Props::String
+      class ActionArea
+        def initialize(view_context, submit_default_value)
+          self.view_context = view_context
+          self.submit_default_value = submit_default_value
+        end
 
         def submit(value = nil, props: {})
           props[:type] ||= "submit"
+          props[:text] ||= value || submit_default_value
+
           button(value, props: props)
         end
 
         def button(value = nil, props:)
-          props[:text] ||= value || submit_default_value
-
-          content_tag(:li) do
-            pb_rails("button", props: props)
+          view_context.content_tag(:li) do
+            view_context.pb_rails("button", props: props)
           end
         end
+
+      private
+
+        attr_accessor :view_context, :submit_default_value
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_form/simple_form.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/simple_form.html.erb
@@ -1,6 +1,4 @@
-<%= simple_form_for model, options do |form| %>
-  <% instance_exec form, &children %>
-<% end %>
+<%= simple_form_for model, options, &method(:render_form) %>
 
 <% if validate %>
   <% content_for :pb_js do %>

--- a/playbook/app/pb_kits/playbook/pb_form/simple_form.rb
+++ b/playbook/app/pb_kits/playbook/pb_form/simple_form.rb
@@ -48,6 +48,10 @@ module Playbook
         prop(:options).fetch(:html, {})
       end
 
+      def render_form(builder)
+        view_context.capture(builder, &children)
+      end
+
       def render_in(view_context, &_block)
         super(view_context, &nil)
       end


### PR DESCRIPTION
Form builders manipulate their view contexts and makes it hard to maintain the expected flow. This PR standardizes that across form with and simple form in Playbook and fixes the rendering of Action area buttons.