### PR TITLE
[PLAY-697] Updating Sandpack docs styles

### DIFF
--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -115,6 +115,10 @@ module ApplicationHelper
     super kit, props: dark_mode_props(props), &block
   end
 
+  def description(kit, example_key)
+    read_kit_file(kit, "_#{example_key}.md")
+  end
+
 private
 
   def dark_mode_props(props)
@@ -123,5 +127,10 @@ private
 
   def dark_mode?
     cookies[:dark_mode].eql? "true"
+  end
+
+  def read_kit_file(kit, *args)
+    path = ::Playbook.kit_path(kit, "docs", *args)
+    path.exist? ? path.read : ""
   end
 end

--- a/playbook-website/app/javascript/components/KitDocs/index.tsx
+++ b/playbook-website/app/javascript/components/KitDocs/index.tsx
@@ -6,11 +6,13 @@ import {
   SandpackCodeEditor,
 } from "@codesandbox/sandpack-react"
 
-import { CircleIconButton, Card, Caption } from "playbook-ui"
+import AnimateHeight from 'react-animate-height'
+import { Button, Caption } from "playbook-ui"
 import entryPoint from "./entryPoint"
 
 const KitDocs = ({ source, exampleTitle }) => {
-  const [showCode, setShowCode] = useState(false)
+  const [editorHeight, setEditorHeight] = useState(0);
+
   const code = source
     .replace(
       /import (\w+) from ('|")\.\.\/_(\w+)('|")/g,
@@ -23,64 +25,86 @@ const KitDocs = ({ source, exampleTitle }) => {
 
   return (
     <>
-      <Card className='pb--doc' padding='none'>
-        <SandpackProvider
-          files={{
-            "/style.css": {
-              code: `body { background: white };`,
-              hidden: true,
-            },
-            "/App.js": {
-              code: code,
-            },
-            "/index.js": {
-              code: entryPoint,
-              hidden: true,
-            },
-          }}
-          theme='dark'
-          template='react'
-          customSetup={{
-            entry: "/src/index.js",
-            dependencies: {
-              "playbook-ui": "latest",
-            },
-          }}
-          options={{
-            externalResources: [
-              "https://kit.fontawesome.com/098a1cd4d5.js",
-              "https://unpkg.com/playbook-ui@latest/dist/playbook.css",
-              "https://unpkg.com/playbook-ui@latest/dist/reset.css",
-            ],
-          }}
-        >
-          <SandpackLayout style={{ backgroundColor: "white", border: "none" }}>
-            <div style={{ width: "100%" }}>
-              <div className='pb--kit-example'>
-                <Caption paddingBottom='md' text={exampleTitle}></Caption>
+      <SandpackProvider
+        files={{
+          "/style.css": {
+            code: `body { background: white };`,
+            hidden: true,
+          },
+          "/App.js": {
+            code: code,
+          },
+          "/index.js": {
+            code: entryPoint,
+            hidden: true,
+          },
+        }}
+        theme='dark'
+        template='react'
+        customSetup={{
+          entry: "/src/index.js",
+          dependencies: {
+            "playbook-ui": "latest",
+          },
+        }}
+        options={{
+          externalResources: [
+            "https://kit.fontawesome.com/098a1cd4d5.js",
+            "https://unpkg.com/playbook-ui@latest/dist/playbook.css",
+            "https://unpkg.com/playbook-ui@latest/dist/reset.css",
+          ],
+        }}
+      >
+        <SandpackLayout style={{ backgroundColor: "white", border: "none" }}>
+          <div style={{ width: "100%" }}>
+            <div className='pb--kit-example'>
+              <Caption paddingBottom='md' text={exampleTitle}></Caption>
 
-                <SandpackPreview
-                  style={{ height: "450px" }}
-                  showOpenInCodeSandbox={false}
-                  showRefreshButton={false}
-                  actionsChildren={
-                    <CircleIconButton
-                      icon='pen'
-                      variant='secondary'
-                      onClick={() => setShowCode(!showCode)}
-                    />
-                  }
+              <SandpackPreview
+                showOpenInCodeSandbox={false}
+                showRefreshButton={false}
+              />
+            </div>
+
+            {editorHeight === 0 && (
+              <div style={{ width: "100%", display: "flex", justifyContent: "right" }}>
+                <Button
+                  icon='code'
+                  marginRight='xl'
+                  onClick={() => setEditorHeight('auto')}
+                  paddingX="none"
+                  tabIndex={0}
+                  text='Show Code'
+                  variant='link'
                 />
               </div>
-            </div>
-            {showCode && (
-              <SandpackCodeEditor
-                style={{ height: "100%", maxHeight: "450px" }}
-              />
             )}
-          </SandpackLayout>
-        </SandpackProvider>
-      </Card>
+
+            {editorHeight === 'auto' && (
+              <div style={{ width: "100%", display: "flex", justifyContent: "right" }}>
+                <Button
+                  icon='times'
+                  marginRight='xl'
+                  onClick={() => setEditorHeight(0)}
+                  paddingX="none"
+                  tabIndex={0}
+                  text='Close Code'
+                  variant='link'
+                />
+              </div>
+            )}
+
+            <AnimateHeight
+              duration={500}
+              height={editorHeight}
+            >
+              <SandpackCodeEditor
+                style={{ height: "100%", maxHeight: "300px" }}
+              />
+            </AnimateHeight>
+          </div>
+        </SandpackLayout>
+      </SandpackProvider>
     </>
   )
 }

--- a/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
@@ -43,6 +43,11 @@
       }
     }
     padding: calc(2rem + 4px) 2rem 1rem;
+
+    &.sandpack-markdown {
+      padding-bottom: 0;
+      padding-top: 0;
+    }
   }
 
   .pb--kit-example {

--- a/playbook-website/app/views/pages/kit_show_new.html.erb
+++ b/playbook-website/app/views/pages/kit_show_new.html.erb
@@ -6,15 +6,19 @@
 </div>
 
 <div class="kit-show-wrapper">
-
-    <% @examples.each do |example| %>
+  <% @examples.each do |example| %>
+    <%= pb_rails("card", props: { classname: "pb--doc", padding: "none" }) do %>
       <%= react_component("KitDocs", 
         kit: @kit, 
         source: get_source(example.keys.first), 
         exampleTitle: example.values.first)
       %>
-    <% end %>
 
+      <div class="sandpack-markdown markdown pb--kit-example-markdown <%= cookies[:dark_mode] == "true" ? 'dark' : '' %>">
+        <%= markdown(description(@kit, example.keys.first)) %>
+      </div> 
+    <% end %>
+  <% end %>
 
   <div class="markdown <%= cookies[:dark_mode] == "true" ? 'dark' : '' %>">
     <br>


### PR DESCRIPTION
#### Screens

<img width="971" alt="image" src="https://user-images.githubusercontent.com/2573205/229206083-69e97dc0-b402-436a-8b20-182fb82d308a.png">

#### Breaking Changes

No

#### Runway Ticket URL

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-697)

#### How to test this

Go to any kit/sandpack page on Playbook.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** Please add the `Milano` label when you are ready for a review.
- [x] **SCREENSHOT** Please add a screen shot or two.
- [ ] **SPECS** Please cover your changes with specs.
- [ ] **READ DOCS** Please make sure you have read and understand the [Playbook Release Process](https://github.com/powerhome/playbook/wiki/Playbook-Releases)
