### PR TITLE
[PLAY-146]Title Kit Convert to Typescript

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 import React from 'react'
 import classnames from 'classnames'
-import Title from '../pb_title/_title.jsx'
+import Title from '../pb_title/_title'
 import Icon from '../pb_icon/_icon.jsx'
 import Avatar from '../pb_avatar/_avatar'
 import { globalProps } from '../utilities/globalProps'

--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.jsx
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.jsx
@@ -3,7 +3,7 @@
 import React from 'react'
 
 import classnames from 'classnames'
-import Title from '../pb_title/_title.jsx'
+import Title from '../pb_title/_title'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
-import { deprecatedProps, globalProps } from '../utilities/globalProps'
+import { deprecatedProps, GlobalProps, globalProps } from '../utilities/globalProps'
 
 type TitleProps = {
-  aria?: object,
-  children?: array<React.ReactNode> | React.ReactNode,
+  aria?: {[key: string]: string},
+  children?: React.ReactChild[]
   className?: string,
   color?: "default" | "light" | "lighter" | "success" | "error" | "link",
-  data?: object,
+  data?: {[key: string]: string},
   id?: string,
   size?: 1 | 2 | 3 | 4,
   tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div" | "span",
   text?: string,
   variant?: null | "link",
-}
+} & GlobalProps
 
-const Title = (props: TitleProps) => {
+const Title = (props: TitleProps): React.ReactElement => {
   if (props.variant) deprecatedProps('Title', ['variant']) //variant prop is deprecated, use color instead
   const {
     aria = {},
@@ -31,14 +31,14 @@ const Title = (props: TitleProps) => {
     variant = null,
   } = props
 
-  const ariaProps = buildAriaProps(aria)
-  const dataProps = buildDataProps(data)
+  const ariaProps: {[key: string]: any} = buildAriaProps(aria)
+  const dataProps: {[key: string]: any} = buildDataProps(data)
   const classes = classnames(
-    buildCss('pb_title_kit', size, variant, color),
+    buildCss('pb_title_kit', `size_${size}`, variant, color),
     globalProps(props),
     className,
   )
-  const Tag = `${tag}`
+  const Tag: React.ReactElement | any = `${tag}`
 
   return (
     <Tag

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -5,7 +5,7 @@ import { deprecatedProps, GlobalProps, globalProps } from '../utilities/globalPr
 
 type TitleProps = {
   aria?: {[key: string]: string},
-  children?: React.ReactChild[]
+  children?: React.ReactChild[],
   className?: string,
   color?: "default" | "light" | "lighter" | "success" | "error" | "link",
   data?: {[key: string]: string},

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -31,8 +31,8 @@ const Title = (props: TitleProps): React.ReactElement => {
     variant = null,
   } = props
 
-  const ariaProps: {[key: string]: any} = buildAriaProps(aria)
-  const dataProps: {[key: string]: any} = buildDataProps(data)
+  const ariaProps: {[key: string]: string | number} = buildAriaProps(aria)
+  const dataProps: {[key: string]: string | number} = buildDataProps(data)
   const classes = classnames(
     buildCss('pb_title_kit', `size_${size}`, variant, color),
     globalProps(props),

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'

--- a/playbook/app/pb_kits/playbook/pb_title/title.test.js
+++ b/playbook/app/pb_kits/playbook/pb_title/title.test.js
@@ -12,7 +12,7 @@ test('returns namespaced class name', () => {
   )
 
   const kit = screen.getByTestId('primary-test')
-  expect(kit).toHaveClass('pb_title_kit_3')
+  expect(kit).toHaveClass('pb_title_kit_size_3')
 })
 
 test('with colors', () => {
@@ -25,5 +25,5 @@ test('with colors', () => {
   )
 
   const kit = screen.getByTestId('primary-test')
-  expect(kit).toHaveClass('pb_title_kit_3_success')
+  expect(kit).toHaveClass('pb_title_kit_size_3_success')
 })


### PR DESCRIPTION
![React Kit Coverage](https://img.shields.io/badge/React%20Kit%20Coverage-13.48%25-red)WIP

#### Breaking Changes:
No

#### Runway Ticket URL:
https://nitro.powerhrg.com/runway/backlog_items/PLAY-146


#### How to test this:
Test in Milano enviroment 

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **SPECS** Please cover your changes with specs.
- [X] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
