### PR TITLE
[PLAY-260]-TS-Conversion of Icon Circle Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 
 import classnames from 'classnames'
@@ -10,10 +8,10 @@ import { globalProps } from '../utilities/globalProps'
 import Icon from '../pb_icon/_icon'
 
 type IconCircleProps = {
-  aria?: object,
+  aria?: {[key:string]: string},
   className?: string,
   dark?: boolean,
-  data?: object,
+  data?: {[key:string]: string},
   icon: string,
   id?: string,
   size?: "base" | "xs" | "sm" | "md" | "lg" | "xl",


### PR DESCRIPTION

#### Screens

![Playbook-Design-System (2)](https://user-images.githubusercontent.com/73710701/184199824-c6c85f7a-242c-4042-89b8-8613b47d405b.png)

#### Breaking Changes

No, PR just converts all .jsx files in Icon Circle kit to .tsx

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-260)

#### How to test this

Review in Milano environment

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
