### PR TITLE
Use recent deployer image

### DIFF
--- a/playbook-website/bin/deployer
+++ b/playbook-website/bin/deployer
@@ -7,7 +7,7 @@ if [ -t 0 ]; then
   AWS_CREDS_MOUNT="--mount type=bind,source=${HOME}/.aws/credentials,destination=/root/.aws/credentials,readonly"
 fi
 
-DEPLOYER_IMAGE="quay.io/powerhome/deployer:master-e4c01702624ac34f2663f894fbdb68a369b09629-588"
+DEPLOYER_IMAGE="quay.io/powerhome/deployer:master-5246eafb24c81acae0dd9ccc3e421d0bb8d18328-1288"
 DEPLOYER_MOUNTS="${AWS_CREDS_MOUNT} --mount type=bind,source=$(pwd),destination=/app --mount type=bind,source=${HOME}/.kube,destination=/root/.kube"
 RUN_DEPLOYER="docker run --tty ${INTERACTIVE} ${EXTRA_ARGS} --rm --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY ${DEPLOYER_MOUNTS} ${DEPLOYER_IMAGE}"
 


### PR DESCRIPTION
This gets us a newer version of krane (1.1.3 -> 2.2.0) which we think handles mismatched CRD versions within an apiGroup better.

See:
* https://github.com/Shopify/krane/issues/804
* https://github.com/powerhome/nitro-web/pull/21909
* https://github.com/powerhome/portal/pull/125
* https://github.com/powerhome/incidents/pull/8
* https://github.com/powerhome/APP/pull/1180