### PR TITLE
[FINC-1393] Add Precision to Stat Value Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_default.md
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_default.md
@@ -1,1 +1,1 @@
-Use this as value for displaying number data at a high level. It’s primary function is to create hierarchy of data within a view. 
+Use this as value for displaying number data at a high level. It’s primary function is to create hierarchy of data within a view.

--- a/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_precision.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_precision.html.erb
@@ -1,0 +1,3 @@
+<%= pb_rails("stat_value", props: { value: 1529.00000, precision: 2 }) %>
+
+<%= pb_rails("stat_value", props: { value: 1529.13, precision: 4 }) %>

--- a/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_precision.md
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_precision.md
@@ -1,0 +1,2 @@
+Use this to specify how many decimal places you want to show.
+In react, you can pass in a string or number, but for this rails kit, we only accept numeric values and rails will not show trailing zero's unless specified.

--- a/playbook/app/pb_kits/playbook/pb_stat_value/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/docs/example.yml
@@ -3,6 +3,7 @@ examples:
   rails:
   - stat_value_default: Default
   - stat_value_unit: Unit Value
+  - stat_value_precision: Precision Value
 
 
   react:

--- a/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.rb
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.rb
@@ -5,9 +5,14 @@ module Playbook
     class StatValue < Playbook::KitBase
       prop :unit
       prop :value, type: Playbook::Props::Numeric
+      prop :precision, type: Playbook::Props::Numeric
 
       def formatted_value
-        number_with_delimiter(value, delimiter: ",", separator: ".")
+        if precision.nil?
+          number_with_delimiter(value, delimiter: ",", separator: ".")
+        else
+          number_with_precision(value, precision: precision, delimiter: ",", separator: ".")
+        end
       end
 
       def classname

--- a/playbook/spec/pb_kits/playbook/kits/stat_value_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/stat_value_spec.rb
@@ -10,11 +10,31 @@ RSpec.describe Playbook::PbStatValue::StatValue do
     is_expected.to define_prop(:value)
       .of_type(Playbook::Props::Numeric)
   }
+  it {
+    is_expected.to define_prop(:precision)
+      .of_type(Playbook::Props::Numeric)
+  }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_stat_value_kit"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_stat_value_kit additional_class"
+    end
+  end
+
+  describe "when props are filled" do
+    it "shows a unit" do
+      stat_value = subject.new(value: 1842.3, unit: "monkeys")
+
+      expect(stat_value.value).to eq 1842.3
+      expect(stat_value.unit).to eq "monkeys"
+    end
+
+    it "uses precision" do
+      stat_value = subject.new(value: 1842, precision: 3)
+
+      expect(stat_value.value).to eq 1842.000
+      expect(stat_value.precision).to eq 3
     end
   end
 end


### PR DESCRIPTION
![React Kit Coverage](https://img.shields.io/badge/React%20Kit%20Coverage-14.41%25-red)

**Pay attention to your PR titles and use Title Case!**

Here is a bad 👎 example: "Updates kit props and children"

_Why is it bad? Indistinct title which is not using title case._

Here is a good 👍 example: "Updates Props and Children in Body Kit"

_Why is it good? Distinct title which is using title case._

____

#### Screens

<img width="1313" alt="Screen Shot 2022-07-13 at 3 34 07 PM" src="https://user-images.githubusercontent.com/64422843/178817468-9f06bb08-aa48-4b97-bd86-36635a05297a.png">

#### Breaking Changes

I dont think there should be. For places already using the kit its okay if they dont specify the precision so it shouldnt break existing usage

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/FINC-1393

#### How to test this

make sure you see the precision prop (?) and it shows the right about of decimals specifies

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
