### PR TITLE
[PLAY-671] Adding classname prop to Typeahead kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.jsx
@@ -29,6 +29,7 @@ import { noop, buildDataProps } from '../utilities/props'
 
 type TypeaheadProps = {
   async?: boolean,
+  className?: string,
   components?: object,
   createable?: boolean,
   dark?: boolean,
@@ -49,6 +50,7 @@ type TypeaheadProps = {
 
 const Typeahead = ({
   async,
+  className,
   components = {},
   createable,
   error = "",
@@ -111,8 +113,12 @@ const Typeahead = ({
   }
 
   const dataProps = buildDataProps(data)
+  const classes = classnames(
+    'pb_typeahead_kit react-select',
+    globalProps(props),
+    className
+  )
 
-  const classes = `pb_typeahead_kit react-select ${globalProps(props)}`
   const inlineClass = selectProps.inline ? 'inline' : null
 
   return (

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
@@ -93,3 +93,18 @@ test('typeahead multi select with badges and small pills', () => {
   expect(badge).toBeInTheDocument()
 })
 
+test('should pass className prop', () => {
+  const className = 'custom-class-name'
+  render(
+    <Typeahead
+        className={className}
+        data={{ testid: 'typeahead-test' }}
+        defaultValue={[options[0]]}
+        label="Colors"
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId('typeahead-test')
+  expect(kit).toHaveClass(className)
+})


### PR DESCRIPTION
#### Breaking Changes

No

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-671)

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [ ] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
