### PR TITLE
[PLAY-331] Section Separator Type Bug

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
@@ -7,13 +7,13 @@ import { globalProps } from '../utilities/globalProps'
 import Caption from '../pb_caption/_caption'
 
 type SectionSeparatorProps = {
-  aria: { [key: string]: string; },
-  className: string,
+  aria?: { [key: string]: string; },
+  className?: string,
   dark?: boolean,
-  data: { [key: string]: string; },
-  id: string,
+  data?: { [key: string]: string; },
+  id?: string,
   orientation?: "horizontal" | "vertical",
-  text: string,
+  text?: string,
   variant?: "card" | "background",
 }
 


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-09-19 at 2 37 34 PM](https://user-images.githubusercontent.com/8194056/191079164-4238fa50-dc7f-4941-962a-45b27ca1ad9f.png)

#### Breaking Changes

No breaking changes. The kit was obligating the user to declare props, but the `line separator` doesn't need any to work.

#### Runway Ticket URL

[[PLAY-331]
](https://nitro.powerhrg.com/runway/backlog_items/PLAY-331)

#### How to test this

- Run tests locally
- Try implementing the kit in different ways with and without props.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
