### PR TITLE
[PLAY-297] Fixing Jest Test that Breaks CI Intermittently

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -5,16 +5,22 @@ import { fireEvent, render, screen, waitFor, within } from '../utilities/test-ut
 import DatePicker from './_date_picker'
 import { getTimezoneText } from './plugins/timeSelect'
 
+
+
+jest.setSystemTime(new Date('01/01/2020'));
+
 const DEFAULT_DATE = new Date()
-DEFAULT_DATE.setFullYear(2022)
-DEFAULT_DATE.setMonth(1)
-DEFAULT_DATE.setDate(1)
-DEFAULT_DATE.setHours(12)
-DEFAULT_DATE.setMinutes(0)
+// DEFAULT_DATE.setFullYear(2022)
+// DEFAULT_DATE.setMonth(1)
+// DEFAULT_DATE.setDate(1)
+// DEFAULT_DATE.setHours(12)
+// DEFAULT_DATE.setMinutes(0)
+
+
 
 describe('DatePicker Kit', () => {
   beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => { });
   });
 
   test('renders DatePicker input field', () => {
@@ -44,10 +50,13 @@ describe('DatePicker Kit', () => {
 
     const kit = screen.getByTestId(testId)
 
+
     const input = within(kit).getByPlaceholderText('Select Date')
     expect(input).toBeInTheDocument()
+
     await waitFor(() => {
-      expect(input).toHaveValue('02/01/2022')
+
+      expect(input).toHaveValue('01/01/2020')
     })
   })
 
@@ -143,7 +152,7 @@ describe('DatePicker Kit', () => {
       }),
     )
     await waitFor(() => {
-      expect(input).toHaveValue('02/01/2022 at 12:00 AM')
+      expect(input).toHaveValue('01/01/2020 at 12:00 AM')
     })
 
     fireEvent(
@@ -154,7 +163,7 @@ describe('DatePicker Kit', () => {
       }),
     )
     await waitFor(() => {
-      expect(input).toHaveValue('02/01/2022 at 12:00 PM')
+      expect(input).toHaveValue('01/01/2020 at 12:00 PM')
     })
   })
 })

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -8,14 +8,7 @@ import { getTimezoneText } from './plugins/timeSelect'
 
 
 jest.setSystemTime(new Date('01/01/2020'));
-
 const DEFAULT_DATE = new Date()
-// DEFAULT_DATE.setFullYear(2022)
-// DEFAULT_DATE.setMonth(1)
-// DEFAULT_DATE.setDate(1)
-// DEFAULT_DATE.setHours(12)
-// DEFAULT_DATE.setMinutes(0)
-
 
 
 describe('DatePicker Kit', () => {
@@ -55,7 +48,6 @@ describe('DatePicker Kit', () => {
     expect(input).toBeInTheDocument()
 
     await waitFor(() => {
-
       expect(input).toHaveValue('01/01/2020')
     })
   })

--- a/playbook/jest.config.js
+++ b/playbook/jest.config.js
@@ -182,7 +182,7 @@ module.exports = {
   // testURL: "http://localhost",
 
   // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
-  // timers: "real",
+  timers: "modern",
 
   // A map from regular expressions to paths to transformers
   // transform: undefined,


### PR DESCRIPTION
#### Screens
![Screen Shot 2022-08-30 at 12 22 18 AM](https://user-images.githubusercontent.com/9158723/187248097-aefdff57-59bc-4f22-a82d-e90b9fff88fa.png)

#### Breaking Changes

No

#### Runway Ticket URL

https://nitro.powerhrg.com/runway/backlog_items/PLAY-297

#### How to test this

Passes CI = good to go.

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
