### PR TITLE
Limit Number of Jest Workers

### DIFF
--- a/playbook/jest.config.js
+++ b/playbook/jest.config.js
@@ -71,7 +71,7 @@ module.exports = {
   // globals: {},
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-  // maxWorkers: "50%",
+  maxWorkers: "2",
 
   // An array of directory names to be searched recursively up from the requiring module's location
   moduleDirectories: [


### PR DESCRIPTION
Often playbook builds use a large amount of memory, and are constantly sitting right up against their limits. We've seen OOMKills when there just aren't enough resources to go around. This will reduce the amount of memory used.

![image](https://user-images.githubusercontent.com/62253265/191811905-361a697b-2171-4172-b35d-f1a4e94c1f29.png)
