### PR TITLE
[PLAY-114] Bug fix for User kit sizing prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_user/_user.jsx
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.jsx
@@ -53,7 +53,7 @@ const User = (props: UserProps) => {
   const dataProps = buildDataProps(data)
 
   const classes = classnames(
-    buildCss('pb_user_kit', align, orientation),
+    buildCss('pb_user_kit', align, orientation, size),
     globalProps(props),
     className,
   )

--- a/playbook/app/pb_kits/playbook/pb_user/_user.jsx
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.jsx
@@ -53,7 +53,7 @@ const User = (props: UserProps) => {
   const dataProps = buildDataProps(data)
 
   const classes = classnames(
-    buildCss('pb_user_kit', align, orientation, size),
+    buildCss('pb_user_kit', align, orientation),
     globalProps(props),
     className,
   )

--- a/playbook/app/pb_kits/playbook/pb_user/user.rb
+++ b/playbook/app/pb_kits/playbook/pb_user/user.rb
@@ -20,7 +20,7 @@ module Playbook
       prop :territory
 
       def classname
-        generate_classname("pb_user_kit", align, orientation)
+        generate_classname("pb_user_kit", align, orientation, size)
       end
 
       def avatar_size

--- a/playbook/app/pb_kits/playbook/pb_user/user.rb
+++ b/playbook/app/pb_kits/playbook/pb_user/user.rb
@@ -20,18 +20,11 @@ module Playbook
       prop :territory
 
       def classname
-        generate_classname("pb_user_kit", align, orientation, size)
+        generate_classname("pb_user_kit", align, orientation)
       end
 
       def avatar_size
-        case size
-        when "lg"
-          "xl"
-        when "md"
-          "md"
-        else
-          "sm"
-        end
+        size == "lg" ? "xl" : size
       end
 
       def title_size

--- a/playbook/spec/pb_kits/playbook/kits/user_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/user_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Playbook::PbUser::User do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_user_kit_left_horizontal_sm"
-      expect(subject.new(classname: "additional_class").classname).to eq "pb_user_kit_left_horizontal_sm additional_class"
+      expect(subject.new({ classname: "additional_class" }).classname).to eq "pb_user_kit_left_horizontal_sm additional_class"
       expect(subject.new({ size: "lg" }).classname).to eq "pb_user_kit_left_horizontal_lg"
       expect(subject.new({ orientation: "vertical" }).classname).to eq "pb_user_kit_left_vertical_sm"
       expect(subject.new({ align: "right" }).classname).to eq "pb_user_kit_right_horizontal_sm"


### PR DESCRIPTION
#### Screens

[WIP]

#### Breaking Changes

No, this addresses a bug that applies size properties to a kit when adding custom margin/padding classes on a kit.

#### Runway Ticket URL

[https://nitro.powerhrg.com/runway/backlog_items/PLAY-114](url)

#### How to test this

1. Add a 'user' kit to a .jsx or .erb file
2. Apply a custom margin or padding to the kit using global props
3. Make sure the margin/padding you use does not override the sizing of the user kit

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
