### PR TITLE
[PLAY-332] Bug - Text Input not full-width with addOn prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
@@ -103,7 +103,6 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
     <React.Fragment>
       <Flex
           className={`add-on-${addOnAlignment} ${borderCss}`}
-          inline
           vertical="center"
       >
         {addOnAlignment == 'left' && <>


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-09-19 at 3 56 25 PM](https://user-images.githubusercontent.com/8194056/191094192-ddfefbeb-83ac-420e-9ef6-7cc36485d8e2.png)

#### Breaking Changes

No breaking changes. Fixed the bug that was causing the input to not display in full-width.

#### Runway Ticket URL

[[PLAY-332]](https://nitro.powerhrg.com/runway/backlog_items/PLAY-332)

#### How to test this

Use Text Input kit sending the `addOn` prop. Test in multiple forms.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
