### PR TITLE
[PLAY-412] Bar Graph borders don't match theme

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -108,7 +108,6 @@ const BarGraph = ({
     plotOptions: {
       series: {
         pointStart: pointStart,
-        borderColor: 'transparent',
         events: {},
         dataLabels: {
           enabled: false,

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -13,7 +13,7 @@ import classnames from "classnames";
 type BarGraphProps = {
   align?: "left" | "right" | "center";
   axisTitle: string;
-  dark?: Boolean;
+  dark?: boolean;
   xAxisCategories: [];
   yAxisMin: number;
   yAxisMax: number;
@@ -62,7 +62,7 @@ const BarGraph = ({
   x = 0,
   y = 0,
   ...props
-}: BarGraphProps) => {
+}: BarGraphProps): React.ReactElement => {
   const ariaProps = buildAriaProps(aria);
   const dataProps = buildDataProps(data);
   const setupTheme = () => {
@@ -108,6 +108,7 @@ const BarGraph = ({
     plotOptions: {
       series: {
         pointStart: pointStart,
+        borderColor: 'transparent',
         events: {},
         dataLabels: {
           enabled: false,
@@ -130,14 +131,14 @@ const BarGraph = ({
 
   return (
     <HighchartsReact
-      containerProps={{
-        className: classnames(globalProps(props), className),
-        id: id,
-        ...ariaProps,
-        ...dataProps,
-      }}
-      highcharts={Highcharts}
-      options={options}
+        containerProps={{
+          className: classnames(globalProps(props), className),
+          id: id,
+          ...ariaProps,
+          ...dataProps,
+        }}
+        highcharts={Highcharts}
+        options={options}
     />
   );
 };

--- a/playbook/app/pb_kits/playbook/pb_dashboard/pbChartsDarkTheme.ts
+++ b/playbook/app/pb_kits/playbook/pb_dashboard/pbChartsDarkTheme.ts
@@ -136,6 +136,8 @@ const highchartsDarkTheme: ThemeProps = {
 
   plotOptions: {
     series: {
+      borderColor: colors.bg_dark_card,
+      borderWidth: 2,
       type: 'area',
       nullColor: colors.text_dk_lighter,
       fillColor: {

--- a/playbook/app/pb_kits/playbook/tokens/_colors.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_colors.scss
@@ -59,9 +59,11 @@ $main_colors: (
 Background colors ------------------*/
 $bg_light:            $silver !default;
 $bg_dark:             #0a0527 !default;
+$bg_dark_card:        #231E3D;
 $background_colors: (
   bg_light:           $bg_light,
-  bg_dark:            $bg_dark
+  bg_dark:            $bg_dark,
+  bg_dark_card:       $bg_dark_card 
 );
 
 /* Card colors ------------------*/


### PR DESCRIPTION
#### Screens

<img width="345" alt="Screen Shot 2023-02-06 at 12 10 34 PM" src="https://user-images.githubusercontent.com/73671109/217038584-0d10ce84-57f2-4145-9476-192b72e4dc85.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-412)

#### How to test this

Check Bar graph to make sure borders are transparent

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
