### PR TITLE
[PLAY-257] Typescript Conversion: Form Group

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.tsx
@@ -1,12 +1,10 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type FormGroupProps = {
-  aria?: object,
+  aria?: {[key: string]: string},
   children?: Node,
   className?: string,
   data?: object,
@@ -27,7 +25,6 @@ const FormGroup = (props: FormGroupProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const classes = classnames(buildCss('pb_form_group_kit', { full: fullWidth }), globalProps(props), className)
-
   return (
     <div
         {...ariaProps}

--- a/playbook/app/pb_kits/playbook/pb_form_group/form_group.test.js
+++ b/playbook/app/pb_kits/playbook/pb_form_group/form_group.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render } from "../utilities/test-utils";
+
+import { Button, FormGroup } from "..";
+
+test("should render a div with a button child", () => {
+  const testId = "primary-test"
+  const { queryByTestId } = render(
+    <FormGroup>
+      <Button 
+          data={{ testid: testId }} 
+          text={"some text"} />
+    </FormGroup>
+  )
+
+  expect(queryByTestId("primary-test")).not.toBeNull;
+})

--- a/playbook/app/pb_kits/playbook/utilities/props.ts
+++ b/playbook/app/pb_kits/playbook/utilities/props.ts
@@ -47,5 +47,5 @@ export const buildDataProps = (data: {[key: string]: any}) => buildPrefixedProps
  * @param {Object} rules a 'classnames' compliant rules object, used to derive the root className.
  * @returns {String} the derived root className value.
  */
-export const buildCss = (...rules: (string | { [x: string]: string; } | { [x: string]: boolean; })[]): string => classnames(rules).replace(/\s/g, '_')
+export const buildCss = (...rules: (string | { [x: string]: string | boolean; })[]): string => classnames(rules).replace(/\s/g, '_')
 

--- a/playbook/app/pb_kits/playbook/utilities/props.ts
+++ b/playbook/app/pb_kits/playbook/utilities/props.ts
@@ -47,5 +47,5 @@ export const buildDataProps = (data: {[key: string]: any}) => buildPrefixedProps
  * @param {Object} rules a 'classnames' compliant rules object, used to derive the root className.
  * @returns {String} the derived root className value.
  */
-export const buildCss = (...rules: (string | { [x: string]: string; })[]): string => classnames(rules).replace(/\s/g, '_')
+export const buildCss = (...rules: (string | { [x: string]: string; } | { [x: string]: boolean; })[]): string => classnames(rules).replace(/\s/g, '_')
 


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-08-31 at 3 06 16 PM](https://user-images.githubusercontent.com/8194056/187748699-1015b9ef-8bcb-4cb5-ba5e-30be61f6290f.png)
T]

#### Breaking Changes

No breaking changes. I had to also change a typing in `props.ts` regarding the `buildCss` function, it should accept booleans as well.

#### Runway Ticket URL

[[PLAY-257]
](https://nitro.powerhrg.com/runway/backlog_items/PLAY-257)
#### How to test this

Open the localhost and try the kit with different props. Check if the console has any error.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
