### PR TITLE
[NUXE-479] - Add margin overrides to select

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.rb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.rb
@@ -1,31 +1,30 @@
 # frozen_string_literal: true
 
 module Playbook
-    module PbDialog
-      class DialogHeader
-        include Playbook::Props
-  
-        partial "pb_dialog/child_kits/dialog_header"
+  module PbDialog
+    class DialogHeader
+      include Playbook::Props
 
-        prop :closeable, type: Playbook::Props::Boolean, default: true
-        prop :padding 
-        prop :separator, type: Playbook::Props::Boolean, default: true
-        prop :spacing
-        prop :text
-        prop :title
-  
-        def dialog_header_options
-          {
-            id: id,
-            closeable: closeable,
-            padding: padding,
-            separator: separator,
-            spacing: spacing,
-            text: text,
-            title: title,
-          }
-        end
+      partial "pb_dialog/child_kits/dialog_header"
+
+      prop :closeable, type: Playbook::Props::Boolean, default: true
+      prop :padding
+      prop :separator, type: Playbook::Props::Boolean, default: true
+      prop :spacing
+      prop :text
+      prop :title
+
+      def dialog_header_options
+        {
+          id: id,
+          closeable: closeable,
+          padding: padding,
+          separator: separator,
+          spacing: spacing,
+          text: text,
+          title: title,
+        }
       end
     end
   end
-  
+end

--- a/playbook/app/pb_kits/playbook/pb_select/_select.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.jsx
@@ -37,6 +37,8 @@ type SelectProps = {
   id?: string,
   includeBlank?: string,
   label?: string,
+  margin: string,
+  marginBottom: string,
   multiple?: boolean,
   name?: string,
   required?: boolean,
@@ -74,7 +76,14 @@ const Select = ({
   const dataProps = buildDataProps(data)
   const optionsList = createOptions(options)
 
-  const classes = classnames(buildCss('pb_select'), globalProps(props), className)
+  const classes = classnames(
+    buildCss('pb_select'),
+    globalProps({
+      ...props,
+      marginBottom: props.marginBottom || props.margin || 'sm',
+    }),
+    className)
+
   const selectWrapperClass = classnames(buildCss('pb_select_kit_wrapper'), { error }, className)
 
   return (

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -4,7 +4,6 @@
 @import "../tokens/colors";
 
 [class^=pb_select] {
-  margin-bottom: $space_sm;
   select {
     @include pb_textarea_light;
     @include pb_body_light;
@@ -65,36 +64,34 @@
     transform: translateY(-50%);
     pointer-events: none;
   }
-  &.dark {
-    select {
-      @include pb_textarea_dark;
-      @include pb_body_light_dark;
-      background: none;
-      background-color: rgba($white,.10);
-      box-shadow: inset 0 -11px 20px rgba($white, 0.05);
-      text-shadow: 0 0 0 $text_dk_default;
-      padding-right: $space_xl;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      @media (hover:hover) {
-        &:hover, &:active, &:focus {
-          background-color: rgba($white,.05);
-        }
-      }
-      &:focus{
-        border-color: $active_dark;
+}
+
+[class^=pb_select].dark {
+  select {
+    @include pb_textarea_dark;
+    @include pb_body_light_dark;
+    background: none;
+    background-color: rgba($white,.10);
+    box-shadow: inset 0 -11px 20px rgba($white, 0.05);
+    text-shadow: 0 0 0 $text_dk_default;
+    padding-right: $space_xl;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    @media (hover:hover) {
+      &:hover, &:active, &:focus {
+        background-color: rgba($white,.05);
       }
     }
-    .pb_select_kit_caret {
-      color: $white;
-    }
-    .pb_select_kit_wrapper {
-      &.error {
-        .pb_select_kit_wrapper {
-          > select:first-child {
-            border-color: $error_dark;
-          }
+  }
+  .pb_select_kit_caret {
+    color: $white;
+  }
+  .pb_select_kit_wrapper {
+    &.error {
+      .pb_select_kit_wrapper {
+        > select:first-child {
+          border-color: $error_dark;
         }
       }
     }

--- a/playbook/app/pb_kits/playbook/pb_select/select.rb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.rb
@@ -17,11 +17,15 @@ module Playbook
       prop :required, type: Playbook::Props::Boolean, default: false
 
       def classname
-        generate_classname("pb_select")
+        generate_classname("pb_select", select_margin_bottom, separator: " ")
       end
 
       def select_wrapper_class
         "pb_select_kit_wrapper" + error_class
+      end
+
+      def select_margin_bottom
+        margin.present? || margin_bottom.present? ? nil : "mb_sm"
       end
 
       def options_to_array

--- a/playbook/spec/pb_kits/playbook/kits/select_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/select_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Playbook::PbSelect::Select do
   it { is_expected.to define_boolean_prop(:disabled).with_default(false) }
   it { is_expected.to define_string_prop(:include_blank) }
   it { is_expected.to define_string_prop(:label) }
+  it { is_expected.to define_string_prop(:margin) }
+  it { is_expected.to define_string_prop(:margin_bottom) }
   it { is_expected.to define_boolean_prop(:multiple).with_default(false) }
   it { is_expected.to define_string_prop(:name) }
   it { is_expected.to define_string_prop(:onchange) }
@@ -16,8 +18,10 @@ RSpec.describe Playbook::PbSelect::Select do
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
-      expect(subject.new({}).classname).to eq "pb_select"
-      expect(subject.new({dark: true}).classname).to eq "pb_select dark"
+      expect(subject.new({}).classname).to eq "pb_select mb_sm"
+      expect(subject.new(dark: true).classname).to eq "pb_select mb_sm dark"
+      expect(subject.new(margin: "lg").classname).to eq "pb_select m_lg"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_select mb_sm additional_class"
     end
   end
 end


### PR DESCRIPTION
#### Screens

<img width="600" alt="global-margin-select" src="https://user-images.githubusercontent.com/4315934/111371872-b4a76980-8678-11eb-8033-475bf2821611.png">


#### Breaking Changes

No - Sets defaults, new margin bottom 

#### Runway Ticket URL

[NUXE-479](https://nitro.powerhrg.com/runway/backlog_items/NUXE-479)

#### How to test this
Playbook Select margin should look identical but expand if new margin is added.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
