### PR TITLE
[PLAY-620] Selectable List kit active background color is wrong

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.scss
@@ -8,7 +8,7 @@
       background-color: $bg_light;
     }
     &[class*=checked_item] {
-      background-color: $bg_light;
+      background-color: $active_light;
     }
   }
   [class^=pb_radio_kit] {


### PR DESCRIPTION
#### Screens

<img width="829" alt="Screen Shot 2023-02-21 at 10 50 00 AM" src="https://user-images.githubusercontent.com/73671109/220393425-029cabdb-76cc-4842-85c8-369628ecbfc5.png">

#### Breaking Changes

NO

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-620)

#### How to test this

Check an item in selectable list and inspect to make sure it is using $active_light

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [x] **SPECS** Please cover your changes with specs.
- [x] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
