### PR TITLE
[PLAY-98] fIxed dark mode colors

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_caption/_caption.scss
+++ b/playbook/app/pb_kits/playbook/pb_caption/_caption.scss
@@ -26,10 +26,11 @@
     color: $primary;
   }
 
-  &[class*="dark"] {
-    @each $dark_color_name, $dark_color_value in $pb_dark_caption_colors {
-      &[class*="_#{$dark_color_name}"][class*="dark"] {
-      @include caption_color($dark_color_value);
+  &.dark {
+    @include caption_dark;
+    @each $name, $color in $pb_dark_caption_colors {
+      &[class*="_#{$name}"] {
+        color: $color;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_caption/_caption_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_caption/_caption_mixin.scss
@@ -8,9 +8,9 @@ $pb_caption_colors: (
 );
 
 $pb_dark_caption_colors: (
-  default:        #fff,
+  default:        $text_dk_default,
   light:          $text_dk_light,
-  link:           $primary-action,
+  link:           $primary,
 );
 
 


### PR DESCRIPTION
#### Screens

BEFORE: 

<img width="1488" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/150213405-e6864753-deda-4a04-85d8-4449d2f58805.png">

AFTER: 

<img width="1569" alt="Playbook_Design_System_and_Zoom_Meeting" src="https://user-images.githubusercontent.com/82796889/150213791-bfe0a3d3-25d5-4105-bbc5-d0de1e71ee07.png">


#### Breaking Changes
No. This PR is fixing a bug on dark mode colors setup in Caption kit. 

#### Runway Ticket URL
https://nitro.powerhrg.com/runway/backlog_items/PLAY-98

#### How to test this
Turn on dark mode and open the dev tools in a browser. `dark` should be added inside the class name , and the color should be white. 

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
