### PR TITLE
[PLAY-634] Converting Passphrase kit to Typescript

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
@@ -15,7 +15,7 @@ import PbReactPopover from '../pb_popover/_popover'
 import TextInput from '../pb_text_input/_text_input'
 
 type PassphraseProps = {
-  aria?: object,
+  aria?: { [key: string]: string },
   confirmation?: boolean,
   className?: string,
   data?: object,
@@ -23,7 +23,7 @@ type PassphraseProps = {
   id?: string,
   inputProps?: {},
   label?: string,
-  onChange: (String) => void,
+  onChange: (arg0: String) => void,
   showTipsBelow?: "always" | "xs" | "sm" | "md" | "lg" | "xl",
   tips?: Array<string>,
   uncontrolled?: boolean,
@@ -40,7 +40,7 @@ const Passphrase = (props: PassphraseProps) => {
     id,
     inputProps = {},
     label = confirmation ? "Confirm Passphrase" : "Passphrase",
-    onChange = () => {},
+    onChange = () => { },
     showTipsBelow = "always",
     tips = [],
     uncontrolled = false,
@@ -62,11 +62,11 @@ const Passphrase = (props: PassphraseProps) => {
   )
 
   const toggleShowPopover = () => setShowPopover(!showPopover)
-  const handleShouldClosePopover = (shouldClosePopover) => {
+  const handleShouldClosePopover = (shouldClosePopover: boolean) => {
     setShowPopover(!shouldClosePopover)
   }
 
-  const toggleShowPassphrase = (e) => {
+  const toggleShowPassphrase = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault()
     setShowPassphrase(!showPassphrase)
   }
@@ -86,54 +86,54 @@ const Passphrase = (props: PassphraseProps) => {
 
   const popoverReference = (
     <CircleIconButton
-        className={tipClass}
-        dark={dark}
-        icon="info-circle"
-        onClick={toggleShowPopover}
-        variant="link"
+      className={tipClass}
+      dark={dark}
+      icon="info-circle"
+      onClick={toggleShowPopover}
+      variant="link"
     />
   )
 
   return (
-    <div 
-        {...ariaProps} 
-        {...dataProps} 
-        className={classes} 
-        id={id}
+    <div
+      {...ariaProps}
+      {...dataProps}
+      className={classes}
+      id={id}
     >
       <label>
         <Flex align="baseline">
-          <Caption 
-              className="passphrase-label" 
-              text={label} 
+          <Caption
+            className="passphrase-label"
+            text={label}
           />
-          <If condition={tips.length > 0 && !confirmation}>
+          {tips.length > 0 && !confirmation &&
             <PbReactPopover
-                className="passphrase-tips"
-                closeOnClick="outside"
-                placement="right"
-                reference={popoverReference}
-                shouldClosePopover={handleShouldClosePopover}
-                show={showPopover}
+              className="passphrase-tips"
+              closeOnClick="outside"
+              placement="right"
+              reference={popoverReference}
+              shouldClosePopover={handleShouldClosePopover}
+              show={showPopover}
             >
-              <Flex 
-                  align="center" 
-                  orientation="column"
+              <Flex
+                align="center"
+                orientation="column"
               >
-                <Caption 
-                    marginBottom="xs" 
-                    text="Tips for a good passphrase" 
+                <Caption
+                  marginBottom="xs"
+                  text="Tips for a good passphrase"
                 />
                 <div>
                   {tips.map((tip, i) => (
-                    <Caption 
-                        key={i} 
-                        marginBottom="xs" 
-                        size="xs"
+                    <Caption
+                      key={i}
+                      marginBottom="xs"
+                      size="xs"
                     >
-                      <Icon 
-                          icon="shield-check" 
-                          marginRight="xs" 
+                      <Icon
+                        icon="shield-check"
+                        marginRight="xs"
                       />
                       {tip}
                     </Caption>
@@ -141,34 +141,34 @@ const Passphrase = (props: PassphraseProps) => {
                 </div>
               </Flex>
             </PbReactPopover>
-          </If>
+          }
         </Flex>
         <div className="passphrase-text-input-wrapper">
           <TextInput
-              className="passphrase-text-input"
-              dark={dark}
-              marginBottom="xs"
-              onChange={handleChange}
-              placeholder="Enter a passphrase..."
-              type={showPassphrase ? "text" : "password"}
-              value={displayValue}
-              {...inputProps}
+            className="passphrase-text-input"
+            dark={dark}
+            marginBottom="xs"
+            onChange={handleChange}
+            placeholder="Enter a passphrase..."
+            type={showPassphrase ? "text" : "password"}
+            value={displayValue}
+            {...inputProps}
           />
-          <span 
-              className="show-passphrase-icon" 
-              onClick={toggleShowPassphrase}
+          <span
+            className="show-passphrase-icon"
+            onClick={toggleShowPassphrase}
           >
             <Body
-                className={showPassphrase ? "hide-icon" : ""}
-                color="light"
-                dark={dark}
+              className={showPassphrase ? "hide-icon" : ""}
+              color="light"
+              dark={dark}
             >
               <Icon icon="eye-slash" />
             </Body>
             <Body
-                className={showPassphrase ? "" : "hide-icon"}
-                color="light"
-                dark={dark}
+              className={showPassphrase ? "" : "hide-icon"}
+              color="light"
+              dark={dark}
             >
               <Icon icon="eye" />
             </Body>

--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
@@ -23,7 +23,7 @@ type PassphraseProps = {
   id?: string,
   inputProps?: {},
   label?: string,
-  onChange: (arg0: String) => void,
+  onChange: (inputValue: String) => void,
   showTipsBelow?: "always" | "xs" | "sm" | "md" | "lg" | "xl",
   tips?: Array<string>,
   uncontrolled?: boolean,

--- a/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
@@ -28,9 +28,9 @@ type PbPopoverProps = {
   offset?: boolean;
   reference: PopperReference & any;
   show?: boolean;
-  shouldClosePopover?: (arg0: boolean) => boolean | boolean;
-} & GlobalProps &
-  PopperProps<any>;
+  shouldClosePopover?: (arg0: boolean) => void;
+} & GlobalProps & Omit<PopperProps<any>, 'children'>
+& { children?: React.ReactChild[] | React.ReactChild }
 
 // Prop enabled default modifiers here
 // https://popper.js.org/docs/v2/modifiers


### PR DESCRIPTION
#### Breaking Changes

No

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-634)

#### How to test this

Use the Passphrase kit and ensure it works as expected after the Typescript conversion.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
