### PR TITLE
[PLAY-519] Update Error Color Token

### DIFF
--- a/playbook/app/pb_kits/playbook/tokens/_colors.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_colors.scss
@@ -8,7 +8,7 @@ Colors -----------------------------*/
 $royal:               #0056CF !default;
 $purple:              #9E64E9 !default;
 $teal:                #00C4D7 !default;
-$red:                 #FF2229 !default;
+$red:                 #DA0014 !default;
 $red_dark:            #ff4a50 !default;
 $yellow:              #F9BB00 !default;
 $green:               #00CA74 !default;
@@ -160,7 +160,7 @@ $warning_secondary:   lighten($warning, 10%);
 $warning_subtle:      rgba($warning, $opacity_1);
 $error:               $red !default;
 $error_dark:          $red_dark !default;
-$error_dark_body:     lighten($error_dark, 2%);
+$error_dark_body:     $error_dark;
 $error_secondary:     lighten($error, 10%);
 $error_subtle:        rgba($error, $opacity_1);
 $info:                $teal !default;


### PR DESCRIPTION


#### Screens
![Screenshot 2022-12-19 at 12 46 22 PM](https://user-images.githubusercontent.com/73710701/208487922-e8feab93-a1af-4374-a6ed-3fc9b2791ef2.png)

#### Breaking Changes

No Breaking changes, PR only changes hex color for tokens.

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-519)

#### How to test this

Compare tokens in review env to ones on prod to see changes to red color. 

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
