### PR TITLE
PLAY-261-TS Conversion Icon Stat Value Kit + Jest Test

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon_stat_value/_icon_stat_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_stat_value/_icon_stat_value.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 
@@ -13,7 +11,7 @@ import IconCircle from '../pb_icon_circle/_icon_circle'
 import Title from '../pb_title/_title'
 
 type IconStatValueProps = {
-  aria?: object,
+  aria?: { [key: string]: string; },
   className?: string,
   data?: object,
   icon: string,
@@ -53,7 +51,7 @@ const IconStatValue = (props: IconStatValueProps) => {
     buildCss('pb_icon_stat_value_kit', orientation, size, variant), globalProps(props),
     className
   )
-  const titleSize = function(size) {
+  const titleSize = function(size: "sm" | "md" | "lg") {
     if (size == 'lg') {
       return (
         <Title

--- a/playbook/app/pb_kits/playbook/pb_icon_stat_value/_icon_stat_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_stat_value/_icon_stat_value.tsx
@@ -11,7 +11,7 @@ import IconCircle from '../pb_icon_circle/_icon_circle'
 import Title from '../pb_title/_title'
 
 type IconStatValueProps = {
-  aria?: { [key: string]: string; },
+  aria?: { [key: string]: string },
   className?: string,
   data?: object,
   icon: string,

--- a/playbook/app/pb_kits/playbook/pb_icon_stat_value/icon_stat_value.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_stat_value/icon_stat_value.test.js
@@ -1,0 +1,154 @@
+import React from 'react'
+import { cleanup, render, screen } from '../utilities/test-utils'
+
+import IconStatValue from './_icon_stat_value'
+
+const testId = "iconstatvalue-kit"
+
+describe("IconStatValue Kit", () => {
+    test("renders IconStatValue classname", () => {
+        render(
+            <IconStatValue
+                data={{ testid: testId }}
+                icon="lightbulb-on"
+                text="Electric"
+                unit="kw"
+                value={64.18}
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        expect(kit).toHaveClass("pb_icon_stat_value_kit_horizontal_sm_default")
+    })
+
+    test("renders icon", () => {
+        render(
+            <IconStatValue
+                data={{ testid: testId }}
+                icon="lightbulb-on"
+                text="Electric"
+                unit="kw"
+                value={64.18}
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const icon = kit.querySelector(".fa-lightbulb-on.pb_icon_kit.fa-fw")
+        expect(icon).toBeInTheDocument()
+    })
+
+    test("renders text", () => {
+        render(
+            <IconStatValue
+                data={{ testid: testId }}
+                icon="lightbulb-on"
+                text="Electric"
+                unit="kw"
+                value={64.18}
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const text = kit.querySelector(".pb_caption_kit_md")
+        expect(text.textContent).toEqual("Electric")
+    })
+
+    test("renders unit", () => {
+        render(
+            <IconStatValue
+                data={{ testid: testId }}
+                icon="lightbulb-on"
+                text="Electric"
+                unit="kw"
+                value={64.18}
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const unit = kit.querySelector(".pb_body_kit")
+        expect(unit.textContent).toEqual("kw")
+    })
+
+    test("renders value", () => {
+        render(
+            <IconStatValue
+                data={{ testid: testId }}
+                icon="lightbulb-on"
+                text="Electric"
+                unit="kw"
+                value={64.18}
+      />
+        )
+
+        const kit = screen.getByTestId(testId)
+        const value = kit.querySelector(".pb_title_kit_size_3")
+        expect(value.textContent).toEqual("64.18")
+    })
+
+    test("renders size prop", () => {
+        ["sm", 
+        "md", 
+        "lg"].forEach((sizeProp) => {
+            render(
+                <IconStatValue
+                    data={{ testid: testId }}
+                    icon="lightbulb-on"
+                    size={sizeProp}
+                    text="Electric"
+                    unit="kw"
+                    value={64.18}
+          />
+            )
+    
+            const kit = screen.getByTestId(testId)
+            expect(kit).toHaveClass(`pb_icon_stat_value_kit_horizontal_${sizeProp}_default`)
+
+            cleanup()
+        })
+    })
+
+    test("renders color prop", () => {
+        ["default",
+        "royal",
+        "blue",
+        "purple",
+        "teal",
+        "red",
+        "yellow",
+        "green"].forEach(
+            (colorProp) => {
+            render(
+                <IconStatValue
+                    data={{ testid: testId }}
+                    icon="lightbulb-on"
+                    text="Electric"
+                    unit="kw"
+                    value={64.18}
+                    variant={colorProp}
+          />
+            )
+    
+            const kit = screen.getByTestId(testId)
+            expect(kit).toHaveClass(`pb_icon_stat_value_kit_horizontal_sm_${colorProp}`)
+
+            cleanup()
+        }) 
+    })
+
+    test("renders vertical prop", () => {
+            render(
+                <IconStatValue
+                    data={{ testid: testId }}
+                    icon="lightbulb-on"
+                    orientation="vertical"
+                    text="Electric"
+                    unit="kw"
+                    value={64.18}
+          />
+            )
+    
+            const kit = screen.getByTestId(testId)
+            expect(kit).toHaveClass("pb_icon_stat_value_kit_vertical_sm_default")
+    })
+
+})


### PR DESCRIPTION
#### Screens
![Playbook-Design-System (10)](https://user-images.githubusercontent.com/73710701/191032070-e4781c25-ed1b-4186-85f8-8dc729e1add7.png)

#### Breaking Changes

No breaking changes, converted .jsx to .tsx and added jest test

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-261)

#### How to test this

review in milano env, make sure kit functions as expected in each example

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
