### PR TITLE
[PLAY-123] Added red_dark color and updated error_dark value

### DIFF
--- a/playbook/app/pb_kits/playbook/tokens/_colors.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_colors.scss
@@ -9,6 +9,7 @@ $royal:               #0056CF;
 $purple:              #9E64E9;
 $teal:                #00C4D7;
 $red:                 #FF2229;
+$red_dark:            #ff4a50;
 $yellow:              #F9BB00;
 $green:               #00CA74;
 $orange:              #FD804C;
@@ -154,7 +155,7 @@ $data_colors: (
 $success:             $green;
 $warning:             $yellow;
 $error:               $red;
-$error_dark:          lighten($error, 5%);
+$error_dark:          $red_dark;
 $error_dark_body:     lighten($error_dark, 2%);
 $info:                $teal;
 $neutral:             $slate;


### PR DESCRIPTION
![React Kit Coverage](https://img.shields.io/badge/React%20Kit%20Coverage-13.39%25-red)#### Screens

[INSERT SCREENSHOT]

#### Breaking Changes

[Yes/No (Explain)]

#### Runway Ticket URL

[[PLAY-123]](https://nitro.powerhrg.com/runway/backlog_items/PLAY-123)

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
