### PR TITLE
Updated user css file

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_nav/_vertical_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_vertical_nav.scss
@@ -16,7 +16,7 @@ $selector: ".pb_nav_list";
     list-style: none;
   }
 
-  [class*=_title] {
+  [class*=pb_nav_list_title] {
     padding: 0 $space_md $space_sm;
   }
 

--- a/playbook/app/pb_kits/playbook/pb_nav/docs/_block_nav.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_nav/docs/_block_nav.html.erb
@@ -1,6 +1,42 @@
-<%= pb_rails("nav", props: {title: "Menu", link: "#"}) do %>
-  <%= pb_rails("nav/item", props: { link: "#", active: true }) do%>Photos<% end %>
-  <%= pb_rails("nav/item", props: { link: "#" }) do%>Music<% end %>
-  <%= pb_rails("nav/item", props: { link: "#" }) do%>Video<% end %>
-  <%= pb_rails("nav/item", props: { link: "#" }) do%>Files<% end %>
+<%= pb_rails("nav", props: {title: "Users", link: "#"}) do %>
+  <%= pb_rails("nav/item", props: { link: "#", active: true }) do%>
+    <%= pb_rails("user", props: {
+      name: "Anna Black",
+      territory: "PHL",
+      title: "Remodeling Consultant",
+      orientation: "horizontal",
+      align: "left",
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg"
+    }) %>
+  <% end %>
+  <%= pb_rails("nav/item", props: { link: "#" }) do%>
+    <%= pb_rails("user", props: {
+      name: "Julie Hamilton",
+      territory: "PHL",
+      title: "Inside Sales Agent",
+      orientation: "horizontal",
+      align: "left",
+      avatar_url: "https://randomuser.me/api/portraits/women/45.jpg"
+      }) %>
+    <% end %>
+  <%= pb_rails("nav/item", props: { link: "#" }) do%>
+    <%= pb_rails("user", props: {
+      name: "Dennis Wilks",
+      territory: "PHL",
+      title: "Senior Remodeling Consultant",
+      orientation: "horizontal",
+      align: "left",
+      avatar_url: "https://randomuser.me/api/portraits/men/44.jpg"
+      }) %>
+    <% end %>
+  <%= pb_rails("nav/item", props: { link: "#" }) do%>
+    <%= pb_rails("user", props: {
+      name: "Ronnie Martin",
+      territory: "PHL",
+      title: "Customer Development Representative",
+      orientation: "horizontal",
+      align: "left",
+      avatar_url: "https://randomuser.me/api/portraits/men/46.jpg"
+      }) %>
+    <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_nav/docs/_block_nav.jsx
+++ b/playbook/app/pb_kits/playbook/pb_nav/docs/_block_nav.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Nav } from '../../'
+import { Nav, User } from '../../'
 import NavItem from '../_item.jsx'
 
 const BlockNav = (props) => {
   return (
     <Nav
         link="#"
-        title="Menu"
+        title="Users"
         {...props}
     >
       <NavItem
@@ -14,11 +14,49 @@ const BlockNav = (props) => {
           link="#"
           {...props}
       >
-        {'Photos'}
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            name="Anna Black"
+            orientation="horizontal"
+            territory="PHL"
+            title="Remodeling Consultant"
+            {...props}
+        />
       </NavItem>
-      <NavItem link="#">{'Music'}</NavItem>
-      <NavItem link="#">{'Video'}</NavItem>
-      <NavItem link="#">{'Files'}</NavItem>
+      <NavItem link="#">
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/women/45.jpg"
+            name="Julie Hamilton"
+            orientation="horizontal"
+            territory="PHL"
+            title="Inside Sales Agent"
+            {...props}
+        />
+      </NavItem>
+      <NavItem link="#">
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/men/44.jpg"
+            name="Dennis Wilks"
+            orientation="horizontal"
+            territory="PHL"
+            title="Senior Remodeling Consultant"
+            {...props}
+        />
+      </NavItem>
+      <NavItem link="#">
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/men/46.jpg"
+            name="Ronnie Martin"
+            orientation="horizontal"
+            territory="PHL"
+            title="Customer Development Representative"
+            {...props}
+        />
+      </NavItem>
     </Nav>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_user/_user.scss
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.scss
@@ -38,9 +38,6 @@
 
   &[class*=_horizontal]  {
     align-items: center;
-    .content_wrapper > * {
-      padding: 0 0 0 0;
-    }
 
     &[class*=_center]  {
       justify-content: center;

--- a/playbook/app/pb_kits/playbook/pb_user/_user.scss
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.scss
@@ -38,6 +38,9 @@
 
   &[class*=_horizontal]  {
     align-items: center;
+    .content_wrapper > * {
+      padding: 0 0 0 0;
+    }
 
     &[class*=_center]  {
       justify-content: center;


### PR DESCRIPTION
#### Screens
*Before*
<img width="687" alt="Screen Shot 2021-04-05 at 12 11 54 PM" src="https://user-images.githubusercontent.com/42459486/113604884-e37b8480-9613-11eb-9aaa-e731c25f1daa.png">

*After*
<img width="686" alt="Screen Shot 2021-04-05 at 12 22 15 PM" src="https://user-images.githubusercontent.com/42459486/113604887-e4141b00-9613-11eb-8092-34d48f95f296.png">

*Old NavItem Block  doc example*
<img width="597" alt="Screen Shot 2021-04-05 at 2 04 19 PM" src="https://user-images.githubusercontent.com/42459486/113607983-e8423780-9617-11eb-9e9c-a717acd1bca8.png">

*New NavItem Block doc example*
<img width="780" alt="Screen Shot 2021-04-05 at 2 03 56 PM" src="https://user-images.githubusercontent.com/42459486/113607996-ed9f8200-9617-11eb-9e47-e82430dff61e.png">

#### Breaking Changes

No –– this PR only affects the CSS class in User Kit.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-584

#### How to test this

I tested this bug by updating the doc example so that a User Kit is in Nav/NavItem to confirm that the styling is behaving as expected.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
