### PR TITLE
[PLAY-514] Custom Tooltip Prop for Circle Chart

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
@@ -32,6 +32,7 @@ type CircleChartProps = {
   startAngle?: number;
   style?: string;
   title?: string;
+  tooltipHtml: string;
   useHtml?: boolean;
   zMin?: number;
   layout?: "horizontal" | "vertical" | "proximate";
@@ -78,6 +79,7 @@ const CircleChart = ({
   startAngle = null,
   style = "pie",
   title,
+  tooltipHtml,
   useHtml = false,
   zMin = null,
   layout = "horizontal",
@@ -100,9 +102,7 @@ const CircleChart = ({
   Highcharts.setOptions({
     tooltip: {
       headerFormat: null,
-      pointFormat:
-        '<span style="font-weight: bold; color:{point.color};">●</span>{point.name}: ' +
-        "<b>{point.y}</b>",
+      pointFormat: tooltipHtml ? tooltipHtml : '<span style="font-weight: bold; color:{point.color};">●</span>{point.name}: ' + "<b>{point.y}</b>",
       useHTML: useHtml,
     },
   });

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/circle_chart.rb
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/circle_chart.rb
@@ -24,6 +24,9 @@ module Playbook
       prop :use_html, type: Playbook::Props::Boolean, default: false
       prop :legend, type: Playbook::Props::Boolean, default: false
       prop :title, default: ""
+      prop :tooltip_html, default: '<span style="font-weight: bold; color:{point.color};">&#9679; </span>
+                                      {point.name}: ' + '<b>{point.y}
+                                    </b>'
       prop :height
       prop :rounded, type: Playbook::Props::Boolean, default: false
       prop :colors, type: Playbook::Props::Array,

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/docs/_circle_chart_custom_tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/docs/_circle_chart_custom_tooltip.html.erb
@@ -1,0 +1,20 @@
+<% data = [{
+    name: 'Waiting for Calls',
+    value: 41,
+  },
+  {
+    name: 'On Call',
+    value: 49,
+  },
+  {
+    name: 'After call',
+    value: 10,
+  }
+] %>
+
+
+<%= pb_rails("circle_chart", props: {
+    chart_data: data,
+    tooltip_html: "<p>Custom tooltip for {point.name} <br/>with value: {point.y}</p>",
+    id: "default-test"
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/docs/_circle_chart_custom_tooltip.jsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/docs/_circle_chart_custom_tooltip.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import CircleChart from '../_circle_chart'
+
+const data = [
+  {
+    name: 'Waiting for Calls',
+    value: 41,
+  },
+  {
+    name: 'On Call',
+    value: 49,
+  },
+  {
+    name: 'After call',
+    value: 10,
+  },
+]
+
+const CircleChartCustomTooltip = (props) => (
+  <div>
+    <CircleChart
+        chartData={data}
+        id="circle-chart-default"
+        tooltipHtml= '<p>Custom tooltip for {point.name} <br/>with value: {point.y}</p>'
+        {...props}
+    />
+  </div>
+)
+
+export default CircleChartCustomTooltip

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/docs/_circle_chart_custom_tooltip.md
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/docs/_circle_chart_custom_tooltip.md
@@ -1,0 +1,3 @@
+A custom tooltip format can be specified. The desired format can be passed as a `string` of custom HTML to the `tooltipHtml` prop.
+
+`{point.name}` and `{point.y}` are useful values that can be referenced for each point in the graph.

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/docs/example.yml
@@ -9,7 +9,8 @@ examples:
   - circle_chart_with_legend_kit: Legend
   - circle_chart_legend_position: Legend Position
   - circle_chart_with_title: Title
-  - circle_chart_inner_sizes: Inner Circle Size Options  
+  - circle_chart_inner_sizes: Inner Circle Size Options
+  - circle_chart_custom_tooltip: Tooltip Customization
 
   react:
   - circle_chart_default: Default Style
@@ -22,5 +23,6 @@ examples:
   - circle_chart_legend_position: Legend Position
   - circle_chart_with_title: Title
   - circle_chart_inner_sizes: Inner Circle Size Options  
+  - circle_chart_custom_tooltip: Tooltip Customization
 
 

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/docs/index.js
@@ -8,3 +8,4 @@ export { default as CircleChartWithLegendKit } from './_circle_chart_with_legend
 export { default as CircleChartLegendPosition } from './_circle_chart_legend_position.jsx'
 export { default as CircleChartWithTitle } from './_circle_chart_with_title.jsx'
 export { default as CircleChartInnerSizes } from './_circle_chart_inner_sizes.jsx'
+export { default as CircleChartCustomTooltip } from "./_circle_chart_custom_tooltip.jsx"


### PR DESCRIPTION
#### Screens

<img width="1020" alt="Screenshot 2023-03-29 at 7 46 07 AM" src="https://user-images.githubusercontent.com/73710701/228529567-18067b8d-a703-4499-b3da-01d310c79b47.png">

<img width="1084" alt="Screenshot 2023-03-29 at 7 46 01 AM" src="https://user-images.githubusercontent.com/73710701/228529580-526788cf-ac4b-47fb-ab67-83bbac82efd7.png">


#### Breaking Changes

No
#### Runway Ticket URL

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-514)

#### How to test this

[INSERT TESTING DETAILS]

