### PR TITLE
Fix clicking on formatted links in Rich Text Editor

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.jsx
@@ -115,9 +115,10 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     const trixEditorContainer = clickedElement.closest('.pb_rich_text_editor_kit')
     if (!trixEditorContainer) return
 
-    if (clickedElement.nodeName === 'A' && clickedElement.hasAttribute('href')) {
-      window.open(clickedElement.href)
-    }
+    const anchorElement = clickedElement.closest('a')
+    if (!anchorElement) return
+
+    if (anchorElement.hasAttribute('href')) window.open(anchorElement.href)
   }
 
   const handleClick = (event) => {


### PR DESCRIPTION
[This PR](https://github.com/powerhome/playbook/pull/1591) made links in the Rich Text Editor clickable and opens the link in a new window. However, if the link was formatted (i.e. wrapped in bold or italic tags) the click event listener on the `trix-editor` was returning the `<strong>` or `<em>` tag instead of the `<a>` tag. This PR fixes that by looking for the clicked element's closest `<a>` tag.

#### Screens

This PR doesn't have any visual changes.

#### Breaking Changes

No -- this PR fixes clicking on formatted links in the Rich Text Editor

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/BOP-1108

#### How to test this

1. Add a non-formatted link (i.e. a link not wrapped in any other tag) in the Rich Text Editor and click on it; it should open in a new window.
2. Add a formatted link (i.e. a link wrapped in a bold or italic tag) in the Rich Text Editor and click on it; it should also open in a new winow.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
