### PR TITLE
[PLAY-347] Filter Kit Dropdown updates

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_close_popover.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_close_popover.jsx
@@ -7,7 +7,7 @@ const FilterClosePopover = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
 
   return (
@@ -17,6 +17,7 @@ const FilterClosePopover = (props) => {
           'Full Name': 'John Wick',
           'City': 'San Francisco',
         }}
+        minWidth="375px"
         results={1}
         sortOptions={{
           popularity: 'Popularity',

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.html.erb
@@ -1,5 +1,6 @@
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "1",
     filters: [
       { name: "name", value: "John Wick" },
@@ -16,21 +17,16 @@
 %>
   <%
     example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
   <%= pb_rails("form", props: { form_system_options: { scope: :example, method: :get } }) do |form| %>
     <%= form.text_field :example_text_field, props: { label: true } %>
-    <%= form.collection_select :example_collection_select, example_collection, :value, :name, props: { label: true } %>
+    <%= form.collection_select :example_collection_select, example_collection, :value, :name, props: {max_width: "sm", label: true } %>
 
     <%= form.actions do |action| %>
       <%= action.submit props: { text: "Apply", data: { disable_with: "<i class='far fa-spinner fa-spin mr-3'></i>Searching...".html_safe },}%>
@@ -44,8 +40,8 @@
 
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "def2",
-
     sort_menu: [
       { item: "Popularity", link: "?q[sorts]=managers_popularity+asc", active: true, direction: "desc" },
       { item: "Mananger's Title", link: "?q[sorts]=managers_title+asc", active: false },
@@ -57,21 +53,16 @@
 %>
   <%
     example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
   <%= pb_rails("form", props: { form_system_options: { scope: :example, method: :get } }) do |form| %>
     <%= form.text_field :example_text_field, props: { label: true } %>
-    <%= form.collection_select :example_collection_select, example_collection, :value, :name, props: { label: true } %>
+    <%= form.collection_select :example_collection_select, example_collection, :value, :name, props: {max_width: "sm", label: true } %>
 
     <%= form.actions do |action| %>
       <%= action.submit props: { text: "Apply", data: { disable_with: "<i class='far fa-spinner fa-spin mr-3'></i>Searching...".html_safe },}%>

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.jsx
@@ -11,7 +11,7 @@ const FilterDefault = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
   return (
 
@@ -22,6 +22,7 @@ const FilterDefault = (props) => {
             'Full Name': 'John Wick',
             'City': 'San Francisco',
           }}
+          minWidth="375px"
           onSortChange={SortingChangeCallback}
           results={1}
           sortOptions={{
@@ -43,6 +44,7 @@ const FilterDefault = (props) => {
         <Select
             blankSelection="Select One..."
             label="Territory"
+            maxWidth="sm"
             name="location"
             options={options}
             {...props}
@@ -67,6 +69,7 @@ const FilterDefault = (props) => {
 
       <Filter
           double
+          minWidth="375px"
           onSortChange={SortingChangeCallback}
           results={1}
           sortOptions={{

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_min_width.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_min_width.html.erb
@@ -1,6 +1,6 @@
 <%=
   pb_rails("filter", props: {
-    min_width: "600px",
+    min_width: "375px",
     id: "25",
     position: "top",
     filters: [
@@ -17,17 +17,12 @@
   }) do
 %>
   <%
-    example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+   example_collection = [
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
   <%= pb_rails("form", props: { form_system_options: { scope: :example, method: :get } }) do |form| %>

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_min_width.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_min_width.jsx
@@ -7,7 +7,7 @@ const FilterMinWidth = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
   return (
     <Filter
@@ -17,7 +17,7 @@ const FilterMinWidth = (props) => {
           'Full Name': 'John Wick',
           'City': 'San Francisco',
         }}
-        minWidth="600px"
+        minWidth="375px"
         results={1}
         sortOptions={{
           popularity: 'Popularity',

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_background.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_background.html.erb
@@ -1,5 +1,6 @@
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "3",
     background: false,
     filters: [
@@ -16,17 +17,12 @@
   }) do
 %>
   <%
-    example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+     example_collection = [
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
 
@@ -45,6 +41,7 @@
 
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "4",
     background: false,
     filters: [
@@ -61,16 +58,11 @@
 %>
   <%
     example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
   <%= pb_rails("form", props: { form_system_options: { scope: :example, method: :get } }) do |form| %>

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_background.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_background.jsx
@@ -7,7 +7,7 @@ const FilterNoBackground = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
   return (
     <>
@@ -17,6 +17,7 @@ const FilterNoBackground = (props) => {
           'Full Name': 'John Wick',
           'City': 'Las Vegas',
         }}
+          minWidth="375px"
           results={3}
           sortOptions={{
           popularity: 'Popularity',
@@ -64,6 +65,7 @@ const FilterNoBackground = (props) => {
           'Full Name': 'John Wick',
           'City': 'Las Vegas',
         }}
+          minWidth="375px"
           results={3}
           sortOptions={{
           popularity: 'Popularity',

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_sort.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_sort.html.erb
@@ -1,5 +1,6 @@
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "nosort",
     filters: [
       { name: "name", value: "John Wick" }
@@ -9,17 +10,12 @@
   }) do
 %>
   <%
-    example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+   example_collection = [
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
 

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_sort.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_sort.jsx
@@ -7,13 +7,14 @@ const FilterNoSort = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
   return (
     <Filter
         filters={{
           'Full Name': 'John Wick',
         }}
+        minWidth="375px"
         results={546}
         sortValue={[{ name: 'popularity', dir: 'desc' }]}
         {...props}

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_only.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_only.html.erb
@@ -1,5 +1,6 @@
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "fo",
     filters: [
       { name: "name", value: "John Wick" }
@@ -8,17 +9,12 @@
   }) do
 %>
   <%
-    example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+   example_collection = [
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
   <%= pb_rails("form", props: { form_system_options: { scope: :example, method: :get } }) do |form| %>

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_only.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_only.jsx
@@ -7,11 +7,12 @@ const FilterOnly = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
   return (
     <Filter
         filters={{ 'Full Name': 'John Wick' }}
+        minWidth="375px"
         {...props}
     >
       <TextInput

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_placement.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_placement.html.erb
@@ -1,5 +1,6 @@
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "pla",
     filters: [
       { name: "name", value: "John Wick" }
@@ -9,17 +10,12 @@
   }) do
 %>
   <%
-    example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+   example_collection = [
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
   <%= pb_rails("form", props: { form_system_options: { scope: :example, method: :get } }) do |form| %>

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_placement.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_placement.jsx
@@ -11,13 +11,14 @@ const FilterPlacement = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
   return (
 
     <>
       <Filter
           double
+          minWidth="375px"
           onSortChange={SortingChangeCallback}
           placement={"right"}
           results={1}

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_single.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_single.html.erb
@@ -1,5 +1,6 @@
 <%=
   pb_rails("filter", props: {
+    min_width: "375px",
     id: "2",
     filters: [
       { name: "name", value: "John Wick" }
@@ -14,17 +15,12 @@
   }) do
 %>
   <%
-    example_collection = [
-      OpenStruct.new(name: "Alabama", value: 1),
-      OpenStruct.new(name: "Alaska", value: 2),
-      OpenStruct.new(name: "Arizona", value: 3),
-      OpenStruct.new(name: "Arkansas", value: 4),
-      OpenStruct.new(name: "California", value: 5),
-      OpenStruct.new(name: "Colorado", value: 6),
-      OpenStruct.new(name: "Connecticut", value: 7),
-      OpenStruct.new(name: "Delaware", value: 8),
-      OpenStruct.new(name: "Florida", value: 9),
-      OpenStruct.new(name: "Georgia", value: 10),
+   example_collection = [
+      OpenStruct.new(name: "USA", value: 1),
+      OpenStruct.new(name: "Canada", value: 2),
+      OpenStruct.new(name: "Brazil", value: 3),
+      OpenStruct.new(name: "Philippines", value: 4),
+      OpenStruct.new(name: "A galaxy far far away, like really far away...", value: 5)
     ]
   %>
 

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_single.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_single.jsx
@@ -13,13 +13,14 @@ const FilterSingle = (props) => {
     { value: 'Canada' },
     { value: 'Brazil' },
     { value: 'Philippines' },
-    { value: 'A Galaxy Far Far Away Like Really Far Away' },
+    { value: 'A galaxy far far away, like really far away...' },
   ]
   return (
     <Filter
         filters={{
           'Full Name': 'John Wick',
         }}
+        minWidth="375px"
         results={546}
         sortOptions={{
           popularity: 'Popularity',


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-10-10 at 1 41 15 PM](https://user-images.githubusercontent.com/73671109/194927102-534e26e4-e7ef-4c2f-b9fc-7403e5f6d90b.png)

* If you add a max width, then the dropdown select will grow to the designated size, but will not truncate the actual items in the menu
* 
![Screen Shot 2022-10-10 at 2 03 50 PM](https://user-images.githubusercontent.com/73671109/194927428-13082eae-68a7-4b65-93da-652c3f2e51bf.png)

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-347)

#### How to test this

[INSERT TESTING DETAILS]

N/A

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
