### PR TITLE
[PLAY-520] Popover Kit Updates for Dropdown Doc Example

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.html.erb
@@ -1,6 +1,5 @@
 <%= pb_rails("button", props: { variant: "secondary", id: 'list' }) do %>
-    Filter By
-    <%= pb_rails("icon", props: { icon: "angle-down"}) %>
+    Filter By 
 <% end %>
 <%= pb_rails("popover", props: {trigger_element_id: "list", tooltip_id: "list-tooltip", position: 'bottom', padding: "none"}) do %>
     <%= pb_rails("list", props: {ordered: false, dark: false, borderless: false, xpadding: true}) do %>
@@ -11,3 +10,27 @@
         <%= pb_rails("list/item") do %><a>Date Ended </a><% end %>
     <% end %>
 <% end %>
+
+
+<script type="text/javascript">
+const button = document.querySelector("#list")
+let buttonClicked = false
+
+let arrowDiv = document.createElement("div")
+arrowDiv.style.marginLeft = "4px"
+button.append(arrowDiv)
+arrowDiv.innerHTML = '<i class="far fa-angle-down"></i>'
+
+button.onclick = () => {
+    buttonClicked = !buttonClicked    
+    if (buttonClicked) {
+        arrowDiv.innerHTML = '<i class="far fa-angle-up"></i>'
+    } else {
+        arrowDiv.innerHTML = '<i class="far fa-angle-down"></i>'
+    }
+}
+
+
+
+
+</script>

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.html.erb
@@ -1,5 +1,10 @@
 <%= pb_rails("button", props: { variant: "secondary", id: 'list' }) do %>
-    Filter By 
+    <%= pb_rails("flex", props: {align: "center"}) do %>
+        Filter By 
+        <%= pb_rails("flex/flex_item", props: {margin_left: "xxs"}) do %>
+        <div id="arrow-icon" style="display: flex"></div>
+        <% end %>
+    <% end %>
 <% end %>
 <%= pb_rails("popover", props: {trigger_element_id: "list", tooltip_id: "list-tooltip", position: 'bottom', padding: "none"}) do %>
     <%= pb_rails("list", props: {ordered: false, dark: false, borderless: false, xpadding: true}) do %>
@@ -16,9 +21,7 @@
 const button = document.querySelector("#list")
 let buttonClicked = false
 
-let arrowDiv = document.createElement("div")
-arrowDiv.style.marginLeft = "4px"
-button.append(arrowDiv)
+const arrowDiv = document.querySelector("#arrow-icon")
 arrowDiv.innerHTML = '<i class="far fa-angle-down"></i>'
 
 button.onclick = () => {
@@ -29,8 +32,4 @@ button.onclick = () => {
         arrowDiv.innerHTML = '<i class="far fa-angle-down"></i>'
     }
 }
-
-
-
-
 </script>

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
@@ -5,6 +5,7 @@ import {
   List,
   ListItem,
   PbReactPopover,
+  Flex,
 } from '../..'
 
 const PopoverWithButton = (props) => {
@@ -19,11 +20,19 @@ const PopoverWithButton = (props) => {
         onClick={handleTogglePopover}
         variant="secondary"
     >
-      {'Filter By'}
-      <Icon
-          fixedWidth
-          icon="angle-down"
-      />
+      <Flex align="center">
+        {"Filter By"}
+        <Flex
+            className={showPopover ? "fa-flip-vertical" : ""}
+            display="inline_flex"
+        >
+          <Icon 
+              fixedWidth 
+              icon="angle-down" 
+              margin-left="sm" 
+          />
+        </Flex>
+      </Flex>
     </Button>
   )
 

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
@@ -29,7 +29,7 @@ const PopoverWithButton = (props) => {
           <Icon 
               fixedWidth 
               icon="angle-down" 
-              margin-left="sm" 
+              margin-left="xxs" 
           />
         </Flex>
       </Flex>


### PR DESCRIPTION
#### Screens

With dropdown closed:
![Screenshot 2022-12-27 at 2 07 55 PM](https://user-images.githubusercontent.com/73710701/209712045-4bbcd909-a058-4408-a44f-3a8121f0b96b.png)

With dropdown open:
![Screenshot 2022-12-27 at 2 08 10 PM](https://user-images.githubusercontent.com/73710701/209712054-af7be2c8-842d-4d03-9166-74c645484a5d.png)


#### Breaking Changes

No Breaking changes, updates to DOCs only

#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-520)

#### How to test this

Test in review env to make sure icon on dropdown example changes when clicked

#### Checklist:

- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
