### PR TITLE
[PLAY-262]- TS Conversion of Icon Value Kit + Jest Test

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon_value/_icon_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_value/_icon_value.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 
@@ -11,12 +9,12 @@ import Icon from '../pb_icon/_icon'
 
 type IconValueProps = {
   align?: "left" | "center" | "right",
-  aria?: object,
+  aria?: { [key: string]: string; },
   className?: string,
   dark?: boolean,
   data?: object,
   icon: string,
-  id?: number,
+  id?: string,
   text: string,
 }
 

--- a/playbook/app/pb_kits/playbook/pb_icon_value/icon_value.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_value/icon_value.test.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import IconValue from './_icon_value'
+
+const testId = "iconvalue-kit";
+
+describe("IconValue Kit", () => {
+    test("renders IconValue classname", () => {
+        render(
+            <IconValue
+                data={{ testid: testId }}
+                icon="clipboard"
+                text="33-123456"
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        expect(kit).toHaveClass("pb_icon_value_kit_left")
+    })
+
+    test("renders icon", () => {
+        render(
+            <IconValue
+                data={{ testid: testId }}
+                icon="clipboard"
+                text="33-123456"
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const icon = kit.querySelector(".fa-clipboard.pb_icon_kit.fa-fw")
+        expect(icon).toBeInTheDocument()
+    })
+
+    test("renders value", () => {
+        render(
+            <IconValue
+                data={{ testid: testId }}
+                icon="clipboard"
+                text="33-123456"
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const value = kit.querySelector(".pb_body_kit_light")
+        expect(value.textContent).toEqual("33-123456")
+    })
+
+    test("aligns content center", () => {
+        render(
+            <IconValue
+                align="center"
+                data={{ testid: testId }}
+                icon="clipboard"
+                text="33-123456"
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        expect(kit).toHaveClass("pb_icon_value_kit_center")
+    })
+
+    test("aligns content right", () => {
+        render(
+            <IconValue
+                align="right"
+                data={{ testid: testId }}
+                icon="clipboard"
+                text="33-123456"
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        expect(kit).toHaveClass("pb_icon_value_kit_right")
+    })
+})


### PR DESCRIPTION
#### Screens
![Screen Shot 2022-09-16 at 3 59 17 PM](https://user-images.githubusercontent.com/73710701/190723652-0bd54e86-0eba-45c3-b354-0034177de090.png)

#### Breaking Changes

No, converted .jsx file to .tsx and added jest test

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-262)

#### How to test this

Review in milano env, make sure examples work as expected

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
