### PR TITLE
[PLAY-317] - Visual Guidelines Improvements

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/LineHeight.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/LineHeight.tsx
@@ -8,6 +8,7 @@ import {
   Body,
   Caption,
   Card,
+  Flex
 } from 'playbook-ui'
 
 const HEIGHTS = ['tightest', 'tighter', 'tight', 'normal', 'loose', 'looser', 'loosest']
@@ -35,7 +36,12 @@ const LineHeight = ({ example, tokensExample }: {example: string, tokensExample?
         example={tokensExample}
         tokens={TOKENS}
     >
-      <div className="zindex-wrapper">
+      <Flex
+        align='center'
+        flexWrap='wrap'
+        justifyContent='center'
+        orientation='row'
+      >
         {Object.keys(TOKENS).map((token) => (
           <Card
               borderNone
@@ -51,7 +57,7 @@ const LineHeight = ({ example, tokensExample }: {example: string, tokensExample?
             />
           </Card>
         ))}
-      </div>
+      </Flex>
     </Example>
   </React.Fragment>
 )

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Positioning.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Positioning.tsx
@@ -6,6 +6,7 @@ import {
   Body,
   Caption,
   Card,
+  Flex
 } from 'playbook-ui'
 
 import Example from '../Templates/Example'
@@ -38,10 +39,16 @@ const Positioning = ({ example, tokensExample }: {example: string, tokensExample
         example={tokensExample}
         tokens={TOKENS}
     >
-      <div className="zindex-wrapper">
+      <Flex
+        align='center'
+        flexWrap='wrap'
+        justifyContent='center'
+        orientation='row'
+      >
+
         {Object.keys(TOKENS).map((token) => (
           <Card
-              className="zIndex one-z-index-example"
+              className="zIndex zIndex-card"
               key={`token-example-${token}`}
               shadow="deeper"
               zIndex={TOKENS[token]}
@@ -50,7 +57,7 @@ const Positioning = ({ example, tokensExample }: {example: string, tokensExample
             <Caption size="md">{`value: ${TOKENS[token]}`}</Caption>
           </Card>
         ))}
-      </div>
+      </Flex>
     </Example>
   </React.Fragment>
 )

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Spacing.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Spacing.tsx
@@ -50,7 +50,7 @@ const Spacing = ({ example, tokensExample }: {example: string, tokensExample?: s
         example={tokensExample}
         tokens={TOKENS}
     >
-      <Flex justify="evenly">
+      <Flex justify="evenly" wrap>
         { Object.keys(TOKENS).map((token) => (
           <Flex
               key={token}

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Spacing.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Spacing.tsx
@@ -10,25 +10,24 @@ import {
 } from 'playbook-ui'
 
 import Example from '../Templates/Example'
+import SpacingProps from '../Templates/SpacingProps'
 
 const PROPVALUES = ['none', 'xs', 'sm', 'md', 'lg', 'xl']
-
-const PROPS = {
-  margin: PROPVALUES,
-  marginLeft: PROPVALUES,
-  marginBottom: PROPVALUES,
-  marginRight: PROPVALUES,
-  marginTop: PROPVALUES,
-  marginX: PROPVALUES,
-  marginY: PROPVALUES,
-  padding: PROPVALUES,
-  paddingLeft: PROPVALUES,
-  paddingBottom: PROPVALUES,
-  paddingRight: PROPVALUES,
-  paddingTop: PROPVALUES,
-  paddingX: PROPVALUES,
-  paddingY: PROPVALUES,
-}
+const PROPNAMES = [
+  'margin', 
+  'marginLeft', 
+  'marginBottom', 
+  'marginRight', 
+  'marginTop', 
+  'marginX', 
+  'marginY', 
+  'padding', 
+  'paddingBottom', 
+  'paddingTop', 
+  'paddingLeft', 
+  'paddingRight', 
+  'paddingX', 
+  'paddingY' ]
 
 const TOKENS = {
   'Extra Small': 'space_xs',
@@ -41,11 +40,12 @@ const TOKENS = {
 const Spacing = ({ example, tokensExample }: {example: string, tokensExample?: string}) => (
   <React.Fragment>
     <Example
-        description="Used for building Kits: Spacing is sized by 8px which serves as the starting point and base that all spacing options follow."
-        example={example}
-        globalProps={PROPS}
-        title="Spacing"
-    />
+      description="Used for building Kits: Spacing is sized by 8px which serves as the starting point and base that all spacing options follow."
+      example={example}
+      title="Spacing"
+    >
+      <SpacingProps propValues={PROPVALUES} propNames={PROPNAMES} />
+    </Example>
     <Example
         example={tokensExample}
         tokens={TOKENS}

--- a/playbook-website/app/javascript/components/VisualGuidelines/Templates/SpacingProps.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Templates/SpacingProps.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable flowtype/no-types-missing-file-annotation */
+// React Pure component - do not use state!
+
+// This template is specifically for props section of the Spacing example.
+// All other examples use PropsValues.tsx
+// This template does not have a Visual Guide section.
+
+import React from "react";
+import {
+  Caption,
+  Card,
+  Flex,
+  FlexItem,
+  Pill,
+  SectionSeparator,
+} from "playbook-ui";
+
+type Props = {
+  propValues: string[];
+  propNames: string[];
+};
+
+const SpacingProps = ({ propNames, propValues }: Props): React.ReactElement => {
+  return (
+    <Flex
+      inline="flex-container"
+      justifyContent="center"
+      orientation="row"
+      vertical="stretch"
+    >
+      <FlexItem flex={1}>
+        <Card.Body>
+          <Caption marginBottom="sm" text="Props" />
+          {propNames.map((prop) => (
+            <Pill
+              key={prop}
+              text={prop}
+              marginRight="xs"
+              textTransform="none"
+            />
+          ))}
+        </Card.Body>
+      </FlexItem>
+      <SectionSeparator
+        marginBottom="md"
+        marginTop="md"
+        orientation="vertical"
+        variant="card"
+      />
+
+      <FlexItem flex={1}>
+        <Card.Body>
+          <Caption marginBottom="sm" text="Values" />
+          {propValues.map((value) => (
+            <Pill
+              key={value}
+              text={value}
+              marginRight="xs"
+              textTransform="none"
+              variant="warning"
+            />
+          ))}
+        </Card.Body>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default SpacingProps;

--- a/playbook-website/app/javascript/site_styles/_visual_guidelines.scss
+++ b/playbook-website/app/javascript/site_styles/_visual_guidelines.scss
@@ -54,6 +54,9 @@
       //width: 20%;
       background-color: white;
     }
+    .zIndex-card {
+      max-width: 100px;
+    }
     .two-zIndex {
       //width: 20%;
       //transform: translateX(-10px);


### PR DESCRIPTION

#### Screens

#### Spacing Props:
![Screen Shot 2022-09-08 at 11 19 54 AM](https://user-images.githubusercontent.com/73710701/189165303-168cf29b-d2e1-465d-8559-3e4c9142cba0.png)

#### Spacing Tokens on smaller screens:
![Screen Shot 2022-09-08 at 11 23 47 AM](https://user-images.githubusercontent.com/73710701/189165524-de3c7b56-0e5f-42f3-a1ad-862413eaec79.png)

#### LineHeight Tokens on smaller screens:
![Screen Shot 2022-09-08 at 11 20 35 AM](https://user-images.githubusercontent.com/73710701/189165436-a8659a68-5eaa-42fa-adfd-5946fd15e245.png)

#### Positioning Tokens on smaller screens:
![Screen Shot 2022-09-08 at 11 21 20 AM](https://user-images.githubusercontent.com/73710701/189165453-1f23776b-bd3b-475c-b14d-a9f10c54cb7f.png)

#### Breaking Changes

No breaking changes, edits to visual guidelines react styling

#### Runway Ticket URL

Screenshots of what screens looked like before changes can be seen on linked runway ticket: 

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-317)

#### How to test this

Review in milano env at /visual_guidelines_react 
Changes to Spacing, Positioning and Line Height examples
#### Make sure to review react version of visual guidelines (as specified in url above). No changes to rails version of guidelines

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
