### PR TITLE
[PLAY-227] Converting Enhanced Element to Typescript

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_enhanced_element/element_observer.ts
+++ b/playbook/app/pb_kits/playbook/pb_enhanced_element/element_observer.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import PbEnhancedElement from "./index"
 
 export default class ElementObserver {

--- a/playbook/app/pb_kits/playbook/pb_enhanced_element/element_observer.ts
+++ b/playbook/app/pb_kits/playbook/pb_enhanced_element/element_observer.ts
@@ -1,34 +1,45 @@
+import PbEnhancedElement from "./index"
+
 export default class ElementObserver {
-  constructor(matchDelegate, target = document) {
+  matchDelegate: PbEnhancedElement
+  target: Document
+  _mutationObserver: MutationObserver
+
+  constructor(matchDelegate: PbEnhancedElement, target = document) {
     this.matchDelegate = matchDelegate
     this.target = target
   }
 
-  start() {
+  get mutationObserver(): MutationObserver {
+    return this._mutationObserver =
+      this._mutationObserver || new MutationObserver((mutationList) => this.processMutationList(mutationList))
+  }
+
+  start(): void {
     this.mutationObserver.observe(this.target, { attributes: true, childList: true, subtree: true })
     this.catchup()
   }
 
-  stop() {
+  stop(): void {
     this.mutationObserverdisconnect()
   }
 
-  catchup() {
-    this.handleAdditions(this.matchDelegate.matches(this.target))
+  catchup(): void {
+    this.handleAdditions(this.matchDelegate.matches(this.target as unknown as Element))
   }
 
-  processMutationList(mutationList) {
+  processMutationList(mutationList: Array<MutationRecord>): void {
     for (const mutation of mutationList) {
       if (mutation.type == 'attributes') {
-        this.processAttributeChange(mutation.target)
+        this.processAttributeChange(mutation.target as Element)
       } else if (mutation.type == 'childList') {
-        this.processRemovedNodes(Array.from(mutation.removedNodes))
-        this.processAddedNodes(Array.from(mutation.addedNodes))
+        this.processRemovedNodes(Array.from(mutation.removedNodes) as Array<Element>)
+        this.processAddedNodes(Array.from(mutation.addedNodes) as Array<Element>)
       }
     }
   }
 
-  processAttributeChange(node) {
+  processAttributeChange(node: Element): void | Array<Element> {
     if (node.nodeType !== Node.ELEMENT_NODE) return
 
     const matches = this.matchDelegate.matches(node)
@@ -38,30 +49,25 @@ export default class ElementObserver {
     this.handleAdditions(matches)
   }
 
-  processRemovedNodes(nodes) {
+  processRemovedNodes(nodes: Array<Element>): void {
     for (const node of nodes) {
       if (node.nodeType !== Node.ELEMENT_NODE) continue
       this.handleRemovals(this.matchDelegate.matches(node))
     }
   }
 
-  processAddedNodes(nodes) {
+  processAddedNodes(nodes: Array<Element>): void {
     for (const node of nodes) {
       if (node.nodeType !== Node.ELEMENT_NODE) continue
       this.handleAdditions(this.matchDelegate.matches(node))
     }
   }
 
-  handleRemovals(elements) {
+  handleRemovals(elements: Array<Element>): void {
     for (const element of elements) this.matchDelegate.removeMatch(element)
   }
 
-  handleAdditions(elements) {
+  handleAdditions(elements: Array<Element>): void {
     for (const element of elements) this.matchDelegate.addMatch(element)
-  }
-
-  get mutationObserver() {
-    return this._mutationObserver =
-      this._mutationObserver || new MutationObserver((mutationList) => this.processMutationList(mutationList))
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_enhanced_element/index.ts
+++ b/playbook/app/pb_kits/playbook/pb_enhanced_element/index.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import ElementObserver from './element_observer'
 
 export default class PbEnhancedElement {
@@ -63,5 +65,6 @@ export default class PbEnhancedElement {
     console.warn('Redefine the connect function in a subclass.', this)
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   disconnect(): void {}
 }

--- a/playbook/app/pb_kits/playbook/pb_enhanced_element/index.ts
+++ b/playbook/app/pb_kits/playbook/pb_enhanced_element/index.ts
@@ -1,21 +1,29 @@
-import ElementObserver from './element_observer.js'
+import ElementObserver from './element_observer'
 
 export default class PbEnhancedElement {
-  static get elements() {
+  static _elements: Map<Element, PbEnhancedElement>
+  static _observer: ElementObserver
+  element: Element
+
+  constructor(element: Element) {
+    this.element = element
+  }
+
+  static get elements(): Map<Element, PbEnhancedElement> {
     return this._elements = (this._elements || new Map)
   }
 
-  static get observer() {
+  static get observer(): ElementObserver {
     return this._observer = (this._observer || new ElementObserver(this))
   }
 
-  static get selector() {
+  static get selector(): string {
     // eslint-disable-next-line no-console
     console.warn('Define a static property for selector or redefine the matches function in a subclass.', this)
     return null
   }
 
-  static matches(node) {
+  static matches(node: Element): Array<Element> {
     if (!this.selector) return []
 
     const matches = []
@@ -25,7 +33,7 @@ export default class PbEnhancedElement {
     return (matches)
   }
 
-  static addMatch(element) {
+  static addMatch(element: Element): void {
     if (element._pbEnhanced || this.elements.has(element)) return
 
     const enhansedElement = new this(element)
@@ -34,7 +42,7 @@ export default class PbEnhancedElement {
     element._pbEnhanced = enhansedElement
   }
 
-  static removeMatch(element) {
+  static removeMatch(element: Element): void {
     if (!this.elements.has(element)) return
 
     const enhansedElement = this.elements.get(element)
@@ -42,22 +50,18 @@ export default class PbEnhancedElement {
     this.elements.delete(element)
   }
 
-  static start() {
+  static start(): void {
     this.observer.start()
   }
 
-  static stop() {
+  static stop(): void {
     this.mutationObserver.stop()
   }
 
-  constructor(element) {
-    this.element = element
-  }
-
-  connect() {
+  connect(): void {
     // eslint-disable-next-line no-console
     console.warn('Redefine the connect function in a subclass.', this)
   }
 
-  disconnect() { }
+  disconnect(): void {}
 }


### PR DESCRIPTION
#### Breaking Changes

No. We converted the Enhanced Element to Typescript, but we did not change any signature or behavior.

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-227)

#### How to test this

We can test the kits that make use of the Enhanced Element. They are PbCollapsible, PbFixedConfirmationToast, PbFormValidation, PbPopover, PbTable, PbTextarea, PbTooltip, PbTypeahead.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
