### PR TITLE
Dialog Kit shows a strange border intermittently

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
@@ -8,7 +8,7 @@
 
 
 
-// Dialog Animations 
+// Dialog Animations
 
 @keyframes modalFadeIn {
 	from {
@@ -72,7 +72,7 @@
 	border: 0;
 	max-height: calc(100vh - #{$gutter * 2});
 	max-width: calc(100vw - #{$gutter * 2});
-	overflow: scroll;
+	overflow: auto;
 	animation-name: modalFadeIn;
 	animation-duration: $animation-duration;
 	outline: none;


### PR DESCRIPTION
#### Problem 

Sometimes for some people the dialog kit has a border on the right and bottom sides. I have changed the scss from `overflow: scroll` to `overflow:auto` and this fixed the problem for me.

#### Screens

PROBLEM:
<img width="1582" alt="Screen Shot 2022-03-07 at 1 58 42 PM" src="https://user-images.githubusercontent.com/51907753/157102322-5048d3d8-96dd-41c7-9383-91c32b4da6ef.png">

SOLUTION:
<img width="1578" alt="Screen Shot 2022-03-07 at 2 00 37 PM" src="https://user-images.githubusercontent.com/51907753/157102375-fc1e0a20-1453-443a-a284-0b725577773e.png">

#### Breaking Changes

No. This change shouldn't break anything.

#### How to test this

Check to make sure the dialog kit is working without the strange border. For some people this bug was not reproducible and we're not sure why.

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [X] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [X] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
