### PR TITLE
PLAY-387- Fixed Form Group Kit Highlight Missing Border

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -27,8 +27,13 @@
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
       border-right-width: 0;
-    }
+    
+    &:focus {
+       outline: $primary solid 1px;
+       outline-offset: -1px;
   }
+}
+}
 
   & > [class^=pb_text_input_kit]:not(:first-child) {
     .text_input_wrapper input, [class^=pb_text_input_kit] .text_input_wrapper .text_input {


### PR DESCRIPTION
____

#### Screens

![Screen Shot 2022-10-13 at 4 53 43 PM](https://user-images.githubusercontent.com/73710701/195708651-372384c1-18ce-4afa-802e-e82201898c69.png)


#### Breaking Changes

No, fixed issue where border was not showing on right of input field on focus

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-387)

#### How to test this

Review in milano env. Click on Form Group  input fields in doc examples and make sure blue highlight shows up on all sides of input field.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
