### PR TITLE
[Play-301]- Timestamp Kit Last Updated Text as Optional Prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.jsx
@@ -21,6 +21,7 @@ type TimestampProps = {
   id?: string,
   showDate?: boolean,
   showUser?: boolean,
+  hideUpdated?: boolean,
   showTimezone?: boolean,
   variant?: "default" | "elapsed" | "updated"
 }
@@ -37,6 +38,7 @@ const Timestamp = (props: TimestampProps) => {
     timezone,
     showDate = true,
     showUser = false,
+    hideUpdated = false,
     showTimezone = false,
     variant = 'default',
   } = props
@@ -57,6 +59,7 @@ const Timestamp = (props: TimestampProps) => {
   const dateDisplay = `${dateTimestamp.toMonth()} ${dateTimestamp.toDay()}`
   const shouldShowUser = showUser == true && text.length > 0
   const shouldShowTimezone = showTimezone == true && timezone.length > 0
+  const updatedText = hideUpdated ? "" : "Last updated"
   const userDisplay = shouldShowUser ? ` by ${text}` : ''
 
   let timeDisplay = `${dateTimestamp.toHour()}:${dateTimestamp.toMinute()}${dateTimestamp.toMeridian()}`
@@ -81,7 +84,7 @@ const Timestamp = (props: TimestampProps) => {
   }
 
   const formatElapsedString = () => {
-    return `Last updated ${userDisplay} ${dateTimestamp.value.fromNow()}`
+    return `${updatedText} ${userDisplay} ${dateTimestamp.value.fromNow()}`
   }
 
   const captionText = () => {
@@ -89,7 +92,7 @@ const Timestamp = (props: TimestampProps) => {
     case 'updated':
       return formatUpdatedString(userDisplay, dateTimestamp)
     case 'elapsed':
-      return formatElapsedString(userDisplay, timeDisplay)
+      return formatElapsedString(userDisplay, timeDisplay, updatedText)
     default:
       return showDate ? timestamp ? fullDateDisplay() : text : fullTimeDisplay()
     }

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.html.erb
@@ -12,3 +12,12 @@
   variant: "elapsed",
   show_user: false
 }) %>
+
+<br>
+
+<%= pb_rails("timestamp", props: {
+  timestamp: DateTime.now,
+  variant: "elapsed",
+  show_user: false,
+  hide_updated: true
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.jsx
@@ -28,6 +28,16 @@ const TimestampElapsed = (props) => {
           variant="elapsed"
           {...props}
       />
+
+      <br />
+
+      <Timestamp
+          hideUpdated
+          showUser={false}
+          timestamp={customDate}
+          variant="elapsed"
+          {...props}
+      />
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
@@ -12,6 +12,8 @@ module Playbook
       prop :align,  type: Playbook::Props::Enum,
                     values: %w[left center right],
                     default: "left"
+      prop :hide_updated, type: Playbook::Props::Boolean,
+                          default: false
       prop :show_date, type: Playbook::Props::Boolean,
                        default: true
       prop :show_timezone, type: Playbook::Props::Boolean,
@@ -70,8 +72,9 @@ module Playbook
       def format_elapsed_string
         user_string = show_user ? " by #{text}" : ""
         datetime_string = " #{time_ago_in_words(pb_date_time.convert_to_timestamp)} ago"
+        updated_string = hide_updated ? "" : "Last updated"
 
-        "Last updated#{user_string}#{datetime_string}"
+        "#{updated_string}#{user_string}#{datetime_string}"
       end
 
       def datetime_or_text

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.test.js
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.test.js
@@ -1,0 +1,164 @@
+import React from "react";
+import { render, screen } from "../utilities/test-utils";
+
+import Timestamp from "./_timestamp";
+
+const TEST_DATE = "01/01/2020 00:00:000 GMT-0500";
+jest.setSystemTime(new Date(TEST_DATE));
+
+const testId = "timestamp-kit";
+const realDate = Date;
+const futureDate = new Date(
+  new Date().getFullYear() + 4,
+  new Date().getMonth(),
+  new Date().getDate(),
+  new Date().getHours(),
+  new Date().getMinutes()
+);
+
+beforeEach(() => {
+  global.Date.now = jest.fn(() => new Date(TEST_DATE).getTime());
+});
+
+afterEach(() => {
+  global.Date = realDate;
+});
+
+describe("Timestamp Kit", () => {
+  test("renders Timestamp className", () => {
+    render(
+      <Timestamp
+          align="left"
+          data={{ testid: testId }}
+          showDate
+          timestamp={new Date(Date.now())}
+      />
+    );
+
+    const kit = screen.getByTestId(testId);
+    expect(kit).toHaveClass("pb_timestamp_kit_left_variant");
+  });
+
+  test("renders Timestamp time", () => {
+    render(
+      <Timestamp
+          align="left"
+          data={{ testid: testId }}   
+          showDate={false}
+          timestamp={new Date(Date.now())}
+      />
+    );
+
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_xs");
+    expect(text.textContent).toEqual("12:00a");
+  });
+
+  test("renders Timestamp date and time with future year", () => {
+    render(
+      <Timestamp
+          align="left"
+          data={{ testid: testId }}
+          showDate
+          timestamp={new Date(futureDate)}
+      />
+    );
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_xs");
+    expect(text.textContent).toEqual("Jan 1, 2024  ·  12:00a");
+  });
+
+  test("renders Timestamp className with alignment", () => {
+    render(
+      <Timestamp
+          align="center"
+          data={{ testid: testId }}
+          showDate
+          timestamp={new Date(Date.now())}
+      />
+    );
+
+    const kit = screen.getByTestId(testId);
+    expect(kit).toHaveClass("pb_timestamp_kit_center_variant");
+  });
+
+  test("renders Timestamp timezone", () => {
+    render(
+      <Timestamp
+          align="left"
+          data={{ testid: testId }}
+          showDate={false}
+          showTimezone
+          timestamp={new Date()}
+          timezone="America/New_York"
+      />
+    );
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_xs");
+    expect(text.textContent).toEqual("12:00a EST");
+  });
+
+  test("renders Timestamp updated variant with user", () => {
+    render(
+      <Timestamp
+          data={{ testid: testId }}
+          showDate={false}
+          showUser
+          text="Maricris Nonato"
+          timestamp={new Date()}
+          variant="updated"
+      />
+    );
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_xs");
+    expect(text.textContent).toEqual(
+      "Last updated  by Maricris Nonato on Jan 1 at 12:00a"
+    );
+  });
+
+  test("renders Timestamp updated variant without user", () => {
+    render(
+      <Timestamp
+          data={{ testid: testId }}
+          showDate={false}
+          timestamp={new Date()}
+          variant="updated"
+      />
+    );
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_xs");
+    expect(text.textContent).toEqual("Last updated  on Jan 1 at 12:00a");
+  });
+
+  test("renders Timestamp elapsed variant with user", () => {
+    render(
+      <Timestamp
+          data={{ testid: testId }}
+          showUser
+          text="Maricris Nonato"
+          timestamp={new Date()}
+          variant="elapsed"
+      />
+    );
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_xs");
+    expect(text.textContent).toEqual(
+      "Last updated  by Maricris Nonato a few seconds ago"
+    );
+  });
+
+  test("renders Timestamp elapsed variant without user and without updated text", () => {
+    render(
+      <Timestamp
+          data={{ testid: testId }}
+          hideUpdated
+          showUser={false}
+          timestamp={new Date()}
+          variant="elapsed"
+      />
+    );
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_xs");
+    expect(text.textContent).toEqual("  a few seconds ago");
+  });
+});


### PR DESCRIPTION

#### Screens

![Screen Shot 2022-09-09 at 11 00 36 AM](https://user-images.githubusercontent.com/73710701/189409485-d6a86bd6-671c-40be-bdea-1c6ced292c0e.png)


#### Breaking Changes

No breaking changes, added a new optional prop that allows users to not display 'Last Updated' text on elapsed variant. Default is set to display the text.

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-301)

#### How to test this

Review Timestamp Kit in milano env, example titled 'Time Ago'. Last item in example should display timestamp without 'Last updated' Text prefixing it.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
