### PR TITLE
[PLAY-700] Adding Card Header support to striped colors

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.scss
@@ -33,6 +33,19 @@
         color: lightenText($color_value);
       }
     }
+    @each $color_name, $color_value in $pb_card_header_colors {
+      &[class*=_#{$color_name}_striped] {
+        @if ((type-of($color_value) == color)) {
+          background: repeating-linear-gradient(
+            45deg,
+            $color_value,
+            $color_value 10px,
+            lighten( $color_value, 5% ) 10px,
+            lighten( $color_value, 5% ) 20px
+          );
+        }
+      }
+    }
     &[class*=_white] {
       border-bottom: 1px solid $border_light;
     }

--- a/playbook/app/pb_kits/playbook/pb_card/_card.tsx
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.tsx
@@ -28,6 +28,7 @@ type CardPropTypes = {
 
 type CardHeaderProps = {
   headerColor?: BackgroundColors | ProductColors | CategoryColors | "none",
+  headerColorStriped?: boolean,
   children: React.ReactChild[] | React.ReactChild,
   className?: string,
   padding?: string,
@@ -41,8 +42,8 @@ type CardBodyProps = {
 
 // Header component
 const Header = (props: CardHeaderProps) => {
-  const { children, className, headerColor = 'category_1', padding = 'sm' } = props
-  const headerCSS = buildCss('pb_card_header_kit', `${headerColor}`)
+  const { children, className, headerColor = 'category_1', headerColorStriped = false, padding = 'sm' } = props
+  const headerCSS = buildCss('pb_card_header_kit', `${headerColor}`, headerColorStriped ? 'striped' : '')
 
   const headerSpacing = globalProps(props, { padding })
 

--- a/playbook/app/pb_kits/playbook/pb_card/card_header.rb
+++ b/playbook/app/pb_kits/playbook/pb_card/card_header.rb
@@ -5,9 +5,17 @@ module Playbook
     class CardHeader < Playbook::KitBase
       prop :header_color, type: Playbook::Props::String,
                           default: "category_1"
+      prop :header_color_striped, type: Playbook::Props::Boolean,
+                                  default: false
 
       def classname
-        generate_classname("pb_card_header_kit", header_color)
+        generate_classname("pb_card_header_kit", header_color, color_striped_classname)
+      end
+
+    private
+
+      def color_striped_classname
+        header_color_striped ? "striped" : nil
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_card/docs/_card_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/docs/_card_header.html.erb
@@ -57,3 +57,14 @@
     Body
   <% end %>
 <% end %>
+
+<%= pb_rails("title", props: { text: "Striped Colors", tag: "h4", size: 4, margin_bottom: "sm" }) %>
+
+<%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+  <%= pb_rails("card/card_header", props: { padding: "sm", header_color: "category_1", header_color_striped: true }) do %>
+    <%= pb_rails("body", props: { text: "Striped Category 1", dark: true }) %>
+  <% end %>
+  <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+    Body
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_card/docs/_card_header.jsx
+++ b/playbook/app/pb_kits/playbook/pb_card/docs/_card_header.jsx
@@ -1,158 +1,188 @@
 import React from 'react'
-
 import Card from '../_card'
 import Title from '../../pb_title/_title'
 import Body from '../../pb_body/_body'
 
 const CardHeader = (props) => {
-  return (
-    <div>
-      <Title
-          {...props}
-          marginBottom='sm'
-          size={4}
-          tag="h4"
-          text="Category Colors"
-      />
+    return (
+        <>
+            <Title
+                {...props}
+                marginBottom='sm'
+                size={4}
+                tag="h4"
+                text="Category Colors"
+            />
 
-      <Card
-          {...props}
-          marginBottom='sm'
-          padding="none"
-      >
-        <Card.Header headerColor="category_1" >
-          <Body
-              dark
-              text="Category 1"
-          />
-        </Card.Header>
-        <Card.Body>
-          <Body
-              {...props}
-              text="Body"
-          />
-        </Card.Body>
-      </Card>
+            <Card
+                {...props}
+                marginBottom='sm'
+                padding="none"
+            >
+                <Card.Header headerColor="category_1" >
+                    <Body
+                        dark
+                        text="Category 1"
+                    />
+                </Card.Header>
+                <Card.Body>
+                    <Body
+                        {...props}
+                        text="Body"
+                    />
+                </Card.Body>
+            </Card>
 
-      <Card
-          {...props}
-          marginBottom='sm'
-          padding="none"
-      >
-        <Card.Header
-            headerColor="category_3"
-        >
-          <Body text="Category 3" />
-        </Card.Header>
-        <Card.Body
-            padding="md"
-        >
-          <Body
-              {...props}
-              text="Body"
-          />
-        </Card.Body>
-      </Card>
-
-
-      <Title
-          {...props}
-          marginBottom='sm'
-          size={4}
-          tag="h4"
-          text="Product Colors"
-      />
-
-      <Card
-          {...props}
-          marginBottom='sm'
-          padding="none"
-      >
-        <Card.Header
-            headerColor="product_2_background"
-        >
-          <Body
-              {...props}
-              dark
-              text="Product 2 Background"
-          />
-        </Card.Header>
-        <Card.Body>
-          <Body
-              {...props}
-              text="Body"
-          />
-        </Card.Body>
-      </Card>
-
-      <Card
-          {...props}
-          marginBottom='sm'
-          padding="none"
-      >
-        <Card.Header headerColor="product_6_background" >
-          <Body
-              {...props}
-              dark
-              text="Product 6 Background"
-          />
-        </Card.Header>
-        <Card.Body>
-          <Body
-              {...props}
-              text="Body"
-          />
-        </Card.Body>
-      </Card>
+            <Card
+                {...props}
+                marginBottom='sm'
+                padding="none"
+            >
+                <Card.Header
+                    headerColor="category_3"
+                >
+                    <Body text="Category 3" />
+                </Card.Header>
+                <Card.Body
+                    padding="md"
+                >
+                    <Body
+                        {...props}
+                        text="Body"
+                    />
+                </Card.Body>
+            </Card>
 
 
-      <Title
-          {...props}
-          marginBottom='sm'
-          size={4}
-          tag="h4"
-          text="Background Colors"
-      />
+            <Title
+                {...props}
+                marginBottom='sm'
+                size={4}
+                tag="h4"
+                text="Product Colors"
+            />
 
-      <Card
-          {...props}
-          marginBottom='sm'
-          padding="none"
-      >
-        <Card.Header
-            headerColor="white"
-        >
-          <Body text="White" />
-        </Card.Header>
-        <Card.Body>
-          <Body
-              {...props}
-              text="Body"
-          />
-        </Card.Body>
-      </Card>
+            <Card
+                {...props}
+                marginBottom='sm'
+                padding="none"
+            >
+                <Card.Header
+                    headerColor="product_2_background"
+                >
+                    <Body
+                        {...props}
+                        dark
+                        text="Product 2 Background"
+                    />
+                </Card.Header>
+                <Card.Body>
+                    <Body
+                        {...props}
+                        text="Body"
+                    />
+                </Card.Body>
+            </Card>
 
-      <Card
-          {...props}
-          padding="none"
-      >
-        <Card.Header
-            headerColor="dark"
-        >
-          <Body
-              dark
-              text="Dark"
-          />
-        </Card.Header>
-        <Card.Body>
-          <Body
-              {...props}
-              text="Body"
-          />
-        </Card.Body>
-      </Card>
-    </div>
-  )
+            <Card
+                {...props}
+                marginBottom='sm'
+                padding="none"
+            >
+                <Card.Header headerColor="product_6_background" >
+                    <Body
+                        {...props}
+                        dark
+                        text="Product 6 Background"
+                    />
+                </Card.Header>
+                <Card.Body>
+                    <Body
+                        {...props}
+                        text="Body"
+                    />
+                </Card.Body>
+            </Card>
+
+
+            <Title
+                {...props}
+                marginBottom='sm'
+                size={4}
+                tag="h4"
+                text="Background Colors"
+            />
+
+            <Card
+                {...props}
+                marginBottom='sm'
+                padding="none"
+            >
+                <Card.Header
+                    headerColor="white"
+                >
+                    <Body text="White" />
+                </Card.Header>
+                <Card.Body>
+                    <Body
+                        {...props}
+                        text="Body"
+                    />
+                </Card.Body>
+            </Card>
+
+            <Card
+                {...props}
+                marginBottom='sm'
+                padding="none"
+            >
+                <Card.Header
+                    headerColor="dark"
+                >
+                    <Body
+                        dark
+                        text="Dark"
+                    />
+                </Card.Header>
+                <Card.Body>
+                    <Body
+                        {...props}
+                        text="Body"
+                    />
+                </Card.Body>
+            </Card>
+
+            <Title
+                {...props}
+                marginBottom='sm'
+                size={4}
+                tag="h4"
+                text="Striped Colors"
+            />
+
+            <Card
+                {...props}
+                marginBottom='sm'
+                padding="none"
+            >
+                <Card.Header
+                    headerColor="category_1"
+                    headerColorStriped
+                >
+                    <Body
+                        dark
+                        text="Striped Category 1"
+                    />
+                </Card.Header>
+                <Card.Body>
+                    <Body
+                        {...props}
+                        text="Body"
+                    />
+                </Card.Body>
+            </Card>
+        </>
+    )
 }
 
 export default CardHeader


### PR DESCRIPTION
**What does this PR do?**
This PR allows applying striped (aka hashed) colors to Card kit headers.
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-700)


**Screenshots:**
![image](https://user-images.githubusercontent.com/2573205/230817056-654d346f-aeab-4042-bd77-cbb0bad3b788.png)


**How to test?**
1. Go to Card Kit on Playbook doc
2. Go to the Header Card variant
3. Check the Striped Colors section
 

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.