### PR TITLE
Only spread to DOM element compatible props

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.jsx
@@ -37,6 +37,11 @@ type TextInputProps = {
 
 const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
   const {
+    addOn = { icon: null, alignment: 'right', border: true },
+    ...domSafeProps
+  } = props
+
+  const {
     aria = {},
     className,
     data = {},
@@ -53,7 +58,6 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
     type = 'text',
     value = '',
     children = null,
-    addOn = { icon: null, alignment: 'right', border: true },
   } = props
 
   const ariaProps = buildAriaProps(aria)
@@ -85,7 +89,7 @@ const TextInput = (props: TextInputProps, ref: React.ElementRef<"input">) => {
   )
   const textInput = (
     <input
-        {...props}
+        {...domSafeProps}
         className="text_input"
         disabled={disabled}
         id={id}


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-03-10 at 14 20 49](https://user-images.githubusercontent.com/386460/157728843-c0a77a40-8331-4417-aac5-711d8f94e210.png)


#### Breaking Changes

No

#### Runway Ticket URL

None

#### How to test this

Open up the browser console, navigates to `/kits/text_input/react` and make sure that the attached warning is not showing up.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
