### PR TITLE
[NUXE-616] Added option for tooltips in progress_steps

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_progress_step/docs/_progress_step_tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/docs/_progress_step_tooltip.html.erb
@@ -1,0 +1,59 @@
+<%= pb_rails("progress_step", props: {orientation: "horizontal"}) do %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "complete", classname: "tooltip-trigger-1", tooltip: "Tooltip for step 1", tooltip_position: "right", step_direction: "horizontal" }) do %>
+  step 1
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "complete", classname: "tooltip-trigger-2", tooltip: "Tooltip for step 2", step_direction: "horizontal" }) do %>
+  step 2
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "active", classname: "tooltip-trigger-3", tooltip: "Tooltip for step 3", tooltip_position: "left", step_direction: "horizontal" }) do %>
+  step 3
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "inactive", classname: "tooltip-trigger-4", tooltip: "Tooltip for step 4", tooltip_position: "bottom" }) do %>
+  step 4
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "inactive", classname: "tooltip-trigger-5", tooltip: "Tooltip for step 5" }) do %>
+  step 5
+  <% end %>
+<% end %>
+
+<br /><br />
+
+<%= pb_rails("progress_step", props: {orientation: "vertical"}) do %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "complete", classname: "tooltip-trigger-6", tooltip: "Tooltip step 1", step_direction: "vertical" }) do %>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "active", classname: "tooltip-trigger-7", tooltip: "Tooltip step 2", tooltip_position: "left"}) do %>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "inactive", classname: "tooltip-trigger-8", tooltip: "Tooltip step 3", tooltip_position: "top", step_direction: "vertical" }) do %>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "inactive", classname: "tooltip-trigger-9", tooltip: "Tooltip step 4", tooltip_position: "bottom"}) do %>
+  <% end %>
+<% end %>
+
+<br /><br>
+<%= pb_rails("progress_step",props:{ variant:"tracker", icon:true}) do %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "complete", classname: "tooltip-trigger-10", tooltip: "The order has been received", step_direction: "horizontal" , tooltip_position: "right"  }) do %>
+      <%= pb_rails("caption", props:{text: "Ordered"})%>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "active", classname: "tooltip-trigger-11", tooltip:"Item(s) have been shipped" }) do %>
+      <%= pb_rails("caption", props:{text: "Shipped"})%>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "inactive", classname: "tooltip-trigger-12", tooltip:"This step has not been reached", tooltip_position: "left" }) do %>
+      <%= pb_rails("caption", props:{text: "Delivered"})%>
+  <% end %>
+<% end %>
+
+<br /><br>
+<%= pb_rails("progress_step",props:{ variant:"tracker", icon:true}) do %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "complete", classname: "tooltip-trigger-13", tooltip: "The order has been processed", tooltip_position: "right" }) do %>
+      <%= pb_rails("caption", props:{text: "Ordered"})%>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "active", icon: "exclamation-triangle", classname: "tooltip-trigger-14", tooltip: "More details needed before shipment", tooltip_position: "bottom" }) do %>
+      <%= pb_rails("caption", props:{text: "Shipped"})%>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "inactive", classname: "tooltip-trigger-15", tooltip: "This step is inactive"}) do %>
+      <%= pb_rails("caption", props:{text: "Out for Delivery"})%>
+  <% end %>
+  <%= pb_rails("progress_step/progress_step_item", props: {status: "inactive", classname: "tooltip-trigger-16", tooltip: "Estimated delivery: Jun 27", tooltip_position: "left"}) do %>
+      <%= pb_rails("caption", props:{text: "Delivered"})%>
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_progress_step/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/docs/example.yml
@@ -4,8 +4,8 @@ examples:
   - progress_step_vertical: Vertical
   - progress_step_tracker: Tracker
   - progress_step_custom_icon: Custom Icon
-  
-  
+  - progress_step_tooltip: Tooltip
+
   react:
   - progress_step_default: Default
   - progress_step_vertical: Vertical

--- a/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.html.erb
@@ -2,10 +2,21 @@
   id: object.id,
   data: object.data,
   class: object.classname) do %>
-  <div class="box">
+  <div class="box" style="max-width: min-content;" id="<%= object.box_classname %>">
     <div class="circle">
       <%= pb_rails("icon", props: { icon: object.icon, size: "xs" }) if object.icon.present? %>
     </div>
+    <% if object.tooltip.present? %>
+      <div>
+        <%= pb_rails("tooltip", props: {
+          trigger_element_selector: "##{object.box_classname}",
+          tooltip_id: "example-tooltip",
+          position: object.get_tooltip_position
+        }) do %>
+            <%= object.tooltip %>
+      <% end %>
+      </div>
+    <% end %>
     <div class="content">
       <%= content.presence %>
     <div>

--- a/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.rb
@@ -8,6 +8,11 @@ module Playbook
                     default: "inactive"
 
       prop :icon, required: false, default: "check"
+      prop :tooltip, required: false
+      prop :tooltip_position, required: false
+      prop :step_direction, type: Playbook::Props::Enum,
+                            values: %w[horizontal vertical],
+                            default: "horizontal"
 
       def name_icon
         icon || "check"
@@ -15,6 +20,22 @@ module Playbook
 
       def classname
         generate_classname("pb_progress_step_item", status)
+      end
+
+      def box_classname
+        classname.split(" ").last # used for tooltips, returns tooltip-trigger-<num>
+      end
+
+      def step_tooltip_position
+        if tooltip_position.present?
+          if step_direction == "vertical"
+            "right"
+          else
+            "top"
+          end
+        else
+          tooltip_position
+        end
       end
     end
   end


### PR DESCRIPTION
#### Screens

<img width="1792" alt="Screen Shot 2021-10-04 at 1 28 59 PM" src="https://user-images.githubusercontent.com/8978311/135897750-4a03ae64-cd7c-4a31-aad7-5390b6cad704.png">

<img width="1792" alt="Screen Shot 2021-10-04 at 1 28 56 PM" src="https://user-images.githubusercontent.com/8978311/135897767-6740005e-30d3-46b3-a2e3-818cfaa606f1.png">

<img width="1792" alt="Screen Shot 2021-10-04 at 1 28 52 PM" src="https://user-images.githubusercontent.com/8978311/135897793-4cd81397-ad21-4368-a203-90d67e593b4c.png">

<img width="1792" alt="Screen Shot 2021-10-04 at 1 28 49 PM" src="https://user-images.githubusercontent.com/8978311/135897804-f01acd8a-1bfc-4f69-976f-19ce1ea25545.png">



#### Breaking Changes

[Yes/No (Explain)]

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUXE-616

#### How to test this

Mouse over 'dot' on progress steps to view tooltip. Tooltip will disappear after mouse leaves the dot.

#### Checklist:

- ✅ **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- ✅ **URGENCY** Please select a release milestone
- ✅ **DEPLOY** Please add the `Milano` label when you are ready for a review.
- ✅ **SCREENSHOT** Please add a screen shot or two.
- [] **SPECS** Please cover your changes with specs.
- ✅ **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
