### PR TITLE
[PLAY-415] Text Input kit Left-Aligned Add On With No Border padding missing

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -215,7 +215,7 @@
       }
       .text_input {
         border-left: 0;
-        padding-left: 0;
+        padding-left: 16px;
       }
     }
     &_left_on {

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on.html.erb
@@ -8,6 +8,12 @@
   add_on: { icon: "user", alignment: 'right', border: true }
 }) %>
 
+
+<%= pb_rails("text_input", props: {
+  label: "Right-Aligned Add On With No Border",
+  add_on: { icon: "percent", alignment: 'right', border: false }
+}) %>
+
 <%= pb_rails("text_input", props: {
   label: "Left-Aligned Add On With No Border",
   add_on: { icon: "percent", alignment: 'left', border: false }
@@ -16,9 +22,4 @@
 <%= pb_rails("text_input", props: {
   label: "Left-Aligned Add On With Border",
   add_on: { icon: "user", alignment: 'left', border: true }
-}) %>
-
-<%= pb_rails("text_input", props: {
-  label: "Right-Aligned Add On With No Border",
-  add_on: { icon: "percent", alignment: 'right', border: false }
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on.jsx
@@ -51,19 +51,19 @@ const TextInputAddOn = (props) => {
       </div>
       <div>
         <TextInput
-            addOn={{ icon: 'percent', alignment: 'left', border: false }}
-            label="Left-Aligned Add On With No Border"
-            onChange={handleUpdateSecondInput}
-            value={secondInput}
+            addOn={{ icon: 'percent', alignment: 'right', border: false }}
+            label="Right-Aligned Add On With No Border"
+            onChange={handleUpdateThirdInput}
+            value={thirdInput}
             {...props}
         />
       </div>
       <div>
         <TextInput
-            addOn={{ icon: 'percent', alignment: 'right', border: false }}
-            label="Right-Aligned Add On With No Border"
-            onChange={handleUpdateThirdInput}
-            value={thirdInput}
+            addOn={{ icon: 'percent', alignment: 'left', border: false }}
+            label="Left-Aligned Add On With No Border"
+            onChange={handleUpdateSecondInput}
+            value={secondInput}
             {...props}
         />
       </div>


### PR DESCRIPTION
#### Screens

<img width="819" alt="Screen Shot 2023-02-16 at 12 00 27 PM" src="https://user-images.githubusercontent.com/73671109/219435453-b5a7ff09-89f9-4c24-915a-5bbb4858ab20.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-415)

#### How to test this

Use the Text Input `LEFT-ALIGNED ADD ON WITH NO BORDER` variant and ensure that the blinking cursor is visible.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
