### PR TITLE
[CHMN-78] Hotfix passphrase strength bar display

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_passphrase/useZxcvbn.js
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/useZxcvbn.js
@@ -15,9 +15,9 @@ export default function useZxcvbn(options) {
 
   useEffect(() => {
     if (confirmation) return
-
-    setResult(calculator(passphrase))
-    const str = result.score
+    const newResult = calculator(passphrase)
+    setResult(newResult)
+    const str = newResult.score
 
     const noPassphrase = passphrase.length <= 0
     const commonPassphrase = common || isPwned


### PR DESCRIPTION
By trying to rely on a value set in a use state hook, the logic for which color to show was one input behind, and therefore showing the wrong color when thresholds are crossed.

#### Screens

<img width="1283" alt="Screen Shot 2021-04-23 at 3 16 08 PM" src="https://user-images.githubusercontent.com/28073714/115921280-4741e200-a449-11eb-881d-e7b8172a61e1.png">
<img width="1287" alt="Screen Shot 2021-04-23 at 3 15 32 PM" src="https://user-images.githubusercontent.com/28073714/115921281-4741e200-a449-11eb-89e6-ac60be388304.png">


#### Breaking Changes
No, fixes an issue

#### Runway Ticket URL
[CHMN-78](https://nitro.powerhrg.com/runway/backlog_items/CHMN-78)
#### How to test this

https://playbook.powerapp.cloud/kits/popover/react
Look at the example kit on the Passphrase page in playbook that shows the strength on the page. This number is right, the meter should match. (0,1 are red, 2 is yellow, 3,4 is green the default settings)

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
