### PR TITLE
[PLAY-411] Collapsible kit icon size and color

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_collapsible/_collapsible.tsx
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/_collapsible.tsx
@@ -7,6 +7,8 @@ import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import CollapsibleContent from './child_kits/CollapsibleContent'
 import CollapsibleMain from './child_kits/CollapsibleMain'
 import CollapsibleContext from './context'
+import IconSizes from "../pb_icon/_icon"
+
 
 type CollapsibleProps = {
   children?: JSX.Element | [],
@@ -14,10 +16,11 @@ type CollapsibleProps = {
   className?: string,
   collapsed?: boolean,
   data?: object,
+  iconColor?: 'default' | 'light' | 'lighter' | 'link' | 'error' | 'success',
+  iconSize?: typeof IconSizes
   id?: string,
   padding?: string,
 }
-
 
 const useCollapsible = (initial = false) => {
   const [collapsed, setCollapsed] = useState(initial)
@@ -34,6 +37,8 @@ const Collapsible = ({
   children = [],
   collapsed = true,
   data = {},
+  iconColor = 'default',
+  iconSize,
   id,
   padding = 'md',
   ...props
@@ -59,7 +64,7 @@ const Collapsible = ({
   )
 
   return (
-    <CollapsibleContext.Provider value={{ collapsed: isCollapsed, collapse }}>
+    <CollapsibleContext.Provider value={{ collapsed: isCollapsed, collapse, iconSize, iconColor }}>
       <div
           {...ariaProps}
           {...dataProps}

--- a/playbook/app/pb_kits/playbook/pb_collapsible/child_kits/CollapsibleMain.tsx
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/child_kits/CollapsibleMain.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 
 import classnames from 'classnames'
 import React, { useContext } from 'react'
@@ -8,26 +9,51 @@ import Flex from '../../pb_flex/_flex'
 import FlexItem from '../../pb_flex/_flex_item'
 import CollapsibleContext from '../context'
 
+
+type colorMap = {
+  default: string,
+  light: string,
+  lighter: string,
+  link: string,
+  error: string,
+  success: string
+}
+
+const colorMap = {
+  default: "#242B42",
+  light: "#687887",
+  lighter: "#C1CDD6",
+  link: "#0056CF",
+  error: "#FF2229",
+  success: "#00CA74",
+}
+
 type CollapsibleMainProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
   padding?: string,
-  cursor?: string
+  cursor?: string,
+
 }
+type IconColors =  "default" | "light" | "lighter" | "link" | "error" | "success"
 
 type IconProps = {
   collapsed: boolean | (()=> void)
+  iconColor?: IconColors
+  iconSize?: string | (() => void)
 }
 
-const Icon = ({ collapsed }: IconProps) => {
+const Icon = ({ collapsed, iconSize, iconColor }: IconProps) => {
   const direction = collapsed ? 'down' : 'up'
+  const size = iconSize
+  const color = colorMap[iconColor]
 
   return (
     <div
         key={direction}
-        style={{ verticalAlign: 'middle' }}
+        style={{ verticalAlign: 'middle', color: color }}
     >
-      <i className={`far fa-chevron-${direction} fa-fw`} />
+      <i className={`far fa-chevron-${direction} fa-fw ${size && `fa-${size}`}`} />
     </div>
   )
 }
@@ -37,22 +63,27 @@ const CollapsibleMain = ({
   className,
   cursor = 'pointer',
   padding = 'md',
-
   ...props
-}: CollapsibleMainProps) => {
-  const context: {[key: string]: (()=> void)} | boolean = useContext(CollapsibleContext)
+}: CollapsibleMainProps): React.ReactElement=> {
+  const context: {[key: string]: IconColors | (() => void)} | boolean = useContext(CollapsibleContext)
   const mainCSS = buildCss('pb_collapsible_main_kit')
   const mainSpacing = globalProps(props, { cursor, padding })
 
   return (
     <div className={classnames(mainCSS, className, mainSpacing)}>
-      <div onClick={() => context.collapse()}>
+      <div onClick={context.collapse as (() => void)}>
         <Flex
             spacing="between"
             vertical="center"
         >
           <FlexItem>{children}</FlexItem>
-          <FlexItem><Icon collapsed={context.collapsed}/></FlexItem>
+          <FlexItem>
+            <Icon
+                collapsed={context.collapsed as () => void}
+                iconColor={context.iconColor as IconColors}
+                iconSize={context.iconSize}
+            />
+            </FlexItem>
         </Flex>
       </div>
     </div>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_main.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_main.html.erb
@@ -9,8 +9,10 @@
         <%= content.presence %>
       <% end %>
       <%= pb_rails("flex/flex_item") do %>
-        <i class="far fa-chevron-down"></i>
-        <i class="far fa-chevron-up" style="display: none"></i>
+        <div style="color: <%= object.icon_color %>">
+          <i class="far fa-chevron-down <%= object.icon_size %>"></i>
+          <i class="far fa-chevron-up <%= object.icon_size %>"></i>
+        </div>
       <% end %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_main.rb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_main.rb
@@ -3,12 +3,32 @@
 module Playbook
   module PbCollapsible
     class CollapsibleMain < Playbook::KitBase
+      prop :color, type: Playbook::Props::Enum,
+                   values: %w[default light lighter link success error],
+                   default: "default"
+      prop :size, type: Playbook::Props::Enum,
+                  values: ["lg", "xs", "sm", "1x", "2x", "3x", "4x", "5x", "6x", "7x", "8x", "9x", "10x", nil],
+                  default: nil
       def data
         Hash(prop(:data)).merge(collapsible_main: true)
       end
 
       def classname
         generate_classname("pb_collapsible_main_kit", padding, separator: " ")
+      end
+
+      def icon_size
+        return "" if size.nil?
+
+        size_object = { lg: "fa-lg", xs: "fa-xs", sm: "fa-sm", "1x": "fa-1x", "2x": "fa-2x", "3x": "fa-3x", "4x": "fa-4x", "5x": "fa-5x", "6x": "fa-6x", "7x": "fa-7x", "8x": "fa-8x", "9x": "fa-9x", "10x": "fa-10x" }
+        size_object[size.to_sym]
+      end
+
+      def icon_color
+        return "" if color.nil?
+
+        color_object = { light: "#687887", lighter: "#C1CDD6", link: "#0056CF", success: "#00CA74", error: "#FF2229", default: "#242B42" }
+        color_object[color.to_sym]
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_color.html.erb
@@ -1,0 +1,60 @@
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", color: "default"}) do %>
+    <%= pb_rails("body", props: { text: "Default Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", color: "light"}) do %>
+    <%= pb_rails("body", props: { text: "Light Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", color: "lighter"}) do %>
+    <%= pb_rails("body", props: { text: "Lighter Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", color: "link"}) do %>
+    <%= pb_rails("body", props: { text: "Link Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", color: "error"}) do %>
+    <%= pb_rails("body", props: { text: "Error Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", color: "success"}) do %>
+    <%= pb_rails("body", props: { text: "Success Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_color.jsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { Collapsible } from '../..'
+
+const CollapsibleColor = () => (
+  <div>
+    <Collapsible
+        iconColor='default'
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Default Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        iconColor='light'
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Light Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        iconColor='lighter'
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Lighter Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        iconColor='link'
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Link Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        iconColor='error'
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Error Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        iconColor='success'
+    >
+      <Collapsible.Main>
+        <div>{'Success Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+  </div>
+)
+
+export default CollapsibleColor

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_color.md
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_color.md
@@ -1,0 +1,4 @@
+##### Prop
+This kit uses `default` color by default, and can be replaced with colors below:
+
+* `light` `lighter` `success` `error` `link`

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_default.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("collapsible", props: { name: "default-example" }) do %>
-  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main"}) do %>
     <%= pb_rails("body", props: { text: "Main Section"}) %>
   <% end %>
   <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_size.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_size.html.erb
@@ -1,0 +1,40 @@
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", size: "xs" }) do %>
+    <%= pb_rails("body", props: { text: "Extra Small Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", size: "sm" }) do %>
+    <%= pb_rails("body", props: { text: "Small Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main" }) do %>
+    <%= pb_rails("body", props: { text: "Medium Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>
+<%= pb_rails("collapsible", props: { name: "default-example", margin_bottom: "xs" }) do %>
+  <%= pb_rails("collapsible/collapsible_main", props: { padding: "md", name: "default-main", size: "lg" }) do %>
+    <%= pb_rails("body", props: { text: "Large Section"}) %>
+  <% end %>
+  <%= pb_rails("collapsible/collapsible_content", props: { padding: "md" }) do %>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis, risus a fringilla luctus, sapien eros sodales ex, quis molestie est nulla non turpis. Vestibulum aliquet at ipsum eget posuere. Morbi sed laoreet erat. Sed commodo posuere lectus, at porta nulla ornare a. Suspendisse quam est, sollicitudin ut enim sit amet, commodo placerat enim. Donec laoreet metus ac mauris pellentesque mattis. Pellentesque luctus vel mauris non aliquam. Mauris hendrerit mattis porttitor. Curabitur vehicula justo non ex consectetur commodo. Quisque posuere aliquet quam. Maecenas malesuada magna mauris, ac tempor metus euismod at.
+    <br><br>
+    Cras ornare fermentum magna mollis efficitur. Sed vitae nulla vel purus ultrices mollis. Maecenas id nulla id libero faucibus feugiat quis sit amet turpis. In commodo pellentesque risus at fringilla. Integer non interdum leo, non commodo ante. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut mi augue, dignissim at orci vel, egestas aliquam mi. Proin finibus aliquet tempor. Integer cursus, ex quis gravida rhoncus, nisi elit viverra ipsum, non efficitur est ex ac tortor. Praesent vitae odio massa.
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_size.jsx
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_size.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { Collapsible } from '../..'
+
+const CollapsibleSize = () => (
+  <div>
+    <Collapsible
+        iconSize="xs"
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Extra Small Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        iconSize="sm"
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Small Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Default Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+    <Collapsible
+        iconSize="lg"
+        marginBottom="xs"
+    >
+      <Collapsible.Main>
+        <div>{'Large Section'}</div>
+      </Collapsible.Main>
+      <Collapsible.Content>
+        <div>
+          {
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In vel erat sed purus hendrerit viverra. Duis et vestibulum metus. Sed consequat ut ante non vehicula. Etiam nunc massa, pharetra vel quam id, posuere rhoncus quam. Quisque imperdiet arcu enim, nec aliquet justo auctor eget. Curabitur in metus nec nunc rhoncus faucibus vitae ac elit. Nulla facilisi. Vestibulum quis pretium nulla. Nulla ut accumsan velit. Duis varius urna sed sem tempor, sit amet fermentum nibh auctor. Praesent lorem arcu, egestas non ante quis, placerat pellentesque lectus.Vestibulum lacinia ipsum quis venenatis tristique. Vivamus suscipit, libero eu fringilla egestas, orci urna commodo arcu, vel gravida turpis ipsum molestie nibh. Donec cursus eu ante sagittis ultrices. Phasellus id sagittis risus. Mauris dapibus neque faucibus, tempor ligula vel, cursus ante. Donec faucibus gravida porta. Nullam egestas est quis aliquam feugiat. Sed eget metus diam. Cras eget placerat libero.'
+          }
+        </div>
+      </Collapsible.Content>
+    </Collapsible>
+  </div>
+)
+
+export default CollapsibleSize

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_size.md
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/_collapsible_size.md
@@ -1,0 +1,4 @@
+##### Prop
+This kit uses `icon` sizes. If you don't give it a size, it will default to medium. You can be replaced with the sizes below:
+
+* `lg` `xs` `sm` `1x` `2x` `3x` `4x` `5x` `6x` `7x` `8x` `9x` `10x`

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/example.yml
@@ -1,9 +1,11 @@
 examples:
 
   rails:
-  - collapsible_default: Light
+  - collapsible_default: Default
+  - collapsible_size: Size
+  - collapsible_color: Color
 
   react:
-  - collapsible_default: Light
-  
-  
+  - collapsible_default: Default
+  - collapsible_size: Size
+  - collapsible_color: Color

--- a/playbook/app/pb_kits/playbook/pb_collapsible/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/docs/index.js
@@ -1,1 +1,3 @@
 export { default as CollapsibleDefault } from './_collapsible_default.jsx'
+export { default as CollapsibleSize } from './_collapsible_size.jsx'
+export { default as CollapsibleColor } from './_collapsible_color.jsx'


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-10-13 at 2 27 48 PM](https://user-images.githubusercontent.com/73671109/195677197-fc83b6e6-ff66-4cf4-b741-d618dc6bdc60.png)

![Screen Shot 2022-10-13 at 2 27 56 PM](https://user-images.githubusercontent.com/73671109/195677218-eed19178-9506-434d-be5e-98735c35c96d.png)

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-411)

#### How to test this

N/A

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
