### PR TITLE
Fix dialog kit border-radius

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
@@ -72,7 +72,7 @@
 	background-color: $white;
 	box-shadow: $shadow_deepest;
 	border: 0;
-	border-radius: 0;
+	border-radius: $border_radius_md;
 	max-height: calc(100vh - #{$gutter * 2});
 	max-width: calc(100vw - #{$gutter * 2});
 	overflow: auto;
@@ -138,7 +138,6 @@
 			opacity: $opacity_hidden;
 		}
 		&[class*="full_height"] {
-
 			&[class*="_left"]{
 				justify-content: flex-start;
 			}
@@ -152,6 +151,7 @@
 			}
 
 			.pb_dialog {
+				border-radius: 0;
 				height: 100%;
 				max-height: 100%;
 				max-width: none;


### PR DESCRIPTION
Bug fix: border-radius should only be `0` in the `full-height` variant of the Dialog Kit.

#### Screens

![Screen Shot 2022-10-12 at 3 32 58 PM](https://user-images.githubusercontent.com/8194056/195431782-20d89ad0-0248-423a-a3f4-64dadaa223d8.png)
![Screen Shot 2022-10-12 at 3 32 42 PM](https://user-images.githubusercontent.com/8194056/195431730-4b4e2d57-aef2-4bf1-9ab7-3ac7f38d7e25.png)

#### Breaking Changes

No breaking changes, css fix for the dialog kit.

#### Runway Ticket URL

[INSERT URL]

#### How to test this

Check milano build. Resize your screen simulating different resolutions. Only the full height variant should not have `border-radius`. 

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
