### PR TITLE
[CHMN-101] Don't allow popover to open when clicking on eyeball in the passphrase kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.jsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.jsx
@@ -74,7 +74,10 @@ const Passphrase = (props: PassphraseProps) => {
   }
 
   const [showPassphrase, setShowPassphrase] = useState(false)
-  const toggleShowPassphrase = () => setShowPassphrase(!showPassphrase)
+  const toggleShowPassphrase = (e) => {
+    e.preventDefault()
+    setShowPassphrase(!showPassphrase)
+  }
 
   const classes = classnames(buildCss('pb_passphrase'), globalProps(props), className)
 


### PR DESCRIPTION
#### Screens

No new visuals.

#### Breaking Changes

No, additive changes to the passphrase kit. Other kits not affected. Passphrase kit not used yet (but will be soon)

We had an issue where clicking on the "eye" icon would trigger the "info" icon to open its popover. 

#### Runway Ticket URL

[Runway URL](https://nitro.powerhrg.com/runway/backlog_items/CHMN-101)

#### How to test this

/kits/passphrase/react
/kits/passphrase/

See that clicking on the eye icon inside the tips example does not open the info icon popover 

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
