### PR TITLE
Add the value of a Dialog's portalClassName prop to the React Modal portal DIV class attribute

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.jsx
@@ -55,7 +55,7 @@ const Dialog = (props: DialogProps) => {
   const dataProps = buildDataProps(data)
 
   const dialogClassNames = {
-    base: classnames('pb_dialog', buildCss('pb_dialog', size)),
+    base: classnames('pb_dialog', buildCss('pb_dialog', size), className ? buildCss('pb_dialog', className) : null),
     afterOpen: 'pb_dialog_after_open',
     beforeClose: 'pb_dialog_before_close',
   }

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.jsx
@@ -25,6 +25,7 @@ type DialogProps = {
   onClose?: () => void,
   onConfirm?: () => void,
   opened: boolean,
+  portalClassName?: string,
   shouldCloseOnOverlayClick: boolean,
   size?: "sm" | "md" | "lg" | "content",
   text?: string,
@@ -46,6 +47,7 @@ const Dialog = (props: DialogProps) => {
     onCancel = () => {},
     onConfirm = () => {},
     onClose = () => {},
+    portalClassName,
     shouldCloseOnOverlayClick = true,
     text,
     title,
@@ -55,7 +57,7 @@ const Dialog = (props: DialogProps) => {
   const dataProps = buildDataProps(data)
 
   const dialogClassNames = {
-    base: classnames('pb_dialog', buildCss('pb_dialog', size), className ? buildCss('pb_dialog', className) : null),
+    base: classnames('pb_dialog', buildCss('pb_dialog', size)),
     afterOpen: 'pb_dialog_after_open',
     beforeClose: 'pb_dialog_before_close',
   }
@@ -107,6 +109,7 @@ const Dialog = (props: DialogProps) => {
             isOpen={modalIsOpened}
             onRequestClose={onClose}
             overlayClassName={overlayClassNames}
+            portalClassName={portalClassName}
             shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
         >
           <If condition={title}>

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_default.jsx
@@ -12,10 +12,12 @@ const DialogDefault = () => {
       <Dialog
           cancelButton="Cancel"
           confirmButton="Okay"
+          className="wrapper"
           onCancel={close}
           onClose={close}
           onConfirm={close}
           opened={isOpen}
+          portalClassName="portal"
           size="sm"
           text="Hello Body Text, Nice to meet ya."
           title="Header Title is the Title Prop"

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_default.jsx
@@ -11,8 +11,8 @@ const DialogDefault = () => {
       <Button onClick={open}>{'Open Dialog'}</Button>
       <Dialog
           cancelButton="Cancel"
-          confirmButton="Okay"
           className="wrapper"
+          confirmButton="Okay"
           onCancel={close}
           onClose={close}
           onConfirm={close}


### PR DESCRIPTION
#### Screens

This PR takes the value of a Dialog's `portalClassName` prop:

![image](https://user-images.githubusercontent.com/151394/120837943-28407080-c51c-11eb-9a22-1cd404ac5bb5.png)

and adds it to the React Modal portal's `div` class attribute:

![image](https://user-images.githubusercontent.com/151394/120838378-9ab15080-c51c-11eb-85cd-92bc08d8c145.png)

This will allow a specific Dialog's modal to be targeted for CSS or JavaScript purposes.

#### Breaking Changes

No breaking changes. If the `className` prop isn't present then it's not added to the list of CSS class names.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/BOP-968

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
