### PR TITLE
Add default to position prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
@@ -46,7 +46,8 @@ module Playbook
       prop :plugins, type: Playbook::Props::Boolean,
                      default: false,
                      deprecated: true
-      prop :position, type: Playbook::Props::String
+      prop :position, type: Playbook::Props::String,
+                      default: "auto"
       prop :position_element, type: Playbook::Props::String
       prop :scroll_container, type: Playbook::Props::String
       prop :selection_type, type: Playbook::Props::Enum,

--- a/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Playbook::PbDatePicker::DatePicker do
   it { is_expected.to define_prop(:picker_id).of_type(Playbook::Props::String).that_is_required }
   it { is_expected.to define_prop(:placeholder).of_type(Playbook::Props::String) }
   it { is_expected.to define_prop(:plugins).of_type(Playbook::Props::Boolean).with_default(false) }
-  it { is_expected.to define_prop(:position).of_type(Playbook::Props::String) }
+  it { is_expected.to define_prop(:position).of_type(Playbook::Props::String).with_default("auto") }
   it { is_expected.to define_prop(:position_element).of_type(Playbook::Props::String) }
   it { is_expected.to define_prop(:scroll_container).of_type(Playbook::Props::String) }
   it { is_expected.to define_prop(:static_position).of_type(Playbook::Props::Boolean).with_default(true) }


### PR DESCRIPTION
Fixed console error on opening datepicker in Rails only
____

#### Screens

<img width="1048" alt="Screen Shot 2022-09-14 at 2 21 19 PM" src="https://user-images.githubusercontent.com/2293844/190232458-5fedde8e-fcbd-4742-8442-521823060de7.png">


#### Breaking Changes

No

#### How to test this

Open the console, click on date picker rails example. See no error.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
