### PR TITLE
[PLAY-76]Text Input kit spacing fixed

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -4,12 +4,12 @@
 
 
 [class^=pb_text_input_kit] {
+  margin-bottom: $space_sm;
   .pb_text_input_kit_label {
     margin-bottom: $space_xs;
     display: block;
   }
   .text_input_wrapper {
-    margin-bottom: $space_sm;
     display: block;
     input::placeholder,
     .text_input .placeholder {

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.test.js
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.test.js
@@ -75,3 +75,17 @@ test('returns additional class name', () => {
   const kit = screen.getByTestId(testId)
   expect(kit).toHaveClass(`${kitClass} dark error`)
 })
+
+test('returns additional class name', () => {
+  render(
+    <TextInput
+        data={{ testid: testId }}
+        label="First Name"
+        marginBottom="lg"
+        placeholder="Enter first name"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass(`${kitClass} mb_lg`)
+})

--- a/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Playbook::PbTextInput::TextInput do
       expect(subject.new({ inline: true }).classname).to eq "pb_text_input_kit inline"
       expect(subject.new({ error: "Please enter a valid email" }).classname).to eq "pb_text_input_kit error"
       expect(subject.new({ dark: true, error: "Please enter a valid email" }).classname).to eq "pb_text_input_kit dark error"
+      expect(subject.new({ margin_bottom: "lg" }).classname).to eq "pb_text_input_kit mb_lg"
     end
   end
 end


### PR DESCRIPTION
Breaking Changes
No. The default `margin-bottom` small  was removed from the `text_input_wrapper`, but added to the `pb_text_input_kit` class (by default). Visually, any existing implementations of the text input kit will remain the same.

Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/PLAY-76

How to test this
The text input kit should have a small margin on the bottom by default. Developer can pass a margin-bottom prop to text input kit and the default margin-bottom will be overridden.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
