### PR TITLE
[PLAY-368] Lists kit docs are broken

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_list/docs/_description.md
+++ b/playbook/app/pb_kits/playbook/pb_list/docs/_description.md
@@ -2,6 +2,8 @@ Lists display a vertical set of related content.
 
  **Layout Prop**
  
- - Setting the `layout` prop to either `left` or `right` creates a 2 column layout on the the list/item kit. This is useful if you need 2 things on the same line in a list.
- - Using `layout:'left'` will make the first column shrink and the second column grow and align to the left.
- - Using `layout:'right'` will make the first column grow and push the second column to the right.
+ Setting the `layout` prop to either `left` or `right` creates a 2 column layout on the the list/item kit. This is useful if you need 2 things on the same line in a list.
+ 
+ Using `layout:'left'` will make the first column shrink and the second column grow and align to the left.
+ 
+ Using `layout:'right'` will make the first column grow and push the second column to the right.


### PR DESCRIPTION
#### Screens

[INSERT SCREENSHOT]
![Screen Shot 2022-10-10 at 1 29 30 PM](https://user-images.githubusercontent.com/8194056/194922410-7ef68fc2-b37e-43d0-8441-8e842687942e.png)

[Yes/No (Explain)]

No breaking changes, just removing a `li` with flex display that was breaking the code responsiveness.

[[PLAY-368]](https://nitro.powerhrg.com/runway/backlog_items/PLAY-368) 

#### How to test this

Open milano environment and resize your screen.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
