### PR TITLE
[CHMN-98] Add classname to popover on passphrase kit 

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.jsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.jsx
@@ -122,6 +122,7 @@ const Passphrase = (props: PassphraseProps) => {
           />
           <If condition={tips.length > 0 && !confirmation}>
             <PbReactPopover
+                className={"passphrase-tips"}
                 closeOnClick="outside"
                 placement="right"
                 reference={popoverReference}

--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.jsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.jsx
@@ -122,7 +122,7 @@ const Passphrase = (props: PassphraseProps) => {
           />
           <If condition={tips.length > 0 && !confirmation}>
             <PbReactPopover
-                className={"passphrase-tips"}
+                className="passphrase-tips"
                 closeOnClick="outside"
                 placement="right"
                 reference={popoverReference}


### PR DESCRIPTION
#### Screens
"passphrase-tips" is the new classname 
<img width="1099" alt="Screen Shot 2021-05-11 at 9 02 40 AM" src="https://user-images.githubusercontent.com/64423298/117819561-a704ff00-b237-11eb-9ed6-d1a74a93a9fe.png">

#### Breaking Changes

No, additive changes to the passphrase kit. Other kits not affected. Passphrase kit not used yet (but will be soon)

As a Nitro developer I want a way to specifically target the passphrase tips popover so that I can safely apply custom styles in Nitro without affecting other popover elements. 

#### Runway Ticket URL

[RunwayT URL](https://nitro.powerhrg.com/runway/backlog_items/CHMN-98)

#### How to test this

/kits/passphrase/react
/kits/passphrase/

See that the popover has a classname - "passphrase-tips"

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
