### PR TITLE
[PLAY-343]- Date Pickr SCSS Bug Fix

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_flatpickr_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_flatpickr_styles.scss
@@ -659,9 +659,6 @@ span.flatpickr-weekday {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   overflow: hidden;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
 }
 .flatpickr-time:after {
   content: "";


### PR DESCRIPTION
#### Screens

## What it looked like broken:
<img width="715" alt="screen-shot-2022-09-21-at-8-48-59-am" src="https://user-images.githubusercontent.com/73710701/191769243-8f6b28e6-c02d-4009-ae3d-7f3a045a7e96.png">

## What it looks like with fix:
![Screen Shot 2022-09-22 at 9 07 07 AM](https://user-images.githubusercontent.com/73710701/191755266-ca3045b8-cacc-4c90-882b-f726e904b61e.png)

#### Breaking Changes

No breaking changes, fixes to SCSS that were breaking date pickr with time variant in Nitro

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-343)

#### How to test this

Test in milano env as well as in nitro in dev_docs. Check to make sure 'Time Selection' version of date Pickr renders as expected and SCSS functions properly.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
