### PR TITLE
Form Group Kit alignment bug fixed

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -41,6 +41,7 @@
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
     min-height: 45px;
+    margin-bottom: 16px;
   }
 
   & > [class^=pb_button_kit]:not(:first-child) {
@@ -48,6 +49,7 @@
     border-top-left-radius: 0;
     border-left-width: 0;
     min-height: 45px;
+    margin-bottom: 16px;
   }
 
   & > [class^=pb_date_picker_kit]:not(:last-child) {


### PR DESCRIPTION
#### Screens

BEFORE: 
<img width="805" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/154722361-85d33b47-7fa1-4367-81a6-8d9683e6792e.png">

AFTER:
<img width="730" alt="Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/154722473-21d295bd-c4a7-489c-a3fc-fbfbd3306f44.png">


#### Breaking Changes

No. This PR is fixing an alignment on the form group kit. 

#### Runway Ticket URL

[[INSERT URL](https://nitro.powerhrg.com/runway/backlog_items/PLAY-127)]

#### How to test this

Open a a browser and inspect form group kit. All kits inside the form group should be aligned correctly. 

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
