### PR TITLE
[PLAY-384]- Fixed Selectable Card Kit Border Issue on Error

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -121,7 +121,6 @@ $pb_selectable_card_border: 2px;
       }
       .separator{
         background: $error_dark;
-        width: 2px;
       }
     }
   }
@@ -144,7 +143,6 @@ $pb_selectable_card_border: 2px;
     }
     .separator {
       background: $error;
-      width: 2px;
     }
   }
 }


### PR DESCRIPTION
#### Screens
![Screen Shot 2022-10-12 at 3 37 58 PM](https://user-images.githubusercontent.com/73710701/195432983-7d94f4ae-a583-45c2-829b-753fe97933b9.png)

#### Breaking Changes

No Fixed separator width on error

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-384)

#### How to test this

review in milano env

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
