### PR TITLE
[PLAY-16] File Upload Kit: Can't upload Pages, Numbers, and Keynote files [#1575]

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.jsx
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.jsx
@@ -20,7 +20,7 @@ type FileUploadProps = {
 
 const FileUpload = (props: FileUploadProps) => {
   const {
-    accept = ['*'],
+    accept = null,
     acceptedFilesDescription = '',
     className,
     onFilesAccepted = noop,
@@ -34,13 +34,15 @@ const FileUpload = (props: FileUploadProps) => {
     onDrop,
   })
 
-  const acceptedFileTypes = accept.map((fileType) => {
-    if (fileType.startsWith('image/')) {
-      return fileType.replace('image/', ' ')
-    } else {
-      return fileType
-    }
-  })
+  const acceptedFileTypes = () => {
+    return accept.map((fileType) => {
+      if (fileType.startsWith('image/')) {
+        return fileType.replace('image/', ' ')
+      } else {
+        return fileType
+      }
+    })
+  }
 
   return (
     <div
@@ -53,7 +55,7 @@ const FileUpload = (props: FileUploadProps) => {
           <If condition={isDragActive}>
             <p>{'Drop the files here ...'}</p>
             <Else />
-            <p>{`Choose a file or drag it here. The accepted file types are: ${acceptedFilesDescription || acceptedFileTypes}`}</p>
+            <p>{accept === null ? 'Choose a file or drag it here' : `Choose a file or drag it here. The accepted file types are: ${acceptedFilesDescription || acceptedFileTypes()}`}</p>
           </If>
         </Body>
       </Card>

--- a/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.jsx
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.jsx
@@ -4,7 +4,7 @@ import React, { useCallback } from 'react'
 import { useDropzone } from 'react-dropzone'
 import classnames from 'classnames'
 
-import { buildCss, noop } from '../utilities/props'
+import { buildCss, buildDataProps, noop } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import type { Callback } from '../types'
 
@@ -14,6 +14,7 @@ import Card from '../pb_card/_card'
 type FileUploadProps = {
   accept?: array<string>,
   className?: string,
+  data?: object,
   acceptedFilesDescription?: string,
   onFilesAccepted: Callback,
 }
@@ -23,6 +24,7 @@ const FileUpload = (props: FileUploadProps) => {
     accept = null,
     acceptedFilesDescription = '',
     className,
+    data = {},
     onFilesAccepted = noop,
   } = props
   const onDrop = useCallback((files) => {
@@ -44,9 +46,12 @@ const FileUpload = (props: FileUploadProps) => {
     })
   }
 
+  const dataProps = buildDataProps(data)
+
   return (
     <div
         className={classnames(buildCss('pb_file_upload_kit'), globalProps(props), className)}
+        {...dataProps}
         {...getRootProps()}
     >
       <Card>

--- a/playbook/app/pb_kits/playbook/pb_file_upload/fileupload.test.js
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/fileupload.test.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import FileUpload from './_file_upload'
+
+const testid = 'fileupload-test'
+
+test('returns namespaced class name', () => {
+  render(
+    <FileUpload
+        data={{ testid: testid }}
+    />
+  )
+
+  const kit = screen.getByTestId(testid)
+  expect(kit).toHaveClass('pb_file_upload_kit')
+})
+
+test('shows default drag text', () => {
+  render(
+    <FileUpload
+        data={{ testid: testid }}
+    />
+  )
+
+  const kit = screen.getByTestId(testid)
+  expect(kit).toHaveTextContent('Choose a file or drag it here')
+})
+
+test('shows type-specific drag text', () => {
+  render(
+    <FileUpload
+        accept={['image/svg+xml']}
+        data={{ testid: testid }}
+    />
+  )
+
+  const kit = screen.getByTestId(testid)
+  expect(kit).toHaveTextContent('Choose a file or drag it here. The accepted file types are: svg+xml')
+})


### PR DESCRIPTION
#### Screens

BEFORE:

https://user-images.githubusercontent.com/82796889/152414334-9ba8e405-43b0-4a0b-a1b5-93c5da41cd58.mov

AFTER: 


https://user-images.githubusercontent.com/82796889/152415131-547a72f4-e08f-4ce9-b1ec-1de488300e11.mov


#### Breaking Changes

No. This PR is fixing a bug that was causing File Upload kit to not accept all file types. Setting accept prop default as null will fix the issue. 

#### Runway Ticket URL

[[INSERT URL](https://nitro.powerhrg.com/runway/backlog_items/PLAY-16)]

#### How to test this

Open a browser, go to File Upload kit and try adding different types of files.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
