### PR TITLE
Update image to fix certificate issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM quay.io/powerhome/passenger-customizable:1.0.12
+FROM phusion/passenger-customizable:1.0.19
 ARG precompileassets
+
+RUN mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak
+RUN apt update && apt install -y ca-certificates
 
 RUN bash -lc 'rvm remove all --force && rvm install ruby-2.6.6 && rvm --default use ruby-2.6.6 && gem install bundler -v 2.2.25'
 RUN /pd_build/ruby_support/install_ruby_utils.sh
@@ -19,14 +22,12 @@ RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/insta
     && nvm use default \
     && npm install -g npm@$NPM_VERSION yarn@$YARN_VERSION
 
-RUN mv /etc/apt/sources.list.d{,.bak}
-RUN apt update && apt install -y ca-certificates
-RUN mv /etc/apt/sources.list.d{.bak,}
-
 RUN apt-get update -y \
-    && apt-get install -y shared-mime-info=1.5-2ubuntu0.2\
+    && apt-get install -y shared-mime-info=1.15-1\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mv /etc/apt/sources.list.d.bak /etc/apt/sources.list.d
 
 WORKDIR /home/app/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/insta
     && nvm use default \
     && npm install -g npm@$NPM_VERSION yarn@$YARN_VERSION
 
+RUN mv /etc/apt/sources.list.d{,.bak}
+RUN apt update && apt install -y ca-certificates
+RUN mv /etc/apt/sources.list.d{.bak,}
+
 RUN apt-get update -y \
     && apt-get install -y shared-mime-info=1.5-2ubuntu0.2\
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM phusion/passenger-customizable:1.0.19
 ARG precompileassets
 
-RUN mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak
-RUN apt update && apt install -y ca-certificates
+RUN mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak && \
+    apt update && apt install -y ca-certificates && \
+    mv /etc/apt/sources.list.d.bak /etc/apt/sources.list.d
 
 RUN bash -lc 'rvm remove all --force && rvm install ruby-2.6.6 && rvm --default use ruby-2.6.6 && gem install bundler -v 2.2.25'
 RUN /pd_build/ruby_support/install_ruby_utils.sh
@@ -26,8 +27,6 @@ RUN apt-get update -y \
     && apt-get install -y shared-mime-info=1.15-1\
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN mv /etc/apt/sources.list.d.bak /etc/apt/sources.list.d
 
 WORKDIR /home/app/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/powerhome/passenger-customizable:0.9.35
+FROM quay.io/powerhome/passenger-customizable:1.0.12
 ARG precompileassets
 
 RUN bash -lc 'rvm remove all --force && rvm install ruby-2.6.6 && rvm --default use ruby-2.6.6 && gem install bundler -v 2.2.25'


### PR DESCRIPTION
This changeset applies the suggestion https://github.com/phusion/passenger-docker/issues/322#issuecomment-932263996 to fix an issue with an expired certificate (https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/).

#### Screens

[INSERT SCREENSHOT]

#### Breaking Changes

[Yes/No (Explain)]

#### Runway Ticket URL

[INSERT URL]

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
