### PR TITLE
[PLAY-91] Add unique key prop to text input

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -75,6 +75,8 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
     globalProps(props),
     className,
   ])
+  const uniqueTextInputKey = `${id ? id : ''}${Math.ceil(Math.random() * 100000)}`
+
   const addOnIcon = (
     <Icon
         className="add-on-icon"
@@ -89,7 +91,7 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
         className="text_input"
         disabled={disabled}
         id={id}
-        key={`${id}_${className}`}
+        key={uniqueTextInputKey}
         name={name}
         onChange={onChange}
         placeholder={placeholder}

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -75,9 +75,6 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
     globalProps(props),
     className,
   ])
-  const generateUniqueKey = (id) => {
-    return `text_input_${id}_${ new Date().getTime() }`
-  }
   const addOnIcon = (
     <Icon
         className="add-on-icon"
@@ -107,7 +104,6 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
       <Flex
           className={`add-on-${addOnAlignment} ${borderCss}`}
           inline="flex-container"
-          key={generateUniqueKey(id)}
           vertical="center"
       >
         <If condition={addOnAlignment == 'left'}>

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -89,6 +89,7 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
         className="text_input"
         disabled={disabled}
         id={id}
+        key={`${id}_${className}`}
         name={name}
         onChange={onChange}
         placeholder={placeholder}

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -75,6 +75,9 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
     globalProps(props),
     className,
   ])
+  const generateUniqueKey = (id) => {
+    return `text_input_${id}_${ new Date().getTime() }`
+  }
   const addOnIcon = (
     <Icon
         className="add-on-icon"
@@ -104,6 +107,7 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
       <Flex
           className={`add-on-${addOnAlignment} ${borderCss}`}
           inline="flex-container"
+          key={generateUniqueKey(id)}
           vertical="center"
       >
         <If condition={addOnAlignment == 'left'}>


### PR DESCRIPTION
#### Screens

![image](https://user-images.githubusercontent.com/84349455/150863024-cb591745-55db-4743-aa24-10d69fae92d7.png)

#### Breaking Changes

No. A unique key prop was added to the actual input element of the Text Input kit, clearing the error message that usually persists in the console when working with this kit in React.

#### Runway Ticket URL

[https://nitro.powerhrg.com/runway/backlog_items/PLAY-91](url)

#### How to test this

1. Navigate to http://localhost:3000/kits/text_input/react
2. Open console log
3. Check to make sure error is not there anymore

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
