### PR TITLE
[PLAY-501] Fix Button Hover Bug

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.scss
@@ -31,7 +31,7 @@ $pb_button_sizes: (
     @include pb_button_link;
     @media (hover:hover) {
       &:hover {
-        @include pb_button_hover(mix($primary_action, $white, 3%));
+        color: $text_lt_default;
       }
     } 
   }


### PR DESCRIPTION


#### Screens

No Hover:
![Screen Shot 2022-11-22 at 12 14 03 PM](https://user-images.githubusercontent.com/73710701/203379039-73625293-8639-4d75-a951-e96bfc5bbf9a.png)

With Hover:
![Screen Shot 2022-11-22 at 12 13 58 PM](https://user-images.githubusercontent.com/73710701/203379094-8fc92440-544a-40ad-a90e-31caa01ee3d9.png)

#### Breaking Changes

Yes, Changes hover state for link variant of Button to only change text color NOT background color

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-501)

#### How to test this

[INSERT TESTING DETAILS]

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
