### PR TITLE
[GOG-421] Use UX AWS role for SOPS decryption

### DIFF
--- a/playbook/.sops.yaml
+++ b/playbook/.sops.yaml
@@ -1,13 +1,19 @@
 creation_rules:
-  - filename_regex: production
+  - path_regex: production
     key_groups:
     - kms:
       - arn: "arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c"
+      - arn: "arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c"
+        role: "arn:aws:iam::205083374951:role/UX"
       pgp:
       - "C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B" # Ben Klang
+      - "181D7230C1982F01D9751710F0C07D7B2AC4F268" # Ben Langfeld
 
   - key_groups:
     - kms:
       - arn: "arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41"
+      - arn: "arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41"
+        role: "arn:aws:iam::205083374951:role/UX"
       pgp:
       - "C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B" # Ben Klang
+      - "181D7230C1982F01D9751710F0C07D7B2AC4F268" # Ben Langfeld

--- a/playbook/config/deploy/production/secrets.yaml
+++ b/playbook/config/deploy/production/secrets.yaml
@@ -2,33 +2,56 @@ appConfig:
     secretKeyBase: ENC[AES256_GCM,data:cbjB4yML/kL3c/rAblhzaVeKa1zhSN7rBnTyxPf2XGW/RP12RY8ix1aKqjvYuWbYe4dlJKSa+7tF+eAjx2uoH4TNzbExH05xXdbuxlnymUSObGrYGJ70lYKUMlfWJNTOBpAGRff6F4MOQfCmDc9mL2AwLHtyAW8Ag3ZVczTTF5Q=,iv:QescmNxHPF5E2d0RTDe7RcsWd7bKUQHVQlIqIBr/CdE=,tag:rTJHGL3rp/F2CoGa8ZVDQw==,type:str]
 sops:
     kms:
-    -   arn: arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c
-        created_at: '2018-06-08T13:11:58Z'
-        enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgGgj4zPTwIu1kPqB+oB5dUAAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM2r0lxd9HvOedNhipAgEQgDteJ0pab05z3LuVYqHfW4rtCIu52cJYeQ4OO//ToTHh2t/4NfeBJ5JHSldXCxsg4HwgJ8gCkHxb6n9TLQ==
+        - arn: arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c
+          created_at: "2021-05-04T13:29:39Z"
+          enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgHTnmDEbzjKBtaGjo87ZHWTAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMIaqYdGEL0EF2r2PZAgEQgDvwWWsS5A7FWfwB3rrTmt6J6UdZTmUkrhRLnH6srV6DEbHp2yqDraQ28a6fdaWNMTB7fMAB0LQAbkajAw==
+          aws_profile: ""
+        - arn: arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c
+          role: arn:aws:iam::205083374951:role/UX
+          created_at: "2021-05-04T13:29:39Z"
+          enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgEE3OFeziYP6WS3NxqIWDM/AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMhRUhuLS0NCo1dXEUAgEQgDuDkNdp2Z+bsgPWMoxeihmQFsEvkmsgLZO5jb3kpvMzklu9+3f2xuprFFPh3+Ul87PywFo/grB7rcaqmw==
+          aws_profile: ""
     gcp_kms: []
-    lastmodified: '2019-03-08T16:30:57Z'
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2019-03-08T16:30:57Z"
     mac: ENC[AES256_GCM,data:Wo2o66+jiiie5lba19uYEpH4DmFacWD27R6tx3YU8JKQ30TCeL8YG4eTvmy5eZg99UwIDeicJcysc9JnWGNn6t08kYTAjrVrjKnY3T4uP97gqs0CxvoMInddRRDOOJStWiI3up/TznPKijL/jWVLhWMmdBKJhA1JK7E7R6De1jE=,iv:HYBPgSUtve9EYVkNjfImULCcgGtmrPPxqf7OKjbPKMk=,tag:TcDK/2rNBzTwQBK5bDCzdg==,type:str]
     pgp:
-    -   created_at: '2018-06-08T13:11:58Z'
-        enc: |-
+        - created_at: "2021-05-04T13:29:39Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA2NdqJ8wZEUFARAAf6f4hr3hChUFUg99eX4Zl6XpGlPYiAvBOZMBOeUdgFO5
-            g88N357VDELjj+h4UX0kGECo+5rrR4mQ1PoY8j5tbyVDJ35KrsHPpZsybALViHtJ
-            VrtHRLR5Bwk4IGc9ojqBI62E4C5I2T/fBo9TlHwfLGQrjAnt38n/Ahh6joFEsvwx
-            sW6zkMeT5erVbXs2gRm/aVARZtUYR1HoRsOuxxtFOtXg53VjE+OZ8mMh/tN5LQA+
-            6mPzUjU3n8F9wbV8F5ODaFxgBbVtzN/zjNvH+kwgR4nvy91b36WnaL4Iumg94na2
-            N57K5YujImMooyaGOjKsWz8eiMSGsR0+xysJIw5jHf0TsXOmdHm/0vlfnI9EQgYQ
-            +43AaQxkCJNoCPQ5NbTk3nnlqAMykgRN890XELGkFMXcPtn/zLa7V/U90uJB1wEE
-            tPVG0XHdowlFGyn8+1w5t4JbY4eINM0c6TeT6zuGddsIny9poXuZ3O9GzV5DUnl4
-            SptEhCOCa866FlnKkaM2Rvo65pybi8qANKwglz56L/zeT7L7G2TxjlR8Tee0I0u0
-            cKuFAAB/KlJlmwPOuAoHoXUx38ci1mV4gyjsSAdNy/HGZNj4T3fRFzL+sYLAHmFd
-            MGmgRRRfqlaAWhQ7ivVKhVdNrDJvTu2wqkBUUUoAHLlP2UjxFBqe/pUCzcjLIwHS
-            4AHkIjzmu6mebNC0PPGRMdxwReFjKeDk4CThvY/g++LeyUoe4NXl8qVZD3GX4b4x
-            qFgxfzFuLJayiT/qLlgg3JmBIJEvzergb+R8qBgccphJ413n/NYAgBys4vzWXTbh
-            3KUA
-            =95xw
+            wcFMA2NdqJ8wZEUFARAAlyV0PYWoGcCxuO7LmtMMfpK2OZ6AoZscPloeZY30abjT
+            McRcu9FzZpAvLqxAJnu7alZBe3g70cR26Rb7IsmyTgbYoHi2RYBnoZ8TZ3IYB2WU
+            OE20udtbZ3QTeyKC+1Oit/hu+tKbY4WVAh+74H8TiqPhWizVzZ+NBsYsw75veXgG
+            d6MjS4PPqBWYbhCSEuJdNCbfJXFbFAhmFzTMiFnX9Dip0SKVdjAnf2ghclKyAxha
+            oY3p0ODkwIGfcOVGee5XkIQ/CMGVaCdSs68bSN2fFn/R4x84knNiJcb6ZoUAWWtC
+            98KSCvPgKf6Jo/NdK0d3t3kirkdIaxQfiR+GL5hNRcZppu3x9S/6i0FbmLfUjPyL
+            M9qB22Gtcv1BNNPssgUvGt1a1aXMuZYDoc6qnYhJyAyW0+IIsMI0J4DhfsEvx0XN
+            yWAKApQBKgrBNjlDqZKgmc5mkXjUA55CVaJfTmBQBqUffSi+PQm3+tzpo6oylSea
+            jY4GlAYn54qGq+zAkIPr1D7tJgwuVM123rmjW5Jpkub03y0g78dhxeZR7vlbKo4k
+            ld3zfKGhCBtuwiYiNitC2nOQDSu6IrBfdRfC5dbLux81MN49EWJhPiez2ayr2KMv
+            RpjZSpnlnrVBpyHWiYwy/GKCvGJiLnztz1dFRBtf6MFanyGeLUxF50r1QKlPrYvS
+            5gGS62ISaGmKGTqj+h6ltPtxITP7RYajxSR1D6gUYXSJYYDgrAfjIz0tYP8L7eh7
+            4eQzjHEOZkfYreN//7eIMAbkevm2gOiUTG4vJ6ipg7/ZeuJ5u5VnAA==
+            =AiQN
             -----END PGP MESSAGE-----
-        fp: C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B
+          fp: C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B
+        - created_at: "2021-05-04T13:29:39Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMA4Ms0+/IoZU/AQgAd0TtlrD5KESKe+ga2XlwBT0ArfGLSy+Gm6FCB1Xm+1c2
+            e6gdmS2uNlh8vw3FhqvdpZ9SoXa9Mq8ffDQKARtfiqdKxsevPKuKtTmJxHeMBO1h
+            girtJP6BLLNMU6od9SzOTR/ciSoJ0UX0hu+EwDFsx/qGoGgZ33rd23vlmpRp+t4x
+            McboZefeo9jtr6U7C++ICTWt/Easqhcyg16+A4idsvziNUoK32GouJWJrVm3OmTG
+            IuHkb/WMmc6KUEyBnnqkMYqp4e5881vKW9rfwNDPbKSGJ6ISycw1FRPVVSH/idWh
+            99ccUZe9ng0HJVxDh1Kedpq2PSEsazteZZ++AOcW6dLmAVWEHugoFzDogauSGqN8
+            m2cAKWKoDeWnRLrVli3ycmOm0ERNzvlRXL+E3/PI9ikF8NT1efIXhllKVykaUBgi
+            5uSl8tw5mVoSyrvqpJfwS9nn4oY+6HsA
+            =49cY
+            -----END PGP MESSAGE-----
+          fp: 181D7230C1982F01D9751710F0C07D7B2AC4F268
     unencrypted_suffix: _unencrypted
     version: 3.0.3

--- a/playbook/config/deploy/prs/secrets.yaml
+++ b/playbook/config/deploy/prs/secrets.yaml
@@ -2,33 +2,56 @@ appConfig:
     secretKeyBase: ENC[AES256_GCM,data:de3NakNnqnRRg4RdqxDCQF4WYWuXGl0qY+86Dln3bFhruhTYqSGmQsv+7Rw7vajQqM9qwoC9+1kbJV0JxONwFRSSLqLduv0DxduXniyrL1AtpnuLQzsO5EcJDlb11dqqvfIRmNcJK1724nW4AKW/kRSspfqjllR2GKRxmRCJKRE=,iv:lXmw3b9V+9+utfvEieJAhZSv+GlzxF0Km+CI5+GjWVA=,tag:f+A+9xx19DccNSjFPruhtg==,type:str]
 sops:
     kms:
-    -   arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
-        created_at: '2018-06-08T13:14:07Z'
-        enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgFlBr95YXQ2Ozk6REAhdOUgAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMGrsJA+bQAERzaRnNAgEQgDtHAq2cuz8HYbtkFe3wwNFfJyJNi8ztePQlxQSr2ZVGmTWnJAekaaQcFrwLtX5IPKObnKUzJmssrbbAIw==
+        - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
+          created_at: "2021-05-04T13:30:56Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgHXN8rp2KH6AxGjLvRpxwd2AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMSbdbiI4v7R8VJBg9AgEQgDtd/8XBvtwipxZ24ks+i7Cazndd/rQgzWEHWAOddvd5fIAf+XyAZvRi9sAGn3hk0t4stxUHVaKyoL+Csw==
+          aws_profile: ""
+        - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
+          role: arn:aws:iam::205083374951:role/UX
+          created_at: "2021-05-04T13:30:56Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgHUJVx7HEQBPRbTR9qNRUV/AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMi4GrCjufSwo7lcC8AgEQgDv2Ob5PWYQvEZu2PAMeExBItxv7q1+y5gmM6IpAMZoCngzCjGZzNTxa/z6sk1EDJwZppTANYCJD+rR/oQ==
+          aws_profile: ""
     gcp_kms: []
-    lastmodified: '2019-03-08T16:30:16Z'
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2019-03-08T16:30:16Z"
     mac: ENC[AES256_GCM,data:bl0heFRfOFzSK6M47fLPublbSJefl6nDik+jPeW/GVQOwq75VE7Ebd/s/2H3gIxNS6IsF8PLW3eS/RyvxfwH5HTb80BI63db9MFChIEG3LWPROWI5wkSKjQEKofFCK1Z/zNvgnDi0O3vX5Kdj3/Yo24+F6SZdWPr40my5/lZOnE=,iv:3cCKjm4fkuQmvKakghv0fLMgqVIiVE1ypnTrKPKZENU=,tag:Eq7K2WiD22GttKBUY35+/Q==,type:str]
     pgp:
-    -   created_at: '2018-06-08T13:14:07Z'
-        enc: |-
+        - created_at: "2021-05-04T13:30:56Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA2NdqJ8wZEUFARAAnHsjtSv8J98aXqSbqhB0iXzzDmay992TXSe3I+I848ZV
-            CpSZg4kBaFxrrX8Q1PCZNcubEOxptcVNNCxvRcD4Q0TpxH5U9XfonGI7Gw2V4nCW
-            nsieDwv4CswiNryGkojzKgkn+hpcsNQ4Vv9O97tYnFD+3p1Cv520m3RT4r8qVRC8
-            0q/hpcOfqLKHyz9jzXPchSHX4y8+nKU/0RpbwaVMlwAf4+9pt+AuGJ6bjFbm0MaA
-            i9b8H3D9btxDusUXZ+exHax7fsMKbV/SNjW4BLQpHCtqtDC51IC7l2oHB6DdqYO/
-            qQ5wzSvRSr/LLNd7S6TId2YxaM6u8mn4c1y+SnaiDagQiLZzY2eG1MJHVSniMmne
-            BCNgsTN1lDbbwNMZUbVWqJiFVVvy47gqAV3yyB8H3yZKzLFCnZQzI1B7KeTZ2cHf
-            Exge60BtU+Z6JgCVRmPs2qN2tqVzqF78d/I/kJB+VclqMnfAT4Kx84gJLgW/kogU
-            dIqBWWCpkOv1+r81U88Whohj8Z74AQkjMRLcQZF6xDNvmxcf6+JSyCV6LZkNOLfp
-            nzVoGhcNP/R4DiVit7hL1JhI9Km0yWfdXLOc8ndYoFWu1WrcHQrHDg2Zq/3jKNYm
-            69FwK1SVd2OLSf5r29696fM0TOWU5X4x+Exd7/WhAMPNCjFJ98hjVodcTfxg9NHS
-            4AHk1p++0+6lrGHCm0NJOd2Y3OGO0eCG4Orhf1PgUeIUkQNG4G/l5mrCyZ0gs4GQ
-            1tVyGPLGlvKUrj71Y3r4kSYhjAGkIGPg1OSqvvPti8qwtNkd+yxiWsRF4mFokTzh
-            I6gA
-            =9rUZ
+            wcFMA2NdqJ8wZEUFARAAJSmk5hhwMiGhSpJpNA3BnQQGhyyc5Y7ar4DOTFHDgz1f
+            h2RG+Hqlhc73AqKLdc8ELQD86Ar5c7Cf4l1X/fQ8CSc9vsDDbuyzkGhH13PRaOPr
+            UOrFgY+y4m9mjm14Fyv66GB/VvX/Bne40crLyp+w93fl1YRHpqh++3A5KcIWJXHG
+            dfj/JanlJxvCHdZ1Va/PLXPUQezUt153tKLEaeGJ5dbq508Tyr9niy0jG8QQi8FS
+            LjvdfNQTJFzvh+6+EPvqHNEL6Em30JKTos7OjfogS5rQ66cB0Kua3weARENpz+9m
+            LAnB3Aq9y5RTcbs3Rq7Mj9kOv2I4Qk6wQcQcU9E0Z1pgZxt6It2aAXCj0WPZkc4v
+            W76B6ZeSAqQc41Kt+w7rdgpQ7u/zYZ+EcWc2YD85zKbeqyYvdoJBhcyf7LDQZHg+
+            Ibsud+GsBoLGG1RObu7352PSpzreUjgCK1kcsY+/SS7U7/TScIIM6dvAjCQsq34u
+            x/vyRiFM94ajUcjzBmSBkYfnc3kc0jmNVR5FETrBXLLFysy/R5lA74H5PtFSJX5V
+            g2ScQ7okAI/ssoqxBkeHqchM4qU7N34YypUwoDMM1MlCLXADrzRaOQkz2J4DmBPL
+            rRbjsBgb9oixhk5Hk6Ir0L8kFGOpp0+CqbHQTrzGiHZz7PHhXsqkd8jl9etIpdLS
+            5gFTAJSyV06imU2iY8GbuOXU176u/NxYaTKQKrbcM6+D3CJWnsxohkJAiboDoon1
+            cSinylYau8C8rwPQMYGUlaXk+MBO7X8t3UEj9YCmo12F7+IJdhtbAA==
+            =ORVy
             -----END PGP MESSAGE-----
-        fp: C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B
+          fp: C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B
+        - created_at: "2021-05-04T13:30:56Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMA4Ms0+/IoZU/AQgAFt9jfkL3RXH7bi3xNFbY7QPPoB/S0FDAgXBnsUcE0f3l
+            j4YHpfIOpGbqMJwsb5Db2Sy/MLJlu7o9WQK129Lr4H06VAKu0MeOtZU2NoihdwNS
+            fddxw+GwUOFSJ57naQOox/tglRLehsU4JxKmXf0RZKf/Fk2KHJaMJo0/VWaL/Cv4
+            rGNtPVEhp0EDbOpbGR+Z7h8Nme0Ph+CGJ+dQV8xJCgLrjVlhcNTNDTYxOGKh+Y2p
+            fOHwWbOT0wcBxjAENZyawtVdW+tBmPZhQn9WoBjqyW075v42m3RWH/YmXDkSBFch
+            BaqasHCCHNjpX7jPHA57ZZfYvyRsl2mOVMwl53UGqtLmAUbNgvZYluCl2IXCtP5Y
+            j0iajxyl1pa1U68qE7UFnPpRHEDHTsKIoOGFa/T+9PSBF3k4SmnmCf3mUQWC+zBU
+            zuQIrA7pEnyUhUPpMYK7FePs4utGTZcA
+            =1SzU
+            -----END PGP MESSAGE-----
+          fp: 181D7230C1982F01D9751710F0C07D7B2AC4F268
     unencrypted_suffix: _unencrypted
     version: 3.0.3

--- a/playbook/config/deploy/staging/secrets.yaml
+++ b/playbook/config/deploy/staging/secrets.yaml
@@ -2,33 +2,56 @@ appConfig:
     secretKeyBase: ENC[AES256_GCM,data:de3NakNnqnRRg4RdqxDCQF4WYWuXGl0qY+86Dln3bFhruhTYqSGmQsv+7Rw7vajQqM9qwoC9+1kbJV0JxONwFRSSLqLduv0DxduXniyrL1AtpnuLQzsO5EcJDlb11dqqvfIRmNcJK1724nW4AKW/kRSspfqjllR2GKRxmRCJKRE=,iv:lXmw3b9V+9+utfvEieJAhZSv+GlzxF0Km+CI5+GjWVA=,tag:f+A+9xx19DccNSjFPruhtg==,type:str]
 sops:
     kms:
-    -   arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
-        created_at: '2018-06-08T13:14:07Z'
-        enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgFlBr95YXQ2Ozk6REAhdOUgAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMGrsJA+bQAERzaRnNAgEQgDtHAq2cuz8HYbtkFe3wwNFfJyJNi8ztePQlxQSr2ZVGmTWnJAekaaQcFrwLtX5IPKObnKUzJmssrbbAIw==
+        - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
+          created_at: "2021-05-04T13:31:11Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgEXXpjb9fTfQVWH/zd8gS3+AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMIiT05R23xdmVD8wmAgEQgDvyv5dJRuHffjph8aYkH/NzhsgEGzVXdmztzv6Kc5PC57GzpComtF3rmzOHptUL8tdWc1r1RrBHGdH3qw==
+          aws_profile: ""
+        - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
+          role: arn:aws:iam::205083374951:role/UX
+          created_at: "2021-05-04T13:31:11Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgHbYHaWiTC8FtTQTkj5eIpPAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQME5yHUCuYZveRpEKuAgEQgDs02FsUNbNp/ed2hBu4WtfGvoAizo+HSKrTnhR+7y0+lh2CAaKGxgTJJZqhifOTw44rWhcVKC4t4cuHeQ==
+          aws_profile: ""
     gcp_kms: []
-    lastmodified: '2019-03-08T16:30:16Z'
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2019-03-08T16:30:16Z"
     mac: ENC[AES256_GCM,data:bl0heFRfOFzSK6M47fLPublbSJefl6nDik+jPeW/GVQOwq75VE7Ebd/s/2H3gIxNS6IsF8PLW3eS/RyvxfwH5HTb80BI63db9MFChIEG3LWPROWI5wkSKjQEKofFCK1Z/zNvgnDi0O3vX5Kdj3/Yo24+F6SZdWPr40my5/lZOnE=,iv:3cCKjm4fkuQmvKakghv0fLMgqVIiVE1ypnTrKPKZENU=,tag:Eq7K2WiD22GttKBUY35+/Q==,type:str]
     pgp:
-    -   created_at: '2018-06-08T13:14:07Z'
-        enc: |-
+        - created_at: "2021-05-04T13:31:11Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA2NdqJ8wZEUFARAAnHsjtSv8J98aXqSbqhB0iXzzDmay992TXSe3I+I848ZV
-            CpSZg4kBaFxrrX8Q1PCZNcubEOxptcVNNCxvRcD4Q0TpxH5U9XfonGI7Gw2V4nCW
-            nsieDwv4CswiNryGkojzKgkn+hpcsNQ4Vv9O97tYnFD+3p1Cv520m3RT4r8qVRC8
-            0q/hpcOfqLKHyz9jzXPchSHX4y8+nKU/0RpbwaVMlwAf4+9pt+AuGJ6bjFbm0MaA
-            i9b8H3D9btxDusUXZ+exHax7fsMKbV/SNjW4BLQpHCtqtDC51IC7l2oHB6DdqYO/
-            qQ5wzSvRSr/LLNd7S6TId2YxaM6u8mn4c1y+SnaiDagQiLZzY2eG1MJHVSniMmne
-            BCNgsTN1lDbbwNMZUbVWqJiFVVvy47gqAV3yyB8H3yZKzLFCnZQzI1B7KeTZ2cHf
-            Exge60BtU+Z6JgCVRmPs2qN2tqVzqF78d/I/kJB+VclqMnfAT4Kx84gJLgW/kogU
-            dIqBWWCpkOv1+r81U88Whohj8Z74AQkjMRLcQZF6xDNvmxcf6+JSyCV6LZkNOLfp
-            nzVoGhcNP/R4DiVit7hL1JhI9Km0yWfdXLOc8ndYoFWu1WrcHQrHDg2Zq/3jKNYm
-            69FwK1SVd2OLSf5r29696fM0TOWU5X4x+Exd7/WhAMPNCjFJ98hjVodcTfxg9NHS
-            4AHk1p++0+6lrGHCm0NJOd2Y3OGO0eCG4Orhf1PgUeIUkQNG4G/l5mrCyZ0gs4GQ
-            1tVyGPLGlvKUrj71Y3r4kSYhjAGkIGPg1OSqvvPti8qwtNkd+yxiWsRF4mFokTzh
-            I6gA
-            =9rUZ
+            wcFMA2NdqJ8wZEUFARAAtxS9LMQwfoT3lsr82Od8R9tB22UqF2L7PKgDBY22JdV3
+            797ClnSznP9eJpExCuUyqaNkqi4DDQPs3Pul7S7IhA1k5Q8f+HKMURwuoSGpe/aF
+            64FuABPQsxMuVV0Fv+LS8eIZetSCPs2r/hTFW6MN9FIT0UE1LY2eeDqMuT9EV3qq
+            fuiwgsA9HeJBL+lKyPfMk1eXqAcjygjoB/G1GpNvymgQpMGvub07C708huY7p+uM
+            /wkgbSp9a4cG/aRI7EpXwEE/JXtjGF5BdcayKVWmhgv78KfLGunQKRTS3LYmXiBy
+            ZSzIbB4sVy9ZHbVMgI4KmInpDBbSudYRYoNchbWuQNCJdXgtzGODdty9tusyZwh/
+            /TlHabbUGM2ijo9B7pLa9ZuhfehU5atklf7vIsKezZA8Kk6ywXfj68kou9ien4L6
+            dak5CvQwzjdTFnjkPsRPVZmBp6t5OeLMzPNR/wN0kI1M6oNMREkUdrigf0q+QW2Z
+            lAcXZ+dN6KsOWXhe+VwhFvbAd3skmzKDqbiw/ocD0p3rQWR64TA4ZsdKND+H7ItN
+            IFrf6GuFY5II+ROCOpgiulTzfr5O4Eq7jroHho4FEuF8qG08HeRwRvvYv7H9wjU9
+            1jaUn6EASNYUiauuS7Fy0u57m2fACrWId5459zJBBQ5AhHP4rDV0ratJY9zPrDvS
+            5gFM4qhfwN5D8waGjPh3hnUPs8bhhHAR5WyGXcJQF4jY3DJaW0NmDfhFLzMklv37
+            JhR7Q2pdMA4HYe6gSuj4Ko/kkToHzK+49Uvy7Vj7c0wIK+KN7YhWAA==
+            =uTkc
             -----END PGP MESSAGE-----
-        fp: C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B
+          fp: C534CBAA229396B3FFC0CBB8FEFCDD8B6EB6B73B
+        - created_at: "2021-05-04T13:31:11Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMA4Ms0+/IoZU/AQgAEaxyM8E2JblY8Ue3B1DWSYueItr2mqd0lf+r8fDxERdP
+            ijxs0L898TlF0LbpAai0IskIf+1NzSelPNy9X6QJDJafR7QTsM3vq0hHq8duXa9s
+            CrxfCMUx7xk2brAR177/OtktXPoLH9FEu3fasNkSJJuthOxFHVnOP1/XSLNobDhG
+            i8gqinGIUH6eV7GKhmHbTI8ZwV2Rw4ZFeuMOeYufdM6x1N4GYYA7Z9V1Ng8QLdqi
+            aZD8YRCTTz7duX3Owtjd00BmUEv1WcoM/2cC5cuLHUu2s79IRoAkZ6NfFZHX8pVr
+            vbtY9dRhILTFJIm9nBpbcdoAUiDO5iKUkuwpF6684dLmAcIS8MTd7aAANi7p45Co
+            c/E67fY5ZBiaXAKieIjomWuAGjGLOzcktxj9jj/ors8aYEv497Mw6rT8yBZoeo/z
+            ieRRxRGzRnGqP+771+5mM10z4kcVsvoA
+            =EZem
+            -----END PGP MESSAGE-----
+          fp: 181D7230C1982F01D9751710F0C07D7B2AC4F268
     unencrypted_suffix: _unencrypted
     version: 3.0.3


### PR DESCRIPTION
This causes SOPS to assume the UX role when accessing these secrets, which is necessary based on the new permissions model which grants selective access to KMS keys. Use of the key without a role is also retained for Milano's access.

Previously, all members of the Developers group had access to all KMS keys. We're moving toward access only to those keys which protect secrets that are within the remit of specific groups.

Only UX need access to Playbook secrets.

https://nitro.powerhrg.com/runway/backlog_items/GOG-421
