### PR TITLE
[PLAY-426]-Top Nav Z Index Fix

### DIFF
--- a/playbook-website/app/javascript/site_styles/_site-style.scss
+++ b/playbook-website/app/javascript/site_styles/_site-style.scss
@@ -21,6 +21,7 @@ body {
     flex: 0 0;
     padding: $space_sm $space_md $space_xs $space_md;
     background: $white;
+    border-bottom: $border_light 1px solid;
     h1 {
       display: flex;
       align-items: center;

--- a/playbook-website/app/views/layouts/_nav.html.erb
+++ b/playbook-website/app/views/layouts/_nav.html.erb
@@ -54,7 +54,6 @@
   <%= react_component("KitSearch", classname: "mobile-kit-search", id: "mobile-kit-search", kits: search_list()) %>
 </div>
 
-<%= pb_rails("section_separator", props: {z_index: "5"})%>
 <% flash.each do |name, msg| %>
   <% name = "success" if name == "notice" %>
   <%= pb_rails("fixed_confirmation_toast", props: { text: msg, status: name }) %>


### PR DESCRIPTION

#### Screens
![Screen Shot 2022-10-12 at 12 02 26 PM](https://user-images.githubusercontent.com/73710701/195392962-8f777f00-c898-4416-8d0b-47adae3be88d.png)

![Screen Shot 2022-10-12 at 12 02 45 PM](https://user-images.githubusercontent.com/73710701/195392983-35327771-e663-4778-976f-bb0c18e76462.png)

![Screen Shot 2022-10-12 at 12 02 19 PM](https://user-images.githubusercontent.com/73710701/195393000-259e7d2e-169d-40c7-af06-af1fe5e58dc9.png)


#### Breaking Changes

No, style change to fix section separator showing up on top of dropdown and lightbox kit

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-426)

#### How to test this

review in milano env

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
