### PR TITLE
[PLAY-432] - Pagination Kit Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/_playbook.scss
+++ b/playbook/app/pb_kits/playbook/_playbook.scss
@@ -103,3 +103,5 @@
 @import './utilities/line_height';
 @import './utilities/display';
 @import './utilities/flexbox';
+
+@import 'pb_pagination/pagination';

--- a/playbook/app/pb_kits/playbook/data/menu.yml
+++ b/playbook/app/pb_kits/playbook/data/menu.yml
@@ -60,6 +60,7 @@ kits:
     - badge
     - hashtag
     - pill
+  - pagination
   - popover
   - progress:
     - progress_pills

--- a/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
+++ b/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
@@ -1,0 +1,59 @@
+@import "tokens/colors";
+@import "tokens/typography";
+@import "tokens/border_radius";
+@import "tokens/shadows";
+
+.pb_pagination {
+  .pagination > li > a,
+  .pagination > li > span {
+    border: 0 !important;
+    margin-top: 1px;
+    margin-bottom: 1px;
+  }
+  .pagination > li:first-child > a,
+  .pagination > li:first-child > span {
+    border-right: 1px solid $border_light !important;
+    z-index: 2;
+  }
+  .pagination > li:last-child > a,
+  .pagination > li:last-child > span {
+    border-left: 1px solid $border_light !important;
+    z-index: 2;
+  }
+
+  .pagination {
+    border: 1px solid $border_light;
+    background-color: $white;
+
+    a {
+      color: $text_lt_default !important;
+      font-size: $text_small;
+      font-weight: $bold;
+      border: none;
+      margin-left: 1px;
+      margin-right: 1px;
+
+      &:hover {
+        background-color: $active_light;
+        color: $primary !important;
+        border-radius: $border_rad_light;
+      }
+
+      &:focus {
+        outline: 1px solid $primary !important;
+        border-radius: $border_rad_light;
+        outline-offset: -1px;
+      }
+    }
+    .active > span {
+      background-color: $primary;
+      border-radius: $border_rad_light;
+      margin-left: 1px;
+      margin-right: 1px;
+
+      &:hover {
+        box-shadow: $shadow_deeper;
+      }
+    }
+  }
+}

--- a/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("pagination") %>

--- a/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default.md
+++ b/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default.md
@@ -1,0 +1,1 @@
+To apply our pagination CSS styles in rails, wrap the `will_paginate` component in our pagination component.

--- a/playbook/app/pb_kits/playbook/pb_pagination/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_pagination/docs/example.yml
@@ -1,0 +1,6 @@
+examples:
+  
+  rails:
+  - pagination_default: Default
+  
+  

--- a/playbook/app/pb_kits/playbook/pb_pagination/pagination.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pagination/pagination.html.erb
@@ -1,0 +1,7 @@
+<%= content_tag(:div,
+    aria: object.aria,
+    class: object.classname,
+    data: object.data,
+    id: object.id) do %>
+  <%= content.presence %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_pagination/pagination.rb
+++ b/playbook/app/pb_kits/playbook/pb_pagination/pagination.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbPagination
+    class Pagination < ::Playbook::KitBase
+      def classname
+        generate_classname("pb_pagination")
+      end
+    end
+  end
+end

--- a/playbook/spec/pb_kits/playbook/kits/pagination_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/pagination_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_pagination/pagination"
+
+RSpec.describe Playbook::PbPagination::Pagination do
+  subject { Playbook::PbPagination::Pagination }
+
+  it { is_expected.to define_partial }
+
+  # Do not leave this file blank. Use other spec files for example tests.
+end

--- a/playbook/spec/pb_kits/playbook/kits/pagination_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/pagination_spec.rb
@@ -5,7 +5,9 @@ require_relative "../../../../app/pb_kits/playbook/pb_pagination/pagination"
 RSpec.describe Playbook::PbPagination::Pagination do
   subject { Playbook::PbPagination::Pagination }
 
-  it { is_expected.to define_partial }
-
-  # Do not leave this file blank. Use other spec files for example tests.
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      expect(subject.new({}).classname).to eq "pb_pagination"
+    end
+  end
 end


### PR DESCRIPTION

#### Screens


![Screen Shot 2022-10-25 at 1 40 10 PM](https://user-images.githubusercontent.com/73710701/197844099-1240dd0a-8895-4c29-b89e-32b70ef50881.png)

## Classname being generated in DOM:
![Screen Shot 2022-10-25 at 1 44 08 PM](https://user-images.githubusercontent.com/73710701/197844924-f8025851-a8fe-4847-bd3c-a4b67c22d12f.png)

#### Breaking Changes

No breaking changes. This PR creates the Pagination Kit (Rails only) which is only a wrapping div with custom SCSS to wrap around the `will_paginate` component we are currently using in Nitro. Doc example will be added after testing.

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-432)

#### How to test this

Test via Alpha in nitro to make sure styles come through if used as wrapping div around `will_paginate` component

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
