### PR TITLE
[PLAY-414] Change bg color when selectable list item is selected

### DIFF
--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_item.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_item.jsx
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, { Node } from 'react'
+import React, { Node, useState } from 'react'
 import classnames from 'classnames'
 
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
@@ -50,8 +50,19 @@ const SelectableListItem = ({
     className
   )
 
+  const initialCheckedState = checked
+  const [checkedState, setCheckedState] = useState(initialCheckedState)
+
+  const handleChecked = (event) => {
+    onChange(event)
+    setCheckedState(event.target.checked)
+  }
+
   return (
-    <ListItem {...props}>
+    <ListItem 
+        {...props}
+        className={classnames(checkedState ? "checked_item" : "", className)}
+    >
       <div
           {...ariaProps}
           {...dataProps}
@@ -60,10 +71,10 @@ const SelectableListItem = ({
         <Choose>
           <When condition={variant == 'checkbox'}>
             <Checkbox
-                checked={checked}
+                checked={checkedState}
                 id={id}
                 name={name}
-                onChange={onChange}
+                onChange={handleChecked}
                 // eslint suppressor, text is needed to display on screen
                 text={label || (text && false)}
                 type="checkbox"

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.jsx
@@ -1,5 +1,5 @@
 /* @flow */
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import classnames from 'classnames'
 
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
@@ -29,7 +29,30 @@ const SelectableList = (props: SelectableListProps) => {
   const ariaProps = buildAriaProps(aria)
   const classes = classnames(buildCss('pb_selectable_list_kit'), globalProps(props), className)
   const dataProps = buildDataProps(data)
+  const isRadio = props.variant === "radio"
+  const [selectedRadioValue, setSelectedRadioValue] = useState()
+  
+  const onChangeRadioValue = (event) => {
+    setSelectedRadioValue(event.target.value)
+  }
 
+  let newChildren = children
+
+  useEffect(() => {
+    if (isRadio) {
+      newChildren = children.map(({props}) => {
+        return (
+          <SelectableListItem
+              {...props}
+              className={classnames(selectedRadioValue === props.value ? "checked_item" : "", props.className)}
+              key={props.value}
+              onChange={(evt) => { onChangeRadioValue(evt); props?.onChange?.(evt); }}
+          />
+        )
+      })
+    }
+  }, []);
+  
   return (
     <div
         {...ariaProps}
@@ -38,7 +61,7 @@ const SelectableList = (props: SelectableListProps) => {
         id={id}
     >
       <List {...props}>
-        {children}
+        {newChildren}
       </List>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.jsx
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import classnames from 'classnames'
 
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
@@ -30,28 +30,27 @@ const SelectableList = (props: SelectableListProps) => {
   const classes = classnames(buildCss('pb_selectable_list_kit'), globalProps(props), className)
   const dataProps = buildDataProps(data)
   const isRadio = props.variant === "radio"
-  const [selectedRadioValue, setSelectedRadioValue] = useState()
+  const defaultCheckedRadioValue = children.filter(item => item.props.defaultChecked)[0]?.props?.value
+  const [selectedRadioValue, setSelectedRadioValue] = useState(defaultCheckedRadioValue)
   
-  const onChangeRadioValue = (event) => {
-    setSelectedRadioValue(event.target.value)
+  const onChangeRadioValue = ({ target }) => {
+    setSelectedRadioValue(target.value)
   }
 
-  let newChildren = children
+  let selectableListItems = children
 
-  useEffect(() => {
-    if (isRadio) {
-      newChildren = children.map(({props}) => {
-        return (
-          <SelectableListItem
-              {...props}
-              className={classnames(selectedRadioValue === props.value ? "checked_item" : "", props.className)}
-              key={props.value}
-              onChange={(evt) => { onChangeRadioValue(evt); props?.onChange?.(evt); }}
-          />
-        )
-      })
-    }
-  }, []);
+  if (isRadio) {
+    selectableListItems = children.map(({ props }) => {
+      return (
+        <SelectableListItem
+            {...props}
+            className={classnames(selectedRadioValue === props.value ? "checked_item" : "", props.className)}
+            key={props.value}
+            onChange={evt => { onChangeRadioValue(evt); props?.onChange?.(evt); }}
+        />
+      )
+    })
+  }
   
   return (
     <div
@@ -61,7 +60,7 @@ const SelectableList = (props: SelectableListProps) => {
         id={id}
     >
       <List {...props}>
-        {newChildren}
+        {selectableListItems}
       </List>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.scss
@@ -8,7 +8,7 @@
       background-color: $bg_light;
     }
     &[class*=checked_item] {
-      background-color: #f7fbff;
+      background-color: $bg_light;
     }
   }
   [class^=pb_radio_kit] {

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.scss
@@ -7,6 +7,9 @@
     &:hover {
       background-color: $bg_light;
     }
+    &[class*=checked_item] {
+      background-color: #f7fbff;
+    }
   }
   [class^=pb_radio_kit] {
     margin-left: $space_xs;

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/docs/_selectable_list_radio.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/docs/_selectable_list_radio.jsx
@@ -2,26 +2,37 @@ import React from 'react'
 import { SelectableList } from '../..'
 
 const SelectableListDefault = (props) => {
+  // const [value, setValue] = useState()
+  
+  // const onChange = ({ target }) => {
+  //   setValue(target.value)
+  // }
   return (
     <div>
       <SelectableList variant="radio">
         <SelectableList.Item
+            //className={value === "1" ? "checked_item" : ""}
             label="Small"
             name="radio"
             value="1"
+            //onChange={onChange}
             {...props}
         />
         <SelectableList.Item
+            //className={value === "2" ? "checked_item" : ""}
             defaultChecked
             label="Medium"
             name="radio"
             value="2"
+            //onChange={onChange}
             {...props}
         />
         <SelectableList.Item
+            //className={value === "3" ? "checked_item" : ""}
             label="Large"
             name="radio"
             value="3"
+            //onChange={onChange}
             {...props}
         />
       </SelectableList>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/docs/_selectable_list_radio.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/docs/_selectable_list_radio.jsx
@@ -2,37 +2,26 @@ import React from 'react'
 import { SelectableList } from '../..'
 
 const SelectableListDefault = (props) => {
-  // const [value, setValue] = useState()
-  
-  // const onChange = ({ target }) => {
-  //   setValue(target.value)
-  // }
   return (
     <div>
       <SelectableList variant="radio">
         <SelectableList.Item
-            //className={value === "1" ? "checked_item" : ""}
             label="Small"
             name="radio"
             value="1"
-            //onChange={onChange}
             {...props}
         />
         <SelectableList.Item
-            //className={value === "2" ? "checked_item" : ""}
             defaultChecked
             label="Medium"
             name="radio"
             value="2"
-            //onChange={onChange}
             {...props}
         />
         <SelectableList.Item
-            //className={value === "3" ? "checked_item" : ""}
             label="Large"
             name="radio"
             value="3"
-            //onChange={onChange}
             {...props}
         />
       </SelectableList>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
@@ -5,7 +5,7 @@
     id: object.id) do %>
   <%= pb_rails("list") do %>
     <% object.items.each do |item| %>
-      <%= pb_rails("selectable_list/selectable_list_item", props: item.merge(variant: object.variant) )%>
+      <%= pb_rails("selectable_list/selectable_list_item", props: item.merge(variant: object.variant, id: object.get_id(item)) )%>
     <% end %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 module Playbook
   module PbSelectableList
     class SelectableList < Playbook::KitBase
@@ -14,6 +16,10 @@ module Playbook
 
       def classname
         generate_classname("pb_selectable_list_kit")
+      end
+
+      def get_id(item)
+        item[:id] || ("a".."z").to_a.sample(12).join
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
@@ -14,4 +14,20 @@
       <%= content %>
     <% end %>
   <% end %>
+
+  <% if object.variant == "checkbox"%>
+    <script>
+      var checkboxElement = document.querySelector("#<%=object.id%> input[type=checkbox]")
+      
+      checkboxElement.addEventListener("change", (evt) => {
+        var listItemElement = document.querySelector("#<%=object.id%>")
+        
+        if (evt.target.checked) {
+          listItemElement.classList.add("checked_item");
+        } else {
+          listItemElement.classList.remove("checked_item")
+        }
+      })
+    </script>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
@@ -29,5 +29,21 @@
         }
       })
     </script>
+  <% else %>
+    <script>
+      var radioElement = document.querySelector("#<%=object.id%> input[type=radio]")
+
+      radioElement.addEventListener("change", () => {        
+        var radios = radioElement.closest("ul").querySelectorAll("input[type=radio]")
+        
+        radios.forEach((radio) => {
+          if (radio.checked) {
+            radio.closest("li").classList.add("checked_item");
+          } else {
+            radio.closest("li").classList.remove("checked_item")
+          }
+        });
+      })
+    </script>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
@@ -16,13 +16,13 @@ module Playbook
                            default: {}
 
       def classname
-        generate_classname("pb_item_kit", checked_class, separator: " ")
+        generate_classname("pb_item_kit", checked_class)
       end
 
     private
 
       def checked_class
-        checked ? "checked_item" : ""
+        checked ? " checked_item" : ""
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
@@ -16,7 +16,7 @@ module Playbook
                            default: {}
 
       def classname
-        generate_classname("pb_item_kit", checked_class)
+        generate_classname("pb_item_kit") + checked_class
       end
 
     private

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
@@ -4,7 +4,6 @@ module Playbook
   module PbSelectableList
     class SelectableListItem < Playbook::KitBase
       prop :tabindex
-
       prop :checked, type: Playbook::Props::Boolean,
                      default: false
       prop :name, type: Playbook::Props::String
@@ -17,7 +16,13 @@ module Playbook
                            default: {}
 
       def classname
-        generate_classname("pb_item_kit")
+        generate_classname("pb_item_kit", checked_class, separator: " ")
+      end
+
+    private
+
+      def checked_class
+        checked ? "checked_item" : ""
       end
     end
   end


### PR DESCRIPTION
#### Screens
![image](https://user-images.githubusercontent.com/2573205/201197798-5f679e79-6ef5-47d4-985f-c3d7273e9713.png)
![image](https://user-images.githubusercontent.com/2573205/201197992-31496e59-f7e9-45fb-8e34-85488f6e371a.png)

#### Breaking Changes

No

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-414)

#### How to test this

Go to Selectable List kit.
Select any item.
Its background color should change.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
