### PR TITLE
[PLAY-198] Fix Title Bug

### DIFF
--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -1,5 +1,5 @@
 <div class="pb--kit-show <%=@kit%>-kit">
-  <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin: "xl" }) %>
+  <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin_y: "xl" }) %>
   <div class="markdown <%= cookies[:dark_mode] == "true" ? 'dark' : '' %>">
     <%= markdown(pb_doc_kit_description(@kit)) %>
   </div>

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -1,5 +1,5 @@
 <div class="pb--kit-show <%=@kit%>-kit">
-  <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin_y: "xl" }) %>
+  <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin_top: "xl" }) %>
   <div class="markdown <%= cookies[:dark_mode] == "true" ? 'dark' : '' %>">
     <%= markdown(pb_doc_kit_description(@kit)) %>
   </div>


### PR DESCRIPTION
![React Kit Coverage](https://img.shields.io/badge/React%20Kit%20Coverage-12.17%25-red)#### Screens

Before: 
<img width="1792" alt="Screen Shot 2022-05-24 at 10 26 47 AM" src="https://user-images.githubusercontent.com/84343331/170059838-dad7d44a-6e0d-4275-b379-179a8a80341a.png">

After:
<img width="1792" alt="Screen Shot 2022-05-24 at 10 27 04 AM" src="https://user-images.githubusercontent.com/84343331/170059894-67ed68db-8f5f-41f5-a88c-ae5927aadaaf.png">

#### Breaking Changes

No, fixing a bug.

#### Runway Ticket URL

[Play-198](https://nitro.powerhrg.com/runway/backlog_items/PLAY-198)

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
