### PR TITLE
[PLAY-370] Fixing Typeahead off spacing on dropdown

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
@@ -183,6 +183,10 @@
   }
  
   .typeahead-kit-select__menu {
+    .typeahead-kit-select__menu-list {
+      padding: 0;
+    }
+
     .typeahead-kit-select__option {
       &.typeahead-kit-select__option--is-focused {
         background-color: $hover_light;


### PR DESCRIPTION
#### Screens

![image](https://user-images.githubusercontent.com/2573205/220201942-2d606836-c431-46ba-9d60-cbc30d1fc7f0.png)

#### Breaking Changes

No

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-370)

#### How to test this

- Go to the Typeahead component.
- Click on the "search" input to trigger the dropdown.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
