### PR TITLE
[PLAY-175] Visual Guidelines: Convert Flex Box Props to React

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/FlexBox.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/FlexBox.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Pill, Table } from 'playbook-ui'
+import Example from '../Templates/Example'
+
+const SCREEN_SIZES = ['xs', 'sm', 'md', 'lg', 'xl']
+
+const PROPS = {
+  flexDirection: ['row', 'column', 'rowReverse', 'columnReverse'],
+  flexWrap: ['wrap', 'nowrap', 'wrapReverse'],
+  justifyContent: ['start', 'end', 'center', 'spaceBetween', 'spaceAround', 'spaceEvenly'],
+  justifySelf: ['start', 'end', 'center', 'auto', 'stretch'],
+  alignItems: ['flexStart', 'flexEnd', 'start', 'end', 'center', 'stretch', 'baseline'],
+  alignContent: ['start', 'end', 'center', 'spaceBetween', 'spaceAround', 'spaceEvenly'],
+  alignSelf: ['start', 'end', 'center', 'auto', 'stretch', 'baseline'],
+  flex: ['none', 'initial', 'auto', '1'],
+  flexGrow: ['0', '1'],
+  flexShrink: ['0', '1'],
+  order: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', 'none']
+}
+const TABLE_HEADERS = ['Props', 'Screen Sizes', 'Values']
+
+let buildPillElement = (value, propName) => (
+  <Pill
+    key={`${propName}-${value}`}
+    text={value}
+    textTransform="none"
+    variant="warning"
+  />
+)
+
+const FlexBox = ({example}: {example: string}) => (
+  <Example
+    example={example}
+    customChildren={true}
+    title='Flex Box'
+    globalPropsDescription={'Available in every kit. These are added globally as they are most flexible when developing. *Screen sizes are optional.'}
+  >
+    <Table>
+      <thead>
+        <tr>
+          { TABLE_HEADERS.map((header, idx) => (
+            <th key={`${header}-${idx}`}>{header}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        { Object.keys(PROPS).map((propName: string, idx) => (
+          <tr key={`${propName}-${idx}`}>
+            <td>
+              <Pill
+                text={propName}
+                textTransform="none"
+              />
+            </td>
+            <td>
+              { SCREEN_SIZES.map((value) => (
+                buildPillElement(value, propName)
+              ))}
+            </td>
+            <td>
+              { PROPS[propName].map((value) => (
+                buildPillElement(value, propName)
+              ))}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  </Example>
+)
+
+export default FlexBox

--- a/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
@@ -16,18 +16,22 @@ import PropsValues from './PropsValues'
 
 type ExampleType = {
   children?: React.ReactChild[] | React.ReactChild,
+  customChildren?: boolean,
   description?: string,
   example?: string,
   globalProps?: { [key: string]: string[] | number[] },
+  globalPropsDescription?: string,
   title?: string,
   tokens?: { [key: string]: string | number }
 }
 
 const Example = ({
   children,
+  customChildren,
   description,
   example,
   globalProps,
+  globalPropsDescription,
   title,
   tokens,
 }: ExampleType): React.ReactElement => {
@@ -52,7 +56,7 @@ const Example = ({
           {description}
         </Body>
       )}
-      { globalProps && (
+      { (globalProps || globalPropsDescription) && (
         <React.Fragment>
           <Title
               marginBottom="xs"
@@ -62,7 +66,7 @@ const Example = ({
               text="Global Props"
           />
           <Body marginBottom="lg">
-            {'Available in every kit. These are added globally as they are most flexible when developing.'}
+            {globalPropsDescription || 'Available in every kit. These are added globally as they are most flexible when developing.'}
           </Body>
         </React.Fragment>
       )}
@@ -85,7 +89,7 @@ const Example = ({
           rounded
           shadow="deeper"
       >
-        {children &&  (
+        {children && !customChildren && (
           <FlexItem>
             <Card.Body>
               <Caption
@@ -100,6 +104,7 @@ const Example = ({
             />
           </FlexItem>
         )}
+        {children && customChildren && (children)}
         {globalProps && (
           <PropsValues {...globalProps} />
         )}

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -7,6 +7,7 @@ import Colors from './Colors'
 import MaxWidth from './Examples/MaxWidth'
 import Positioning from './Examples/Positioning'
 import Cursor from './Examples/Cursor'
+import FlexBox from './Examples/FlexBox'
 
 const VisualGuidelines = ({ examples }: {examples: {[key: string]: string}}): React.ReactElement => {
   return (
@@ -18,6 +19,7 @@ const VisualGuidelines = ({ examples }: {examples: {[key: string]: string}}): Re
           tokensExample={examples.position_token}
       />
       <Cursor example={examples.cursor_jsx} />
+      <FlexBox example={examples.justify_self_jsx} />
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Visual Guidelines: Switch Flex Box to React

____

#### Screens
<img width="1238" alt="Screen Shot 2022-05-26 at 20 25 21" src="https://user-images.githubusercontent.com/1093624/170595288-94b8be86-3bd3-48ca-865a-48733d5df14f.png">

#### Breaking Changes
 
I updated the `Example` base template to support custom children element and custom description for global properties but no breaking changes are expected

#### Runway Ticket URL

[PLAY-175](https://nitro.powerhrg.com/runway/backlog_items/PLAY-175)

#### How to test this

It's expected that this template can be seen on `visual_guidelines_react` page. 

[INSERT TESTING DETAILS]

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
