### PR TITLE
Set a default value for flex items

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_flex/_flex_item.jsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex_item.jsx
@@ -14,7 +14,7 @@ type FlexItemPropTypes = {
 }
 
 const FlexItem = (props: FlexItemPropTypes) => {
-  const { children, className, fixedSize, grow, overflow = null, shrink, flex } = props
+  const { children, className, fixedSize, grow, overflow = null, shrink, flex = 'none' } = props
   const growClass = grow === true ? 'grow' : ''
   const flexClass = flex !== 'none' ? `flex_${flex}` : ''
   const overflowClass = overflow ? `overflow_${overflow}` : ''


### PR DESCRIPTION
#### Screens

![Screen Recording 2021-04-15 at 07 02 59 PM](https://user-images.githubusercontent.com/9784112/114948578-44c60380-9e1d-11eb-924f-4d9dbc40fe7f.gif)


#### Breaking Changes

No

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-609[INSERT URL]

#### How to test this

right click on any flex item kit and inspect element check the flex item kit class. If undefined does not appear this PR has resolved the issue.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
