### PR TITLE
[PLAY-427]-Fixed Issue Where Typeahead Kit Was Returning Null Classes

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
@@ -65,12 +65,12 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
   const borderCss = `border_${borderToChange}_${borderToggle}`
 
   const shouldShowAddOn = icon !== null
-  const addOnCss = shouldShowAddOn ? 'text_input_wrapper_add_on' : null
-  const addOnDarkModeCardCss = (shouldShowAddOn && dark) ? 'add-on-card-dark' : null
+  const addOnCss = shouldShowAddOn ? 'text_input_wrapper_add_on' : ""
+  const addOnDarkModeCardCss = (shouldShowAddOn && dark) ? 'add-on-card-dark' : ""
   const css = classnames([
     'pb_text_input_kit',
-    inline ? 'inline' : null,
-    error ? 'error' : null,
+    inline ? 'inline' : "",
+    error ? 'error' : "",
     globalProps(props),
     className,
   ])


### PR DESCRIPTION

#### Screens

![Screen Shot 2022-10-13 at 11 49 42 AM](https://user-images.githubusercontent.com/73710701/195644789-f3bb6644-6d78-44e5-819a-11460c5d6040.png)


#### Breaking Changes

No, fixed issue where a null class was rendering in dom

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-427)

#### How to test this

Review i n milano env. inspect each typeahead and make sure the null class is not rendering in DOM (see story for screenshot of issue)

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
