### PR TITLE
[PLAY-625] Implementing Phone Number Input kit dark mode

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -4,6 +4,7 @@ $transform-rotate-deg: 135deg;
 $input-max-width: 284px;
 $dropdown-min-width: 340px;
 $flag-min-resolution: 192dpi;
+$bg-dark-country-item: #e2eaf4;
 
 .pb_phone_number_input {
   input::placeholder {
@@ -47,7 +48,7 @@ $flag-min-resolution: 192dpi;
     background-color: $hover_light;
 
     .iti__country-name, .iti__dial-code {
-      color: $primary
+      color: $primary;
     }
   }
 
@@ -128,6 +129,66 @@ $flag-min-resolution: 192dpi;
 
   .iti__divider {
     border-bottom: 1px solid $border_light;
+  }
+
+  &.dark {
+    .iti--allow-dropdown .iti__flag-container {
+      background-color: rgba($white, 0);
+
+      &:hover {
+        background-color: rgba($white, 0);
+
+        &+ .text_input {
+          background-color: rgba($white, 0.15);
+        }
+
+        .iti__selected-flag {
+          background-color: rgba($white, 0);
+        }
+      }
+    }
+
+    .iti__selected-flag {
+      background-color: rgba($white, 0);
+      color: $white;
+    }
+
+    .iti__country-list {
+      background-color: $bg_dark; //$card_dark
+      border: 1px solid $border_dark;
+
+      .iti__highlight {
+        background-color: $bg-dark-country-item;
+      }
+    }
+
+    .iti__divider {
+      border-bottom: 1px solid $border_dark;
+    }
+
+    .iti__arrow.iti__arrow--up::before {
+      color: $slate;
+    }
+
+    .iti__country.iti__highlight {  
+      .iti__country-name {
+        color: $text_lt_default;
+      }
+
+      .iti__dial-code {
+        color: $text_lt_light;
+      }
+
+      &.iti__active::after {
+        color: $text_lt_default;
+      }
+    }
+
+    .dropdown_open {
+      .text_input {
+        background-color: rgba($white, 0.025) !important;
+      }
+    }
   }
   
   @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: $flag-min-resolution) {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -4,7 +4,6 @@ $transform-rotate-deg: 135deg;
 $input-max-width: 284px;
 $dropdown-min-width: 340px;
 $flag-min-resolution: 192dpi;
-$bg-dark-country-item: #e2eaf4;
 
 .pb_phone_number_input {
   input::placeholder {
@@ -154,11 +153,19 @@ $bg-dark-country-item: #e2eaf4;
     }
 
     .iti__country-list {
-      background-color: $bg_dark; //$card_dark
+      background-color: $bg_dark;
       border: 1px solid $border_dark;
 
       .iti__highlight {
-        background-color: $bg-dark-country-item;
+        background-color: $hover_dark;
+
+        .iti__country-name {
+          color: $text_dk_default;
+        }
+  
+        .iti__dial-code {
+          color: $text_lt_lighter;
+        }
       }
     }
 
@@ -168,20 +175,6 @@ $bg-dark-country-item: #e2eaf4;
 
     .iti__arrow.iti__arrow--up::before {
       color: $slate;
-    }
-
-    .iti__country.iti__highlight {  
-      .iti__country-name {
-        color: $text_lt_default;
-      }
-
-      .iti__dial-code {
-        color: $text_lt_light;
-      }
-
-      &.iti__active::after {
-        color: $text_lt_default;
-      }
     }
 
     .dropdown_open {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -1,4 +1,3 @@
-/* @flow */
 import React, { useEffect, useRef, useState } from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
@@ -15,19 +14,20 @@ declare global {
 }
 
 type PhoneNumberInputProps = {
-  aria?: { [key: string]: string }
-  className?: string
-  data?: { [key: string]: string }
-  disabled?: boolean
-  id?: string
-  initialCountry?: string
-  isValid?: (valid: boolean) => void
-  label?: string
-  name?: string
-  onChange?: (e: React.FormEvent<HTMLInputElement>) => void
-  onlyCountries: string[]
-  preferredCountries?: string[]
-  value?: string
+  aria?: { [key: string]: string },
+  className?: string,
+  dark?: boolean,
+  data?: { [key: string]: string },
+  disabled?: boolean,
+  id?: string,
+  initialCountry?: string,
+  isValid?: (valid: boolean) => void,
+  label?: string,
+  name?: string,
+  onChange?: (e: React.FormEvent<HTMLInputElement>) => void,
+  onlyCountries: string[],
+  preferredCountries?: string[],
+  value?: string,
 }
 
 enum ValidationError {
@@ -58,6 +58,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps) => {
   const {
     aria = {},
     className,
+    dark = false,
     data = {},
     disabled = false,
     id = "",
@@ -154,6 +155,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps) => {
     <div {...ariaProps} {...dataProps} className={classes}>
       <TextInput
         className={dropDownIsOpen ? 'dropdown_open' : ''}
+        dark={dark}
         disabled={disabled}
         error={error}
         id={id}

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_default.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { PhoneNumberInput } from '../../'
 
-const PhoneNumberInputDefault = () => (
-  <>
-    <PhoneNumberInput id='default' />
-  </>
+const PhoneNumberInputDefault = (props) => (
+    <>
+        <PhoneNumberInput
+            id='default'
+            {...props} />
+    </>
 )
 
 export default PhoneNumberInputDefault

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_initial_country.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_initial_country.jsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { PhoneNumberInput } from '../../'
 
-const PhoneNumberInitialCountry = () => (
-  <>
-    <PhoneNumberInput id='initial'
-        initialCountry='br'
-    />
-  </>
+const PhoneNumberInitialCountry = (props) => (
+    <>
+        <PhoneNumberInput
+            id='initial'
+            initialCountry='br'
+            {...props}
+        />
+    </>
 )
 
 export default PhoneNumberInitialCountry

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_only_countries.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_only_countries.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { PhoneNumberInput } from '../../'
 
-const PhoneNumberInputOnlyCountries = () => (
+const PhoneNumberInputOnlyCountries = (props) => (
   <>
     <PhoneNumberInput
         id='only'
         onlyCountries={['us', 'br']}
+        {...props} 
     />
   </>
 )

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_preferred_countries.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_preferred_countries.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { PhoneNumberInput } from '../../'
 
-const PhoneNumberInputPreferredCountries = () => (
+const PhoneNumberInputPreferredCountries = (props) => (
   <>
     <PhoneNumberInput
         id='preferred'
         preferredCountries={['us', 'br', 'ph', 'gb']}
+        {...props} 
     />
   </>
 )

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
@@ -27,6 +27,7 @@ module Playbook
       def phone_number_input_options
         {
           id: id,
+          dark: dark,
           disabled: disabled,
           initialCountry: initial_country,
           isValid: is_valid,


### PR DESCRIPTION
#### Screens

<img width="801" alt="image" src="https://user-images.githubusercontent.com/2573205/225389199-70d86d63-da0f-485b-ac1f-f3ef23bc253f.png">

#### Breaking Changes

No

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-625)

#### How to test this

Go to the Phone Number Input kit on Playbook and check the dark mode.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
