### PR TITLE
Added back variant prop and tested for Title and Caption

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_body/_body.jsx
+++ b/playbook/app/pb_kits/playbook/pb_body/_body.jsx
@@ -21,6 +21,7 @@ type BodyProps = {
   status?: 'negative' | 'neutral' | 'positive',
   tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'div',
   text?: string,
+  variant: null | 'link',
 }
 
 const Body = (props: BodyProps) => {
@@ -36,12 +37,13 @@ const Body = (props: BodyProps) => {
     status,
     tag = 'div',
     text,
+    variant = null,
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const classes = classnames(
-    buildCss('pb_body_kit', color, status),
+    buildCss('pb_body_kit', color, variant, status),
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_caption/_caption.jsx
+++ b/playbook/app/pb_kits/playbook/pb_caption/_caption.jsx
@@ -30,6 +30,7 @@ const Caption = (props: CaptionProps) => {
     size = 'md',
     tag = 'div',
     text,
+    variant = null,
   } = props
   const tagOptions = [
     'h1',
@@ -48,7 +49,7 @@ const Caption = (props: CaptionProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const css = classnames(
-    buildCss('pb_caption_kit', size, color),
+    buildCss('pb_caption_kit', size, variant, color),
     globalProps(props),
     className,
   )

--- a/playbook/app/pb_kits/playbook/pb_caption/_caption.scss
+++ b/playbook/app/pb_kits/playbook/pb_caption/_caption.scss
@@ -3,6 +3,9 @@
 
 [class^="pb_caption_kit"] {
   @include caption;
+  &[class*="_link"] {
+    color: $primary;
+  }
 
   &[class^="pb_caption_kit_lg"] {
     @include caption_lg;
@@ -10,6 +13,10 @@
 
   &[class^="pb_caption_kit_xs"] {
     @include caption_xs;
+  }
+  
+  &[class*="link"] {
+    color: $primary;
   }
 
   @include pb_caption_kit_colors;

--- a/playbook/app/pb_kits/playbook/pb_caption/caption.rb
+++ b/playbook/app/pb_kits/playbook/pb_caption/caption.rb
@@ -10,14 +10,17 @@ module Playbook
                  values: %w[h1 h2 h3 h4 h5 h6 p span div caption],
                  default: "div"
       prop :text
-      prop :variant, deprecated: true
+      prop :variant, type: Playbook::Props::Enum,
+                     values: [nil, "link"],
+                     default: nil,
+                     deprecated: true
 
       prop :color, type: Playbook::Props::Enum,
                    values: [nil, "default", "light", "lighter", "success", "error", "link"],
                    default: nil
 
       def classname
-        generate_classname("pb_caption_kit", size, color)
+        generate_classname("pb_caption_kit", size, variant, color)
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_title/_title.jsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.jsx
@@ -30,12 +30,13 @@ const Title = (props: TitleProps) => {
     size = 3,
     tag = 'h3',
     text,
+    variant = null,
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const classes = classnames(
-    buildCss('pb_title_kit', size, color),
+    buildCss('pb_title_kit', size, variant, color),
     globalProps(props),
     className,
   )

--- a/playbook/app/pb_kits/playbook/pb_title/title.rb
+++ b/playbook/app/pb_kits/playbook/pb_title/title.rb
@@ -13,10 +13,13 @@ module Playbook
                  values: %w[h1 h2 h3 h4 h5 h6 p div span],
                  default: "h3"
       prop :text
-      prop :variant, deprecated: true
+      prop :variant, type: Playbook::Props::Enum,
+                     values: [nil, "link"],
+                     default: nil,
+                     deprecated: true
 
       def classname
-        generate_classname("pb_title_kit", size, color)
+        generate_classname("pb_title_kit", size, variant, color)
       end
     end
   end


### PR DESCRIPTION
A patch fix for a breaking change that removed variant prop on title and caption kit that was being used in Nitro.