### PR TITLE
[PLAY-401] Rich Text Editor bullet pointing styling misaligned

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
@@ -95,6 +95,12 @@
     a {
       cursor: pointer;
     }
+    ol,
+    ul {
+      li {
+        margin-left: $space_sm;
+      }
+    }
   }
   trix-toolbar {
     .trix-button--icon {


### PR DESCRIPTION

#### Screens

<img width="1402" alt="image" src="https://user-images.githubusercontent.com/8194056/195120370-4c3fe0bb-a433-4732-b414-56877191f3eb.png">

![image](https://user-images.githubusercontent.com/8194056/195127759-8e54ae98-cf54-4c35-888a-d77070cd157a.png)

#### Breaking Changes

No breaking changes, but it should be tested in nitro because a workaround for this issue may have already been implement.

#### Runway Ticket URL

[[PLAY-401]](https://nitro.powerhrg.com/runway/backlog_items/PLAY-401) 

#### How to test this

Open the `rich text editor` kit on the milano build, create some `ol` and `ul` 

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
