### PR TITLE
Display a date's past year in the React Timestamp kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.jsx
@@ -70,7 +70,7 @@ const Timestamp = (props: TimestampProps) => {
 
   const fullDateDisplay = () => {
     let fullDisplay = `${dateTimestamp.toMonth()} ${dateTimestamp.toDay()}`
-    if (dateTimestamp.toYear() > currentYear) {
+    if (dateTimestamp.toYear() !== currentYear) {
       fullDisplay = `${fullDisplay}, ${dateTimestamp.toYear()}`
     }
     return `${fullDisplay} ${' \u00b7 '} ${fullTimeDisplay()}`

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align.html.erb
@@ -20,6 +20,14 @@
   align: "left"
 }) %>
 
+<br>
+
+<%= pb_rails("timestamp", props: {
+  timestamp: DateTime.now - 1.year,
+  show_date: true,
+  align: "left"
+}) %>
+
 <br><br>
 
 <%= pb_rails("timestamp", props: {
@@ -44,6 +52,14 @@
   align: "center"
 }) %>
 
+<br>
+
+<%= pb_rails("timestamp", props: {
+  timestamp: DateTime.now - 1.year,
+  show_date: true,
+  align: "center"
+}) %>
+
 <br><br>
 
 <%= pb_rails("timestamp", props: {
@@ -64,6 +80,14 @@
 
 <%= pb_rails("timestamp", props: {
   timestamp: DateTime.now + 4.years,
+  show_date: true,
+  align: "right"
+}) %>
+
+<br>
+
+<%= pb_rails("timestamp", props: {
+  timestamp: DateTime.now - 1.year,
   show_date: true,
   align: "right"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align.jsx
@@ -2,12 +2,14 @@ import React from 'react'
 import Timestamp from '../_timestamp.jsx'
 
 const todaysDate = new Date()
-const year = new Date().getFullYear() + 4
+const futureYear = new Date().getFullYear() + 4
+const pastYear = new Date().getFullYear() - 1
 const month = new Date().getMonth()
 const date = new Date().getDate()
 const hours = new Date().getHours()
 const minutes = new Date().getMinutes()
-const customDate = new Date(year, month, date, hours, minutes)
+const futureDate = new Date(futureYear, month, date, hours, minutes)
+const pastDate = new Date(pastYear, month, date, hours, minutes)
 
 const TimestampAlign = (props) => {
   return (
@@ -33,7 +35,16 @@ const TimestampAlign = (props) => {
       <Timestamp
           align="left"
           showDate
-          timestamp={customDate}
+          timestamp={futureDate}
+          {...props}
+      />
+
+      <br />
+
+      <Timestamp
+          align="left"
+          showDate
+          timestamp={pastDate}
           {...props}
       />
 
@@ -61,7 +72,16 @@ const TimestampAlign = (props) => {
       <Timestamp
           align="center"
           showDate
-          timestamp={customDate}
+          timestamp={futureDate}
+          {...props}
+      />
+
+      <br />
+
+      <Timestamp
+          align="center"
+          showDate
+          timestamp={pastDate}
           {...props}
       />
 
@@ -89,7 +109,16 @@ const TimestampAlign = (props) => {
       <Timestamp
           align="right"
           showDate
-          timestamp={customDate}
+          timestamp={futureDate}
+          {...props}
+      />
+
+      <br />
+
+      <Timestamp
+          align="right"
+          showDate
+          timestamp={pastDate}
           {...props}
       />
     </div>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default.html.erb
@@ -19,3 +19,11 @@
   show_date: true,
   align: "left"
 }) %>
+
+<br>
+
+<%= pb_rails("timestamp", props: {
+  timestamp: DateTime.now - 1.year,
+  show_date: true,
+  align: "left"
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default.jsx
@@ -2,12 +2,14 @@ import React from 'react'
 import Timestamp from '../_timestamp.jsx'
 
 const todaysDate = new Date()
-const year = new Date().getFullYear() + 4
+const futureYear = new Date().getFullYear() + 4
+const pastYear = new Date().getFullYear() - 1
 const month = new Date().getMonth()
 const date = new Date().getDate()
 const hours = new Date().getHours()
 const minutes = new Date().getMinutes()
-const customDate = new Date(year, month, date, hours, minutes)
+const futureDate = new Date(futureYear, month, date, hours, minutes)
+const pastDate = new Date(pastYear, month, date, hours, minutes)
 
 const TimestampDefault = (props) => {
   return (
@@ -33,7 +35,16 @@ const TimestampDefault = (props) => {
       <Timestamp
           align="left"
           showDate
-          timestamp={customDate}
+          timestamp={futureDate}
+          {...props}
+      />
+
+      <br />
+
+      <Timestamp
+          align="left"
+          showDate
+          timestamp={pastDate}
           {...props}
       />
     </div>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones.html.erb
@@ -29,6 +29,16 @@
 <br>
 
 <%= pb_rails("timestamp", props: {
+  timestamp: DateTime.now - 1.year,
+  show_date: true,
+  show_timezone: true,
+  timezone: "America/New_York",
+  align: "left"
+}) %>
+
+<br>
+
+<%= pb_rails("timestamp", props: {
   timestamp: DateTime.now,
   show_date: false,
   show_timezone: true,
@@ -50,6 +60,16 @@
 
 <%= pb_rails("timestamp", props: {
   timestamp: DateTime.now + 4.years,
+  show_date: true,
+  show_timezone: true,
+  timezone: "Asia/Hong_Kong",
+  align: "left"
+}) %>
+
+<br>
+
+<%= pb_rails("timestamp", props: {
+  timestamp: DateTime.now - 1.year,
   show_date: true,
   show_timezone: true,
   timezone: "Asia/Hong_Kong",

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones.jsx
@@ -2,12 +2,14 @@ import React from 'react'
 import Timestamp from '../_timestamp.jsx'
 
 const todaysDate = new Date()
-const year = new Date().getFullYear() + 4
+const futureYear = new Date().getFullYear() + 4
+const pastYear = new Date().getFullYear() - 1
 const month = new Date().getMonth()
 const date = new Date().getDate()
 const hours = new Date().getHours()
 const minutes = new Date().getMinutes()
-const customDate = new Date(year, month, date, hours, minutes)
+const futureDate = new Date(futureYear, month, date, hours, minutes)
+const pastDate = new Date(pastYear, month, date, hours, minutes)
 
 const TimestampTimezones = (props) => {
   return (
@@ -38,7 +40,18 @@ const TimestampTimezones = (props) => {
           align="left"
           showDate
           showTimezone
-          timestamp={customDate}
+          timestamp={futureDate}
+          timezone="America/New_York"
+          {...props}
+      />
+
+      <br />
+
+      <Timestamp
+          align="left"
+          showDate
+          showTimezone
+          timestamp={pastDate}
           timezone="America/New_York"
           {...props}
       />
@@ -71,7 +84,18 @@ const TimestampTimezones = (props) => {
           align="left"
           showDate
           showTimezone
-          timestamp={customDate}
+          timestamp={futureDate}
+          timezone="Asia/Hong_Kong"
+          {...props}
+      />
+
+      <br />
+
+      <Timestamp
+          align="left"
+          showDate
+          showTimezone
+          timestamp={pastDate}
           timezone="Asia/Hong_Kong"
           {...props}
       />


### PR DESCRIPTION
#### Screens

![image](https://user-images.githubusercontent.com/151394/136254316-31d8b5b9-8434-4858-a620-fcac65c39dbf.png)

#### Breaking Changes

No breaking changes. Previously, the React Timestamp kit was only displaying the date's year if the year was greater than the current year. This PR changes that behavior to display the date's year if it is not equal to the current year, thereby displaying the year from a past year. This new behavior is now on par with the Rails Timestamp kit, which is already displaying the date's year from a past year.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/BOP-1068

#### How to test this

Create a date object in a past year and pass that date object to the React Timestamp's `timestamp` prop.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **URGENCY** Please select a release milestone
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
