### PR TITLE
Updating new kit architecture names

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -76,7 +76,7 @@ class PagesController < ApplicationController
 
   def kit_show_new
     @kit = params[:name]
-    render "pages/kit_show_react", layout: "layouts/kits"
+    render "pages/kit_show_new", layout: "layouts/kits"
   end
 
   def principles; end

--- a/playbook-website/app/javascript/components/KitDocs/index.tsx
+++ b/playbook-website/app/javascript/components/KitDocs/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Title } from 'playbook-ui'
 
-const PbKitReact = ({ kit }) => {
+const KitDocs = ({ kit }) => {
   return (
     <>
       <Title
@@ -14,4 +14,4 @@ const PbKitReact = ({ kit }) => {
   )
 }
 
-export default PbKitReact
+export default KitDocs

--- a/playbook-website/app/javascript/packs/application.js
+++ b/playbook-website/app/javascript/packs/application.js
@@ -15,14 +15,14 @@ import DarkModeToggle from '../components/DarkModeToggle'
 import KitSearch from '../components/KitSearch'
 import SnippetToggle from '../components/SnippetToggle'
 import Sidebar from '../components/Sidebar'
-import PbKitReact from '../components/PbKitReact'
+import KitDocs from '../components/KitDocs'
 
 WebpackerReact.setup({
   DarkModeToggle,
   KitSearch,
   SnippetToggle,
   Sidebar,
-  PbKitReact,
+  KitDocs,
 })
 
 // Produce image assets

--- a/playbook-website/app/views/pages/kit_show_new.html.erb
+++ b/playbook-website/app/views/pages/kit_show_new.html.erb
@@ -1,0 +1,1 @@
+<%= react_component("KitDocs", kit: @kit) %>

--- a/playbook-website/app/views/pages/kit_show_react.html.erb
+++ b/playbook-website/app/views/pages/kit_show_react.html.erb
@@ -1,1 +1,0 @@
-<%= react_component("PbKitReact", kit: @kit) %>


### PR DESCRIPTION
#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-518)

#### How to test this

In the URL type in /kits/:name/new and check to see that the correct kit name is being rendered as a title

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
