### PR TITLE
Datepicker closeOnSelect Prop

### DIFF
--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -9,6 +9,7 @@ const getPositionElement = (element: string | Element) => {
 }
 
 type DatePickerConfig = {
+  closeOnSelect?: boolean,
   disableDate?: number[],
   disableRange?: number[],
   disableWeekdays?: number[],
@@ -29,6 +30,7 @@ type DatePickerConfig = {
 const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HTMLElement) => {
   const {
     allowInput,
+    closeOnSelect = true,
     defaultDate,
     disableDate,
     disableRange,
@@ -110,6 +112,7 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
   // ===========================================================
 
   flatpickr(`#${pickerId}`, {
+    closeOnSelect,
     disableMobile: true,
     dateFormat: getDateFormat(),
     defaultDate: defaultDateGetter(),

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_time.jsx
@@ -1,22 +1,38 @@
-import React from 'react'
+/* eslint-disable react/no-multi-comp */
+import React, { useMemo, useState } from 'react'
 
 import DatePicker from '../_date_picker'
+import Body from '../../pb_body/_body'
 
 const DEFAULT_DATE = new Date()
 DEFAULT_DATE.setHours(12)
 DEFAULT_DATE.setMinutes(0)
 
-const DatePickerTime = (props) => (
-  <div>
-    <DatePicker
-        defaultDate={DEFAULT_DATE}
-        enableTime
-        pickerId="date-picker-time"
-        showTimezone
-        {...props}
-    />
+const DatePickerTime = (props) => {
+  const [selectedDateTime, setSelectedDateTime] = useState(DEFAULT_DATE)
 
-  </div>
-)
+  const refExample = React.createRef()
+
+  const handleOnInputChanged = (dateTime) => {
+    setSelectedDateTime(dateTime)
+  }
+
+  return (
+    <div ref={refExample}>
+      <Body marginBottom="md">{selectedDateTime.toString()}</Body>
+      {useMemo(() => (
+        <DatePicker
+            closeOnSelect={false}
+            defaultDate={DEFAULT_DATE}
+            enableTime
+            onChange={handleOnInputChanged}
+            pickerId="date-picker-time"
+            showTimezone
+            {...props}
+        />
+      ), [props])}
+    </div>
+  )
+}
 
 export default DatePickerTime


### PR DESCRIPTION
Story TBD 

I was recently talking with @kellyeryan about issues with Datepicker closing on date selection before being able to select the time in her working view. We noticed that state mutations will trigger the datepicker instance to close and that Flatpickr has a `closeOnClick` config prop that you can pass to prevent this behavior. In a normal vanilla JS UI, this config prop alone would do the trick, however, in a stateful React app we must add one more thing to prevent unnecessary re-drawing of the datepicker instance: add `useMemo` hook. 

____

#### Screens

<img width="1435" alt="Screenshot 2022-11-23 at 4 26 29 PM" src="https://user-images.githubusercontent.com/2293844/203648867-796b63d5-721a-4a64-a9a4-1bb0e203b79c.png">


#### Breaking Changes

No

#### Runway Ticket URL

TBD

#### How to test this

See the time example. The Datepicker should not close on date or time selection. Only on click outside should it close.

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
