### PR TITLE
[Play-529] Typescript Conversion Stat Value

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_stat_value/_stat_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/_stat_value.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 
@@ -10,10 +8,10 @@ type StatValueProps = {
   className?: string,
   id?: string,
   unit?: string,
-  value: string | number
+  value: string | number,
 }
 
-const StatValue = (props: StatValueProps) => {
+const StatValue = (props: StatValueProps): React.ReactElement => {
   const {
     className,
     id,
@@ -21,7 +19,7 @@ const StatValue = (props: StatValueProps) => {
     value = 0,
   } = props
 
-  const displayValue = function(value) {
+  const displayValue = function(value: string | number) {
     if (value || value === 0) {
       return (
         <Title
@@ -33,7 +31,7 @@ const StatValue = (props: StatValueProps) => {
     }
   }
 
-  const displayUnit = function(unit) {
+  const displayUnit = function(unit: string) {
     if (unit) {
       return (
         <Title

--- a/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_unit.jsx
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/docs/_stat_value_unit.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import StatValue from '../_stat_value.jsx'
+import StatValue from '../_stat_value'
 
 const StatValueUnit = (props) => {
   return (

--- a/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.test.js
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+
+import StatValue from './_stat_value'
+
+test('it renders the component with the value', () => {
+  render(
+    <StatValue
+        value={1048}
+    />
+  )
+
+  const kit = screen.getByText('1048')
+  expect(kit).toBeTruthy()
+})
+
+test('it renders the component with the unit', () => {
+  render(
+    <StatValue
+        unit="appt"
+        value="5,294"
+    />
+  )
+
+  const kit = screen.getByText('appt')
+  expect(kit).toBeTruthy()
+})


### PR DESCRIPTION
#### Screens

<img width="378" alt="Screen Shot 2023-02-03 at 2 38 42 PM" src="https://user-images.githubusercontent.com/73671109/216692515-c2187fee-9364-48e8-a22f-0c1df19ca021.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-529)

#### How to test this

Check to make sure all stat changes kits still render properly

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
