### PR TITLE
[PLAY-385] Added Hover State to Buttons with Link Variant

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.scss
@@ -1,4 +1,5 @@
 @import "./button_mixins";
+@import "../tokens/colors";
 
 $pb_button_sizes: (
   "sm":   0.75rem,
@@ -28,6 +29,11 @@ $pb_button_sizes: (
   }
   &[class*=_link]  {
     @include pb_button_link;
+    @media (hover:hover) {
+      &:hover {
+        @include pb_button_hover(mix($primary_action, $white, 3%));
+      }
+    } 
   }
 
   // Disabled =================

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.html.erb
@@ -1,5 +1,5 @@
-<%= pb_rails("button", props: { text: "Button Primary" }) %>
-<%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary" }) %>
-<%= pb_rails("button", props: { text: "Button Link", variant: "link" }) %>
-<%= pb_rails("button", props: { text: "Button Disabled", disabled: true }) %>
+<%= pb_rails("button", props: { text: "Button Primary", margin_right: "lg" }) %>
+<%= pb_rails("button", props: { text: "Button Secondary", variant: "secondary", margin_right: "lg" }) %>
+<%= pb_rails("button", props: { text: "Button Link", variant: "link", margin_right: "lg" }) %>
+<%= pb_rails("button", props: { text: "Button Disabled", disabled: true, margin_right: "lg" }) %>
 

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_default.jsx
@@ -1,32 +1,33 @@
-import React from 'react'
-import { Button } from '../../'
+import React from "react"
+import { Button } from "../../"
 
 const ButtonDefault = (props) => (
   <div>
     <Button
-        marginRight="xl"
-        onClick={() => alert('button clicked!')}
-        text="Button Primary"
+        marginRight='lg'
+        onClick={() => alert("button clicked!")}
+        text='Button Primary'
         {...props}
-    />
-    {' '}
+    />{" "}
     <Button
-        onClick={() => alert('button clicked!')}
-        text="Button Secondary"
-        variant="secondary"
+        marginRight='lg'
+        onClick={() => alert("button clicked!")}
+        text='Button Secondary'
+        variant='secondary'
         {...props}
-    />
-    {' '}
+    />{" "}
     <Button
-        onClick={() => alert('button clicked!')}
-        text="Button Link"
-        variant="link"
+        marginRight='lg'
+        onClick={() => alert("button clicked!")}
+        text='Button Link'
+        variant='link'
         {...props}
     />
     <Button
         disabled
-        onClick={() => alert('button clicked!')}
-        text="Button Disabled"
+        marginRight='lg'
+        onClick={() => alert("button clicked!")}
+        text='Button Disabled'
         {...props}
     />
   </div>


### PR DESCRIPTION
#### Screens
<img width="260" alt="Screen Shot 2022-11-02 at 5 37 06 PM" src="https://user-images.githubusercontent.com/9158723/199607882-f137d054-72c1-4059-8213-7ed7b9a221fe.png">

Adds hover to the button with the link variant.
It mimics the same style we have inside of Playbook's sidebar that shows our components. 


#### Breaking Changes

No

#### Runway Ticket URL

[Runway story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-385)

#### How to test this

Hover that link button, yo!

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [X] **SCREENSHOT** Please add a screen shot or two.
~- [ ] **SPECS** Please cover your changes with specs.~
- [X] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
