### PR TITLE
[Play-311] - Add Sidebar For Visual Guidelines React Page

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -88,6 +88,7 @@ class PagesController < ApplicationController
       kit_examples[example_path.split("/").last.sub(".txt", "")] = formatted_example_txt
     end
     @kit_examples_json = kit_examples
+    render "pages/visual_guidelines_react", layout: "layouts/visual_guidelines"
   end
 
   # TODO: remove this method once all guidelines are completed

--- a/playbook-website/app/javascript/components/ReactSidebar/index.tsx
+++ b/playbook-website/app/javascript/components/ReactSidebar/index.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {Nav, NavItem, Caption} from 'playbook-ui'
+
+export const MENU_ITEMS = [
+  "Colors",
+  "Max Width",
+  "Number Spacing",
+  "Positioning",
+  "Line Height",
+  "Spacing",
+  "Border Radius",
+  "Typography",
+  "Shadows",
+  "Display",
+  "Cursor",
+  "Flex Box",
+];
+
+const ReactSidebar = () => {
+
+  return (
+    <>
+    <Caption marginY="md" marginLeft="md" text="Visual Guidelines"/>
+    <Nav variant="subtle">
+        {
+            MENU_ITEMS.map(item => (
+                <NavItem
+                link={`#${item.replace(/\s+/g, '')}`}
+                text={item}
+                />
+            ))
+        }
+    </Nav>
+    </>
+  )
+  
+};
+
+export default ReactSidebar;

--- a/playbook-website/app/javascript/components/Sidebar/index.tsx
+++ b/playbook-website/app/javascript/components/Sidebar/index.tsx
@@ -16,7 +16,7 @@ export const MENU_ITEMS = [
   "Flex Box",
 ];
 
-const ReactSidebar = () => {
+const Sidebar = () => {
 
   return (
     <>
@@ -36,4 +36,4 @@ const ReactSidebar = () => {
   
 };
 
-export default ReactSidebar;
+export default Sidebar;

--- a/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
@@ -40,7 +40,7 @@ const Example = ({
     exampleHtml = parsedExample.body.innerHTML
 
   return (
-    <div>
+    <div id={title?.replace(/\s+/g, '')}>
       {title && (
         <Title
             marginBottom="xs"

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable flowtype/no-types-missing-file-annotation */
 
 // React Pure component - do not use state!
-import React from 'react'
+import React, {useRef, useEffect} from 'react'
 
 import Colors from './Colors'
 import MaxWidth from './Examples/MaxWidth'
@@ -17,9 +17,20 @@ import Cursor from './Examples/Cursor'
 import FlexBox from './Examples/FlexBox'
 
 const VisualGuidelines = ({ examples }: {examples: {[key: string]: string}}): React.ReactElement => {
+  const myRef = useRef(null)
+useEffect(() => {
+    setTimeout(() => {
+        const scrollToRef = (ref: any) => {
+          window.scrollTo(0, ref.current.offsetTop)
+        }
+        scrollToRef(myRef)
+    }, 0)
+  }, [])
   return (
     <React.Fragment>
+      <div id='Colors'>
       <Colors />
+      </div>
       <MaxWidth example={examples.width_jsx} />
       <Positioning
           example={examples.positioning_jsx}
@@ -38,7 +49,9 @@ const VisualGuidelines = ({ examples }: {examples: {[key: string]: string}}): Re
           example={examples.spacing_global_props_jsx}
           tokensExample={examples.spacing_tokens_jsx}
       />
+      <div id='BorderRadius'>
       <BorderRadius tokensExample={examples.border_radius_tokens} />
+      </div>
       <Typography example={examples.typography_tokens}/>
       <Display example={examples.display_in_use_jsx} />
       <Cursor example={examples.cursor_jsx} />

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -1,63 +1,67 @@
 /* eslint-disable flowtype/no-types-missing-file-annotation */
 
 // React Pure component - do not use state!
-import React, {useRef, useEffect} from 'react'
+import React, { useRef, useEffect } from "react";
 
-import Colors from './Colors'
-import MaxWidth from './Examples/MaxWidth'
-import Positioning from './Examples/Positioning'
-import LineHeight from './Examples/LineHeight'
-import NumberSpacing from './Examples/NumberSpacing'
-import Shadows from './Examples/Shadows'
-import Spacing from './Examples/Spacing'
-import BorderRadius from './Examples/BorderRadius'
-import Typography from './Examples/Typography'
-import Display from './Examples/Display'
-import Cursor from './Examples/Cursor'
-import FlexBox from './Examples/FlexBox'
+import Colors from "./Colors";
+import MaxWidth from "./Examples/MaxWidth";
+import Positioning from "./Examples/Positioning";
+import LineHeight from "./Examples/LineHeight";
+import NumberSpacing from "./Examples/NumberSpacing";
+import Shadows from "./Examples/Shadows";
+import Spacing from "./Examples/Spacing";
+import BorderRadius from "./Examples/BorderRadius";
+import Typography from "./Examples/Typography";
+import Display from "./Examples/Display";
+import Cursor from "./Examples/Cursor";
+import FlexBox from "./Examples/FlexBox";
 
-const VisualGuidelines = ({ examples }: {examples: {[key: string]: string}}): React.ReactElement => {
-  const myRef = useRef(null)
-useEffect(() => {
+const VisualGuidelines = ({
+  examples,
+}: {
+  examples: { [key: string]: string };
+}): React.ReactElement => {
+  const myRef = useRef(null);
+  useEffect(() => {
     setTimeout(() => {
-        const scrollToRef = (ref: any) => {
-          window.scrollTo(0, ref.current.offsetTop)
-        }
-        scrollToRef(myRef)
-    }, 0)
-  }, [])
+      const scrollToRef = (ref: any) => {
+        window.scrollTo(0, ref.current.offsetTop);
+      };
+      scrollToRef(myRef);
+    }, 0);
+  }, []);
   return (
     <React.Fragment>
-      <div id='Colors'>
-      <Colors />
+      <div id="Colors">
+        <Colors />
       </div>
       <MaxWidth example={examples.width_jsx} />
       <Positioning
-          example={examples.positioning_jsx}
-          tokensExample={examples.position_token}
+        example={examples.positioning_jsx}
+        tokensExample={examples.position_token}
       />
       <LineHeight
-          example={examples.line_height_code_jsx}
-          tokensExample={examples.line_height_jsx}
+        example={examples.line_height_code_jsx}
+        tokensExample={examples.line_height_jsx}
       />
       <NumberSpacing example={examples.number_spacing_jsx} />
       <Shadows
-          example={examples.shadow_in_use_jsx}
-          tokensExample={examples.shadow_erb}
+        example={examples.shadow_in_use_jsx}
+        tokensExample={examples.shadow_erb}
       />
       <Spacing
-          example={examples.spacing_global_props_jsx}
-          tokensExample={examples.spacing_tokens_jsx}
+        example={examples.spacing_global_props_jsx}
+        tokensExample={examples.spacing_tokens_jsx}
       />
-      <div id='BorderRadius'>
-      <BorderRadius tokensExample={examples.border_radius_tokens} />
+      <div id="BorderRadius">
+        <BorderRadius tokensExample={examples.border_radius_tokens} />
       </div>
-      <Typography example={examples.typography_tokens}/>
+      <Typography example={examples.typography_tokens} />
       <Display example={examples.display_in_use_jsx} />
       <Cursor example={examples.cursor_jsx} />
       <FlexBox example={examples.justify_self_jsx} />
     </React.Fragment>
-  )
-}
+  );
+};
 
-export default VisualGuidelines
+export default VisualGuidelines;

--- a/playbook-website/app/javascript/packs/application.js
+++ b/playbook-website/app/javascript/packs/application.js
@@ -12,13 +12,13 @@ import '../site_styles/main.scss'
 import DarkModeToggle from '../components/DarkModeToggle'
 import KitSearch from '../components/KitSearch'
 import SnippetToggle from '../components/SnippetToggle'
-import ReactSidebar from '../components/ReactSidebar'
+import Sidebar from '../components/Sidebar'
 
 WebpackerReact.setup({
   DarkModeToggle,
   KitSearch,
   SnippetToggle,
-  ReactSidebar,
+  Sidebar,
 })
 
 // Produce image assets

--- a/playbook-website/app/javascript/packs/application.js
+++ b/playbook-website/app/javascript/packs/application.js
@@ -12,11 +12,13 @@ import '../site_styles/main.scss'
 import DarkModeToggle from '../components/DarkModeToggle'
 import KitSearch from '../components/KitSearch'
 import SnippetToggle from '../components/SnippetToggle'
+import ReactSidebar from '../components/ReactSidebar'
 
 WebpackerReact.setup({
   DarkModeToggle,
   KitSearch,
   SnippetToggle,
+  ReactSidebar,
 })
 
 // Produce image assets

--- a/playbook-website/app/javascript/packs/react_sidebar.js
+++ b/playbook-website/app/javascript/packs/react_sidebar.js
@@ -1,7 +1,7 @@
 import WebpackerReact from 'webpacker-react'
 
-import ReactSidebar from '../components/ReactSidebar'
+import Sidebar from '../components/Sidebar'
 
 WebpackerReact.setup({
-  ReactSidebar,
+  Sidebar,
 })

--- a/playbook-website/app/javascript/packs/react_sidebar.js
+++ b/playbook-website/app/javascript/packs/react_sidebar.js
@@ -1,0 +1,7 @@
+import WebpackerReact from 'webpacker-react'
+
+import ReactSidebar from '../components/ReactSidebar'
+
+WebpackerReact.setup({
+  ReactSidebar,
+})

--- a/playbook-website/app/views/layouts/_sidebar.html.erb
+++ b/playbook-website/app/views/layouts/_sidebar.html.erb
@@ -79,5 +79,5 @@
 <% end %>
 
 <% if current_page?('/visual_guidelines_react') %>
-  <%= react_component("ReactSidebar") %>
+  <%= react_component("Sidebar") %>
 <% end %>

--- a/playbook-website/app/views/layouts/_sidebar.html.erb
+++ b/playbook-website/app/views/layouts/_sidebar.html.erb
@@ -77,3 +77,7 @@
     <% end %>
   <% end %>
 <% end %>
+
+<% if current_page?('/visual_guidelines_react') %>
+  <%= react_component("ReactSidebar") %>
+<% end %>

--- a/playbook-website/app/views/pages/visual_guidelines_react.html.erb
+++ b/playbook-website/app/views/pages/visual_guidelines_react.html.erb
@@ -1,26 +1,17 @@
 <div class="visual_guidelines">
-<%= pb_rails("layout", props: {classname: "pb--page--content",variant: cookies[:dark_mode] == "true" ? 'dark' : 'light' }) do%>
-  <%= render 'layouts/mobile_hamburger' %>
-  <%= pb_rails("layout/sidebar", props: { classname: "pb--page--sideNav"}) do%> 
-    <%= react_component("ReactSidebar") %>
-  <% end %>
-
-  <%= pb_rails("layout/body", props: {classname: "pb--page--content--main padding-override smooth-scroll"}) do%>
-      <%= pb_rails("background", props: { background_color: "dark", padding: "xl", classname: "visual_guidelines_hero" }) do %>
-        <%= pb_rails("flex", props: { classname: "header-text", orientation: "column", horizontal: "center"}) do %>
-          <div>
-            <%= pb_rails("title", props: { classname: "dark", margin_bottom: "lg", text: "Our Visual Language", tag: "h1", size: 1 }) %>
-            <%= pb_rails("body", props: {
-              classname: "dark",
-              text: "This page outlines the guiding principles that inform Playbook Design System's past, present, and future development.
-              These core concepts are the basis upon which every higher order design element is built.  Some of these principles have been abstracted into sass variables listed below."
-            }) %>
-          </div>
-        <% end %>
-      <% end %>
-      <%= pb_rails("background", props: { classname: "token-wrapper", background_color: "light", padding: "xl" }) do %>
-        <%= react_component("VisualGuidelines", examples: @kit_examples_json) %>
-      <% end %>
+  <%= pb_rails("background", props: { background_color: "dark", padding: "xl", classname: "visual_guidelines_hero" }) do %>
+    <%= pb_rails("flex", props: { classname: "header-text", orientation: "column", horizontal: "center"}) do %>
+      <div>
+        <%= pb_rails("title", props: { classname: "dark", margin_bottom: "lg", text: "Our Visual Language", tag: "h1", size: 1 }) %>
+        <%= pb_rails("body", props: {
+          classname: "dark",
+          text: "This page outlines the guiding principles that inform Playbook Design System's past, present, and future development.
+          These core concepts are the basis upon which every higher order design element is built.  Some of these principles have been abstracted into sass variables listed below."
+          }) %>
+      </div>
     <% end %>
+  <% end %>
+  <%= pb_rails("background", props: { classname: "token-wrapper", background_color: "light", padding: "xl" }) do %>
+    <%= react_component("VisualGuidelines", examples: @kit_examples_json) %>
   <% end %>
 </div>

--- a/playbook-website/app/views/pages/visual_guidelines_react.html.erb
+++ b/playbook-website/app/views/pages/visual_guidelines_react.html.erb
@@ -1,17 +1,26 @@
 <div class="visual_guidelines">
-  <%= pb_rails("background", props: { background_color: "dark", padding: "xl", classname: "visual_guidelines_hero" }) do %>
-    <%= pb_rails("flex", props: { classname: "header-text", orientation: "column", horizontal: "center"}) do %>
-      <div>
-        <%= pb_rails("title", props: { classname: "dark", margin_bottom: "lg", text: "Our Visual Language", tag: "h1", size: 1 }) %>
-        <%= pb_rails("body", props: {
-          classname: "dark",
-          text: "This page outlines the guiding principles that inform Playbook Design System's past, present, and future development.
-          These core concepts are the basis upon which every higher order design element is built.  Some of these principles have been abstracted into sass variables listed below."
-        }) %>
-      </div>
-    <% end %>
+<%= pb_rails("layout", props: {classname: "pb--page--content",variant: cookies[:dark_mode] == "true" ? 'dark' : 'light' }) do%>
+  <%= render 'layouts/mobile_hamburger' %>
+  <%= pb_rails("layout/sidebar", props: { classname: "pb--page--sideNav"}) do%> 
+    <%= react_component("ReactSidebar") %>
   <% end %>
-  <%= pb_rails("background", props: { classname: "token-wrapper", background_color: "light", padding: "xl" }) do %>
-    <%= react_component("VisualGuidelines", examples: @kit_examples_json) %>
+
+  <%= pb_rails("layout/body", props: {classname: "pb--page--content--main padding-override smooth-scroll"}) do%>
+      <%= pb_rails("background", props: { background_color: "dark", padding: "xl", classname: "visual_guidelines_hero" }) do %>
+        <%= pb_rails("flex", props: { classname: "header-text", orientation: "column", horizontal: "center"}) do %>
+          <div>
+            <%= pb_rails("title", props: { classname: "dark", margin_bottom: "lg", text: "Our Visual Language", tag: "h1", size: 1 }) %>
+            <%= pb_rails("body", props: {
+              classname: "dark",
+              text: "This page outlines the guiding principles that inform Playbook Design System's past, present, and future development.
+              These core concepts are the basis upon which every higher order design element is built.  Some of these principles have been abstracted into sass variables listed below."
+            }) %>
+          </div>
+        <% end %>
+      <% end %>
+      <%= pb_rails("background", props: { classname: "token-wrapper", background_color: "light", padding: "xl" }) do %>
+        <%= react_component("VisualGuidelines", examples: @kit_examples_json) %>
+      <% end %>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION

#### Screens
![Screen Shot 2022-09-07 at 11 30 28 AM](https://user-images.githubusercontent.com/73710701/188918614-d367d47a-7757-4ba8-bb41-a3e8121368c3.png)

![Screen Shot 2022-09-07 at 11 30 48 AM](https://user-images.githubusercontent.com/73710701/188918645-d4b50822-8249-47af-9a7f-568eb5239bf5.png)


#### Breaking Changes

No breaking changes, adding to playbook website only

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-311)

#### How to test this

Test in milano env

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
