### PR TITLE
[PLAY-620] Nav kit active background color is wrong

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_nav/_horizontal_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_horizontal_nav.scss
@@ -83,7 +83,7 @@ $selector: ".pb_nav_list";
       margin: 0;
     }
     [class*=_active] {
-      background-color: $active_light;
+      background-color: $bg_light;
       &[class*=dark] {
         background-color: rgba($white, $opacity_1);
       }

--- a/playbook/app/pb_kits/playbook/pb_nav/_vertical_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_vertical_nav.scss
@@ -101,7 +101,7 @@ $selector: ".pb_nav_list";
   // Show Highlight
   &[class*=_highlight] {
     [class*=_active] {
-      background-color: $active_light;
+      background-color: $bg_light;
     }
     &[class*=dark]{
       [class*=_active] {


### PR DESCRIPTION
#### Screens

<img width="821" alt="Screen Shot 2023-02-17 at 10 51 16 AM" src="https://user-images.githubusercontent.com/73671109/219701578-e50ba69c-53c3-4c6c-abb8-ec0ca197279b.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-620)

#### How to test this

Use Nav kit and ensure active nav item is correct color

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
