### PR TITLE
fix issuerCert typo prod

### DIFF
--- a/playbook-website/config/deploy/production/values.yaml
+++ b/playbook-website/config/deploy/production/values.yaml
@@ -1,2 +1,2 @@
 ingress:
-  issueCerts: true
+  issueCert: true

--- a/playbook-website/config/deploy/prs/values.yaml
+++ b/playbook-website/config/deploy/prs/values.yaml
@@ -1,2 +1,2 @@
 ingress:
-  issueCerts: false # Certificate is issued once per cluster in the playbook-prs namespace
+  issueCert: false # Certificate is issued once per cluster in the playbook-prs namespace

--- a/playbook-website/config/deploy/staging/values.yaml
+++ b/playbook-website/config/deploy/staging/values.yaml
@@ -1,2 +1,2 @@
 ingress:
-  issueCerts: true
+  issueCert: true


### PR DESCRIPTION
![React Kit Coverage](https://img.shields.io/badge/React%20Kit%20Coverage-12.17%25-red)## Description
Because of this type the `certificate` resource wasn't being created and because of that cert-manager didn't know that it needed to manage that certificate.

____

#### Screens

[INSERT SCREENSHOT]

#### Breaking Changes

[Yes/No (Explain)]

#### Runway Ticket URL

[INSERT URL]

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
