### PR TITLE
Add 🥵 script

### DIFF
--- a/playbook/hot.sh
+++ b/playbook/hot.sh
@@ -1,0 +1,6 @@
+echo "Creating Local Release"
+yarn release
+rm dist/playbook-rails.css && mv dist/playbook-react.css dist/playbook.css
+
+echo "Copying local release to Nitro"
+cp -R dist/* $1/node_modules/playbook-ui/dist/


### PR DESCRIPTION
Just a simple shell script for hot loading a local distribution into another repo's `node_modules` for local testing.

![](https://cdn.shopify.com/s/files/1/0915/1060/products/GhostPepper1_88234648-8bcb-4c4b-9c10-a5b5ebac5abb_1600x.jpg?v=1592242142)

Useage: `./hot.sh $OTHER_LOCAL_REPO`