### PR TITLE
[PLAY-499] Added ClassName prop to Tooltip Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -17,6 +17,7 @@ import Flex from "../pb_flex/_flex"
 
 type TooltipProps = {
   aria?: { [key: string]: string },
+  className?: string | string[],
   data?: { [key: string]: string },
   text: string,
   icon?: string,
@@ -26,9 +27,10 @@ type TooltipProps = {
   zIndex?: Pick<GlobalProps, "ZIndex">,
 } & GlobalProps
 
-const Tooltip = (props: TooltipProps) => {
+const Tooltip = (props: TooltipProps): React.ReactElement => {
   const {
     aria = {},
+    className,
     children,
     data = {},
     icon = null,
@@ -42,7 +44,10 @@ const Tooltip = (props: TooltipProps) => {
   const dataProps: { [key: string]: any } = buildDataProps(data)
   const ariaProps: { [key: string]: any } = buildAriaProps(aria)
 
-  const css = classnames(globalProps({...rest}))
+  const css = classnames(
+    globalProps({...rest}),
+    className
+  )
   const [open, setOpen] = useState(false)
   const arrowRef = useRef(null)
   const {
@@ -92,44 +97,47 @@ const Tooltip = (props: TooltipProps) => {
   return (
     <>
       <div
-        ref={reference}
-        className={`pb_tooltip_kit ${css}`}
-        style={{ display: "inline-flex" }}
-        role="tooltip_trigger"
-        {...ariaProps}
-        {...dataProps}
+          className={`pb_tooltip_kit ${css}`}
+          ref={reference}
+          role="tooltip_trigger"
+          style={{ display: "inline-flex" }}
+          {...ariaProps}
+          {...dataProps}
       >
         {children}
       </div>
       {open && (
         <div
-          {...getFloatingProps({
-            role: "tooltip",
-            ref: floating,
-            className: `tooltip_tooltip ${placement} visible`,
-            style: {
-              position: strategy,
-              top: y ?? 0,
-              left: x ?? 0,
-              zIndex: zIndex ?? 0,
-            },
-          })}
+            {...getFloatingProps({
+              role: "tooltip",
+              ref: floating,
+              className: `tooltip_tooltip ${placement} visible`,
+              style: {
+                position: strategy,
+                top: y ?? 0,
+                left: x ?? 0,
+                zIndex: zIndex ?? 0,
+              },
+            })}
         >
-          <Flex gap="xs" align="center">
+          <Flex 
+              align="center"
+              gap="xs"
+          >
             {icon && (
             <i className={`pb_icon_kit far fa-${icon} fa-fw`} />
             )}
             {text}
           </Flex>
           <div
-            ref={arrowRef}
-            className="arrow_bg"
-            style={{
-              position: strategy,
-              left: arrowX != null ? `${arrowX}px` : "",
-              top: arrowY != null ? `${arrowY}px` : "",
-              [staticSide]: "-5px",
-            }}
+              className="arrow_bg"
+              ref={arrowRef}
+              style={{
+                position: strategy,
+                left: arrowX != null ? `${arrowX}px` : "",
+                top: arrowY != null ? `${arrowY}px` : "",
+                [staticSide]: "-5px",
+              }}
           />
         </div>
       )}

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_default_react.jsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_default_react.jsx
@@ -14,7 +14,7 @@ const TooltipDefaultReact = (props) => {
    >
     <FlexItem>
       <Tooltip 
-          className={"This is a custom className using the className prop"}
+          className={"customClassNameHere"}
           placement='top' 
           text="Whoa. I'm a Tooltip" 
           zIndex={10}

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_default_react.jsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_default_react.jsx
@@ -14,6 +14,7 @@ const TooltipDefaultReact = (props) => {
    >
     <FlexItem>
       <Tooltip 
+          className={"This is a custom className using the className prop"}
           placement='top' 
           text="Whoa. I'm a Tooltip" 
           zIndex={10}

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.test.jsx
@@ -51,3 +51,17 @@ test("closes on mouseleave", async () => {
     cleanup();
   })
 });
+
+test("closes on mouseleave", async () => {
+  render(
+    <Tooltip
+        className={"Hello World"}
+        data={{ testid: "className-test" }}
+    />
+  );
+
+  const kit = screen.getByTestId("className-test");
+  expect(kit).toHaveClass("Hello World");
+
+  cleanup();
+});


### PR DESCRIPTION
#### Screens

<img width="190" alt="Screen Shot 2023-02-03 at 3 34 51 PM" src="https://user-images.githubusercontent.com/73671109/216708178-447368ef-c91a-48b6-b30f-e8658004678b.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-499)

#### How to test this

Add a custom class name using the className prop and inspect to make sure the className was passed

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
