### PR TITLE
Incl. branch as part of Playbook's image tag

### DIFF
--- a/playbook-website/config/deploy/templates/deployment.yaml.erb
+++ b/playbook-website/config/deploy/templates/deployment.yaml.erb
@@ -20,7 +20,7 @@ spec:
         - name: quay-robot-powerhome
       containers:
         - name: playbook
-          image: "image-registry.powerapp.cloud/playbook/playbook:master-<%= image_tag %>"
+          image: "image-registry.powerapp.cloud/playbook/playbook:<%= image_tag %>"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/playbook-website/config/deploy/templates/deployment.yaml.erb
+++ b/playbook-website/config/deploy/templates/deployment.yaml.erb
@@ -20,7 +20,7 @@ spec:
         - name: quay-robot-powerhome
       containers:
         - name: playbook
-          image: "image-registry.powerapp.cloud/playbook/playbook:<%= image_tag %>"
+          image: "image-registry.powerapp.cloud/playbook/playbook:master-<%= image_tag %>"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
### PR Description

This PR includes a `master-*` tag on stable (`master` branch builds) to prevent them from being removed on Harbor's self-cleaning tasks.

#### Related issues

It is related to https://github.com/powerhome/playbook/issues/1897.

