### PR TITLE
Revert "Revert "Allow url to be empty so form_with can generate a url based on the model""

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
@@ -14,7 +14,7 @@
 %>
 
 <%= pb_rails("form/form_with", props: {
-    scope: :example, method: :get, url: "",
+    options: { scope: :example, method: :get, url: "" },
     validate: true
   }) do |form| %>
   <%= form.text_field :example_text_field, props: { label: true, required: true } %>

--- a/playbook/app/pb_kits/playbook/pb_form/form_with.rb
+++ b/playbook/app/pb_kits/playbook/pb_form/form_with.rb
@@ -16,7 +16,6 @@ module Playbook
 
       def form_options
         {
-          url: "",
           id: id,
           aria: aria,
           class: classname,

--- a/playbook/spec/pb_kits/playbook/pb_form/form_with_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_form/form_with_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Playbook::PbForm::FormWith do
+  describe "#form_options" do
+    it "allows the user to set the URL" do
+      model = double
+      kit = ::Playbook::PbForm::FormWith.new(options: { model: model, url: "http://example.org" })
+
+      expect(kit.form_options).to include(url: "http://example.org", model: model)
+    end
+
+    it "allows the user to not set a URL" do
+      model = double
+      kit = ::Playbook::PbForm::FormWith.new(options: { model: model })
+
+      expect(kit.form_options).to_not have_key(:url)
+    end
+  end
+end


### PR DESCRIPTION
Reverts powerhome/playbook#1400