### PR TITLE
[PLAY-586] Typescript Conversion: TimeStamp

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 
@@ -11,8 +9,8 @@ import Caption from '../pb_caption/_caption'
 
 type TimestampProps = {
   align?: "left" | "center" | "right",
-  aria?: object,
-  className?: string | array<string>,
+  aria?: { [key: string]: string },
+  className?: string | string[],
   dark?: boolean,
   data?: string,
   text: string,
@@ -26,7 +24,7 @@ type TimestampProps = {
   variant?: "default" | "elapsed" | "updated"
 }
 
-const Timestamp = (props: TimestampProps) => {
+const Timestamp = (props: TimestampProps): React.ReactElement => {
   const {
     align = 'left',
     aria = {},
@@ -90,9 +88,9 @@ const Timestamp = (props: TimestampProps) => {
   const captionText = () => {
     switch (variant) {
     case 'updated':
-      return formatUpdatedString(userDisplay, dateTimestamp)
+      return formatUpdatedString()
     case 'elapsed':
-      return formatElapsedString(userDisplay, timeDisplay, updatedText)
+      return formatElapsedString()
     default:
       return showDate ? timestamp ? fullDateDisplay() : text : fullTimeDisplay()
     }

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Timestamp from '../_timestamp.jsx'
+import Timestamp from '../_timestamp'
 
 const todaysDate = new Date()
 const futureYear = new Date().getFullYear() + 4

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Timestamp from '../_timestamp.jsx'
+import Timestamp from '../_timestamp'
 
 const todaysDate = new Date()
 const futureYear = new Date().getFullYear() + 4

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Timestamp from '../_timestamp.jsx'
+import Timestamp from '../_timestamp'
 
 const todaysDate = new Date()
 const year = new Date().getFullYear()

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Timestamp from '../_timestamp.jsx'
+import Timestamp from '../_timestamp'
 
 const todaysDate = new Date()
 const futureYear = new Date().getFullYear() + 4

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Timestamp from '../_timestamp.jsx'
+import Timestamp from '../_timestamp'
 
 const todaysDate = new Date()
 


### PR DESCRIPTION
#### Screens

<img width="496" alt="Screen Shot 2023-02-06 at 10 48 45 AM" src="https://user-images.githubusercontent.com/73671109/217018212-216a312f-1232-4a07-b240-4f6a3797511b.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-586)

#### How to test this

Check that the Timestamp kit still works as expected and has no errors in console.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
