### PR TITLE
[PLAY-344]- Add XXS Spacing Token

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Spacing.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Spacing.tsx
@@ -12,7 +12,7 @@ import {
 import Example from '../Templates/Example'
 import SpacingProps from '../Templates/SpacingProps'
 
-const PROPVALUES = ['none', 'xs', 'sm', 'md', 'lg', 'xl']
+const PROPVALUES = ['none', 'xxs', 'xs', 'sm', 'md', 'lg', 'xl']
 const PROPNAMES = [
   'margin', 
   'marginLeft', 
@@ -30,11 +30,12 @@ const PROPNAMES = [
   'paddingY' ]
 
 const TOKENS = {
-  'Extra Small': 'space_xs',
+  'XX Small': 'space_xxs',
+  'X Small': 'space_xs',
   'Small': 'space_sm',
   'Medium': 'space_md',
   'Large': 'space_lg',
-  'Extra Large': 'space_xl',
+  'X Large': 'space_xl',
 }
 
 const Spacing = ({ example, tokensExample }: {example: string, tokensExample?: string}) => (
@@ -55,6 +56,7 @@ const Spacing = ({ example, tokensExample }: {example: string, tokensExample?: s
           <Flex
               key={token}
               orientation="column"
+              align="center"
           >
             <FlexItem>
               <div className="pb--tokens-spacing-token-example">

--- a/playbook/app/pb_kits/playbook/tokens/_spacing.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_spacing.scss
@@ -1,9 +1,11 @@
+$space_xxs:   4px;
 $space_xs:    8px;
 $space_sm:    16px;
 $space_md:    24px;
 $space_lg:    32px;
 $space_xl:    40px;
 $spaces:(
+  space_xxs:  $space_xxs,
   space_xs:   $space_xs,
   space_sm:   $space_sm,
   space_md:   $space_md,

--- a/playbook/app/pb_kits/playbook/utilities/_spacing.scss
+++ b/playbook/app/pb_kits/playbook/utilities/_spacing.scss
@@ -1,6 +1,7 @@
 @import "../tokens/spacing";
 
 $space_classes: (
+	xxs: $space_xxs,
 	xs: $space_xs,
 	sm: $space_sm,
 	md: $space_md,

--- a/playbook/lib/playbook/spacing.rb
+++ b/playbook/lib/playbook/spacing.rb
@@ -40,7 +40,7 @@ module Playbook
     end
 
     def spacing_values
-      %w[none xs sm md lg xl]
+      %w[none xxs xs sm md lg xl]
     end
 
     def spacing_props


### PR DESCRIPTION
#### Screens
![Screen Shot 2022-09-29 at 2 12 27 PM](https://user-images.githubusercontent.com/73710701/193112796-7f8d40e1-15d9-4cec-9a91-9f0c888e9c7f.png)

#### Breaking Changes

No breaking changes, adds a new size for spacing tokens (xxs)

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-344)

#### How to test this

Review in milano env.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
