### PR TITLE
[PLAY-217]- Convert Date Range Stacked to TS + Added Jest Test

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/_date_range_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/_date_range_stacked.tsx
@@ -1,9 +1,7 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss } from '../utilities/props'
+import { buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -13,7 +11,7 @@ import DateYearStacked from '../pb_date_year_stacked/_date_year_stacked'
 import Icon from '../pb_icon/_icon'
 
 type DateRangeStackedProps = {
-  className?: string | array<string>,
+  className?: string | string[],
   data?: string,
   dark?: boolean,
   endDate: string,
@@ -22,15 +20,16 @@ type DateRangeStackedProps = {
 }
 
 const DateRangeStacked = (props: DateRangeStackedProps) => {
-  const { className, dark = false, endDate, startDate } = props
+  const { className, dark = false, endDate, startDate, data={} } = props
   const css = classnames(
     buildCss('pb_date_range_stacked'),
     globalProps(props),
     className
   )
+  const dataProps = buildDataProps(data)
 
   return (
-    <div className={css}>
+    <div {...dataProps} className={css}>
       <Flex vertical="center">
         <FlexItem>
           <DateYearStacked

--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/date_range_stacked.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/date_range_stacked.test.js
@@ -1,0 +1,127 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import DateRangeStacked from './_date_range_stacked'
+
+jest.useFakeTimers()
+const testId = "daterangestacked-kit";
+
+describe("DateRangeStacked Kit", () => {
+    test("renders DateRangeStacked className", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+        )
+
+        const kit = screen.getByTestId(testId)
+        expect(kit).toHaveClass("pb_date_range_stacked")
+    })
+
+    test("renders DateRangeStacked start date container", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const text = kit.querySelector('.pb_date_year_stacked_right')
+        expect(text).toBeInTheDocument()
+    })
+
+    test("renders DateRangeStacked end date container", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const text = kit.querySelector('.pb_date_year_stacked_left')
+        expect(text).toBeInTheDocument()
+    })
+
+    test("renders arrow icon", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const arrowicon = kit.querySelector('.pb_icon_kit.fa-fw.pb_date_range_stacked_arrow')
+        expect(arrowicon).toBeInTheDocument()
+    })
+
+
+    test("renders DateRangeInline start date", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+
+        )
+
+        const kit = screen.getByTestId(testId)
+        const text = kit.querySelector('.pb_date_year_stacked_right>.pb_title_kit_size_4')
+        expect(text.textContent).toEqual("18 JUN")
+    })
+
+    test("renders DateRangeInline start date year", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+
+        )
+
+        const kit = screen.getByTestId(testId)
+        const text = kit.querySelector(".pb_date_year_stacked_right>.pb_body_kit_light")
+        expect(text.textContent).toEqual("2019")
+    })
+
+    test("renders DateRangeInline end date", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+
+        )
+
+        const kit = screen.getByTestId(testId)
+        const text = kit.querySelector('.pb_date_year_stacked_left>.pb_title_kit_size_4')
+        expect(text.textContent).toEqual("20 MAR")
+    })
+
+    test("renders DateRangeInline end date year", () => {
+        render(
+            <DateRangeStacked
+                data={{ testid: testId }}
+                endDate={new Date('20 Mar 2020')}
+                startDate={new Date('18 Jun 2019')}
+            />
+
+        )
+
+        const kit = screen.getByTestId(testId)
+        const text = kit.querySelector(".pb_date_year_stacked_left>.pb_body_kit_light")
+        expect(text.textContent).toEqual("2020")
+    })
+
+
+})


### PR DESCRIPTION

#### Screens

![Screen Shot 2022-09-14 at 2 26 27 PM](https://user-images.githubusercontent.com/73710701/190233710-71b99ed9-9f4b-4b68-b8e0-e2f94710f6a9.png)


#### Breaking Changes

No breaking changes, converted .jsx file to .tsx and added Jest test

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-217)

#### How to test this

Review in milano env, confirm that kit example functions as expected.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
