### PR TITLE
React Line Graph - line graph height doc example missing a fixed height prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_height.jsx
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_height.jsx
@@ -11,6 +11,7 @@ const LineGraphDefault = (props) => (
     <LineGraph
         axisTitle="Number of Employees"
         chartData={data}
+        height="300px"
         id="line-fixed-height"
         title="Fixed Height (300px)"
         xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']}


### PR DESCRIPTION
#### Screens

BEFORE: 
<img width="1541" alt="Playbook_Design_System_and_Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/154813689-b5f6aa94-cf37-4512-8fed-c6444c63cafb.png">

AFTER: 

<img width="1506" alt="Playbook_Design_System_and_Playbook_Design_System" src="https://user-images.githubusercontent.com/82796889/154813753-dc102167-6d5a-4c71-9e7f-9813c6f6bb82.png">

#### Breaking Changes

No. This PR is fixing a bug on React Line Graph kit. One of the doc examples is showing a graph when height is fixed(`height="300px"`) but the height prop is missing which shows incorrect kit example. 

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/NUX-2724

#### How to test this

Open a browser and go to Line Graph kit. Under the `Height` section there's a fixed height graph. Open a code example and see `height="300px"` being passed to the kit.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
