### PR TITLE
[PLAY-635] Converting Person Contact kit to Typescript

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_person_contact/_person_contact.tsx
+++ b/playbook/app/pb_kits/playbook/pb_person_contact/_person_contact.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 
@@ -17,14 +15,13 @@ type ContactItem = {
 }
 
 type PersonContactProps = {
-  aria?: object,
-  className?: string | array<string>,
-  dark?: boolean,
+  aria?: { [key: string]: string },
+  className?: string | string[],
   data?: object,
   firstName: string,
   id?: string,
   lastName: string,
-  contacts?: array<ContactItem>,
+  contacts?: ContactItem[],
 }
 
 const PersonContact = (props: PersonContactProps) => {
@@ -60,34 +57,34 @@ const PersonContact = (props: PersonContactProps) => {
 
   return (
     <div
-        {...ariaProps}
-        {...dataProps}
-        className={classes}
-        id={id}
+      {...ariaProps}
+      {...dataProps}
+      className={classes}
+      id={id}
     >
       <Person
-          firstName={firstName}
-          lastName={lastName}
+        firstName={firstName}
+        lastName={lastName}
       />
       {validContacts().map((contactObject, index) => (
         <Contact
-            contactDetail={contactObject.contactDetail}
-            contactType={contactObject.contactType}
-            contactValue={contactObject.contactValue}
-            key={`valid-contact-${index}`}
+          contactDetail={contactObject.contactDetail}
+          contactType={contactObject.contactType}
+          contactValue={contactObject.contactValue}
+          key={`valid-contact-${index}`}
         />
       ))}
       {wrongContacts().map((contactObject, index) => (
         <div key={`wrong-contact-caption-wrapper-${index}`}>
           <Caption
-              className="wrong_numbers"
-              key={`wrong-contact-caption-${index}`}
-              text="wrong number"
+            className="wrong_numbers"
+            key={`wrong-contact-caption-${index}`}
+            text="wrong number"
           />
           <Contact
-              contactType={contactObject.contactType}
-              contactValue={contactObject.contactValue}
-              key={`wrong-contact-${index}`}
+            contactType={contactObject.contactType}
+            contactValue={contactObject.contactValue}
+            key={`wrong-contact-${index}`}
           />
         </div>
       ))}

--- a/playbook/app/pb_kits/playbook/pb_person_contact/person_contact.test.js
+++ b/playbook/app/pb_kits/playbook/pb_person_contact/person_contact.test.js
@@ -1,0 +1,112 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+import PersonContact from './_person_contact'
+
+const testId = 'personContact'
+const multipleTestId = 'personContactMultiple'
+
+const PersonContactTest = (props) => {
+    return (
+        <>
+            <PersonContact
+                aria={{ label: testId }}
+                className={'custom-class'}
+                contacts={[
+                    {
+                        contactType: 'email',
+                        contactValue: 'email@example.com',
+                    },
+                    {
+                        contactValue: '5555555555',
+                        contactDetail: 'Home',
+                    },
+                    {
+                        contactType: 'work',
+                        contactValue: '3245627482',
+                        contactDetail: 'Work',
+                    },
+                ]}
+                data={{ testid: testId }}
+                firstName="Jose"
+                id={testId}
+                lastName="da Silva"
+                {...props}
+            />
+            <PersonContact
+                contacts={[
+                    {
+                        contactValue: '5555555555',
+                        contactType: 'wrong-phone',
+                    },
+                ]}
+                data={{ testid: multipleTestId }}
+                firstName="Brenda"
+                lastName="Walters"
+                {...props}
+            />
+        </>
+    )
+}
+
+test('should render custom class and data', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass('custom-class')
+})
+
+test('should render id', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveProperty('id', testId)
+})
+
+test('should render aria-label', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveAttribute('aria-label', testId)
+})
+
+test('should render firstName', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveTextContent('Jose')
+})
+
+test('should render lastName', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveTextContent('da Silva')
+})
+
+test('should render contact value', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveTextContent('(555) 555-5555')
+})
+
+test('should render contact detail', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveTextContent('Home')
+})
+
+test('should render multiple contacts', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(multipleTestId)
+    expect(kit).toHaveTextContent('Brenda Walters')
+})
+
+test('should render wrong number', () => {
+    render(<PersonContactTest />)
+
+    const kit = screen.getByTestId(multipleTestId)
+    expect(kit).toHaveTextContent('wrong number')
+})


### PR DESCRIPTION
#### Breaking Changes

No

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-635)

#### How to test this

Use the Person Contact kit and ensure it works as expected after the Typescript conversion.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
