### PR TITLE
[PLAY-619] Color tokens need default property

### DIFF
--- a/playbook/app/pb_kits/playbook/tokens/_colors.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_colors.scss
@@ -59,7 +59,7 @@ $main_colors: (
 Background colors ------------------*/
 $bg_light:            $silver !default;
 $bg_dark:             #0a0527 !default;
-$bg_dark_card:        #231E3D;
+$bg_dark_card:        #231E3D !default;
 $background_colors: (
   bg_light:           $bg_light,
   bg_dark:            $bg_dark,
@@ -68,7 +68,7 @@ $background_colors: (
 
 /* Card colors ------------------*/
 $card_light:          $white !default;
-$card_dark:           rgba($white, $opacity_1);
+$card_dark:           rgba($white, $opacity_1) !default;
 $card_colors: (
   card_light:         $card_light,
   card_dark:          $card_dark
@@ -80,7 +80,7 @@ $action_colors: (
 );
 
 /* Active colors ----------------------*/
-$active_light:        lighten(#E5F2FF, 3.5%);
+$active_light:        lighten(#E5F2FF, 3.5%) !default;
 $active_dark:         #0082ff !default;
 $active_colors: (
   active_light:       $active_light,
@@ -88,17 +88,17 @@ $active_colors: (
 );
 
 /* Hover colors -----------------------*/
-$hover_light:         darken($silver, 5%);
-$hover_dark:          rgba($white, $opacity_2);
+$hover_light:         darken($silver, 5%) !default;
+$hover_dark:          rgba($white, $opacity_2) !default;
 $hover_colors: (
   hover_light:        $hover_light,
   hover_dark:         $hover_dark
 );
 
 /* Focus colors -----------------------*/
-$focus_color:         $primary;
-$focus_input_light:   rgba($active_light, $opacity_5);
-$focus_input_dark:    rgba(#144075, $opacity_5);
+$focus_color:         $primary !default;
+$focus_input_light:   rgba($active_light, $opacity_5) !default;
+$focus_input_dark:    rgba(#144075, $opacity_5) !default;
 $focus_input_colors: (
   focus_input_light:        $focus_input_light,
   focus_input_dark:         $focus_input_dark,
@@ -107,14 +107,14 @@ $focus_input_colors: (
 
 /* Border colors ----------------------*/
 $border_light:        #E4E8F0 !default;
-$border_dark:         rgba($white, $opacity_1);
+$border_dark:         rgba($white, $opacity_1) !default;
 $border_colors: (
   border_light:       $border_light,
   border_dark:        $border_dark
 );
 
 /* Shadow colors ----------------------*/
-$shadow:        rgba(#3C6AAC, $opacity_2);
+$shadow:        rgba(#3C6AAC, $opacity_2) !default;
 $shadow_colors: (
   shadow:       $shadow,
 );
@@ -124,8 +124,8 @@ $text_lt_default:     $charcoal !default;
 $text_lt_light:       #687887 !default;
 $text_lt_lighter:     $slate !default;
 $text_dk_default:     $white !default;
-$text_dk_light:       rgba($white, $opacity_6);
-$text_dk_lighter:     rgba($white, $opacity_4);
+$text_dk_light:       rgba($white, $opacity_6) !default;
+$text_dk_lighter:     rgba($white, $opacity_4) !default;
 $text_colors: (
   text_lt_default:    $text_lt_default,
   text_lt_light:      $text_lt_light,
@@ -157,24 +157,24 @@ $data_colors: (
 
 /* Status colors ----------------------*/
 $success:             $green !default;
-$success_secondary:   lighten($success, 10%);
-$success_subtle:      rgba($success, $opacity_1);
+$success_secondary:   lighten($success, 10%) !default;
+$success_subtle:      rgba($success, $opacity_1) !default;
 $warning:             $yellow !default;
-$warning_secondary:   lighten($warning, 10%);
-$warning_subtle:      rgba($warning, $opacity_1);
+$warning_secondary:   lighten($warning, 10%) !default;
+$warning_subtle:      rgba($warning, $opacity_1) !default;
 $error:               $red !default;
 $error_dark:          $red_dark !default;
-$error_dark_body:     $error_dark;
-$error_secondary:     lighten($error, 10%);
-$error_subtle:        rgba($error, $opacity_1);
+$error_dark_body:     $error_dark !default;
+$error_secondary:     lighten($error, 10%) !default;
+$error_subtle:        rgba($error, $opacity_1) !default;
 $info:                $teal !default;
-$info_secondary :     lighten($info, 10%);
-$info_subtle:         rgba($info, $opacity_1);
+$info_secondary :     lighten($info, 10%) !default;
+$info_subtle:         rgba($info, $opacity_1) !default;
 $neutral:             $slate !default;
-$neutral_secondary:   lighten($neutral, 10%);
-$neutral_subtle:      rgba($neutral, $opacity_1);
+$neutral_secondary:   lighten($neutral, 10%) !default;
+$neutral_subtle:      rgba($neutral, $opacity_1) !default;
 $primary:             $primary !default;
-$primary_secondary:   lighten($primary, 10%);
+$primary_secondary:   lighten($primary, 10%) !default;
 
 $status_colors: (
   success:            $success,


### PR DESCRIPTION
#### Screens

![Screen Shot 2023-02-17 at 11 44 08 AM](https://user-images.githubusercontent.com/73671109/219713327-e2f74e73-7270-42a6-8fd4-53823bcf0b46.png)

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-619)

#### How to test this

Try to override playbooks color tokens 

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
