### PR TITLE
[PLAY] Override add on padding for text input

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -169,7 +169,7 @@
     &-card {
       height: 45px;
       margin: 0;
-      padding: 0;
+      padding: 0 !important;
       align-items: center;
       justify-content: center;
       width: 45px;

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -92,13 +92,13 @@
       .add-on {
         &-right {
           .add-on-card {
-            border: 1px solid red;
+            border: 1px solid $error;
             border-left: 0;
           }
         }
         &-left {
           .add-on-card {
-            border: 1px solid red;
+            border: 1px solid $error;
             border-right: 0;
           }
         }


### PR DESCRIPTION
#### Screens

BEFORE:
![image](https://user-images.githubusercontent.com/84349455/150847399-84c64f89-6715-4352-b521-550332070e96.png)

AFTER:
![image](https://user-images.githubusercontent.com/84349455/150847536-9c07b4e3-d814-4a62-b314-4fe23828b71d.png)


#### Breaking Changes

No, this was a bug that is being fixed by overriding the padding inherited from the card kit when creating an add on.

#### Runway Ticket URL

[https://nitro.powerhrg.com/runway/backlog_items/PLAY-44](url) (Original story)

#### How to test this

1. Use a text input kit with an add-on in React
2. Make sure that the input and add-on are in line with eachother

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
