### PR TITLE
[PLAY-391] - Legend Kit to Take Custom Colors

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_legend/_legend.jsx
+++ b/playbook/app/pb_kits/playbook/pb_legend/_legend.jsx
@@ -34,8 +34,16 @@ const Legend = (props: LegendProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+
+  const customColor = color.charAt(0) === '#' && color
+
+  const customColorStyle = {
+  background: customColor
+}
+
+ 
   const bodyCss = classnames(
-    buildCss('pb_legend_kit', color),
+    buildCss('pb_legend_kit', customColor ? "" : color),
     globalProps(props),
     className
   )
@@ -48,7 +56,9 @@ const Legend = (props: LegendProps) => {
         id={id}
     >
       <Body color={dark ? 'lighter' : 'light'}>
-        <span className="pb_legend_indicator_circle" />
+        <span className={`${customColor ? "pb_legend_indicator_circle_custom" : "pb_legend_indicator_circle"}`}
+            style={customColorStyle} 
+        />
         <If condition={prefixText}>
           <Title
               dark={dark}

--- a/playbook/app/pb_kits/playbook/pb_legend/_legend.scss
+++ b/playbook/app/pb_kits/playbook/pb_legend/_legend.scss
@@ -23,6 +23,12 @@
   @include indicator-colors($data_colors);
   @include indicator-colors($status_colors);
   @include indicator-colors($product_colors);
-  @include indicator-colors($category_colors)
+  @include indicator-colors($category_colors);
 
+  .pb_legend_indicator_circle_custom {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_legend/docs/_legend_custom_colors.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_legend/docs/_legend_custom_colors.html.erb
@@ -1,0 +1,3 @@
+<%= pb_rails("legend", props: { color: "#dc418a", text: "Windows" }) %>
+<%= pb_rails("legend", props: { color: "#3ef0b8", text: "Windows" }) %>
+<%= pb_rails("legend", props: { color: "#ab8b04", text: "Windows" }) %>

--- a/playbook/app/pb_kits/playbook/pb_legend/docs/_legend_custom_colors.jsx
+++ b/playbook/app/pb_kits/playbook/pb_legend/docs/_legend_custom_colors.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Legend } from '../..'
+
+const LegendCustomColors = (props) => (
+  <div>
+    <Legend
+        color="#dc418a"
+        text="Windows"
+        {...props}
+    />
+    <Legend
+        color="#3ef0b8"
+        text="Windows"
+        {...props}
+    />
+    <Legend
+        color="#ab8b04"
+        text="Windows"
+        {...props}
+    />
+  </div>
+)
+
+export default LegendCustomColors

--- a/playbook/app/pb_kits/playbook/pb_legend/docs/_legend_custom_colors.md
+++ b/playbook/app/pb_kits/playbook/pb_legend/docs/_legend_custom_colors.md
@@ -1,0 +1,1 @@
+The color prop also allows for use of custom colors passed in as HEX codes. 

--- a/playbook/app/pb_kits/playbook/pb_legend/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_legend/docs/example.yml
@@ -4,8 +4,10 @@ examples:
   - legend_default: Default
   - legend_prefix: With Prefix Text
   - legend_colors: Colors
+  - legend_custom_colors: Custom Colors
 
   react:
   - legend_default: Default
   - legend_prefix: With Prefix Text
   - legend_colors: Colors
+  - legend_custom_colors: Custom Colors

--- a/playbook/app/pb_kits/playbook/pb_legend/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_legend/docs/index.js
@@ -1,3 +1,4 @@
 export { default as LegendDefault } from './_legend_default.jsx'
 export { default as LegendPrefix } from './_legend_prefix.jsx'
 export { default as LegendColors } from './_legend_colors'
+export { default as LegendCustomColors} from './_legend_custom_colors'

--- a/playbook/app/pb_kits/playbook/pb_legend/legend.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_legend/legend.html.erb
@@ -4,7 +4,7 @@
     data: object.data,
     class: object.classname) do %>
   <%= pb_rails("body", props: {color: object.body_color}) do %>
-    <span class="pb_legend_indicator_circle"></span>
+    <span style="<%= object.custom_color %>" class=<%= object.custom_color_class %>></span>
     <%= pb_rails("title", props: { dark: object.dark, text: object.prefix_text, tag: "span", size: 4 }) %>
     <%= object.text %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_legend/legend.rb
+++ b/playbook/app/pb_kits/playbook/pb_legend/legend.rb
@@ -15,6 +15,14 @@ module Playbook
       def classname
         generate_classname("pb_legend_kit", color)
       end
+
+      def custom_color
+        color.start_with?("#") ? "background: #{color}" : ""
+      end
+
+      def custom_color_class
+        color.start_with?("#") ? "pb_legend_indicator_circle_custom" : "pb_legend_indicator_circle"
+      end
     end
   end
 end

--- a/playbook/app/pb_kits/playbook/pb_legend/legend.rb
+++ b/playbook/app/pb_kits/playbook/pb_legend/legend.rb
@@ -12,16 +12,16 @@ module Playbook
         dark ? "lighter" : "light"
       end
 
-      def classname
-        generate_classname("pb_legend_kit", color)
-      end
-
       def custom_color
         color.start_with?("#") ? "background: #{color}" : ""
       end
 
       def custom_color_class
         color.start_with?("#") ? "pb_legend_indicator_circle_custom" : "pb_legend_indicator_circle"
+      end
+
+      def classname
+        generate_classname("pb_legend_kit", color.start_with?("#") ? nil : color)
       end
     end
   end


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-10-20 at 4 18 25 PM](https://user-images.githubusercontent.com/73710701/197049689-e98aa21f-48e0-46b1-891e-4edc1ca12248.png)

#### Breaking Changes

No, adds functionality that allows color prop to accept hex values. 

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-391)

#### How to test this

In milano env check to make sure 'custom color' example functions as expected for react as well as rails

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
