### PR TITLE
Allow deployments to proceed smoothly within quota

### DIFF
--- a/playbook-website/config/deploy/templates/deployment.yaml.erb
+++ b/playbook-website/config/deploy/templates/deployment.yaml.erb
@@ -8,10 +8,10 @@ metadata:
     krane.shopify.io/required-rollout: "maxUnavailable"
 spec:
   replicas: 2
-  strategy:                                                                                                                                                                       │
-    rollingUpdate:                                                                                                                                                                │
-      maxSurge: 50%                                                                                                                                                               │
-      maxUnavailable: 50%                                                                                                                                                         │
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 50%
     type: RollingUpdate
   selector:
     matchLabels:

--- a/playbook-website/config/deploy/templates/deployment.yaml.erb
+++ b/playbook-website/config/deploy/templates/deployment.yaml.erb
@@ -8,6 +8,11 @@ metadata:
     krane.shopify.io/required-rollout: "maxUnavailable"
 spec:
   replicas: 2
+  strategy:                                                                                                                                                                       │
+    rollingUpdate:                                                                                                                                                                │
+      maxSurge: 50%                                                                                                                                                               │
+      maxUnavailable: 50%                                                                                                                                                         │
+    type: RollingUpdate
   selector:
     matchLabels:
       app: playbook


### PR DESCRIPTION
The namespace quota is sufficiently sized for 3 replicas of this pod. The default parameters (25% capacity flux either way) would cause an attempt to execute 4 pods concurrently. These parameters allow rollouts to operate within the quota of 3 pods concurrently.