### PR TITLE
[PLAY-369] Getting Started markdown code background styling is the wrong color

### DIFF
--- a/playbook-website/app/javascript/site_styles/_getting_started.scss
+++ b/playbook-website/app/javascript/site_styles/_getting_started.scss
@@ -9,7 +9,6 @@
   .markdown {
     code {
       // override
-      background: none;
       @at-root pre {
         background: $bg_dark;
         padding: $space_sm;


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-10-10 at 3 00 51 PM](https://user-images.githubusercontent.com/73671109/194935252-d1afc632-f70b-4d0f-8001-475207283b9c.png)


#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-369)

#### How to test this

N/A

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
