### PR TITLE
[PLAY-111] Size Prop styling needs to be corrected: Avatar

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar/_avatar.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/_avatar.jsx
@@ -44,7 +44,7 @@ const Avatar = (props: AvatarProps) => {
   const dataProps = buildDataProps(data)
   const ariaProps = buildAriaProps(aria)
   const classes = classnames(
-    buildCss('pb_avatar_kit', size),
+    buildCss('pb_avatar_kit', `size_${size}`),
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_avatar/_avatar.scss
+++ b/playbook/app/pb_kits/playbook/pb_avatar/_avatar.scss
@@ -16,8 +16,8 @@ $avatar-sizes: (
   position: relative;
 
   @each $name, $size in $avatar-sizes {
-    &[class*=_#{$name}],
-    &[class*=_#{$name}_thumb] {
+    &[class*=_size_#{$name}],
+    &[class*=_size_#{$name}_thumb] {
       width: $size;
       height: $size;
       object-fit: cover;

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
@@ -18,7 +18,7 @@ module Playbook
       end
 
       def classname
-        generate_classname("pb_avatar_kit", size)
+        generate_classname("pb_avatar_kit", "size_#{size}")
       end
 
       def online_status_props

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.test.js
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.test.js
@@ -22,7 +22,7 @@ test('loads the given image url and name', () => {
   const image    = screen.getByAltText(imageAlt)
   const initials = name.split(/\s/)[0].substr(0, 1) + name.split(/\s/)[1].substr(0, 1)
 
-  expect(kit).toHaveClass('pb_avatar_kit_md')
+  expect(kit).toHaveClass('pb_avatar_kit_size_md')
   expect(kit).toHaveAttribute('data-initials', initials)
   expect(image).toHaveAttribute('data-src', imageUrl)
   expect(image).toHaveAttribute('src', imageUrl)

--- a/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Playbook::PbAvatar::Avatar do
   }
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
-      expect(subject.new({}).classname).to eq "pb_avatar_kit_md"
-      expect(subject.new(classname: "additional_class").classname).to eq "pb_avatar_kit_md additional_class"
+      expect(subject.new({}).classname).to eq "pb_avatar_kit_size_md"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_avatar_kit_size_md additional_class"
       expect(subject.new(size: "lg").classname).to eq "pb_avatar_kit_size_lg"
     end
   end

--- a/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Playbook::PbAvatar::Avatar do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_avatar_kit_md"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_avatar_kit_md additional_class"
-      expect(subject.new(size: "lg").classname).to eq "pb_avatar_kit_lg"
+      expect(subject.new(size: "lg").classname).to eq "pb_avatar_kit_size_lg"
     end
   end
 end


### PR DESCRIPTION
#### Screens
BEFORE
<img width="1561" alt="avatar_props_before" src="https://user-images.githubusercontent.com/92755007/152008207-7e71eb64-9c12-48ab-9d79-61569b7f5a6c.png">

AFTER
<img width="1686" alt="Screen Shot 2022-02-01 at 11 07 22 AM" src="https://user-images.githubusercontent.com/92755007/152008259-de8daedb-cfa6-400f-8cca-4ed57deed538.png">

BELOW: ALL SCREENSHOTS ARE FROM ALPHA TEST

SALES REPS 
![Screen Shot 2022-02-03 at 1 13 47 PM](https://user-images.githubusercontent.com/92755007/152416694-5d2f5d85-0458-4136-9ee3-fac9c583382e.png)

USER PROFILE
<img width="1777" alt="Screen Shot 2022-02-03 at 3 32 35 PM" src="https://user-images.githubusercontent.com/92755007/152424253-148e7c57-ebd7-411b-9d3b-ab774461fd39.png">

POWER STORY
<img width="1777" alt="Screen Shot 2022-02-04 at 9 21 03 AM" src="https://user-images.githubusercontent.com/92755007/152545155-ada88bc2-0529-414c-b5b7-b086efc26ed3.png">

RUNWAY
<img width="1777" alt="Screen Shot 2022-02-03 at 2 46 10 PM" src="https://user-images.githubusercontent.com/92755007/152417985-72bbb8d2-4d88-4291-b52f-83aab3be5b1b.png">

Video Showcasing how adding a size props no longer changes that avatar kit size. Test done in alpha:


https://user-images.githubusercontent.com/92755007/152423540-60d3b209-286c-4181-bdb6-bb5d1fa6b9ca.mov








#### Breaking Changes

This will add word `size` on avatar kits but the actual size will remain the same. The only thing we need to do is make sure avatar kits with size on are not being targeted anywhere in Nitro so we can safely update the classname.

[Yes/No (Explain)]

#### Runway Ticket URL

[INSERT URL]

#### How to test this

Add a margin or padding prop to the avatar kit and see if image size will change.

[INSERT TESTING DETAILS]

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
