### PR TITLE
Add & operator to guard against nil

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -26,7 +26,7 @@ module Playbook
       end
 
       def city_state
-        [city.titleize, state].join(", ")
+        [city&.titleize, state].join(", ")
       end
 
       def zip


### PR DESCRIPTION
#### Screens

The kit was causing an error whenever a "city" was `nil` because of the use of `titleize`. The other fields (address, addresscont, etc) in the kit have the `&` operator when using `titleize` to prevent errors, but "city" got overlooked. This PR remedies that problem.

EXAMPLE:
<img width="429" alt="Screen Shot 2021-11-12 at 12 27 25 PM" src="https://user-images.githubusercontent.com/51907753/141509898-85afd063-831d-4bb3-9ae5-0ed793865b4f.png">

ERROR:
<img width="1197" alt="Screen Shot 2021-11-12 at 12 26 28 PM" src="https://user-images.githubusercontent.com/51907753/141509754-e5231a76-8225-4564-bc4a-178c39fc9888.png">

#### Breaking Changes

No only additive changes.

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/LGA-1009

#### How to test this

Try putting `nil` in for the "city" field in the examples already created for the kit.

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **URGENCY** Please select a release milestone
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [X] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)

*The normal release cut off deadline is 3p EDT each week. Please reach out to the release team if you have an urgent request or need a release off cycle.*
