### PR TITLE
Don't specify compatible versions of npm/yarn

### DIFF
--- a/playbook/package.json
+++ b/playbook/package.json
@@ -21,9 +21,7 @@
   "author": "powerhome",
   "license": "ISC",
   "engines": {
-    "node": "10.17.0 || 12.20.1",
-    "npm": "6.11.3",
-    "yarn": "1.13.0 || 1.22.5"
+    "node": "10.17.0 || 12.20.1"
   },
   "directories": {
     "lib": "dist"


### PR DESCRIPTION
Playbook shouldn't care about the versions of these tools because they are only used to install it, and playbook doesn't depend on them at runtime.

This unblocks things like https://github.com/powerhome/tempo/pull/142.