### PR TITLE
[PLAY-103] Section separator: Add ability to remove margin from vertical orentation

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
@@ -61,6 +61,8 @@ $section_colors_dark: (
       }
     }
     &[class*=_vertical] {
+      margin-left: $space_xs;
+      margin-right: $space_xs;
       &::after {
         @include section_separator_vertical(true);
       }

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
@@ -36,13 +36,15 @@ $section_colors_dark: (
     justify-content: center;
   }
   &[class*=_vertical] {
+    margin-left: $space_xs;
+    margin-right: $space_xs;
     &::after {
       @include section_separator_vertical(false);
     }
   }
-  
+
   // Dark =========================
-  
+
   &.dark {
     &::after {
       @include section_separator_horizontal(true);

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
@@ -10,8 +10,6 @@
     content: "";
     height: 100%;
     width: 1px;
-    margin-left: $space_xs;
-    margin-right: $space_xs;
     position: initial;
     z-index: 0;
 }


### PR DESCRIPTION
#### Screens

<img width="1588" alt="Playbook_Design_System_and_jelenadurovic_Jelenas-MacBook-Pro___Desktop_Nitro_playbook_playbook_playbook" src="https://user-images.githubusercontent.com/82796889/151060870-939f9b01-6494-4417-8c90-ef3d3912e4be.png">


#### Breaking Changes

No. This PR is fixing margin default on section separator kit with vertical orientation.. Default remains the same- 8px margin left and 8px margin right. Developer can pass a margin prop to overwrite the default.

#### Runway Ticket URL

[[Runway ticket]](https://nitro.powerhrg.com/runway/backlog_items/PLAY-103)

#### How to test this

Add a margin left or right to overwrite the default.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
