### PR TITLE
[PCA-17] React Rich Text Editor Kit: Field doesn't update with an external value update [#1579]

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.jsx
@@ -129,6 +129,10 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     trixRef.current.addEventListener('click', handleClick)
   }, [])
 
+  useEffect(() => {
+    trixRef.current.editor.loadHTML(value)
+  }, [value])
+
   const RichTextEditorClass = 'pb_rich_text_editor_kit'
   const SimpleClass = simple ? 'simple' : ''
   const FocusClass = focus ? 'focus-editor-targets' : ''


### PR DESCRIPTION
#### Screens

BEFORE
<img width="1738" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/152071030-e043ae15-7d08-4e49-b08e-07ccae1eeb24.png">

SEE VIDEO:

[Reproducing bug- editor does not update when value change ](https://user-images.githubusercontent.com/82796889/152073557-147ef5b9-4aa6-4cb6-a961-cfe88a2b8f91.mov)

AFTER

<img width="1457" alt="Playbook_Design_System_and_Desktop" src="https://user-images.githubusercontent.com/82796889/152072182-9bf143db-40d4-4ba9-a9e9-978c6a5f1e7c.png">

SEE VIDEO: 

https://user-images.githubusercontent.com/82796889/152073624-332cfaf0-dcc2-4d6f-adab-734070010c47.mov

#### Breaking Changes

No. This PR is fixing a bug on React Rich Text Editor kit. The problem was when value prop  is changed externally editor content will not update, meaning if we set a value as a state and we attempt to change state value editor will not reflect those changes. 


#### Runway Ticket URL

[[INSERT URL](https://nitro.powerhrg.com/runway/backlog_items/PLAY-17)]

#### How to test this

To reproduce this we need to pass value as a state, and have an external button change this state onClick. When this state is changed, the trix editor content should reflect the change..

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
