### PR TITLE
Typeahead AsyncCreatable

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import Select from 'react-select'
 import AsyncSelect from 'react-select/async'
 import CreateableSelect from 'react-select/creatable'
+import AsyncCreateableSelect from 'react-select/async-creatable'
 import { get } from 'lodash'
 import { globalProps } from '../utilities/globalProps.js'
 import classnames from 'classnames'
@@ -73,7 +74,7 @@ const Typeahead = (props: Props) => {
   if (typeof(props.getOptionValue) === 'string') selectProps.getOptionValue = get(window, props.getOptionValue)
 
   let Tag = props.async ? AsyncSelect : Select
-  if (props.createable) Tag = CreateableSelect
+  if (props.createable) Tag = props.async ? AsyncCreateableSelect : CreateableSelect
 
   const handleOnChange = (data, { action, option, removedValue }) => {
     if (action === 'select-option') {

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_async_createable.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_async_createable.jsx
@@ -1,0 +1,56 @@
+// @flow
+
+import React from 'react'
+import { Typeahead } from '../..'
+
+/**
+ *
+ * @const filterResults
+ * @ignore
+ * @returns {[Object]} - a custom mapping of objects, minimally containing
+ * `value` and `label` among other possible fields
+ * @summary - for doc example purposes only
+ */
+
+const filterResults = (results) =>
+  results.items.map((result) => {
+    return {
+      name: result.login,
+      id: result.id,
+    }
+  })
+
+/**
+*
+* @const promiseOptions
+* @ignore
+* @returns {Promise} - fetch API data results from Typeahead input text
+* @see - https://react-select.com/home#async
+* @summary - for doc example purposes only
+*/
+
+const promiseOptions = (inputValue) =>
+  new Promise((resolve) => {
+    if (inputValue) {
+      fetch(`https://api.github.com/search/users?q=${inputValue}`)
+        .then((response) => response.json())
+        .then((results) => resolve(filterResults(results)))
+    } else {
+      resolve([])
+    }
+  })
+
+const TypeaheadAsyncCreateable = (props) => {
+  return (
+    <Typeahead
+        async
+        createable
+        isMulti
+        label="Existing or User Created Options"
+        loadOptions={promiseOptions}
+        {...props}
+    />
+  )
+}
+
+export default TypeaheadAsyncCreateable

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
@@ -17,3 +17,4 @@ examples:
     - typeahead_inline: Inline
     - typeahead_multi_kit: Multi Kit Options
     - typeahead_createable: Createable
+    - typeahead_async_createable: Createable (+ Async Data)

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/index.js
@@ -6,3 +6,4 @@ export { default as TypeaheadWithPillsAsyncCustomOptions } from './_typeahead_wi
 export { default as TypeaheadInline } from './_typeahead_inline.jsx'
 export { default as TypeaheadMultiKit } from './_typeahead_multi_kit.jsx'
 export { default as TypeaheadCreateable } from './_typeahead_createable.jsx'
+export { default as TypeaheadAsyncCreateable } from './_typeahead_async_createable.jsx'


### PR DESCRIPTION
Adds `AsyncCreatable` as an option if `async` prop is provided. 

#### Screens

None

#### Breaking Changes

No

#### Runway Ticket URL

None

#### How to test this

See the documentation for an example. New feature enhancement.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
