### PR TITLE
Button's min-height bug fix

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.scss
@@ -13,9 +13,9 @@ $pb_button_sizes: (
     &[class*=size_#{$name}] {
       font-size: $size;
       padding: calc(#{$size} / 2) calc(#{$size} * 2.42) !important;
-    }
-    @if $name == "sm" {
-      min-height: 0;
+      @if $name == "sm" {
+        min-height: 0;
+      }
     }
   }
 


### PR DESCRIPTION
#### Screens

BEFORE:
<img width="1559" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/154515202-3b281164-6b3f-4e55-9c28-a493d6531eb2.png">


AFTER:

<img width="1469" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/154515496-3a71f15d-ae0b-493c-b4c1-c574e3e79e28.png">

#### Breaking Changes

No. This PR is fixing a button's min-height bug. 

#### Runway Ticket URL

[[INSERT URL](https://nitro.powerhrg.com/runway/backlog_items/PLAY-126)]

#### How to test this

Open a browser and inspect a button kit styles. Only `sm` size button should have `min-height: 0`. Every other size, including the default, should have `min-height: 40`

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
