### PR TITLE
[CHMN-64] Playbook - Fixed Confirmation Toast Responsive

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -26,7 +26,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const [showToast, toggleToast] = useState(true)
   const { className, closeable = false, multiLine = false, status = 'neutral', text } = props
   const css = classnames(
-    `pb_fixed_confirmation_toast_kit_${status}${multiLine === true ? "_multi_line" : ""}`,
+    `pb_fixed_confirmation_toast_kit_${status}${multiLine === true ? '_multi_line' : ''}`,
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -27,7 +27,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const { className, closeable = false, multiLine = false, status = 'neutral', text } = props
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
-    multiLine ? '_multi_line' : null,
+    {'_multi_line' : multiLine},
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -18,7 +18,7 @@ type FixedConfirmationToastProps = {
   data?: string,
   id?: string,
   multiLine?: boolean,
-  status?: "success" | "error" | "neutral" | "tip",
+  status?: 'success' | 'error' | 'neutral' | 'tip',
   text: string,
 }
 

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -17,15 +17,16 @@ type FixedConfirmationToastProps = {
   closeable?: boolean,
   data?: string,
   id?: string,
+  multiLine?: boolean,
   status?: "success" | "error" | "neutral" | "tip",
   text: string,
 }
 
 const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const [showToast, toggleToast] = useState(true)
-  const { className, closeable = false, status = 'neutral', text } = props
+  const { className, closeable = false, multiLine = false, status = 'neutral', text } = props
   const css = classnames(
-    `pb_fixed_confirmation_toast_kit_${status}`,
+    `pb_fixed_confirmation_toast_kit_${status}${multiLine === true ? "_multi_line" : ""}`,
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -26,7 +26,8 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const [showToast, toggleToast] = useState(true)
   const { className, closeable = false, multiLine = false, status = 'neutral', text } = props
   const css = classnames(
-    `pb_fixed_confirmation_toast_kit_${status}${multiLine === true ? '_multi_line' : ''}`,
+    `pb_fixed_confirmation_toast_kit_${status}`,
+    multiLine ? '_multi_line' : null,
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.jsx
@@ -27,7 +27,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const { className, closeable = false, multiLine = false, status = 'neutral', text } = props
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
-    {'_multi_line' : multiLine},
+    { '_multi_line': multiLine },
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
@@ -47,6 +47,15 @@ $confirmation_toast_colors: (
       .pb_icon {
         color: $white;
       }
+
+      &[class*=_multi_line]  {
+        .pb_fixed_confirmation_toast_text {
+          color: $white;
+          margin: 0 $space_md 0 $space_md;
+          max-width: 100%;
+          white-space: break-spaces;
+        }
+      }
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.scss
@@ -48,13 +48,11 @@ $confirmation_toast_colors: (
         color: $white;
       }
 
-      &[class*=_multi_line]  {
-        .pb_fixed_confirmation_toast_text {
-          color: $white;
-          margin: 0 $space_md 0 $space_md;
-          max-width: 100%;
-          white-space: break-spaces;
-        }
+      &[class*=_multi_line] .pb_fixed_confirmation_toast_text {
+        color: $white;
+        margin: 0 $space_md 0 $space_md;
+        max-width: 100%;
+        white-space: break-spaces;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.html.erb
@@ -1,4 +1,5 @@
 <%= pb_rails("fixed_confirmation_toast", props: {
-  text: "Scan to Assign Selected Items.\nClick here to generate report",
+  multi_line: true,
+  text: "Scan to Assign Selected Items. Click here to generate report",
   status: "tip",
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.jsx
@@ -7,7 +7,7 @@ const FixedConfirmationToastMultiLine = (props) => {
       <FixedConfirmationToast
           multiLine
           status="tip"
-          text={'Scan to Assign Selected Items. Click here to generate report'}
+          text="Scan to Assign Selected Items. Click here to generate report"
           {...props}
       />
     </div>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.jsx
@@ -5,8 +5,9 @@ const FixedConfirmationToastMultiLine = (props) => {
   return (
     <div>
       <FixedConfirmationToast
+          multiLine
           status="tip"
-          text={'Scan to Assign Selected Items.\n Click here to generate report'}
+          text={'Scan to Assign Selected Items. Click here to generate report'}
           {...props}
       />
     </div>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.md
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_multi_line.md
@@ -1,2 +1,2 @@
 
-Multi-line is used when the given text will not fit on one line. Using Multi Line allows the height of the confirmation toast to grow.
+Multi-line is used when the given text will not fit on one line. Using Multi Line allows the height of the confirmation toast to grow. Simply resize the screen to see the fixed confirmation toast wrap the text.

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
@@ -7,6 +7,8 @@ module Playbook
                     values: %w[success error neutral tip],
                     default: "neutral"
       prop :text, type: Playbook::Props::String
+      prop :multi_line, type: Playbook::Props::Boolean,
+                       default: false
       prop :closeable, type: Playbook::Props::Boolean,
                        default: false
 
@@ -16,6 +18,10 @@ module Playbook
 
       def close_class
         closeable.present? ? " remove_toast" : ""
+      end
+
+      def multi_line_class
+        multi_line.present? ? "_multi_line" : ""
       end
 
       def icon_value
@@ -32,7 +38,7 @@ module Playbook
       end
 
       def classname
-        generate_classname("pb_fixed_confirmation_toast_kit", status) + close_class
+        generate_classname("pb_fixed_confirmation_toast_kit", status) + multi_line_class + close_class
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
@@ -21,7 +21,7 @@ module Playbook
       end
 
       def multi_line_class
-        multi_line.present? ? "_multi_line" : ""
+        multi_line.present? ? "multi_line" : ""
       end
 
       def icon_value
@@ -38,7 +38,7 @@ module Playbook
       end
 
       def classname
-        generate_classname("pb_fixed_confirmation_toast_kit", status) + multi_line_class + close_class
+        generate_classname("pb_fixed_confirmation_toast_kit", status, multi_line_class) + close_class
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
@@ -21,7 +21,7 @@ module Playbook
       end
 
       def multi_line_class
-        multi_line.present? ? "multi_line" : ""
+        multi_line.present? ? "multi_line" : nil
       end
 
       def icon_value

--- a/playbook/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Playbook::PbFixedConfirmationToast::FixedConfirmationToast do
   subject { Playbook::PbFixedConfirmationToast::FixedConfirmationToast }
 
   it { is_expected.to define_prop(:text).of_type(Playbook::Props::String) }
+  it { is_expected.to define_prop(:multi_line).of_type(Playbook::Props::Boolean) }
   it { is_expected.to define_enum_prop(:status)
                       .with_default("neutral")
                       .with_values("success", "error", "neutral", "tip") }
@@ -44,6 +45,7 @@ RSpec.describe Playbook::PbFixedConfirmationToast::FixedConfirmationToast do
       expect(subject.new(text: text, status: "tip").classname).to eq "pb_fixed_confirmation_toast_kit_tip"
       expect(subject.new(text: text, status: "tip", dark: true).classname).to eq "pb_fixed_confirmation_toast_kit_tip dark"
       expect(subject.new(text: text, status: "tip", closeable: true).classname).to eq "pb_fixed_confirmation_toast_kit_tip remove_toast"
+      expect(subject.new(text: text, status: "error", multi_line: true).classname).to eq "pb_fixed_confirmation_toast_kit_error_multi_line"
     end
   end
 end


### PR DESCRIPTION
#### Screens

![Screen+Recording+2021-04-07+at+01 29 07+PM](https://user-images.githubusercontent.com/51907753/113909170-608a3380-97a5-11eb-9d30-e5b87348c16c.gif)

<img width="547" alt="Screen Shot 2021-04-07 at 11 21 43 AM" src="https://user-images.githubusercontent.com/51907753/113895741-43e6ff00-9797-11eb-92a9-02b9582ff0d6.png">
<img width="561" alt="Screen Shot 2021-04-07 at 11 22 13 AM" src="https://user-images.githubusercontent.com/51907753/113895745-447f9580-9797-11eb-9f01-095e53d96e20.png">

#### Breaking Changes

No, this should not affect any current uses of the kit.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/CHMN-64

#### How to test this

Open up PB and go to the multi-line Fixed Confirmation Toast doc. Resize your screen and watch the text stack!

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [X] **SCREENSHOT** Please add a screen shot or two.
- [X] **SPECS** Please cover your changes with specs.
- [X] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
