### PR TITLE
[PLAY-489] Reinstated Flatpickr Default AM/PM Toggle

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -108,54 +108,54 @@ describe('DatePicker Kit', () => {
     })
   })
 
-  test('shows DatePicker meridiem toggle', async () => {
-    const testId = 'datepicker-meridiem'
-    render(
-      <DatePicker
-          data={{ testid: testId }}
-          defaultDate={DEFAULT_DATE}
-          enableTime
-          pickerId="date-picker-meridiem"
-      />
-    )
+  // test('shows DatePicker meridiem toggle', async () => {
+  //   const testId = 'datepicker-meridiem'
+  //   render(
+  //     <DatePicker
+  //         data={{ testid: testId }}
+  //         defaultDate={DEFAULT_DATE}
+  //         enableTime
+  //         pickerId="date-picker-meridiem"
+  //     />
+  //   )
 
-    const kit = screen.getByTestId(testId)
-    const input = within(kit).getByPlaceholderText('Select Date')
+  //   const kit = screen.getByTestId(testId)
+  //   const input = within(kit).getByPlaceholderText('Select Date')
 
-    fireEvent(
-      input,
-      new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
-    const meridiemToggleAM = within(kit).getByLabelText('AM')
-    const meridiemTogglePM = within(kit).getByLabelText('PM')
-    await waitFor(() => {
-      expect(meridiemToggleAM).toBeInTheDocument()
-      expect(meridiemTogglePM).toBeInTheDocument()
-    })
+  //   fireEvent(
+  //     input,
+  //     new MouseEvent('click', {
+  //       bubbles: true,
+  //       cancelable: true,
+  //     }),
+  //   )
+  //   const meridiemToggleAM = within(kit).getByLabelText('AM')
+  //   const meridiemTogglePM = within(kit).getByLabelText('PM')
+  //   await waitFor(() => {
+  //     expect(meridiemToggleAM).toBeInTheDocument()
+  //     expect(meridiemTogglePM).toBeInTheDocument()
+  //   })
 
-    fireEvent(
-      meridiemToggleAM,
-      new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
-    await waitFor(() => {
-      expect(input).toHaveValue('01/01/2020 at 12:00 AM')
-    })
+  //   fireEvent(
+  //     meridiemToggleAM,
+  //     new MouseEvent('click', {
+  //       bubbles: true,
+  //       cancelable: true,
+  //     }),
+  //   )
+  //   await waitFor(() => {
+  //     expect(input).toHaveValue('01/01/2020 at 12:00 AM')
+  //   })
 
-    fireEvent(
-      meridiemTogglePM,
-      new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      }),
-    )
-    await waitFor(() => {
-      expect(input).toHaveValue('01/01/2020 at 12:00 PM')
-    })
-  })
+  //   fireEvent(
+  //     meridiemTogglePM,
+  //     new MouseEvent('click', {
+  //       bubbles: true,
+  //       cancelable: true,
+  //     }),
+  //   )
+  //   await waitFor(() => {
+  //     expect(input).toHaveValue('01/01/2020 at 12:00 PM')
+  //   })
+  // })
 })

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
@@ -16,13 +16,6 @@ const DatePickerTime = (props) => (
         {...props}
     />
 
-    <DatePicker
-        defaultDate={DEFAULT_DATE}
-        enableTime
-        pickerId="date-picker-time2"
-        showTimezone
-        {...props}
-    />
   </div>
 )
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
@@ -15,6 +15,14 @@ const DatePickerTime = (props) => (
         showTimezone
         {...props}
     />
+
+    <DatePicker
+        defaultDate={DEFAULT_DATE}
+        enableTime
+        pickerId="date-picker-time2"
+        showTimezone
+        {...props}
+    />
   </div>
 )
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/plugins/timeSelect.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/plugins/timeSelect.ts
@@ -41,96 +41,96 @@ export const getTimezoneText = (inputDate: {
 
 function timeSelectPlugin(props: { caption: string; showTimezone: boolean }) {
   return function (fp: FpTypes) {
-    const generateMeridiemCard = (text: string) => {
-      const selectableCard = document.createElement("div");
-      selectableCard.className = "pb_selectable_card_kit_enabled";
+    // const generateMeridiemCard = (text: string) => {
+    //   const selectableCard = document.createElement("div");
+    //   selectableCard.className = "pb_selectable_card_kit_enabled";
 
-      const cardInput = document.createElement("input"),
-        cardInputId = `datePicker${text}`;
+    //   const cardInput = document.createElement("input"),
+    //     cardInputId = `datePicker${text}`;
 
-      cardInput.id = cardInputId;
-      cardInput.name = "datepicker-ampm";
-      cardInput.type = "radio";
-      cardInput.value = text;
+    //   cardInput.id = cardInputId;
+    //   cardInput.name = "datepicker-ampm";
+    //   cardInput.type = "radio";
+    //   cardInput.value = text;
 
-      const cardLabel = document.createElement("label"),
-        cardLabelBuffer = document.createElement("div");
-      cardLabel.className = `label-${text.toLowerCase()}`;
-      cardLabel.setAttribute("for", cardInputId);
-      cardLabelBuffer.className = "buffer";
-      cardLabelBuffer.innerHTML = text;
+    //   const cardLabel = document.createElement("label"),
+    //     cardLabelBuffer = document.createElement("div");
+    //   cardLabel.className = `label-${text.toLowerCase()}`;
+    //   cardLabel.setAttribute("for", cardInputId);
+    //   cardLabelBuffer.className = "buffer";
+    //   cardLabelBuffer.innerHTML = text;
 
-      cardLabel.append(cardLabelBuffer);
-      selectableCard.prepend(cardInput);
-      selectableCard.append(cardLabel);
+    //   cardLabel.append(cardLabelBuffer);
+    //   selectableCard.prepend(cardInput);
+    //   selectableCard.append(cardLabel);
 
-      return selectableCard;
-    };
+    //   return selectableCard;
+    // };
 
-    const generateMeridiemToggle = () => {
-      fp.amPM.style.display = "none";
-      const formGroupKit = document.createElement("div");
-      formGroupKit.className = "pb_form_group_kit";
+    // const generateMeridiemToggle = () => {
+    //   fp.amPM.style.display = "none";
+    //   const formGroupKit = document.createElement("div");
+    //   formGroupKit.className = "pb_form_group_kit";
 
-      const amCard = generateMeridiemCard("AM");
-      amCard.addEventListener("click", () => {
-        fp.selectedDates[0].setHours(
-          (fp.selectedDates[0].getHours() % 12) + 12 * 0
-        );
-        fp.setDate(fp.selectedDates[0], true);
-      });
+    //   const amCard = generateMeridiemCard("AM");
+    //   amCard.addEventListener("click", () => {
+    //     fp.selectedDates[0].setHours(
+    //       (fp.selectedDates[0].getHours() % 12) + 12 * 0
+    //     );
+    //     fp.setDate(fp.selectedDates[0], true);
+    //   });
 
-      const pmCard = generateMeridiemCard("PM");
-      pmCard.addEventListener("click", () => {
-        fp.selectedDates[0].setHours(
-          (fp.selectedDates[0].getHours() % 12) + 12 * 1
-        );
-        fp.setDate(fp.selectedDates[0], true);
-      });
+    //   const pmCard = generateMeridiemCard("PM");
+    //   pmCard.addEventListener("click", () => {
+    //     fp.selectedDates[0].setHours(
+    //       (fp.selectedDates[0].getHours() % 12) + 12 * 1
+    //     );
+    //     fp.setDate(fp.selectedDates[0], true);
+    //   });
 
-      formGroupKit.prepend(amCard);
-      formGroupKit.append(pmCard);
+    //   formGroupKit.prepend(amCard);
+    //   formGroupKit.append(pmCard);
 
-      const meridiemContainer = document.createElement("div");
-      meridiemContainer.className = "meridiem";
-      meridiemContainer.append(formGroupKit);
-      document.querySelector(".pb_time_selection").append(meridiemContainer);
-    };
+    //   const meridiemContainer = document.createElement("div");
+    //   meridiemContainer.className = "meridiem";
+    //   meridiemContainer.append(formGroupKit);
+    //   document.querySelector(".pb_time_selection").append(meridiemContainer);
+    // };
 
-    const getMeridiem = (dateObj: string | any[]) => {
-      return dateObj[0].getHours() < 12 ? "AM" : "PM";
-    };
+    // const getMeridiem = (dateObj: string | any[]) => {
+    //   return dateObj[0].getHours() < 12 ? "AM" : "PM";
+    // };
 
-    const updateMeridiemToggle = (forceClick: boolean) => {
-      if (!fp.selectedDates.length) return;
+    // const updateMeridiemToggle = (forceClick: boolean) => {
+    //   if (!fp.selectedDates.length) return;
 
-      const uncheckedClass = "pb_selectable_card_kit_enabled",
-        checkedClass = "pb_selectable_card_kit_checked_enabled",
-        pickerAM: HTMLElement & { [x: string]: any } =
-          document.getElementById("datePickerAM"),
-        pickerPM: HTMLElement & { [x: string]: any } =
-          document.getElementById("datePickerPM"),
-        meridiem = getMeridiem(fp.selectedDates);
+    //   const uncheckedClass = "pb_selectable_card_kit_enabled",
+    //     checkedClass = "pb_selectable_card_kit_checked_enabled",
+    //     pickerAM: HTMLElement & { [x: string]: any } =
+    //       document.getElementById("datePickerAM"),
+    //     pickerPM: HTMLElement & { [x: string]: any } =
+    //       document.getElementById("datePickerPM"),
+    //     meridiem = getMeridiem(fp.selectedDates);
 
-      if (forceClick) {
-        pickerAM.checked = false;
-        pickerPM.checked = false;
-        pickerPM.checked = meridiem === "PM";
-        pickerAM.checked = meridiem === "AM";
-      }
+    //   if (forceClick) {
+    //     pickerAM.checked = false;
+    //     pickerPM.checked = false;
+    //     pickerPM.checked = meridiem === "PM";
+    //     pickerAM.checked = meridiem === "AM";
+    //   }
 
-      if (meridiem === "PM") {
-        pickerPM.parentElement.className = checkedClass;
-        pickerAM.parentElement.className = uncheckedClass;
-      } else if (meridiem === "AM") {
-        pickerAM.parentElement.className = checkedClass;
-        pickerPM.parentElement.className = uncheckedClass;
-      }
-    };
+    //   if (meridiem === "PM") {
+    //     pickerPM.parentElement.className = checkedClass;
+    //     pickerAM.parentElement.className = uncheckedClass;
+    //   } else if (meridiem === "AM") {
+    //     pickerAM.parentElement.className = checkedClass;
+    //     pickerPM.parentElement.className = uncheckedClass;
+    //   }
+    // };
 
     return {
       onValueUpdate() {
-        updateMeridiemToggle(true);
+        // updateMeridiemToggle(true);
       },
       onReady() {
         const id = fp.input.id;
@@ -151,8 +151,8 @@ function timeSelectPlugin(props: { caption: string; showTimezone: boolean }) {
         }
 
         // add meridiem toggle
-        generateMeridiemToggle();
-        updateMeridiemToggle(true);
+        // generateMeridiemToggle();
+        // updateMeridiemToggle(true);
 
         // add timezone text
         if (props.showTimezone) {

--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
@@ -7,6 +7,16 @@
     color: inherit;
     text-align: left;
     margin-left: $space_sm;
+
+    span.flatpickr-am-pm {
+      margin-left: $space_sm;
+      border-radius: 5px;
+      color: $primary;
+      &:hover{
+        background-color: rgba($primary, 0.03);
+        color: $primary;
+      }
+    }
     .numInputWrapper {
       width: auto;
       input.numInput {

--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
@@ -16,6 +16,10 @@
         background-color: rgba($primary, 0.03);
         color: $primary;
       }
+      &:focus{
+        background-color: unset;
+        color: $primary;
+      }
     }
     .numInputWrapper {
       width: auto;

--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
@@ -14,11 +14,12 @@
       color: $primary;
       &:hover{
         background-color: rgba($primary, 0.03);
-        color: $primary;
       }
       &:focus{
         background-color: unset;
-        color: $primary;
+        &:hover{
+          background-color: rgba($primary, 0.03);
+        }
       }
     }
     .numInputWrapper {


### PR DESCRIPTION

#### Screens

AM/PM toggle
![Screen Shot 2022-11-11 at 11 04 44 AM](https://user-images.githubusercontent.com/73710701/201383615-28cf000d-eeda-455e-beed-5c87c6a396eb.png)

AM/PM toggle on hover
![Screen Shot 2022-11-11 at 11 05 31 AM](https://user-images.githubusercontent.com/73710701/201383701-5831111a-aee1-4d8b-9ad1-dd93adb946df.png)


#### Breaking Changes

No, see runway story for full details. 

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-489)

#### How to test this

Test in review env. Scroll down to 'Time Selection' doc example and click on calendar to show Date Picker. Make sure thev Am/PM toggle works to change the Am/PM in the display. 

There are 2 Date Pickers in that example, make sure toggle works correctly on each and does not interfere with the other Date Picker's toggle (see story for details)

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
