### PR TITLE
Date variant small with icon

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date/_date.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date/_date.jsx
@@ -100,9 +100,9 @@ const PbDate = (props: PbDateProps) => {
                 tag="span"
             >
               <Icon
-                  size='xs'
                   fixedWidth
                   icon="calendar-alt"
+                  size="xs"
               />
             </Caption>
           </If>

--- a/playbook/app/pb_kits/playbook/pb_date/_date.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date/_date.jsx
@@ -95,16 +95,16 @@ const PbDate = (props: PbDateProps) => {
         <Else />
         <>
           <If condition={showIcon}>
-            <Body
+            <Caption
                 className="pb_icon_kit_container"
-                color="light"
                 tag="span"
             >
               <Icon
+                  size='xs'
                   fixedWidth
                   icon="calendar-alt"
               />
-            </Body>
+            </Caption>
           </If>
           <If condition={showDayOfWeek}>
             <Caption tag="div">

--- a/playbook/app/pb_kits/playbook/pb_date/date.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date/date.html.erb
@@ -39,11 +39,10 @@
 
     <!-- icon -->
     <% if object.show_icon %>
-      <%= pb_rails("body", props: {
-        color: "light",
+      <%= pb_rails("caption", props: {
         tag: "div",
       }) do %>
-        <%= pb_rails("icon", props: { icon: "calendar-alt", fixed_width: true }) %>
+        <%= pb_rails("icon", props: { icon: "calendar-alt", fixed_width: true, size: 'xs' }) %>
       <% end %>
     <% end %>
 

--- a/playbook/app/pb_kits/playbook/pb_date/docs/_date_variants.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date/docs/_date_variants.html.erb
@@ -1,6 +1,14 @@
 <div>
   <%= pb_rails("date", props: {
     date: DateTime.now,
+    show_icon: true,
+    size: "sm"
+  }) %>
+
+  <br>
+
+  <%= pb_rails("date", props: {
+    date: DateTime.now,
   }) %>
 
   <br>

--- a/playbook/app/pb_kits/playbook/pb_date/docs/_date_variants.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date/docs/_date_variants.jsx
@@ -5,6 +5,16 @@ const DateVariants = (props) => {
   return (
     <div>
       <FormattedDate
+          showIcon
+          size="sm"
+          value="1995-12-25"
+          {...props}
+      />
+
+      <br />
+      <br />
+
+      <FormattedDate
           value="1995-12-25"
           {...props}
       />


### PR DESCRIPTION
#### Screens

![Screen Shot 2021-04-07 at 12 40 31 PM](https://user-images.githubusercontent.com/53874143/113903015-819b5600-979e-11eb-8cba-bbbbe425c9c0.png)


#### Breaking Changes

No, breaking changes. Icon for md is being handled by an < if else > statement.

#### Runway Ticket URL

[NUXE-585](https://nitro.powerhrg.com/runway/backlog_items/NUXE-585)

#### How to test this

Visually assessed that the icon was the correct size for size small. Checked to verify that size md (default) icon was not affected.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
