### PR TITLE
Install pyton2 dependency with asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 ruby 2.7.4
 yarn 1.22.15
 nodejs 14.18.1
+python 2.7.18

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,8 @@ asdf install
 asdf plugin add ruby
 asdf plugin add yarn
 asdf plugin add nodejs
+asdf plugin add python
+asdf install
 
 echo "Running yarn install \n"
 yarn install


### PR DESCRIPTION
Since macOS [12.3 release](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes) python is no longer part of the OS. Playbook uses
node-gyp which requires python2 in order to properly work

This patch adds python2 to the list of dependencies managed by asdf tool

#### Breaking Changes

None expected

#### How to test this

1. Clean your local copy `git clean`
2. Run `./setup.sh`
3. Run `yarn start-dev`

Python should be installed and the successful message should be shown "compiled successfully". Check http://localhost:3000 

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
