### PR TITLE
Allow decimals to be displayed for Rail's StatValue and DashboardValue kits

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/playbook/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -13,14 +13,14 @@ module Playbook
                         default: {}
 
       def formatted_stat_value
-        { **stat_value, value: sanitize_stat_value }
+        { **stat_value, value: sanitized_stat_value }
       end
 
       def classname
         generate_classname("pb_dashboard_value_kit", align)
       end
 
-      def sanitize_stat_value
+      def sanitized_stat_value
         if stat_value[:value].to_f == stat_value[:value].to_i
           stat_value[:value].to_i
         else

--- a/playbook/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
+++ b/playbook/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.rb
@@ -13,11 +13,19 @@ module Playbook
                         default: {}
 
       def formatted_stat_value
-        { **stat_value, value: stat_value[:value].to_i }
+        { **stat_value, value: sanitize_stat_value }
       end
 
       def classname
         generate_classname("pb_dashboard_value_kit", align)
+      end
+
+      def sanitize_stat_value
+        if stat_value[:value].to_f == stat_value[:value].to_i
+          stat_value[:value].to_i
+        else
+          stat_value[:value].to_f
+        end
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.rb
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.rb
@@ -4,10 +4,10 @@ module Playbook
   module PbStatValue
     class StatValue < Playbook::KitBase
       prop :unit
-      prop :value, type: Playbook::Props::Number
+      prop :value, type: Playbook::Props::Numeric
 
       def formatted_value
-        number_with_delimiter(value, delimiter: ",")
+        number_with_delimiter(value, delimiter: ",", separator: ".")
       end
 
       def classname

--- a/playbook/spec/pb_kits/playbook/kits/dashboard_value_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/dashboard_value_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Playbook::PbDashboardValue::DashboardValue do
       .of_type(Playbook::Props::Hash)
   }
 
+  describe "#sanitized_stat_value", :aggregate_failures do
+    it "returns integers when fed integers or decimals that end in *.0" do
+      expect(subject.new(stat_value: { value: 142 }).sanitized_stat_value).to eq 142
+      expect(subject.new(stat_value: { value: 67.0 }).sanitized_stat_value).to eq 67
+    end
+
+    it "returns decimals when fed decimals" do
+      expect(subject.new(stat_value: { value: 14.2 }).sanitized_stat_value).to eq 14.2
+      expect(subject.new(stat_value: { value: 67.01 }).sanitized_stat_value).to eq 67.01
+    end
+  end
+
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_dashboard_value_kit_left"

--- a/playbook/spec/pb_kits/playbook/kits/stat_value_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/stat_value_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Playbook::PbStatValue::StatValue do
   it { is_expected.to define_prop(:unit) }
   it {
     is_expected.to define_prop(:value)
-      .of_type(Playbook::Props::Number)
+      .of_type(Playbook::Props::Numeric)
   }
 
   describe "#classname" do


### PR DESCRIPTION
#### Screens

Unable to get playbook running locally.

Am able to run Ruby test suite.

#### Breaking Changes

No

#### Runway Ticket URL

None

#### How to test this

Look over docs for these two kits in the review env.

Ideally, this PR would add to the docs. But I am currently unable to get playbook running locally. -- If the deployment works, I'll add some more docs onto this.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [X] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
