### PR TITLE
[Play-62] Updating size for icon on variant prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date/_date.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date/_date.jsx
@@ -107,7 +107,7 @@ const PbDate = (props: PbDateProps) => {
               <Icon
                   fixedWidth
                   icon="calendar-alt"
-                  size="xs"
+                  size="sm"
               />
             </Caption>
           </If>

--- a/playbook/app/pb_kits/playbook/pb_date/date.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date/date.html.erb
@@ -42,7 +42,7 @@
       <%= pb_rails("caption", props: {
         tag: "div",
       }) do %>
-        <%= pb_rails("icon", props: { icon: "calendar-alt", fixed_width: true, size: 'xs' }) %>
+        <%= pb_rails("icon", props: { icon: "calendar-alt", fixed_width: true, size: "sm" }) %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
#### Screens

BEFORE PIC DESKTOP VIEW: 
<img width="229" alt="variantpic" src="https://user-images.githubusercontent.com/84339183/150173700-e88c0ae7-67ae-4a94-9410-3b03061d60ba.png">

AFTER PIC DESKTOP VIEW: 
<img width="324" alt="Screen Shot 2022-01-19 at 11 33 05 AM" src="https://user-images.githubusercontent.com/84339183/150174055-ab5c8f65-7725-49e8-b735-581bd4f09c56.png">


#### Breaking Changes

No breaking change 

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/PLAY-62

#### How to test this

Go to the date kit, scroll down to the variants option.... notice the icon size change. (reference pictures)

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
