### PR TITLE
[Play-82]Bug Popover close on any

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_popover/_popover.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/_popover.jsx
@@ -150,16 +150,14 @@ export default class PbReactPopover extends React.Component<PbPopoverProps> {
       const targetIsReference =
         target.closest('.pb_popover_reference_wrapper') !== null
 
-      if (targetIsReference) return
-
       switch (closeOnClick) {
       case 'outside':
-        if (!targetIsPopover) {
+        if (!targetIsPopover || targetIsReference) {
           shouldClosePopover(true)
         }
         break
       case 'inside':
-        if (targetIsPopover) {
+        if (targetIsPopover || targetIsReference) {
           shouldClosePopover(true)
         }
         break

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_close.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_close.html.erb
@@ -1,23 +1,23 @@
 <%= pb_rails("flex", props: {classname: "flex-container", spacing: "between"}) do %>
   <span>
-    <%= pb_rails("button", props: { text: "Click Inside", variant: "secondary", id: 'inside-popover-1' }) %>
+    <%= pb_rails("button", props: { text: "Click Inside", variant: "secondary", id: "inside-popover-1" }) %>
     <%= pb_rails("popover", props: {
       close_on_click: "inside",
       trigger_element_id: "inside-popover-1",
       tooltip_id: "inside-tooltip-1",
-      position: 'bottom',
+      position: "bottom",
       offset: true
     }) do %>
       Click on me!
     <% end %>
   </span>
   <span>
-    <%= pb_rails("button", props: { text: "Click Outside", variant: "secondary", id: 'outside-popover-1' }) %>
+    <%= pb_rails("button", props: { text: "Click Outside", variant: "secondary", id: "outside-popover-1" }) %>
     <%= pb_rails("popover", props: {
       close_on_click: "outside",
       trigger_element_id: "outside-popover-1",
       tooltip_id: "outside-tooltip-1",
-      position: 'left',
+      position: "left",
       offset: true
     }) do %>
         Click anywhere but me!
@@ -27,13 +27,13 @@
     <%= pb_rails("button", props: {
       text: "Click Anywhere",
       variant: "secondary",
-      id: 'any-popover-1'
+      id: "any-popover-1"
     }) %>
     <%= pb_rails("popover", props: {
       close_on_click: "any",
       trigger_element_id: "any-popover-1",
       tooltip_id: "any-tooltip-1",
-      position: 'top',
+      position: "top",
       offset: true
     }) do %>
       Click anything!

--- a/playbook/app/pb_kits/playbook/pb_popover/index.js
+++ b/playbook/app/pb_kits/playbook/pb_popover/index.js
@@ -61,7 +61,7 @@ export default class PbPopover extends PbEnhancedElement {
         }
         break
       }
-    }, true)
+    }, { once: true, capture: true })
   }
 
   hideTooltip() {

--- a/playbook/app/pb_kits/playbook/pb_popover/index.js
+++ b/playbook/app/pb_kits/playbook/pb_popover/index.js
@@ -36,15 +36,14 @@ export default class PbPopover extends PbEnhancedElement {
       }
 
       setTimeout(() => {
-        this.popper.update()
         this.toggleTooltip()
+        this.popper.update()
       }, 0)
     })
   }
 
   checkCloseTooltip() {
     document.querySelector('body').addEventListener('click', ({ target }) => {
-      const isTriggerElement = target.closest(`#${this.triggerElementId}`) !== null
       const isTooltipElement = target.closest(`#${this.tooltipId}`) !== null
 
       switch (this.closeOnClick) {
@@ -52,17 +51,17 @@ export default class PbPopover extends PbEnhancedElement {
         this.hideTooltip()
         break
       case 'outside':
-        if (!isTooltipElement || isTriggerElement) {
+        if (!isTooltipElement) {
           this.hideTooltip()
         }
         break
       case 'inside':
-        if (isTooltipElement || isTriggerElement) {
+        if (isTooltipElement) {
           this.hideTooltip()
         }
         break
       }
-    }, { once: true })
+    }, true)
   }
 
   hideTooltip() {

--- a/playbook/app/pb_kits/playbook/pb_popover/index.js
+++ b/playbook/app/pb_kits/playbook/pb_popover/index.js
@@ -61,7 +61,7 @@ export default class PbPopover extends PbEnhancedElement {
         }
         break
       }
-    }, { once: true, capture: true })
+    }, true)
   }
 
   hideTooltip() {

--- a/playbook/app/pb_kits/playbook/pb_popover/index.js
+++ b/playbook/app/pb_kits/playbook/pb_popover/index.js
@@ -52,17 +52,13 @@ export default class PbPopover extends PbEnhancedElement {
         this.hideTooltip()
         break
       case 'outside':
-        if (isTooltipElement) {
-          this.checkCloseTooltip()
-        } else {
+        if (!isTooltipElement || isTriggerElement) {
           this.hideTooltip()
         }
         break
       case 'inside':
         if (isTooltipElement || isTriggerElement) {
           this.hideTooltip()
-        } else {
-          this.checkCloseTooltip()
         }
         break
       }

--- a/playbook/app/pb_kits/playbook/pb_popover/popover.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_popover/popover.html.erb
@@ -3,7 +3,7 @@
   class: object.classname,
   data: object.data,
   id: object.id) do %>
-  <div class="pb_popover_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.z_index_helper %>">
+  <div class="pb_popover_tooltip hide" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.z_index_helper %>">
     <div class="pb_popover_body <%= object.width_height_class_helper %> <%= object.popover_spacing_helper %>" style="<%= object.width_height_helper %>">
       <%= content.presence %>
     </div>


### PR DESCRIPTION
#### Screens

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/84349455/149994817-763a6733-fb40-4f99-a5c3-a94edad00b15.png">

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/84349455/149994841-2fd7f839-9ce3-4c35-809a-468f9e4f86d7.png">

#### Breaking Changes

Yes, this change affects how the popover is closed, so this could possibly be breaking when sensitive data or edits/updates that need to be confirmed are rendered inside of a popover tooltip. Alpha testing is needed.

### NOTE: After Alpha testing, it was found that the popover being used in runway's backlog item modal does not function the way it is intended. All other popover's tested work except for this one. It might be a nitro issue where there is some code in the modal that is overriding the popover's event listener.

<img width="1648" alt="image" src="https://user-images.githubusercontent.com/84349455/151573174-3d692476-6eaf-4baa-b1ae-b8b27973d64c.png">


#### Runway Ticket URL

[https://nitro.powerhrg.com/runway/backlog_items/PLAY-82](url)

#### How to test this

- Create a React or Rails page and use 2 or more pop over kits on the same page
- Set at least one of the `close_on_click` values to "any"
- Click between the buttons (not outside, or in the popover itself. The actual trigger elements), to make sure that when a new popover is rendered, any open popover on the page will disappear.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
