### PR TITLE
[PLAY-266] Typescript Conversion: Layout

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
@@ -7,8 +5,8 @@ import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type LayoutPropTypes = {
-  aria?: object,
-  children?: array<React.ReactNode> | React.ReactNode,
+  aria?: {[key: string]: string},
+  children?: React.ReactChild[] | React.ReactChild,
   className?: string,
   collapse?: "xs" | "sm" | "md" | "lg" | "xl",
   dark?: boolean,
@@ -23,28 +21,28 @@ type LayoutPropTypes = {
 }
 
 type LayoutSideProps = {
-  children: array<React.ReactNode> | React.ReactNode,
+  children: React.ReactNode[] | React.ReactNode,
   className?: string,
 }
 
 type LayoutBodyProps = {
-  children: array<React.ReactNode> | React.ReactNode,
+  children: React.ReactNode[] | React.ReactNode,
   className?: string,
 }
 
 type LayoutItemProps = {
-  children: array<React.ReactNode> | React.ReactNode,
+  children: React.ReactNode[] | React.ReactNode,
   className?: string,
   size?: "sm" | "md" | "lg"
 }
 
 type LayoutHeaderProps = {
-  children: array<React.ReactNode> | React.ReactNode,
+  children: React.ReactNode[] | React.ReactNode,
   className?: string,
 }
 
 type LayoutFooterProps = {
-  children: array<React.ReactNode> | React.ReactNode,
+  children: React.ReactNode[] | React.ReactNode,
   className?: string,
 }
 
@@ -99,8 +97,6 @@ const Footer = (props: LayoutFooterProps) => {
   )
 }
 
-// Main componenet
-
 const Layout = (props: LayoutPropTypes) => {
   const {
     aria = {},
@@ -138,25 +134,23 @@ const Layout = (props: LayoutPropTypes) => {
         ? ''
         : buildCss('layout', position, 'collapse', collapse)
 
-  const layoutChildren =
-    typeof children === 'object' && children.length ? children : [children]
+  const layoutChildren = React.Children.toArray(children)
 
-  const subComponentTags = (tagName) => {
+  const subComponentTags = (tagName: string) => {
     return layoutChildren
-      .filter((c) => {
-        return c.type && c.type.displayName === tagName
+      .filter((c: React.ReactElement & {type: {displayName: string}}) => {
+        return c.type?.displayName === tagName
       })
       .map((child, i) => {
-        return React.cloneElement(child, {
+        return React.cloneElement(child as React.ReactElement, {
           key: `${tagName.toLowerCase()}-${i}`,
         })
       })
   }
 
   const nonSideChildren = layoutChildren.filter(
-    (child) => !child.type || child.type.displayName !== 'Side'
+    (child: React.ReactElement & {type: {displayName: string}}) => child.type?.displayName !== 'Side'
   )
-
   return (
     <div
         {...ariaProps}

--- a/playbook/app/pb_kits/playbook/pb_layout/layout.test.js
+++ b/playbook/app/pb_kits/playbook/pb_layout/layout.test.js
@@ -1,0 +1,98 @@
+import React from "react"
+import { render, cleanup } from "../utilities/test-utils"
+import { Layout, Card } from ".."
+
+function LayoutTest(props) {
+  return (
+    <Layout {...props}>
+      <Layout.Side>{"Light"}</Layout.Side>
+      <Layout.Body>{"Body"}</Layout.Body>
+    </Layout>
+  )
+}
+
+test("render all color variants", () => {
+  const testValues = [undefined, "light", "dark", "gradient"]
+  testValues.forEach((variant) => {
+    const { getByTestId } = render(
+      <LayoutTest data={{ testid: `test-${variant}` }}
+          variant={variant} />
+    )
+    expect(getByTestId(`test-${variant}`)).toHaveClass(
+      `pb_layout_kit_sidebar_size_md_left_${
+        variant == undefined ? "light" : variant
+      }`
+    )
+
+    cleanup()
+  })
+})
+
+test("render transparent class", () => {
+  const id = "transparent"
+
+  const { getByTestId } = render(
+    <LayoutTest data={{ testid: `test-${id}` }}
+        variant={id} />
+  )
+  expect(getByTestId(`test-${id}`)).toHaveClass(
+    `pb_layout_kit_sidebar_size_md_left_${id}`
+  )
+
+  cleanup()
+})
+
+test("render all sizes variants", () => {
+  const testValues = ["xs", "sm", "md", "lg", "xl"]
+  testValues.forEach((size) => {
+    const { getByTestId } = render(
+      <LayoutTest data={{ testid: `test-${size}` }}
+          size={size} />
+    )
+    expect(getByTestId(`test-${size}`)).toHaveClass(
+      `pb_layout_kit_sidebar_size_${size}_left_light`
+    )
+
+    cleanup()
+  })
+})
+
+test("render all layout variants", () => {
+  const testValues = [
+    {
+      layout: "collection",
+      expected: "pb_layout_kit_collection",
+    },
+    {
+      layout: "collection_detail",
+      expected: "pb_layout_kit_collection_detail_size_md_left_light",
+    },
+    {
+      layout: "content",
+      expected: "pb_layout_kit_content_size_md_left_light",
+    },
+    {
+      layout: "kanban",
+      expected: "pb_layout_kit_kanban",
+    },
+    {
+      layout: "masonry",
+      expected: "pb_layout_kit_masonry_size_md_left_light",
+    },
+  ]
+
+  testValues.forEach(({ layout, expected }) => {
+    const { getByTestId, container } = render(
+      <Layout data={{ testid: `test-${layout}` }}
+          layout={layout}>
+        <Layout.Body>
+          <Card>{"Card content"}</Card>
+        </Layout.Body>
+      </Layout>
+    )
+    console.log(container)
+
+    expect(getByTestId(`test-${layout}`)).toHaveClass(expected)
+    cleanup()
+  })
+})

--- a/playbook/app/pb_kits/playbook/utilities/props.ts
+++ b/playbook/app/pb_kits/playbook/utilities/props.ts
@@ -47,5 +47,5 @@ export const buildDataProps = (data: {[key: string]: any}) => buildPrefixedProps
  * @param {Object} rules a 'classnames' compliant rules object, used to derive the root className.
  * @returns {String} the derived root className value.
  */
-export const buildCss = (...rules: (string | { [x: string]: string; })[]): string => classnames(rules).replace(/\s/g, '_')
+export const buildCss = (...rules: (string | { [x: string]: string | boolean; })[]): string => classnames(rules).replace(/\s/g, '_')
 


### PR DESCRIPTION
#### Screens
![Screen Shot 2022-09-05 at 12 15 36 PM](https://user-images.githubusercontent.com/8194056/188479770-d64ccf9e-6592-4f8f-ae43-235c87adc596.png)

#### Breaking Changes

No breaking changes. Typescript conversion of the layout Kit and Jest test.

#### Runway Ticket URL

[[PLAY-266]](https://nitro.powerhrg.com/runway/backlog_items/PLAY-266)

#### How to test this

Create multiple versions of the Layout Kit. 
Run `yarn test`.
Check for console or visual errors.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
