### PR TITLE
[PLAY-486] Date Picker AM/PM Buttons Instead of Toggle

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -108,54 +108,54 @@ describe('DatePicker Kit', () => {
     })
   })
 
-  // test('shows DatePicker meridiem toggle', async () => {
-  //   const testId = 'datepicker-meridiem'
-  //   render(
-  //     <DatePicker
-  //         data={{ testid: testId }}
-  //         defaultDate={DEFAULT_DATE}
-  //         enableTime
-  //         pickerId="date-picker-meridiem"
-  //     />
-  //   )
+  test('shows DatePicker meridiem toggle', async () => {
+    const testId = 'datepicker-meridiem'
+    render(
+      <DatePicker
+          data={{ testid: testId }}
+          defaultDate={DEFAULT_DATE}
+          enableTime
+          pickerId="date-picker-meridiem"
+      />
+    )
 
-  //   const kit = screen.getByTestId(testId)
-  //   const input = within(kit).getByPlaceholderText('Select Date')
+    const kit = screen.getByTestId(testId)
+    const input = within(kit).getByPlaceholderText('Select Date')
 
-  //   fireEvent(
-  //     input,
-  //     new MouseEvent('click', {
-  //       bubbles: true,
-  //       cancelable: true,
-  //     }),
-  //   )
-  //   const meridiemToggleAM = within(kit).getByLabelText('AM')
-  //   const meridiemTogglePM = within(kit).getByLabelText('PM')
-  //   await waitFor(() => {
-  //     expect(meridiemToggleAM).toBeInTheDocument()
-  //     expect(meridiemTogglePM).toBeInTheDocument()
-  //   })
+    fireEvent(
+      input,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    const meridiemToggleAM = within(kit).getByLabelText('AM')
+    const meridiemTogglePM = within(kit).getByLabelText('PM')
+    await waitFor(() => {
+      expect(meridiemToggleAM).toBeInTheDocument()
+      expect(meridiemTogglePM).toBeInTheDocument()
+    })
 
-  //   fireEvent(
-  //     meridiemToggleAM,
-  //     new MouseEvent('click', {
-  //       bubbles: true,
-  //       cancelable: true,
-  //     }),
-  //   )
-  //   await waitFor(() => {
-  //     expect(input).toHaveValue('01/01/2020 at 12:00 AM')
-  //   })
+    fireEvent(
+      meridiemToggleAM,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    await waitFor(() => {
+      expect(input).toHaveValue('01/01/2020 at 12:00 AM')
+    })
 
-  //   fireEvent(
-  //     meridiemTogglePM,
-  //     new MouseEvent('click', {
-  //       bubbles: true,
-  //       cancelable: true,
-  //     }),
-  //   )
-  //   await waitFor(() => {
-  //     expect(input).toHaveValue('01/01/2020 at 12:00 PM')
-  //   })
-  // })
+    fireEvent(
+      meridiemTogglePM,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+    await waitFor(() => {
+      expect(input).toHaveValue('01/01/2020 at 12:00 PM')
+    })
+  })
 })

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.html.erb
@@ -4,10 +4,3 @@
   enable_time: true,
   show_timezone: true
 }) %>
-
-<%= pb_rails("date_picker", props: {
-  default_date: DateTime.now.utc.iso8601,
-  picker_id: "date-picker-time2",
-  enable_time: true,
-  show_timezone: true
-}) %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.html.erb
@@ -4,3 +4,10 @@
   enable_time: true,
   show_timezone: true
 }) %>
+
+<%= pb_rails("date_picker", props: {
+  default_date: DateTime.now.utc.iso8601,
+  picker_id: "date-picker-time2",
+  enable_time: true,
+  show_timezone: true
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
@@ -15,6 +15,13 @@ const DatePickerTime = (props) => (
         showTimezone
         {...props}
     />
+    <DatePicker
+        defaultDate={DEFAULT_DATE}
+        enableTime
+        pickerId="date-picker-time2"
+        showTimezone
+        {...props}
+    />
 
   </div>
 )

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
@@ -15,13 +15,6 @@ const DatePickerTime = (props) => (
         showTimezone
         {...props}
     />
-    <DatePicker
-        defaultDate={DEFAULT_DATE}
-        enableTime
-        pickerId="date-picker-time2"
-        showTimezone
-        {...props}
-    />
 
   </div>
 )

--- a/playbook/app/pb_kits/playbook/pb_date_picker/plugins/timeSelect.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/plugins/timeSelect.ts
@@ -40,97 +40,97 @@ export const getTimezoneText = (inputDate: {
 };
 
 function timeSelectPlugin(props: { caption: string; showTimezone: boolean }) {
-  return function (fp: FpTypes) {
-    // const generateMeridiemCard = (text: string) => {
-    //   const selectableCard = document.createElement("div");
-    //   selectableCard.className = "pb_selectable_card_kit_enabled";
-
-    //   const cardInput = document.createElement("input"),
-    //     cardInputId = `datePicker${text}`;
-
-    //   cardInput.id = cardInputId;
-    //   cardInput.name = "datepicker-ampm";
-    //   cardInput.type = "radio";
-    //   cardInput.value = text;
-
-    //   const cardLabel = document.createElement("label"),
-    //     cardLabelBuffer = document.createElement("div");
-    //   cardLabel.className = `label-${text.toLowerCase()}`;
-    //   cardLabel.setAttribute("for", cardInputId);
-    //   cardLabelBuffer.className = "buffer";
-    //   cardLabelBuffer.innerHTML = text;
-
-    //   cardLabel.append(cardLabelBuffer);
-    //   selectableCard.prepend(cardInput);
-    //   selectableCard.append(cardLabel);
-
-    //   return selectableCard;
-    // };
-
-    // const generateMeridiemToggle = () => {
-    //   fp.amPM.style.display = "none";
-    //   const formGroupKit = document.createElement("div");
-    //   formGroupKit.className = "pb_form_group_kit";
-
-    //   const amCard = generateMeridiemCard("AM");
-    //   amCard.addEventListener("click", () => {
-    //     fp.selectedDates[0].setHours(
-    //       (fp.selectedDates[0].getHours() % 12) + 12 * 0
-    //     );
-    //     fp.setDate(fp.selectedDates[0], true);
-    //   });
-
-    //   const pmCard = generateMeridiemCard("PM");
-    //   pmCard.addEventListener("click", () => {
-    //     fp.selectedDates[0].setHours(
-    //       (fp.selectedDates[0].getHours() % 12) + 12 * 1
-    //     );
-    //     fp.setDate(fp.selectedDates[0], true);
-    //   });
-
-    //   formGroupKit.prepend(amCard);
-    //   formGroupKit.append(pmCard);
-
-    //   const meridiemContainer = document.createElement("div");
-    //   meridiemContainer.className = "meridiem";
-    //   meridiemContainer.append(formGroupKit);
-    //   document.querySelector(".pb_time_selection").append(meridiemContainer);
-    // };
-
-    // const getMeridiem = (dateObj: string | any[]) => {
-    //   return dateObj[0].getHours() < 12 ? "AM" : "PM";
-    // };
-
-    // const updateMeridiemToggle = (forceClick: boolean) => {
-    //   if (!fp.selectedDates.length) return;
-
-    //   const uncheckedClass = "pb_selectable_card_kit_enabled",
-    //     checkedClass = "pb_selectable_card_kit_checked_enabled",
-    //     pickerAM: HTMLElement & { [x: string]: any } =
-    //       document.getElementById("datePickerAM"),
-    //     pickerPM: HTMLElement & { [x: string]: any } =
-    //       document.getElementById("datePickerPM"),
-    //     meridiem = getMeridiem(fp.selectedDates);
-
-    //   if (forceClick) {
-    //     pickerAM.checked = false;
-    //     pickerPM.checked = false;
-    //     pickerPM.checked = meridiem === "PM";
-    //     pickerAM.checked = meridiem === "AM";
-    //   }
-
-    //   if (meridiem === "PM") {
-    //     pickerPM.parentElement.className = checkedClass;
-    //     pickerAM.parentElement.className = uncheckedClass;
-    //   } else if (meridiem === "AM") {
-    //     pickerAM.parentElement.className = checkedClass;
-    //     pickerPM.parentElement.className = uncheckedClass;
-    //   }
-    // };
+    return function (fp: FpTypes & any) {
+      const generateMeridiemCard = (text: string) => {
+        const selectableCard = document.createElement("div");
+        selectableCard.className = "pb_selectable_card_kit_enabled";
+  
+        const cardInput = document.createElement("input"),
+        cardInputId = `datePicker-${fp.element.id}-${text}`;
+        cardInput.className = "datePicker-AMPM"
+        cardInput.id = cardInputId;
+        cardInput.name = "datepicker-ampm";
+        cardInput.type = "radio";
+        cardInput.value = text;
+  
+        const cardLabel = document.createElement("label"),
+          cardLabelBuffer = document.createElement("div");
+        cardLabel.className = `label-${text.toLowerCase()}`;
+        cardLabel.setAttribute("for", cardInputId);
+        cardLabelBuffer.className = "buffer";
+        cardLabelBuffer.innerHTML = text;
+  
+        cardLabel.append(cardLabelBuffer);
+        selectableCard.prepend(cardInput);
+        selectableCard.append(cardLabel);
+  
+        return selectableCard;
+      };
+  
+      const generateMeridiemToggle = () => {
+        fp.amPM.style.display = "none";
+        const formGroupKit = document.createElement("div");
+        formGroupKit.className = "pb_form_group_kit";
+  
+        const amCard = generateMeridiemCard("AM");
+        amCard.addEventListener("click", () => {
+          fp.selectedDates[0].setHours(
+            (fp.selectedDates[0].getHours() % 12) + 12 * 0
+          );
+          fp.setDate(fp.selectedDates[0], true);
+        });
+  
+        const pmCard = generateMeridiemCard("PM");
+        pmCard.addEventListener("click", () => {
+          fp.selectedDates[0].setHours(
+            (fp.selectedDates[0].getHours() % 12) + 12 * 1
+          );
+          fp.setDate(fp.selectedDates[0], true);
+        });
+  
+        formGroupKit.prepend(amCard);
+        formGroupKit.append(pmCard);
+  
+        const meridiemContainer = document.createElement("div");
+        meridiemContainer.className = "meridiem";
+        meridiemContainer.append(formGroupKit);
+        fp.timeContainer.append(meridiemContainer)
+      };
+  
+      const getMeridiem = (dateObj: string | any[]) => {
+        return dateObj[0].getHours() < 12 ? "AM" : "PM";
+      };
+  
+      const updateMeridiemToggle = (forceClick: boolean) => {
+        if (!fp.selectedDates.length) return;
+  
+        const uncheckedClass = "pb_selectable_card_kit_enabled",
+          checkedClass = "pb_selectable_card_kit_checked_enabled",
+          pickerAM: HTMLElement & { [x: string]: any } =
+            document.getElementById(`datePicker-${fp.element.id}-AM`),
+          pickerPM: HTMLElement & { [x: string]: any } =
+            document.getElementById(`datePicker-${fp.element.id}-PM`),
+          meridiem = getMeridiem(fp.selectedDates);
+  
+        if (forceClick) {
+          pickerAM.checked = false;
+          pickerPM.checked = false;
+          pickerPM.checked = meridiem === "PM";
+          pickerAM.checked = meridiem === "AM";
+        }
+  
+        if (meridiem === "PM") {
+          pickerPM.parentElement.className = checkedClass;
+          pickerAM.parentElement.className = uncheckedClass;
+        } else if (meridiem === "AM") {
+          pickerAM.parentElement.className = checkedClass;
+          pickerPM.parentElement.className = uncheckedClass;
+        }
+      };
 
     return {
       onValueUpdate() {
-        // updateMeridiemToggle(true);
+        updateMeridiemToggle(true);
       },
       onReady() {
         const id = fp.input.id;
@@ -151,8 +151,8 @@ function timeSelectPlugin(props: { caption: string; showTimezone: boolean }) {
         }
 
         // add meridiem toggle
-        // generateMeridiemToggle();
-        // updateMeridiemToggle(true);
+        generateMeridiemToggle();
+        updateMeridiemToggle(true);
 
         // add timezone text
         if (props.showTimezone) {

--- a/playbook/app/pb_kits/playbook/pb_date_picker/plugins/timeSelect.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/plugins/timeSelect.ts
@@ -132,6 +132,9 @@ function timeSelectPlugin(props: { caption: string; showTimezone: boolean }) {
       onValueUpdate() {
         updateMeridiemToggle(true);
       },
+      onOpen() {
+        updateMeridiemToggle(true);
+      },
       onReady() {
         const id = fp.input.id;
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_time_selection_styles.scss
@@ -8,20 +8,6 @@
     text-align: left;
     margin-left: $space_sm;
 
-    span.flatpickr-am-pm {
-      margin-left: $space_sm;
-      border-radius: 5px;
-      color: $primary;
-      &:hover{
-        background-color: rgba($primary, 0.03);
-      }
-      &:focus{
-        background-color: unset;
-        &:hover{
-          background-color: rgba($primary, 0.03);
-        }
-      }
-    }
     .numInputWrapper {
       width: auto;
       input.numInput {
@@ -59,7 +45,7 @@
         margin-left: $space_sm;
       }
 
-      #datePickerAM, #datePickerPM {
+      .datePicker-AMPM {
         display: none;
       }
       &:focus, &:hover {


### PR DESCRIPTION
#### Screens

![Screen Shot 2022-11-15 at 3 49 30 PM](https://user-images.githubusercontent.com/73710701/202022544-2796b950-08f1-4cdb-b1a9-bf2b6dad2503.png)

#### Breaking Changes

No, replaces the flatpicker native toggle for AM/PM with custom built component

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-486)

#### How to test this

In milano env scroll down to 'time selection' doc example. Click to open the datepicker and make sure it looks like the image above and that the AM/PM buttons change the value in the input field. There are 2 date pickers in that example, make sure the AM/PM buttons do not interfere with each other and only toggle Am/PM for their own date Picker's input

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
