### PR TITLE
Add Sticky Header Prop for Table Kit

### DIFF
--- a/playbook-website/app/javascript/site_styles/_site-style.scss
+++ b/playbook-website/app/javascript/site_styles/_site-style.scss
@@ -84,7 +84,7 @@ body {
     }
     &--main {
       flex-grow: 1;
-      padding: 40px 60px;
+      padding: 0 60px 40px;
       height: calc(100vh - 89px);
       overflow: auto;
       @include break_at($nav_breakpoint) {

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -1,5 +1,5 @@
 <div class="pb--kit-show <%=@kit%>-kit">
-  <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1 }) %>
+  <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin: "xl" }) %>
   <div class="markdown <%= cookies[:dark_mode] == "true" ? 'dark' : '' %>">
     <%= markdown(pb_doc_kit_description(@kit)) %>
   </div>

--- a/playbook/app/pb_kits/playbook/pb_table/_table.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/_table.jsx
@@ -20,6 +20,7 @@ type TableProps = {
   responsive: "collapse" | "scroll" | "none",
   singleLine: boolean,
   size: "sm" | "md" | "lg",
+  sticky?: boolean,
 }
 
 const Table = (props: TableProps) => {
@@ -37,6 +38,7 @@ const Table = (props: TableProps) => {
     responsive = 'collapse',
     singleLine = false,
     size = 'sm',
+    sticky = false,
   } = props
 
   const ariaProps = buildAriaProps(aria)
@@ -60,6 +62,7 @@ const Table = (props: TableProps) => {
           'data_table': dataTable,
           'single-line': singleLine,
           'no-hover': disableHover,
+          'sticky-header': sticky,
         },
         globalProps(props),
         tableCollapseCss,

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.html.erb
@@ -1,0 +1,83 @@
+<%= pb_rails("table", props: { sticky: true }) do %>
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+      <th>Column 4</th>
+      <th>Column 5</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+  </tbody>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.jsx
@@ -1,0 +1,94 @@
+import React from "react"
+
+import Table from "../_table"
+
+const TableSticky = (props) => (
+  <Table
+      sticky
+      {...props}
+  >
+    <thead>
+      <tr>
+        <th>{'Column 1'}</th>
+        <th>{'Column 2'}</th>
+        <th>{'Column 3'}</th>
+        <th>{'Column 4'}</th>
+        <th>{'Column 5'}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+    </tbody>
+  </Table>
+)
+
+export default TableSticky

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
@@ -1,0 +1,3 @@
+React: Use `sticky` on a table to allow the table header to be fixed in place when the user scrolls up and down on the page.
+
+Rails: Pass `sticky: true` to props.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
@@ -6,5 +6,5 @@ If the table header is not sticking in the right place you will need to pass a i
 React Example: `<thead style={{ top: "-16px" }}>`
 Rails Example: `<thead style="top: -16px">`
 
-Sticky will not work if any parent/ancestor of the sticky element has any of the `overflow` properties set. By specifying a height on the overflowing container, you should be able to make sticky work.
-If the parent element has no `height` set, then the sticky element won't have any area to stick to when scrolling.
+### Troubleshooting CSS Problems
+Sticky may not work if any parent/ancestor of the sticky element has any of the `overflow` properties set. Additionally, specifying a height on the overflowing container provides measurement for this feature to work properly. In some cases, it may be necessary to set the same parent/ancestor container to `position: static` as well.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
@@ -2,6 +2,9 @@ React: Use `sticky` on a table to allow the table header to be fixed in place wh
 
 Rails: Pass `sticky: true` to props.
 
+If the header is not sticking even after using this prop you will need to manually set the height of the `.main-page-content` class.
+You can add the attribute `height: calc(100vh - 90px);` The `90px` refers to the full nav height, so that value could differ.
+
 If the table header is not sticking in the right place you will need to pass a inline `top` style to the `thead`.
 React Example: `<thead style={{ top: "-16px" }}>`
 Rails Example: `<thead style="top: -16px">`

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
@@ -1,3 +1,7 @@
 React: Use `sticky` on a table to allow the table header to be fixed in place when the user scrolls up and down on the page.
 
 Rails: Pass `sticky: true` to props.
+
+If the table header is not sticking in the right place you will need to pass a inline `top` style to the `thead`.
+React Example: `<thead style={{ top: "-16px" }}>`
+Rails Example: `<thead style="top: -16px">`

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
@@ -2,9 +2,9 @@ React: Use `sticky` on a table to allow the table header to be fixed in place wh
 
 Rails: Pass `sticky: true` to props.
 
-If the header is not sticking even after using this prop you will need to manually set the height of the `.main-page-content` class.
-You can add the attribute `height: calc(100vh - 90px);` The `90px` refers to the full nav height, so that value could differ.
-
 If the table header is not sticking in the right place you will need to pass a inline `top` style to the `thead`.
 React Example: `<thead style={{ top: "-16px" }}>`
 Rails Example: `<thead style="top: -16px">`
+
+Sticky will not work if any parent/ancestor of the sticky element has any of the `overflow` properties set. By specifying a height on the overflowing container, you should be able to make sticky work.
+If the parent element has no `height` set then the sticky element won't have any area to stick to when scrolling.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
@@ -7,4 +7,4 @@ React Example: `<thead style={{ top: "-16px" }}>`
 Rails Example: `<thead style="top: -16px">`
 
 Sticky will not work if any parent/ancestor of the sticky element has any of the `overflow` properties set. By specifying a height on the overflowing container, you should be able to make sticky work.
-If the parent element has no `height` set then the sticky element won't have any area to stick to when scrolling.
+If the parent element has no `height` set, then the sticky element won't have any area to stick to when scrolling.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
@@ -3,6 +3,7 @@ examples:
     - table_sm: Small
     - table_md: Medium
     - table_lg: Large
+    - table_sticky: Sticky Header
     - table_alignment_row: Row Alignment
     - table_alignment_column: Column Alignment
     - table_alignment_shift_row: Shift Row
@@ -25,6 +26,7 @@ examples:
     - table_sm: Small
     - table_md: Medium
     - table_lg: Large
+    - table_sticky: Sticky Header
     - table_alignment_row: Row Alignment
     - table_alignment_column: Column Alignment
     - table_alignment_shift_row: Shift Row

--- a/playbook/app/pb_kits/playbook/pb_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/index.js
@@ -1,6 +1,7 @@
 export { default as TableSm } from './_table_sm.jsx'
 export { default as TableMd } from './_table_md.jsx'
 export { default as TableLg } from './_table_lg.jsx'
+export { default as TableSticky } from './_table_sticky.jsx'
 export { default as TableSideHighlight } from './_table_side_highlight.jsx'
 export { default as TableContainer } from './_table_container.jsx'
 export { default as TableDataTable } from './_table_data_table.jsx'

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_all.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_all.scss
@@ -16,3 +16,4 @@
 @import "mobile_collapse";
 @import "tablet_collapse";
 @import "desktop_collapse";
+@import "sticky_header";

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
@@ -14,7 +14,7 @@
       thead {
         position: sticky;
         background: #0a0527;
-        top: 0;
+        top: -40px;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
@@ -13,7 +13,7 @@
   &.dark {
     &.sticky-header {
       thead {
-        background: #0a0527;
+        background: $bg_dark;
         position: sticky;
         top: -40px;
         z-index: 10;

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
@@ -3,18 +3,20 @@
 [class^="pb_table"] {
   &.sticky-header {
     thead {
-      position: sticky;
       background: $white;
+      position: sticky;
       top: -40px;
+      z-index: 10;
     }
   }
 
   &.dark {
     &.sticky-header {
       thead {
-        position: sticky;
         background: #0a0527;
+        position: sticky;
         top: -40px;
+        z-index: 10;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
@@ -5,8 +5,8 @@
     thead {
       background: $white;
       position: sticky;
-      top: -40px;
-      z-index: 10;
+      top: 0;
+      z-index: 1;
     }
   }
 
@@ -15,8 +15,8 @@
       thead {
         background: $bg_dark;
         position: sticky;
-        top: -40px;
-        z-index: 10;
+        top: 0;
+        z-index: 1;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_sticky_header.scss
@@ -1,0 +1,21 @@
+@import "../../tokens/colors";
+
+[class^="pb_table"] {
+  &.sticky-header {
+    thead {
+      position: sticky;
+      background: $white;
+      top: -40px;
+    }
+  }
+
+  &.dark {
+    &.sticky-header {
+      thead {
+        position: sticky;
+        background: #0a0527;
+        top: 0;
+      }
+    }
+  }
+}

--- a/playbook/app/pb_kits/playbook/pb_table/table.rb
+++ b/playbook/app/pb_kits/playbook/pb_table/table.rb
@@ -21,11 +21,13 @@ module Playbook
                       values: %w[sm md lg],
                       default: "sm"
       prop :text
+      prop :sticky, type: Playbook::Props::Boolean,
+                    default: false
 
       def classname
         generate_classname(
           "pb_table", "table-#{size}", single_line_class, dark_class,
-          disable_hover_class, container_class, data_table_class, collapse_class,
+          disable_hover_class, container_class, data_table_class, sticky_class, collapse_class,
           "table-responsive-#{responsive}", separator: " "
         )
       end
@@ -54,6 +56,10 @@ module Playbook
 
       def collapse_class
         responsive != "none" ? "table-collapse-#{collapse}" : ""
+      end
+
+      def sticky_class
+        sticky ? "sticky-header" : nil
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_table/table.test.js
+++ b/playbook/app/pb_kits/playbook/pb_table/table.test.js
@@ -1,0 +1,17 @@
+import { ensureAccessible, renderKit } from "../utilities/test-utils"
+
+import Table from "./_table"
+
+const props = {
+  data: { testid: "table" },
+  sticky: false
+}
+
+it("should be accessible", async () => {
+  ensureAccessible(Table, props)
+})
+
+test("when sticky is true", () => {
+  const kit = renderKit(Table, props, { sticky: true })
+  expect(kit).toHaveClass("pb_table table-sm table-responsive-collapse table-card sticky-header table-collapse-sm")
+})

--- a/playbook/spec/pb_kits/playbook/kits/table_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/table_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Playbook::PbTable::Table do
   it { is_expected.to define_boolean_prop(:disable_hover).with_default(false) }
   it { is_expected.to define_boolean_prop(:container).with_default(true) }
   it { is_expected.to define_prop(:text) }
+  it { is_expected.to define_boolean_prop(:sticky).with_default(false) }
 
   describe "#container" do
     it "returns false when it is specified" do
@@ -34,6 +35,7 @@ RSpec.describe Playbook::PbTable::Table do
       expect(subject.new(container: false).classname).to eq "pb_table table-md table-collapse-sm table-responsive-collapse"
       expect(subject.new(disable_hover: true).classname).to eq "pb_table table-md no-hover table-card table-collapse-sm table-responsive-collapse"
       expect(subject.new(disable_hover: true, dark: true, size: "lg", single_line: true).classname).to eq "pb_table table-lg single-line table-dark no-hover table-card table-collapse-sm table-responsive-collapse dark"
+      expect(subject.new(sticky: true).classname).to eq "pb_table table-md table-card sticky-header table-collapse-sm table-responsive-collapse"
     end
   end
 end


### PR DESCRIPTION
![React Kit Coverage](https://img.shields.io/badge/React%20Kit%20Coverage-13.67%25-red)
#### Screens

![Screen Shot 2022-05-04 at 2 27 06 PM](https://user-images.githubusercontent.com/84343331/166801583-e2990b43-c938-43cd-9c3e-261dd59cfb2f.png)

https://user-images.githubusercontent.com/84343331/166304855-2b881d65-e8b6-4b8b-a123-89d2cf1936e2.mov

#### Breaking Changes

No, this adds a new prop with a `false` default value so nothing in Nitro will be affected until the prop is passed a `true` value.

#### Runway Ticket URL

[PLAY-67](https://nitro.powerhrg.com/runway/backlog_items/PLAY-67)

#### How to test this

Add the `sticky` prop with a value of `true` and see if the table header sticks when you scroll down.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
