### PR TITLE
Add caption html tag to Caption kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_caption/_caption.jsx
+++ b/playbook/app/pb_kits/playbook/pb_caption/_caption.jsx
@@ -12,7 +12,7 @@ type CaptionProps = {
   data?: object,
   id?: string,
   size?: "xs" | "sm" | "md" | "lg" | "xl",
-  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span" | "div",
+  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span" | "div" | "caption",
   text?: string,
   variant?: null | "link",
 }
@@ -29,7 +29,8 @@ const Caption = (props: CaptionProps) => {
     text,
     variant = null,
   } = props
-  const Tag = `${tag}`
+  const tagOptions = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'div', 'caption']
+  const Tag = tagOptions.includes(tag) ? tag : 'div'
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)

--- a/playbook/app/pb_kits/playbook/pb_caption/caption.rb
+++ b/playbook/app/pb_kits/playbook/pb_caption/caption.rb
@@ -7,7 +7,7 @@ module Playbook
                   values: %w[xs sm md base lg xl],
                   default: "md"
       prop :tag, type: Playbook::Props::Enum,
-                 values: %w[h1 h2 h3 h4 h5 h6 p span div],
+                 values: %w[h1 h2 h3 h4 h5 h6 p span div caption],
                  default: "div"
       prop :text
       prop :variant, type: Playbook::Props::Enum,

--- a/playbook/spec/pb_kits/playbook/kits/caption_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/caption_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Playbook::PbCaption::Caption do
     is_expected.to define_enum_prop(:tag)
                    .with_default("div")
                    .with_values("h1", "h2", "h3", "h4", "h5",
-                                "h6", "p", "span", "div")
+                                "h6", "p", "span", "div", "caption")
   end
   it { is_expected.to define_string_prop(:text) }
   it { is_expected.to define_enum_prop(:variant)


### PR DESCRIPTION
#### What does this PR do?

1. Adds `<caption>` html tag to Caption kit.

#### Screens

No visual changes.

#### Breaking Changes

n/a

#### Runway Ticket URL

[Link to Runway Story](https://nitro.powerhrg.com/runway/backlog_items/NUXE-498)

#### How to test this

Try passing "caption" to tag prop in Caption kit.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
