### PR TITLE
[BOP-979] Enhance message kit to accept timestamp object for hover

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react'
-import { Avatar, Body, Caption, Timestamp, Title } from '../'
+import { Avatar, Body, Timestamp, Title } from '../'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
@@ -63,15 +63,28 @@ const Message = (props: MessageProps) => {
         />
       </If>
       <div className="content_wrapper">
-        <Timestamp text={timestamp} className={`pull-right ${timestampObject ? 'message_humanized_time' : null}`} />
+        <Timestamp
+            className={`pull-right ${timestampObject ? 'message_humanized_time' : null}`}
+            text={timestamp}
+        />
         <If condition={timestampObject}>
-          <Timestamp timestamp={timestampObject} className={"pull-right message_timestamp"} />
+          <Timestamp
+              className="pull-right message_timestamp"
+              timestamp={timestampObject}
+          />
         </If>
 
         <If condition={label}>
-          <Title className="message_title" text={label} size={4} />
+          <Title
+              className="message_title"
+              size={4}
+              text={label}
+          />
         </If>
-        <Body className={"pb_message_body"} text={message} />
+        <Body
+            className="pb_message_body"
+            text={message}
+        />
       </div>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -64,7 +64,7 @@ const Message = (props: MessageProps) => {
       </If>
       <div className="content_wrapper">
         <Timestamp
-            className={`pull-right ${timestampObject ? 'message_humanized_time' : null}`}
+            className={`pull-right ${timestampObject ? "message_humanized_time" : null}`}
             text={timestamp}
         />
         <If condition={timestampObject}>
@@ -82,7 +82,7 @@ const Message = (props: MessageProps) => {
           />
         </If>
         <Body
-            className="pb_message_body"
+            className={`pb_message_body ${label ? null : "body_spaced"}`}
             text={message}
         />
       </div>

--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react'
-import { Avatar, Body, Caption, Title } from '../'
+import { Avatar, Body, Caption, Timestamp, Title } from '../'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
@@ -17,6 +17,7 @@ type MessageProps = {
   label?: string,
   message: string,
   timestamp?: string,
+  timestampObject?: string,
 }
 
 const Message = (props: MessageProps) => {
@@ -31,6 +32,7 @@ const Message = (props: MessageProps) => {
     label,
     message,
     timestamp,
+    timestampObject,
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
@@ -61,13 +63,15 @@ const Message = (props: MessageProps) => {
         />
       </If>
       <div className="content_wrapper">
+        <Timestamp text={timestamp} className={`pull-right ${timestampObject ? 'message_humanized_time' : null}`} />
+        <If condition={timestampObject}>
+          <Timestamp timestamp={timestampObject} className={"pull-right message_timestamp"} />
+        </If>
+
         <If condition={label}>
-          <Title classname="message_title" text={label} />
+          <Title className="message_title" text={label} size={4} />
         </If>
-        <Body>{message}</Body>
-        <If condition={timestamp}>
-          <Caption size="xs">{timestamp}</Caption>
-        </If>
+        <Body className={"pb_message_body"} text={message} />
       </div>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -64,7 +64,7 @@ const Message = (props: MessageProps) => {
       </If>
       <div className="content_wrapper">
         <Timestamp
-            className={`pull-right ${timestampObject ? "message_humanized_time" : null}`}
+            className={`pull-right ${timestampObject ? 'message_humanized_time' : null}`}
             text={timestamp}
         />
         <If condition={timestampObject}>
@@ -82,7 +82,7 @@ const Message = (props: MessageProps) => {
           />
         </If>
         <Body
-            className={`pb_message_body ${label ? null : "body_spaced"}`}
+            className={`pb_message_body ${label ? null : 'body_spaced'}`}
             text={message}
         />
       </div>

--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react'
-import { Avatar, Body, Caption } from '../'
+import { Avatar, Body, Caption, Title } from '../'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
@@ -56,13 +56,13 @@ const Message = (props: MessageProps) => {
         <Avatar
             imageUrl={avatarUrl}
             name={avatarName}
-            size="sm"
+            size="xs"
             status={avatarStatus}
         />
       </If>
       <div className="content_wrapper">
         <If condition={label}>
-          <Caption>{label}</Caption>
+          <Title classname="message_title" text={label} />
         </If>
         <Body>{message}</Body>
         <If condition={timestamp}>

--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -18,6 +18,7 @@ type MessageProps = {
   message: string,
   timestamp?: string,
   timestampObject?: string,
+  alignTimestamp?: string,
 }
 
 const Message = (props: MessageProps) => {
@@ -33,6 +34,7 @@ const Message = (props: MessageProps) => {
     message,
     timestamp,
     timestampObject,
+    alignTimestamp = "right",
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
@@ -63,24 +65,25 @@ const Message = (props: MessageProps) => {
         />
       </If>
       <div className="content_wrapper">
-        <Timestamp
-            className={`pull-right ${timestampObject ? 'message_humanized_time' : null}`}
-            text={timestamp}
-        />
-        <If condition={timestampObject}>
+        <Flex orientation="row" justify={alignTimestamp === "left" ? "none" : "between"}>
+          <If condition={label}>
+            <Title
+                className="message_title"
+                size={4}
+                text={label}
+            />
+          </If>
           <Timestamp
-              className="pull-right message_timestamp"
-              timestamp={timestampObject}
+              className={`pull-${alignTimestamp} ${timestampObject ? 'message_humanized_time' : null}`}
+              text={timestamp}
           />
-        </If>
-
-        <If condition={label}>
-          <Title
-              className="message_title"
-              size={4}
-              text={label}
-          />
-        </If>
+          <If condition={timestampObject}>
+            <Timestamp
+                className={`pull-${alignTimestamp} message_timestamp`}
+                timestamp={timestampObject}
+            />
+          </If>
+        </Flex>
         <Body
             className={`pb_message_body ${label ? null : 'body_spaced'}`}
             text={message}

--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -88,7 +88,7 @@ const Message = (props: MessageProps) => {
           </If>
         </Flex>
         <Body
-            className={`pb_message_body ${label ? null : 'body_spaced'}`}
+            className="pb_message_body"
             text={message}
         />
       </div>

--- a/playbook/app/pb_kits/playbook/pb_message/_message.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react'
-import { Avatar, Body, Timestamp, Title } from '../'
+import { Avatar, Body, Flex, Timestamp, Title } from '../'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps.js'
@@ -34,7 +34,7 @@ const Message = (props: MessageProps) => {
     message,
     timestamp,
     timestampObject,
-    alignTimestamp = "right",
+    alignTimestamp = 'right',
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
@@ -65,7 +65,10 @@ const Message = (props: MessageProps) => {
         />
       </If>
       <div className="content_wrapper">
-        <Flex orientation="row" justify={alignTimestamp === "left" ? "none" : "between"}>
+        <Flex
+            justify={alignTimestamp === 'left' ? 'none' : 'between'}
+            orientation="row"
+        >
           <If condition={label}>
             <Title
                 className="message_title"

--- a/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
@@ -10,15 +10,42 @@
     justify-content: center;
     align-items: flex-start;
     flex-direction: column;
+    width: 100%;
+
+    [class^=pb_flex_] {
+      width: 100%;
+    }
 
     .message_text {
       margin: 0 0 $space-xs/2;
     }
+
+    .message_title {
+      font-size: $font_small;
+    }
   }
 
-  &[class*=_avatar]  {
+  &[class*=_avatar] {
     .content_wrapper {
       margin-left: $space-sm;
+    }
+  }
+
+  .pb_message_body {
+    font-size: 15px;
+  }
+
+  .message_timestamp {
+    display: none;
+  }
+
+  &:hover {
+    .message_timestamp {
+      display: block;
+    }
+
+    .message_humanized_time {
+      display: none;
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
@@ -7,8 +7,8 @@
   .content_wrapper {
     width: 100%;
 
-    .pull-right {
-      float: right;
+    .pull-left {
+      margin-left: $space-xs;
     }
 
     [class^=pb_flex_] {
@@ -22,10 +22,6 @@
     .message_title {
       font-size: $font_small;
     }
-  }
-
-  .pb_avatar_kit_xs {
-    margin-top: $space-xs/2;
   }
 
   &[class*=_avatar] {

--- a/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
@@ -34,10 +34,6 @@
     font-size: 15px;
   }
 
-  .body_spaced {
-    margin-top: 7px;
-  }
-
   .message_timestamp {
     display: none;
   }

--- a/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
@@ -6,11 +6,11 @@
   align-items: center;
 
   .content_wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    flex-direction: column;
     width: 100%;
+
+    .pull-right {
+      float: right;
+    }
 
     [class^=pb_flex_] {
       width: 100%;

--- a/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
@@ -3,7 +3,6 @@
 @mixin pb_message {
   display: flex;
   justify-content: flex-start;
-  align-items: center;
 
   .content_wrapper {
     width: 100%;
@@ -25,14 +24,22 @@
     }
   }
 
+  .pb_avatar_kit_xs {
+    margin-top: $space-xs/2;
+  }
+
   &[class*=_avatar] {
     .content_wrapper {
-      margin-left: $space-sm;
+      margin-left: $space-xs;
     }
   }
 
   .pb_message_body {
     font-size: 15px;
+  }
+
+  .body_spaced {
+    margin-top: 7px;
   }
 
   .message_timestamp {

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
@@ -44,3 +44,12 @@
   message: "Please hold for one moment, I'll check with my manager.",
   timestamp: "2 days ago"
 }) %>
+
+<br><br>
+
+<%= pb_rails("message", props: {
+  label: "",
+  message: "We're so sorry you had a bad experience!",
+  timestamp: "2 days ago",
+  avatar_name: "Tim Wenhold"
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
@@ -22,7 +22,6 @@
 <%= pb_rails("message", props: {
   message: "To processs your order, I'll need your full name.",
   timestamp: "4 hours ago",
-  timestamp_object: DateTime.current,
   avatar_name: "Lisa Thompson",
   avatar_url: "https://randomuser.me/api/portraits/women/39.jpg"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
@@ -22,6 +22,7 @@
 <%= pb_rails("message", props: {
   message: "To processs your order, I'll need your full name.",
   timestamp: "4 hours ago",
+  timestamp_object: DateTime.current,
   avatar_name: "Lisa Thompson",
   avatar_url: "https://randomuser.me/api/portraits/women/39.jpg"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("message", props: {
-  label: "Message",
+  label: "Anna Black",
   message: "How can we assist you today?",
   timestamp: "20 seconds ago",
   avatar_name: "Mike Bishop",
@@ -10,27 +10,20 @@
 <br><br>
 
 <%= pb_rails("message", props: {
-  label: "Support",
+  label: "Patrick Welch",
   message: "We'll escalate this issue to a Senior Support agent.",
   timestamp: "9 minutes ago",
-  avatar_name:"Wade Winningham",
-  avatar_url: "https://randomuser.me/api/portraits/men/14.jpg"
+  avatar_name: "Wade Winningham",
+  avatar_url: "https://randomuser.me/api/portraits/men/14.jpg",
+  align_timestamp: "left"
 }) %>
 
 <br><br>
 
 <%= pb_rails("message", props: {
-  message: "To processs your order, I'll need your full name.",
-  timestamp: "4 hours ago",
-  avatar_name: "Lisa Thompson",
-  avatar_url: "https://randomuser.me/api/portraits/women/39.jpg"
-}) %>
-
-<br><br>
-
-<%= pb_rails("message", props: {
-  label: "Application",
+  label: "Lucille Sanchez",
   message: "Application for Kate Smith is waiting for your approval",
+  timestamp: "4 hours ago",
   avatar_name: "Becca Jacobs",
   avatar_url: "https://randomuser.me/api/portraits/women/50.jpg"
 }) %>
@@ -38,7 +31,7 @@
 <br><br>
 
 <%= pb_rails("message", props: {
-  label: "Complaint",
+  label: "Beverly Reyes",
   message: "We're so sorry you had a bad experience!",
   timestamp: "2 days ago",
   avatar_name: "Tim Wenhold"
@@ -47,7 +40,7 @@
 <br><br>
 
 <%= pb_rails("message", props: {
-  label: "Support",
+  label: "Keith Craig",
   message: "Please hold for one moment, I'll check with my manager.",
   timestamp: "2 days ago"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
@@ -8,7 +8,7 @@ const MessageDefault = (props) => {
           avatarName="Mike Bishop"
           avatarStatus="online"
           avatarUrl="https://randomuser.me/api/portraits/men/50.jpg"
-          label="Message"
+          label="Anna Black"
           message="How can we assist you today?"
           timestamp="20 seconds ago"
           {...props}
@@ -20,7 +20,7 @@ const MessageDefault = (props) => {
       <Message
           avatarName="Wade Winningham"
           avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
-          label="Support"
+          label="Patrick Welch"
           message="We will escalate this issue to a Senior Support agent."
           timestamp="9 minutes ago"
           {...props}
@@ -30,20 +30,9 @@ const MessageDefault = (props) => {
       <br />
 
       <Message
-          avatarName="Lisa Thompson"
-          avatarUrl="https://randomuser.me/api/portraits/women/39.jpg"
-          message="To process your order, I will need your full name."
-          timestamp="4 hours ago"
-          {...props}
-      />
-
-      <br />
-      <br />
-
-      <Message
           avatarName="Becca Jacobs"
           avatarUrl="https://randomuser.me/api/portraits/women/50.jpg"
-          label="Application"
+          label="Lucille Sanchez"
           message="Application for Kate Smith is waiting for your approval"
           timestamp="2 days ago"
           {...props}
@@ -54,7 +43,7 @@ const MessageDefault = (props) => {
 
       <Message
           avatarName="Timothy Wenhold"
-          label="Complaint"
+          label="Beverly Reyes"
           message="We are so sorry you had a bad experience!"
           timestamp="2 days ago"
           {...props}
@@ -64,7 +53,7 @@ const MessageDefault = (props) => {
       <br />
 
       <Message
-          label="Support"
+          label="Keith Craig"
           message="Please hold for one moment, I will check with my manager."
           timestamp="2 days ago"
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
@@ -18,12 +18,12 @@ const MessageDefault = (props) => {
       <br />
 
       <Message
+          alignTimestamp="left"
           avatarName="Wade Winningham"
           avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
           label="Patrick Welch"
           message="We will escalate this issue to a Senior Support agent."
           timestamp="9 minutes ago"
-          alignTimestamp="left"
           {...props}
       />
 

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
@@ -23,7 +23,6 @@ const MessageDefault = (props) => {
           label="Support"
           message="We will escalate this issue to a Senior Support agent."
           timestamp="9 minutes ago"
-          timestampObject={new Date}
           {...props}
       />
 

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
@@ -23,6 +23,7 @@ const MessageDefault = (props) => {
           label="Patrick Welch"
           message="We will escalate this issue to a Senior Support agent."
           timestamp="9 minutes ago"
+          alignTimestamp="left"
           {...props}
       />
 

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
@@ -34,6 +34,7 @@ const MessageDefault = (props) => {
           avatarUrl="https://randomuser.me/api/portraits/women/39.jpg"
           message="To process your order, I will need your full name."
           timestamp="4 hours ago"
+          timestampObject={new Date}
           {...props}
       />
 

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_default.jsx
@@ -23,6 +23,7 @@ const MessageDefault = (props) => {
           label="Support"
           message="We will escalate this issue to a Senior Support agent."
           timestamp="9 minutes ago"
+          timestampObject={new Date}
           {...props}
       />
 
@@ -34,7 +35,6 @@ const MessageDefault = (props) => {
           avatarUrl="https://randomuser.me/api/portraits/women/39.jpg"
           message="To process your order, I will need your full name."
           timestamp="4 hours ago"
-          timestampObject={new Date}
           {...props}
       />
 

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
@@ -11,6 +11,7 @@
   label: "Becca Jacobs",
   message: "Application for Kate Smith is waiting for your approval",
   timestamp: "12.20p",
+  align_timestamp: "left",
   timestamp_object: DateTime.current,
   avatar_name: "Lisa Thompson",
   avatar_url: "https://randomuser.me/api/portraits/women/39.jpg"

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
@@ -1,0 +1,8 @@
+<%= pb_rails("message", props: {
+  label: "Message",
+  message: "Hover over me to check out the real time I was made!",
+  timestamp: "4 hours ago",
+  timestamp_object: DateTime.current,
+  avatar_name: "Lisa Thompson",
+  avatar_url: "https://randomuser.me/api/portraits/women/39.jpg"
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
@@ -6,3 +6,12 @@
   avatar_name: "Lisa Thompson",
   avatar_url: "https://randomuser.me/api/portraits/women/39.jpg"
 }) %>
+<br><br>
+<%= pb_rails("message", props: {
+  label: "Becca Jacobs",
+  message: "Application for Kate Smith is waiting for your approval",
+  timestamp: "12.20p",
+  timestamp_object: DateTime.current,
+  avatar_name: "Lisa Thompson",
+  avatar_url: "https://randomuser.me/api/portraits/women/39.jpg"
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("message", props: {
-  label: "Message",
+  label: "Anna Black",
   message: "Hover over me to check out the real time I was made!",
   timestamp: "4 hours ago",
   timestamp_object: DateTime.current,

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
@@ -3,15 +3,28 @@ import { Message } from '../../'
 
 const MessageTimestamp = (props) => {
   return (
-    <Message
-        avatarName="Wade Winningham"
-        avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
-        label="Anna Black"
-        message="We will escalate this issue to a Senior Support agent."
-        timestamp="9 minutes ago"
-        timestampObject={new Date}
-        {...props}
-    />
+    <>
+      <Message
+          avatarName="Wade Winningham"
+          avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
+          label="Anna Black"
+          message="We will escalate this issue to a Senior Support agent."
+          timestamp="9 minutes ago"
+          timestampObject={new Date}
+          {...props}
+      />
+      <br />
+      <br />
+      <Message
+          avatarName="Wade Winningham"
+          avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
+          label="Becca Jacobs"
+          message="Application for Kate Smith is waiting for your approval"
+          timestamp="12.20p"
+          timestampObject={new Date}
+          {...props}
+      />
+    </>
   )
 }
 

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
@@ -16,6 +16,7 @@ const MessageTimestamp = (props) => {
       <br />
       <br />
       <Message
+          alignTimestamp="left"
           avatarName="Wade Winningham"
           avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
           label="Becca Jacobs"

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Message } from '../../'
+
+const MessageTimestamp = (props) => {
+  return (
+    <Message
+        avatarName="Wade Winningham"
+        avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
+        label="Support"
+        message="We will escalate this issue to a Senior Support agent."
+        timestamp="9 minutes ago"
+        timestampObject={new Date}
+        {...props}
+    />
+  )
+}
+
+export default MessageTimestamp

--- a/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/_message_timestamp.jsx
@@ -6,7 +6,7 @@ const MessageTimestamp = (props) => {
     <Message
         avatarName="Wade Winningham"
         avatarUrl="https://randomuser.me/api/portraits/men/14.jpg"
-        label="Support"
+        label="Anna Black"
         message="We will escalate this issue to a Senior Support agent."
         timestamp="9 minutes ago"
         timestampObject={new Date}

--- a/playbook/app/pb_kits/playbook/pb_message/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/example.yml
@@ -1,9 +1,11 @@
 examples:
-  
+
   rails:
   - message_default: Default
-  
-  
+  - message_timestamp: With Timestamp Hover
+
+
   react:
   - message_default: Default
-  
+  - message_timestamp: With Timestamp Hover
+

--- a/playbook/app/pb_kits/playbook/pb_message/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_message/docs/index.js
@@ -1,1 +1,2 @@
 export { default as MessageDefault } from './_message_default.jsx'
+export { default as MessageTimestamp } from './_message_timestamp.jsx'

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       <%= pb_rails("body", props: {
         text: object.message,
-        classname: "pb_message_body #{object.label.blank? ? 'body_spaced' : nil}"
+        classname: "pb_message_body"
       }) %>
     </div>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -12,23 +12,22 @@
       }) %>
     <% end %>
     <div class="content_wrapper">
-      <%= pb_rails("flex", props: { justify: "between" }) do %>
-        <%= pb_rails("title", props: {
-          size: 4,
-          text: object.label,
-          classname: "message_title"
-        }) %>
+      <%= pb_rails("timestamp", props: {
+        text: object.timestamp,
+        classname: "pull-right #{object.timestamp_object.present? ? 'message_humanized_time' : nil}"
+      }) %>
+      <% if object.timestamp_object.present? %>
         <%= pb_rails("timestamp", props: {
-          text: object.timestamp,
-          classname: object.timestamp_object.present? ? "message_humanized_time" : nil
+          timestamp: object.timestamp_object,
+          classname: "pull-right #{object.timestamp_object.present? ? 'message_timestamp' : nil}"
         }) %>
-        <% if object.timestamp_object.present? %>
-          <%= pb_rails("timestamp", props: {
-            timestamp: object.timestamp_object,
-            classname: "message_timestamp",
-          }) %>
-        <% end %>
       <% end %>
+
+      <%= pb_rails("title", props: {
+        size: 4,
+        text: object.label,
+        classname: "message_title"
+      }) %>
       <%= pb_rails("body", props: {
         text: object.message,
         classname: "pb_message_body"

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -6,20 +6,32 @@
     <% if object.valid? %>
       <%= pb_rails("avatar", props: {
         name: object.avatar_name,
-        size: "sm",
+        size: "xs",
         image_url: object.avatar_url,
         status: object.avatar_status
       }) %>
     <% end %>
     <div class="content_wrapper">
-      <%= pb_rails("caption", props: {
-        text: object.label
-      }) %>
+      <%= pb_rails("flex", props: { justify: "between" }) do %>
+        <%= pb_rails("title", props: {
+          size: 4,
+          text: object.label,
+          classname: "message_title"
+        }) %>
+        <%= pb_rails("timestamp", props: {
+          text: object.timestamp,
+          classname: object.timestamp_object.present? ? "message_humanized_time" : nil
+        }) %>
+        <% if object.timestamp_object.present? %>
+          <%= pb_rails("timestamp", props: {
+            timestamp: object.timestamp_object,
+            classname: "message_timestamp",
+          }) %>
+        <% end %>
+      <% end %>
       <%= pb_rails("body", props: {
-        text: object.message
-      }) %>
-      <%= pb_rails("timestamp", props: {
-        text: object.timestamp
+        text: object.message,
+        classname: "pb_message_body"
       }) %>
     </div>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -12,23 +12,25 @@
       }) %>
     <% end %>
     <div class="content_wrapper">
-      <%= pb_rails("timestamp", props: {
-        text: object.timestamp,
-        classname: "pull-right #{object.timestamp_object.present? ? 'message_humanized_time' : nil}"
-      }) %>
-      <% if object.timestamp_object.present? %>
-        <%= pb_rails("timestamp", props: {
-          timestamp: object.timestamp_object,
-          classname: "pull-right message_timestamp"
-        }) %>
-      <% end %>
+      <%= pb_rails("flex", props: { orientation: "row", justify: object.align_timestamp == "left" ? "none" : "between" }) do %>
+        <% if object.label.present? %>
+          <%= pb_rails("title", props: {
+            size: 4,
+            text: object.label,
+            classname: "message_title"
+          }) %>
+        <% end %>
 
-      <% if object.label.present? %>
-        <%= pb_rails("title", props: {
-          size: 4,
-          text: object.label,
-          classname: "message_title"
+        <%= pb_rails("timestamp", props: {
+          text: object.timestamp,
+          classname: "pull-#{object.align_timestamp} #{object.timestamp_object.present? ? 'message_humanized_time' : nil}"
         }) %>
+        <% if object.timestamp_object.present? %>
+          <%= pb_rails("timestamp", props: {
+            timestamp: object.timestamp_object,
+            classname: "pull-#{object.align_timestamp} message_timestamp"
+          }) %>
+        <% end %>
       <% end %>
       <%= pb_rails("body", props: {
         text: object.message,

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -32,7 +32,7 @@
       <% end %>
       <%= pb_rails("body", props: {
         text: object.message,
-        classname: "pb_message_body"
+        classname: "pb_message_body #{object.label.blank? ? 'body_spaced' : nil}"
       }) %>
     </div>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -19,15 +19,17 @@
       <% if object.timestamp_object.present? %>
         <%= pb_rails("timestamp", props: {
           timestamp: object.timestamp_object,
-          classname: "pull-right #{object.timestamp_object.present? ? 'message_timestamp' : nil}"
+          classname: "pull-right message_timestamp"
         }) %>
       <% end %>
 
-      <%= pb_rails("title", props: {
-        size: 4,
-        text: object.label,
-        classname: "message_title"
-      }) %>
+      <% if object.label.present? %>
+        <%= pb_rails("title", props: {
+          size: 4,
+          text: object.label,
+          classname: "message_title"
+        }) %>
+      <% end %>
       <%= pb_rails("body", props: {
         text: object.message,
         classname: "pb_message_body"

--- a/playbook/app/pb_kits/playbook/pb_message/message.rb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.rb
@@ -10,6 +10,7 @@ module Playbook
       prop :message
       prop :timestamp
       prop :timestamp_object
+      prop :align_timestamp, type: Playbook::Props::Enum, values: %w[left right], default: "right"
 
       def classname
         generate_classname("pb_message_kit", avatar_class)

--- a/playbook/app/pb_kits/playbook/pb_message/message.rb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.rb
@@ -9,6 +9,7 @@ module Playbook
       prop :label
       prop :message
       prop :timestamp
+      prop :timestamp_object
 
       def classname
         generate_classname("pb_message_kit", avatar_class)


### PR DESCRIPTION
https://app.abstract.com/share/00ce8869-748b-4ac2-9d38-07083137a6a6?collectionId=afd8ed52-e16b-4afd-b503-f8bc6cf2e80b&collectionLayerId=76a6e707-0640-4352-a903-b37714f4be41&present=true&preview=false&sha=32ff4fbf2dce3bedb52ab8f7e2261e3479cdb658

#### Screens

Normal:
<img width="591" alt="Screenshot 2021-06-08 at 7 26 20 AM" src="https://user-images.githubusercontent.com/21108297/121203513-293b1000-c844-11eb-97cc-8f179378d3f9.png">

On hover:
<img width="600" alt="Screenshot 2021-06-08 at 7 27 05 AM" src="https://user-images.githubusercontent.com/21108297/121203521-29d3a680-c844-11eb-9430-3a0be7635ae7.png">

#### Breaking Changes

No breaking changes. A change was made that you can now pass this kit a `timestamp_object`, which is like `DateTime.current`. When this is present, the hover effect will work, otherwise it will not.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/BOP-979

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
