### PR TITLE
[PLAY-423] Radio kit (React) alignment error

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_radio/_radio.scss
+++ b/playbook/app/pb_kits/playbook/pb_radio/_radio.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  &.vertical {
+  &[class*=vertical] {
     flex-direction: column;
     align-items: center;
     .pb_radio_button {


### PR DESCRIPTION
#### Screens

<img width="840" alt="Screen Shot 2022-10-31 at 2 25 18 PM" src="https://user-images.githubusercontent.com/73671109/199081976-76708394-ad75-4f6e-9242-349c186491cd.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-423)

#### How to test this

Check the react version of the radio kit and make sure the alignment section is aligned properly, with the caption below the radio button instead of next to it. Make sure all other cards work as intended

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
