### PR TITLE
[PLAY-330]-Lightbox Kit Responsive on Mobile

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/Slides.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/Slides.tsx
@@ -10,19 +10,52 @@ type SlidesType = {
   current: number,
   onChange: (index: number) => void,
   onClick: (index: number) => void,
+  setIndex?: (index: number)=> void,
+
+
 }
 
 export default function Slides({
   urls = [],
   current = 0,
   onChange = noop,
+  setIndex,
+
 }: SlidesType): React.ReactElement {
   const [zooming, setZooming] = useState(false)
+
+  const [touchStart, setTouchStart] = useState(null)
+  const [touchEnd, setTouchEnd] = useState(null)
+
+const minSwipeDistance = 40 
+const onTouchStart = (e: React.TouchEvent) => {
+  setTouchEnd(null)
+  setTouchStart(e.targetTouches[0].clientX)
+}
+
+const onTouchMove = (e: React.TouchEvent) => setTouchEnd(e.targetTouches[0].clientX)
+
+const onTouchEnd = () => {
+  if (!touchStart || !touchEnd) return
+  const distance = touchStart - touchEnd
+  const isLeftSwipe = distance > minSwipeDistance
+  const isRightSwipe = distance < -minSwipeDistance
+  if (isLeftSwipe) {
+    setIndex(current < urls.length - 1 ? current + 1 : urls.length - 1)
+  } else if (isRightSwipe) {
+    setIndex(current > 0 ? current - 1 : 0)
+  }
+}
+
+
 
   const handleZoom = (isZooming: boolean) => setZooming(isZooming)
   return (
     <div
         className="Slides"
+        onTouchStart={onTouchStart} 
+        onTouchMove={onTouchMove} 
+        onTouchEnd={onTouchEnd}
     >
       <Slide
           onClick={() => onChange(current)}

--- a/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/Thumbnails.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/Thumbnails.tsx
@@ -28,10 +28,8 @@ export default function Thumbnails({
 }: ThumbnailsType): React.ReactElement {
   const viewportSize = useWindowSize()
   const thumbnailWidth = viewportSize.width / 8
-  const draggable = thumbnailWidth * urls.length > viewportSize.width
   const shouldBeCentered = (thumbnailWidth * urls.length) < (viewportSize.width * 0.9)
-  const css = classnames('Thumbnails', { draggable }, { centered: shouldBeCentered })
-
+  const css = classnames('Thumbnails', { centered: shouldBeCentered })
   const otherProps: { buttonRef?: React.RefObject<HTMLButtonElement> } = {}
 
   const thumbnailsRef: React.RefObject<HTMLDivElement>  = React.createRef()

--- a/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/index.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-control-statements/jsx-use-if-tag */
 import { noop } from 'lodash'
 import React, { useEffect } from 'react'
-
 import Slides from './Slides'
 import Thumbnails from './Thumbnails'
 

--- a/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/index.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/Carousel/index.tsx
@@ -17,6 +17,7 @@ type CarouselType = {
   }[],
   onChange: (index: number) => void,
   onClick?: (index: number) => void,
+  setIndex?: (index: number)=> void,
 }
 
 export default function Carousel({
@@ -24,6 +25,7 @@ export default function Carousel({
   photos,
   onClick = noop,
   onChange = noop,
+  setIndex,
 }: CarouselType): React.ReactElement {
   useEffect(() => {
     document.body.style.overflow = 'hidden'
@@ -40,6 +42,7 @@ export default function Carousel({
   return (
     <div className="Lightbox">
       <Slides
+          setIndex={setIndex}
           current={currentIndex}
           onChange={handleChange}
           onClick={onClick}

--- a/playbook/app/pb_kits/playbook/pb_lightbox/Header/_lightbox_header.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/Header/_lightbox_header.tsx
@@ -2,16 +2,16 @@
 /* @flow */
 import React, { useContext } from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
-import { globalProps, GlobalProps } from '../utilities/globalProps'
-import { LightboxContext } from './_lightbox_context'
+import { buildAriaProps, buildCss, buildDataProps } from '../../utilities/props'
+import { globalProps, GlobalProps } from '../../utilities/globalProps'
+import { LightboxContext } from '../_lightbox_context'
 import { LightboxHeaderIcon } from './_lightbox_header_icon'
-import { IconSizes } from '../pb_icon/_icon'
+import { IconSizes } from '../../pb_icon/_icon'
 
-import Caption from '../pb_caption/_caption'
-import Flex from '../pb_flex/_flex'
-import FlexItem from '../pb_flex/_flex_item'
-import Title from '../pb_title/_title'
+import Caption from '../../pb_caption/_caption'
+import Flex from '../../pb_flex/_flex'
+import FlexItem from '../../pb_flex/_flex_item'
+import Title from '../../pb_title/_title'
 
 type LightboxHeaderProps = {
   aria?: {[key: string]: string},

--- a/playbook/app/pb_kits/playbook/pb_lightbox/Header/_lightbox_header_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/Header/_lightbox_header_icon.tsx
@@ -1,8 +1,8 @@
 /* @flow */
 
 import React from 'react'
-import Icon from '../pb_icon/_icon'
-import {IconSizes} from '../pb_icon/_icon'
+import Icon from '../../pb_icon/_icon'
+import {IconSizes} from '../../pb_icon/_icon'
 
 type LightboxHeaderIconProps = {
   onClose: () => void,

--- a/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
@@ -49,12 +49,12 @@ const Lightbox = (props: LightboxType): React.ReactNode => {
   const [touchEnd, setTouchEnd] = useState(null)
 
 const minSwipeDistance = 40 
-const onTouchStart = (e: any) => {
+const onTouchStart = (e: React.TouchEvent) => {
   setTouchEnd(null)
   setTouchStart(e.targetTouches[0].clientX)
 }
 
-const onTouchMove = (e: any) => setTouchEnd(e.targetTouches[0].clientX)
+const onTouchMove = (e: React.TouchEvent) => setTouchEnd(e.targetTouches[0].clientX)
 
 const onTouchEnd = () => {
   if (!touchStart || !touchEnd) return

--- a/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
@@ -45,28 +45,6 @@ const Lightbox = (props: LightboxType): React.ReactNode => {
     title,
   } = props
   const [activePhoto, setActivePhoto] = useState(initialPhoto)
-  const [touchStart, setTouchStart] = useState(null)
-  const [touchEnd, setTouchEnd] = useState(null)
-
-const minSwipeDistance = 40 
-const onTouchStart = (e: React.TouchEvent) => {
-  setTouchEnd(null)
-  setTouchStart(e.targetTouches[0].clientX)
-}
-
-const onTouchMove = (e: React.TouchEvent) => setTouchEnd(e.targetTouches[0].clientX)
-
-const onTouchEnd = () => {
-  if (!touchStart || !touchEnd) return
-  const distance = touchStart - touchEnd
-  const isLeftSwipe = distance > minSwipeDistance
-  const isRightSwipe = distance < -minSwipeDistance
-  if (isLeftSwipe) {
-    setActivePhoto(activePhoto < photos.length - 1 ? activePhoto + 1 : photos.length - 1)
-  } else if (isRightSwipe) {
-    setActivePhoto(activePhoto > 0 ? activePhoto - 1 : 0)
-  }
-}
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
@@ -120,17 +98,12 @@ const onTouchEnd = () => {
               title={title}
           />
             {children}
-            <div
-            onTouchStart={onTouchStart} 
-            onTouchMove={onTouchMove} 
-            onTouchEnd={onTouchEnd}
-            >
             <Carousel
+                setIndex={setActivePhoto}
                 currentIndex={activePhoto}
                 onChange={handleOnSlide}
                 photos={photosMap}
             />
-            </div>
           </div>
         </div>
       </LightboxContext.Provider>

--- a/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
@@ -3,7 +3,7 @@ import { useKbdControls } from './hooks/useKbdControls'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
-import LightboxHeader from './_lightbox_header'
+import LightboxHeader from './Header/_lightbox_header'
 import { LightboxContext } from './_lightbox_context'
 import { IconSizes } from '../pb_icon/_icon'
 

--- a/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
@@ -45,6 +45,28 @@ const Lightbox = (props: LightboxType): React.ReactNode => {
     title,
   } = props
   const [activePhoto, setActivePhoto] = useState(initialPhoto)
+  const [touchStart, setTouchStart] = useState(null)
+  const [touchEnd, setTouchEnd] = useState(null)
+
+const minSwipeDistance = 40 
+const onTouchStart = (e: any) => {
+  setTouchEnd(null)
+  setTouchStart(e.targetTouches[0].clientX)
+}
+
+const onTouchMove = (e: any) => setTouchEnd(e.targetTouches[0].clientX)
+
+const onTouchEnd = () => {
+  if (!touchStart || !touchEnd) return
+  const distance = touchStart - touchEnd
+  const isLeftSwipe = distance > minSwipeDistance
+  const isRightSwipe = distance < -minSwipeDistance
+  if (isLeftSwipe) {
+    setActivePhoto(activePhoto < photos.length - 1 ? activePhoto + 1 : photos.length - 1)
+  } else if (isRightSwipe) {
+    setActivePhoto(activePhoto > 0 ? activePhoto - 1 : 0)
+  }
+}
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
@@ -98,11 +120,17 @@ const Lightbox = (props: LightboxType): React.ReactNode => {
               title={title}
           />
             {children}
+            <div
+            onTouchStart={onTouchStart} 
+            onTouchMove={onTouchMove} 
+            onTouchEnd={onTouchEnd}
+            >
             <Carousel
                 currentIndex={activePhoto}
                 onChange={handleOnSlide}
                 photos={photosMap}
             />
+            </div>
           </div>
         </div>
       </LightboxContext.Provider>

--- a/playbook/app/pb_kits/playbook/pb_lightbox/lightbox.scss
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/lightbox.scss
@@ -3,56 +3,7 @@
 
 $slides-margin: $space-md;
 
-.carousel {
-  .home-tour-main-content {
-    overflow-y: hidden;
-  }
-
-  .image-gallery-slide-wrapper {
-    width: 1024px;
-    height: 686px;
-  }
-
-  .image-gallery-slide div {
-    height: auto;
-  }
-
-  .image-gallery-slide .image-gallery-image {
-    max-height: 100% !important;
-    max-width: 100% !important;
-    height: 692px !important;
-    width: 100% !important;
-    object-fit: cover;
-  }
-
-  .image-gallery-left-nav .image-gallery-svg, .image-gallery-right-nav .image-gallery-svg {
-    height: 120px;
-    width: 30px;
-    opacity: 0.4;
-  }
-  .image-gallery-thumbnails {
-    overflow-x: auto;
-  }
-
-  .image-gallery-thumbnails-container {
-    width: 1024px;
-    padding-left: 4px;
-  }
-
-  .image-gallery-thumbnails {
-    padding-top: 3px;
-    background: #000;
-  }
-
-  .image-gallery-thumbnail-image {
-    height: 64px;
-    width: 93px;
-  }
-
-  .image-gallery-thumbnail + .image-gallery-thumbnail {
-    margin-left: 2px;
-    margin-top: 2px;
-  }
+ .carousel {
 
   .carousel-header {
     background: rgb(0, 0, 0);
@@ -92,12 +43,13 @@ $slides-margin: $space-md;
 
 .Lightbox {
   width: 100vw;
-  height: 100vh;
+  height: 100%;
   position: fixed;
   left: 0;
   top: 0;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   flex-direction: column;
   background-color: black;
   z-index: 1;
@@ -151,7 +103,6 @@ $slides-margin: $space-md;
 
   @media only screen and (max-width: $screen-xs-max) {
     margin-top: 30px;
-    // height: 80%;
   }
 
   img {
@@ -190,24 +141,15 @@ $slides-margin: $space-md;
 
 .Thumbnails {
   display: flex;
+  width: 100vw;
   padding: 3px;
-  overflow: auto;
-  position: absolute;
-  z-index: 1;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  // @media only screen and (max-width: $screen-xs-max) {
-  //   bottom: 105px;
-  // }
+  overflow: scroll;
+  z-index: 20;
   &.centered {
     justify-content: center;
   }
 }
 
-.Thumbnails.draggable {
-  align-self: flex-start;
-}
 
 .Thumbnail {
   padding: 3px;
@@ -221,6 +163,8 @@ $slides-margin: $space-md;
 
 .Thumbnail.active {
   padding: 6px;
+  display: flex;
+  align-items: center;
   background-color: white;
   box-shadow: 0 0 6px white;
 }

--- a/playbook/app/pb_kits/playbook/pb_lightbox/lightbox.scss
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/lightbox.scss
@@ -151,6 +151,7 @@ $slides-margin: $space-md;
 
   @media only screen and (max-width: $screen-xs-max) {
     margin-top: 30px;
+    // height: 80%;
   }
 
   img {
@@ -196,6 +197,11 @@ $slides-margin: $space-md;
   left: 0;
   right: 0;
   bottom: 0;
+  padding-bottom: env(safe-area-inset-bottom);
+  
+  // @media only screen and (max-width: $screen-xs-max) {
+  //   bottom: 105px;
+  // }
   &.centered {
     justify-content: center;
   }

--- a/playbook/app/pb_kits/playbook/pb_lightbox/lightbox.scss
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/lightbox.scss
@@ -197,8 +197,6 @@ $slides-margin: $space-md;
   left: 0;
   right: 0;
   bottom: 0;
-  padding-bottom: env(safe-area-inset-bottom);
-  
   // @media only screen and (max-width: $screen-xs-max) {
   //   bottom: 105px;
   // }


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-09-23 at 1 32 55 PM](https://user-images.githubusercontent.com/73710701/192025344-c3791f53-afb6-45ee-8c88-2e2d73ef3874.png)


#### Breaking Changes

No, fixes bug where thumbnails at bottom of screen were not visible on chrome and safari on mobile + adds swiping functionality to slides on mobile

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-330)

#### How to test this:
- On Browser: Test Lightbox kit 'Multiple', make sure thumbnails on bottom of screen scroll + active thumbnail stays centered on screen
- On Mobile: Test Lightbox kit 'Multiple', make sure thumbnails show up on bottom of screen, are scrollable and active thumbnail stays centered on screen. Test to make sure slides are swipeable.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
