### PR TITLE
[PLAY-746] Fixing Phone Number Input kit width and method errors

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -10,9 +10,9 @@ $flag-min-resolution: 192dpi;
     color: $focus_input_light;
   }
 
-  .text_input {
-    max-width: $input-max-width;
-  }
+  // .text_input {
+  //   max-width: $input-max-width;
+  // }
 
   .dropdown_open {
     .text_input {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
@@ -7,12 +7,10 @@ module Playbook
                       default: false
       prop :initial_country, type: Playbook::Props::String,
                              default: ""
-      prop :is_valid
       prop :label, type: Playbook::Props::String,
                    default: ""
       prop :name, type: Playbook::Props::String,
                   default: ""
-      prop :onchange
       prop :only_countries, type: Playbook::Props::Array,
                             default: []
       prop :preferred_countries, type: Playbook::Props::Array,
@@ -30,10 +28,8 @@ module Playbook
           dark: dark,
           disabled: disabled,
           initialCountry: initial_country,
-          isValid: is_valid,
           label: label,
           name: name,
-          onChange: onchange,
           onlyCountries: only_countries,
           preferredCountries: preferred_countries,
           value: value,


### PR DESCRIPTION
**What does this PR do?**
- Removing the max-width limitation on the input that causes layout and wiggle (when the selected country is changed) issues.
- Removing Rails onChange and isValid props since they are not used on the Rails side and they are causing errors since they are null and we are trying to call these functions.

**How to test?** Steps to confirm the desired behavior:
1. Go to Phone Number Input Kit
2. Check the Rails version if we are not getting errors when changing the country or typing a number


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.