### PR TITLE
Fix Rich text Focus State

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
@@ -81,6 +81,7 @@
       position: sticky;
       top: 0;
       z-index: 1;
+      background-color: $white;
     }
   }
   trix-editor {
@@ -209,6 +210,11 @@
     &.error {
       trix-editor {
         border-color: $error_dark;
+      }
+    }
+    &.sticky {
+      trix-toolbar {
+        background-color: tint($bg_dark, 10%) !important;
       }
     }
     .trix-dialog.trix-dialog--link.trix-active {


### PR DESCRIPTION
#### Screens


#### Breaking Changes

No

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-586

#### How to test this

Check focus state on sticky rich text editor

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
