### PR TITLE
[PLAY-389]-Page Title Spacing Bug Fix

### DIFF
--- a/playbook-website/app/views/pages/kit_category_show.html.erb
+++ b/playbook-website/app/views/pages/kit_category_show.html.erb
@@ -1,5 +1,5 @@
 <div class="pb--kits">
-  <%= pb_rails("title", props: { text: pb_kit_title(@category), tag: "h1", size: 1 }) %>
+  <%= pb_rails("title", props: { text: pb_kit_title(@category), tag: "h1", size: 1, margin_top:"xl" }) %>
   <br>
   <div class="pb--kit-type-nav">
     <%= pb_rails("nav", props: { orientation: "horizontal" }) do %>

--- a/playbook-website/app/views/pages/kits.html.erb
+++ b/playbook-website/app/views/pages/kits.html.erb
@@ -1,5 +1,5 @@
 <div class="pb--kits">
-  <%= pb_rails("title", props: { text: "Kits", tag: "h1", size: 1 }) %>
+  <%= pb_rails("title", props: { text: "Kits", tag: "h1", size: 1, margin_top:"xl" }) %>
   <br>
   <%= pb_rails("nav", props: { orientation: "horizontal" }) do %>
     <%= pb_rails("nav/item", props: { text: "Rails", link: kits_path('', type: 'rails'), active: @type == 'rails' }) %>


### PR DESCRIPTION

#### Screens

![Screen Shot 2022-10-10 at 2 45 11 PM](https://user-images.githubusercontent.com/73710701/194933231-c1403395-6931-4173-88f7-5fb8cc086654.png)

![Screen Shot 2022-10-10 at 2 45 19 PM](https://user-images.githubusercontent.com/73710701/194933240-f21e6c51-433c-4130-a01c-4dca56ae50cb.png)

#### Breaking Changes

No breaking changes, fixes UI issue on playbook website kits page.

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-389)

#### How to test this

review in milano env

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
