### PR TITLE
Fix for Alphas

### DIFF
--- a/.github/workflows/github-actions-alpha-version.yml
+++ b/.github/workflows/github-actions-alpha-version.yml
@@ -3,10 +3,9 @@ run-name: ${{ github.actor }} is creating an Alpha Version 🚀
 on:
   pull_request:
     types: [ labeled ]
-    labels:
-      - alpha
 jobs:
   Creating-Alpha-Version:
+    if: github.event.label.name == 'alpha'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
I spotted a bug occurring on all PRs that get opened against our master branch. 
They are generating alphas every time someone adds a label. 
This fix will resolve that issue, only triggering the alpha is someone adds the specific `alpha` label. 
