### PR TITLE
Remove relative bin from yarn release

### DIFF
--- a/playbook/package.json
+++ b/playbook/package.json
@@ -12,7 +12,7 @@
     "test": "jest",
     "test-coverage": "jest --collectCoverage",
     "test-coverage-summary": "jest --collectCoverage --coverageReporters=\"json-summary\"",
-    "release": "./bin/webpack --env.production && node-sass --output-style compressed app/pb_kits/playbook/packs/site_styles/_scaffold.scss dist/reset.css"
+    "release": "webpack --env.production && node-sass --output-style compressed app/pb_kits/playbook/packs/site_styles/_scaffold.scss dist/reset.css"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### What does this PR do?
1. Removes `./bin/` from the `yarn release` webpack command.