### PR TITLE
[LGA-719] Fix invalid date in Date Time docs for Firefox

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_time/docs/_date_time_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_time/docs/_date_time_default.jsx
@@ -29,7 +29,8 @@ const DateTimeDefault = (props) => (
     <br />
 
     <DateTime
-        datetime={new Date('2020-12-31 14:24:09 -0500')}
+        datetime={new Date('2020/12/31 14:24:09 -0500')}
+        timeZone="Asia/Tokyo"
         {...props}
     />
   </div>


### PR DESCRIPTION
#### Screens

PROBLEM

<img width="956" alt="DateTimeIssue2" src="https://user-images.githubusercontent.com/51907753/120670137-22845580-c45e-11eb-95d2-89efe75029ee.png">

FIX

<img width="1133" alt="Screen Shot 2021-06-03 at 11 21 53 AM" src="https://user-images.githubusercontent.com/51907753/120670159-27e1a000-c45e-11eb-8989-f6a6a24e99a9.png">


#### Breaking Changes

None. This is just a slight change to the docs to make sure that the date and time are showing up correctly in firefox.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/LGA-719

#### How to test this

Go to `kits/date_time/react` in your browser and check the default docs. You MUST do this in *firefox* because the bug only exists in firefox.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [X] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
