### PR TITLE
[PLAY-729]  🛠️ Update Avatar kit imageAlt default

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar/_avatar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/_avatar.tsx
@@ -67,7 +67,7 @@ const Avatar = (props: AvatarProps): React.ReactElement => {
       >
         { canShowImage && (
           <Image
-              alt={imageAlt}
+              alt={imageAlt ? imageAlt : name}
               onError={handleError}
               url={imageUrl}
           />

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
@@ -4,7 +4,7 @@
     class: object.classname,
     aria: object.aria) do %>
   <%= content_tag(:div, data: { initials: object.initials }, class: "avatar_wrapper") do %>
-    <%= pb_rails("image", props: { alt: object.image_alt, url: object.image_url, on_error: object.handle_img_error }) if object.image_url.present? %>
+    <%= pb_rails("image", props: { alt: object.alt_text, url: object.image_url, on_error: object.handle_img_error }) if object.image_url.present? %>
   <% end %>
   <%= pb_rails("online_status", props: object.online_status_props) if object.status %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
@@ -25,6 +25,14 @@ module Playbook
         { status: status, classname: "size_#{size}" }
       end
 
+      def alt_text
+        if image_alt.present?
+          image_alt
+        else
+          name
+        end
+      end
+
       def handle_img_error
         "this.style.display = 'none'"
       end

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.rb
@@ -26,11 +26,7 @@ module Playbook
       end
 
       def alt_text
-        if image_alt.present?
-          image_alt
-        else
-          name
-        end
+        image_alt.present? ? image_alt : name
       end
 
       def handle_img_error

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.test.js
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.test.js
@@ -28,3 +28,17 @@ test('loads the given image url and name', () => {
   expect(image).toHaveAttribute('src', imageUrl)
   expect(image).toHaveAttribute('alt', imageAlt)
 })
+
+test('uses the name prop as the alt property if no imageAlt prop is passed in', () => {
+  render(
+    <Avatar
+        data={{ testid: testId }}
+        imageUrl={imageUrl}
+        name={name}
+    />
+  )
+
+  const image    = screen.getByAltText(name)
+
+  expect(image).toHaveAttribute('alt', name)
+})

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.html.erb
@@ -1,7 +1,6 @@
 <%= pb_rails("avatar", props: {
     name: "Terry Johnson",
     size: "xxs",
-    image_alt: "Terry Johnson Standing",
     image_url: "https://randomuser.me/api/portraits/men/44.jpg",
     status: "away"
   }) %>

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.jsx
@@ -5,7 +5,7 @@ const AvatarDefault = (props) => {
   return (
     <div>
       <Avatar
-          // imageAlt="Terry Johnson Standing"
+          imageAlt="Terry Johnson Standing"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="xxs"

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_avatar_default.jsx
@@ -5,7 +5,7 @@ const AvatarDefault = (props) => {
   return (
     <div>
       <Avatar
-          imageAlt="Terry Johnson Standing"
+          // imageAlt="Terry Johnson Standing"
           imageUrl="https://randomuser.me/api/portraits/men/44.jpg"
           name="Terry Johnson"
           size="xxs"

--- a/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/avatar_spec.rb
@@ -24,4 +24,11 @@ RSpec.describe Playbook::PbAvatar::Avatar do
       expect(subject.new(size: "lg").classname).to eq "pb_avatar_kit_size_lg"
     end
   end
+
+  describe "#testing avatar kit methods" do
+    it "returns the image alt using either image alt or name prop" do
+      image = subject.new(name: "Terry Johnson")
+      expect(image.alt_text).to eq "Terry Johnson"
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-729)
This PR reconfigured the way the alt attribute is passed into the Image kit from the Avatar kit. Previously it would use the prop `imageAlt` or `image_alt` to pass into the alt attribute. Therefore if a user did not pass in an `imageAlt` prop the alt attribute would be left empty. I've created a conditional that checks for an `imageAtl` prop, if there is none, it passes the `name` prop as the alt attribute.

**Screenshots:** Screenshots to visualize your addition/change

![Screen Shot 2023-04-11 at 11 48 00 AM](https://user-images.githubusercontent.com/73671109/231217824-9aebdf2e-cf78-413d-b4b2-cd0acfb79753.png)

![Screen Shot 2023-04-11 at 11 48 12 AM](https://user-images.githubusercontent.com/73671109/231217876-e376342c-5415-46b5-b39d-d1e6238d6055.png)

**How to test?** Steps to confirm the desired behavior:
1. Go to [the User Kit](https://playbook.powerapp.cloud/kits/user/react) and inspect the page
2. Notice how even though there is no `imageAlt` prop being passes in the image has an alt attribute.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.