### PR TITLE
[Rails 7 fix] Conditionally use render_component method in PbKitHelper

### DIFF
--- a/playbook/lib/playbook/pb_kit_helper.rb
+++ b/playbook/lib/playbook/pb_kit_helper.rb
@@ -6,7 +6,12 @@ module Playbook
 
     def pb_rails(kit_name, props: {}, &block)
       kit = Playbook::KitResolver.resolve(kit_name.to_s)
-      render_component kit.new(props, &block), &block
+
+      if respond_to? :render_component
+        render_component kit.new(props, &block), &block
+      else
+        render kit.new(props, &block), &block
+      end
     end
   end
 end


### PR DESCRIPTION
When using Playbook with Rails 7, the `pb_rails` method attempts to call `render_component` which does not work in later versions of Rails.

Output:
```
undefined method `render_component' for #<ActionView::Base:0x00000000010a68>
Did you mean?  react_component
```

For later Rails versions, `render` should be used instead. Using `respond_to?` should prevent any breaking changes.