### PR TITLE
Update body light & lighter to a more accessible color

### DIFF
--- a/playbook/app/pb_kits/playbook/tokens/_colors.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_colors.scss
@@ -114,7 +114,7 @@ $shadow_colors: (
 
 /* Text colors ------------------------*/
 $text_lt_default:     $charcoal;
-$text_lt_light:       #919EAB;
+$text_lt_light:       #687887;
 $text_lt_lighter:     $slate;
 $text_dk_default:     $white;
 $text_dk_light:       rgba($white, $opacity_6);


### PR DESCRIPTION
#### Screens

<img width="275" alt="Screen Shot 2021-03-31 at 8 52 59 AM" src="https://user-images.githubusercontent.com/9784112/113147606-ec78ea00-91fe-11eb-9875-3ad9229fdd88.png">

<img width="219" alt="Screen Shot 2021-03-31 at 8 56 36 AM" src="https://user-images.githubusercontent.com/9784112/113148001-5db89d00-91ff-11eb-8da8-e6126f413cef.png">




#### Breaking Changes

No

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/NUXE-500

#### How to test this

Inspect the Caption kit or Body Light and see that the color being used is #687887

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
