### PR TITLE
[PLAY-376] Table kit missing space between doc examples

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_alignment_shift_data.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_alignment_shift_data.jsx
@@ -4,68 +4,75 @@ import Table from '../_table'
 
 const TableAlignmentShiftData = (props) => {
   return (
-    <Table
-        {...props}
-    >
-      <thead>
-        <tr>
-          <th>&nbsp;</th>
-          <th>{'Price'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td shift="down">{'Total'}</td>
-          <td>
-            {'$12'}
-            <br />
-            {'$46'}
-            <br />
-            {'$25'}
-            <br />
-            {'-------'}
-            <br />
-            {'$83'}
-          </td>
-        </tr>
-      </tbody>
-      <thead>
-        <tr>
-          <th>{'Espresso Drinks'}</th>
-          <th>{'Ingredients'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td shift="up">{'Cappuccino'}</td>
-          <td>
-            {'Espresso'}
-            <br />
-            {'Steamed Milk'}
-            <br />
-            {'Milk Foam'}
-          </td>
-        </tr>
-        <tr>
-          <td shift="up">{'Macchiato'}</td>
-          <td>
-            {'Espresso'}
-            <br />
-            {'Steamed Milk'}
-          </td>
-        </tr>
-        <tr>
-          <td shift="up">{'Mocha'}</td>
-          <td>
-            {'Espresso'}
-            <br />
-            {'Hot Chocolate'}
-            <br />
-            {'Steamed Milk'}
-          </td>
-        </tr>
-      </tbody>
-    </Table>
+    <div>
+      <Table
+          marginBottom="md"
+          {...props}
+      >
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            <th>{'Price'}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td shift="down">{'Total'}</td>
+            <td>
+              {'$12'}
+              <br />
+              {'$46'}
+              <br />
+              {'$25'}
+              <br />
+              {'-------'}
+              <br />
+              {'$83'}
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+      <Table
+          {...props}
+      >
+        <thead>
+          <tr>
+            <th>{'Espresso Drinks'}</th>
+            <th>{'Ingredients'}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td shift="up">{'Cappuccino'}</td>
+            <td>
+              {'Espresso'}
+              <br />
+              {'Steamed Milk'}
+              <br />
+              {'Milk Foam'}
+            </td>
+          </tr>
+          <tr>
+            <td shift="up">{'Macchiato'}</td>
+            <td>
+              {'Espresso'}
+              <br />
+              {'Steamed Milk'}
+            </td>
+          </tr>
+          <tr>
+            <td shift="up">{'Mocha'}</td>
+            <td>
+              {'Espresso'}
+              <br />
+              {'Hot Chocolate'}
+              <br />
+              {'Steamed Milk'}
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+    </div>
   )
 }
 


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-10-10 at 2 45 44 PM](https://user-images.githubusercontent.com/73671109/194933053-10643785-b2dd-4912-9841-101b4f8c50dd.png)

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-376)

#### How to test this

N/A

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
