### PR TITLE
[PLAY-378] Table kit doc example buttons should be right aligned

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.html.erb
@@ -15,7 +15,7 @@
       <td>Value 3</td>
       <td>Value 4</td>
       <td>
-        <%= pb_rails("flex") do %>
+        <%= pb_rails("flex", props: { justify: "end" }) do %>
             <%= pb_rails("body", props: {classname: "flex-item"}) do %>  
                 <%= pb_rails("circle_icon_button", props: { variant: "link", icon: "pencil" }) %>
             <% end %>
@@ -31,7 +31,7 @@
       <td>Value 3</td>
       <td>Value 4</td>
       <td>
-        <%= pb_rails("flex") do %>
+        <%= pb_rails("flex", props: { justify: "end" }) do %>
             <%= pb_rails("body", props: {classname: "flex-item"}) do %>  
                 <%= pb_rails("circle_icon_button", props: { variant: "link", icon: "pencil" }) %>
             <% end %>
@@ -46,8 +46,8 @@
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td>
-        <%= pb_rails("flex") do %>
+      <td align="right">
+        <%= pb_rails("flex", props: { justify: "end" }) do %>
             <%= pb_rails("body", props: {classname: "flex-item"}) do %>  
                 <%= pb_rails("circle_icon_button", props: { variant: "link", icon: "pencil" }) %>
             <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.jsx
@@ -27,8 +27,11 @@ const TableIconButtons = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
-            <Flex orientation="row">
+          <td align="right">
+            <Flex
+                justifyContent="end"
+                orientation="row"
+            >
               <FlexItem>
                 <CircleIconButton
                     icon="trash-alt"
@@ -51,8 +54,11 @@ const TableIconButtons = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
-            <Flex orientation="row">
+          <td align="right">
+            <Flex 
+                justifyContent="end"
+                orientation="row"
+            >
               <FlexItem>
                 <CircleIconButton
                     icon="trash-alt"
@@ -74,9 +80,12 @@ const TableIconButtons = (props) => {
           <td>{'Value 1'}</td>
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>
-            <Flex orientation="row">
+          <td>{'Value lk'}</td>
+          <td align="right">
+            <Flex 
+                justifyContent="end"
+                orientation="row"
+            >
               <FlexItem>
                 <CircleIconButton
                     icon="trash-alt"

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.html.erb
@@ -14,21 +14,21 @@
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
+      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
     </tr>
     <tr>
       <td>Value 1</td>
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
+      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
     </tr>
     <tr>
       <td>Value 1</td>
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
+      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
     </tr>
   </tbody>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.jsx
@@ -24,7 +24,7 @@ const TableOneAction = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -40,7 +40,7 @@ const TableOneAction = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -56,7 +56,7 @@ const TableOneAction = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.html.erb
@@ -14,8 +14,8 @@
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td>
-      <%= pb_rails("button", props: { text: "Tetriary Action", variant: "link", padding_left: "none" }) %>
+      <td align="right">
+      <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
       <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
       </td>
     </tr>
@@ -24,8 +24,8 @@
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td>
-      <%= pb_rails("button", props: { text: "Tetriary Action", variant: "link", padding_left: "none" }) %>
+      <td align="right">
+      <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
       <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
       </td>
     </tr>
@@ -34,8 +34,8 @@
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td>
-      <%= pb_rails("button", props: { text: "Tetriary Action", variant: "link", padding_left: "none" }) %>
+      <td align="right">
+      <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
       <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
       </td>    
       </tr>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.jsx
@@ -24,7 +24,7 @@ const TableOneAction = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 paddingLeft="none"
@@ -45,7 +45,7 @@ const TableOneAction = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 paddingLeft="none"
@@ -66,7 +66,7 @@ const TableOneAction = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 paddingLeft="none"

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.html.erb
@@ -14,21 +14,21 @@
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
+      <td align="right"> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
     </tr>
     <tr>
       <td>Value 1</td>
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
+      <td align="right"> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
     </tr>
     <tr>
       <td>Value 1</td>
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
-      <td> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
+      <td align="right"> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
       </tr>
   </tbody>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.jsx
@@ -24,7 +24,7 @@ const TableTwoPlusActions = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             {' '}
             <CircleIconButton
                 icon="ellipsis-h"
@@ -38,7 +38,7 @@ const TableTwoPlusActions = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             {' '}
             <CircleIconButton
                 icon="ellipsis-h"
@@ -53,7 +53,7 @@ const TableTwoPlusActions = (props) => {
           <td>{'Value 2'}</td>
           <td>{'Value 3'}</td>
           <td>{'Value 4'}</td>
-          <td>
+          <td align="right">
             {' '}
             <CircleIconButton
                 icon="ellipsis-h"


### PR DESCRIPTION
____

#### Screens

![Screen Shot 2022-10-10 at 2 29 16 PM](https://user-images.githubusercontent.com/8194056/194930874-db5879b1-ff49-4775-a7b7-8dc85781cf5c.png)

#### Breaking Changes

No breaking changes, just add change the flex alignment of last column.

#### Runway Ticket URL

[[PLAY-378]](https://nitro.powerhrg.com/runway/backlog_items/PLAY-378)

#### How to test this

Check milano and see if the buttons are right aligned. Resize your screen to see if it looks good in different resolutions

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
