### PR TITLE
[PLAY-112] Size Prop styling needs to be corrected: Image Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_image/_image.jsx
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.jsx
@@ -34,7 +34,7 @@ const Image = (props: ImageProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const classes = classnames(
-    buildCss('pb_image_kit', size),
+    buildCss('pb_image_kit', size ? `size_${size}` : null),
     'lazyload',
     transition,
     { rounded },

--- a/playbook/app/pb_kits/playbook/pb_image/_image.scss
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.scss
@@ -14,7 +14,7 @@ $image-sizes: (
   object-fit: cover;
 
   @each $name, $size in $image-sizes {
-    &[class*=_#{$name}] {
+    &[class*=size_#{$name}] {
       width: $size;
       height: $size;
       object-fit: cover;
@@ -35,7 +35,7 @@ $image-sizes: (
         transition: opacity 300ms ease-in;
       }
     }
-    
+
     &.blur {
       filter: blur(5px);
       &.lazyloaded {
@@ -44,7 +44,7 @@ $image-sizes: (
         transition: filter 300ms ease-in;
       }
     }
-    
+
     &.scale {
       opacity: 0;
       transform: scale(0.9);

--- a/playbook/app/pb_kits/playbook/pb_image/image.rb
+++ b/playbook/app/pb_kits/playbook/pb_image/image.rb
@@ -27,7 +27,7 @@ module Playbook
       end
 
       def size_class
-        size == "none" ? nil : "_#{size}"
+        size == "none" ? nil : "_size_#{size}"
       end
 
       def transition_class

--- a/playbook/app/pb_kits/playbook/pb_image/image.test.js
+++ b/playbook/app/pb_kits/playbook/pb_image/image.test.js
@@ -26,7 +26,7 @@ test('default classname', () => {
 
 test('size = xs', () => {
   const kit = renderKit(Image, props, { size: 'xs' })
-  expect(kit).toHaveClass('pb_image_kit_xs lazyload')
+  expect(kit).toHaveClass('pb_image_kit_size_xs lazyload')
 })
 
 test('transition = blur', () => {

--- a/playbook/spec/pb_kits/playbook/kits/image_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/image_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Playbook::PbImage::Image do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_image_kit fade lazyload"
-      expect(subject.new({ size: "xs" }).classname).to eq "pb_image_kit_xs fade lazyload"
+      expect(subject.new({ size: "xs" }).classname).to eq "pb_image_kit_size_xs fade lazyload"
       expect(subject.new({ rounded: true }).classname).to eq "pb_image_kit fade lazyload rounded"
     end
   end


### PR DESCRIPTION
#### Screens

BEFORE

<img width="1526" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/151859299-0d0192d9-d2c3-4239-99e9-304360414be3.png">

AFTER

<img width="1569" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/151859502-6624fa7b-e2cf-41e4-b559-f486f95d18e8.png"> 


#### Breaking Changes

This will add word `size` on image kits but the actual size will remain the same. The only thing we need to do is make sure image kits with size on are not being targeted anywhere in Nitro so we can safely update the  classname.


#### Runway Ticket URL

[[INSERT URL](https://nitro.powerhrg.com/runway/backlog_items/PLAY-112)]

#### How to test this
Add a margin or padding prop to the image kit and see if image size will change.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
