### PR TITLE
[Play-80] Updating padding prop to popover kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_scroll_height.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_scroll_height.jsx
@@ -31,7 +31,9 @@ const PopoverScrollHeight = (props) => {
         maxHeight="150px"
         maxWidth="240px"
         offset
-        padding="sm"
+        padding="md"
+        paddingBottom="sm"
+        paddingTop="sm"
         placement="top"
         reference={popoverTrigger}
         shouldClosePopover={handleShouldClosePopover}

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_scroll_height.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_scroll_height.jsx
@@ -31,6 +31,7 @@ const PopoverScrollHeight = (props) => {
         maxHeight="150px"
         maxWidth="240px"
         offset
+        padding="sm"
         placement="top"
         reference={popoverTrigger}
         shouldClosePopover={handleShouldClosePopover}

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_z_index.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_z_index.jsx
@@ -36,6 +36,7 @@ const PopoverZIndex = (props) => {
       <PbReactPopover
           closeOnClick="outside"
           offset
+          padding="sm"
           placement="top"
           reference={popoverTrigger}
           shouldClosePopover={handleShouldClosePopover}


### PR DESCRIPTION
#### Screens

BEFORE DESKTOP VIEW: 
<img width="475" alt="popover jawn" src="https://user-images.githubusercontent.com/84339183/150000886-dcdbdb12-0f58-4abd-8097-4e44ecd796ff.png">


AFTER DESKTOP VIEW:
<img width="1529" alt="Screen Shot 2022-01-18 at 1 54 08 PM" src="https://user-images.githubusercontent.com/84339183/150000813-222de094-fd25-49e7-ab93-92d79ff3c2bc.png">



#### Breaking Changes

No breaking changes

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/PLAY-80

#### How to test this

Go to the popover kit page in playbook, then click on "Click Me" for the Z INDEX & the SCROLL AND HEIGHT SETTINGS

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
