### PR TITLE
[Play-740]  🌐 Update Props table on Kit pages in Rails

### DIFF
--- a/playbook-website/app/javascript/site_styles/_kit_api.scss
+++ b/playbook-website/app/javascript/site_styles/_kit_api.scss
@@ -1,0 +1,9 @@
+@import "playbook-ui/dist/tokens/typography";
+.kearning{
+  letter-spacing: $lspace_looser;
+}
+
+.card{
+  max-width: fit-content;
+  display: inline-block;
+}

--- a/playbook-website/app/javascript/site_styles/main.scss
+++ b/playbook-website/app/javascript/site_styles/main.scss
@@ -33,3 +33,5 @@
 
 //Map Kit styles
 @import "./map_styles/map_default";
+
+@import "./kit_api"

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
@@ -1,7 +1,7 @@
 <div data-action="toggle" data-togglable="prop_example" class="pb--propsTable">
   <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm" }) %>
   <%= pb_rails("card", props: { padding: "none" }) do %>
-<% puts kit_local_props %>
+<% puts local_prop_data %>
 <% puts "===================" %>
     <%= pb_rails("list", props: { xpadding: true }) do %>
       <% kit_props.each do |key, _def| %>

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
@@ -1,18 +1,90 @@
 <div data-action="toggle" data-togglable="prop_example" class="pb--propsTable">
-  <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm" }) %>
-  <%= pb_rails("card", props: { padding: "none" }) do %>
-
-<% puts "===================#{local_prop_data}" %>
-    <%= pb_rails("list", props: { xpadding: true }) do %>
-      <%# <% local_prop_data.each do |hash|%> %>
-        <%# <% hash.values.first.each do |subhash| %> %>
-          <%# <% subhash.each do |value| %> %>
-            <%# <%= pb_rails("list/item") do %> %>
-              <%# <%= value %> %>
-            <%# <% end %> %>
-          <%# <% end %> %>
-        <%# <% end %> %>
-      <%# <% end %> %>
+  <% if local_prop_data.present? %>
+    <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm" }) %>
+    <%= pb_rails("card", props: { padding: "none" }) do %>
+      <%= pb_rails("card/card_body", props: { padding: "sm" }) do %>
+        <%= pb_rails("nav", props: { orientation: "horizontal", variant: "subtle" }) do %>
+          <%= pb_rails("nav/item", props: { text: "Kit Props", link: "#", active: true }) %>
+          <%= pb_rails("nav/item", props: { text: "Global Props", link: "#" }) %>
+        <% end %>
+      <% end %>
+      <%= pb_rails("section_separator") %>
+      <%= pb_rails("card/card_body", props: {}) do %>
+        <%= pb_rails("table", props: {container: false, disable_hover: true}) do %>
+          <thead>
+            <tr>
+              <th>Props</th>
+              <th>Type</th>
+              <th>Values</th>
+              <th>Default</th>
+            </tr>
+          </thead>
+          <tbody>
+          <% local_prop_data.each do |key, value|%>
+              <tr>
+                <td>
+                  <%= pb_rails("title", props: { text: key, tag: "h4", size: 4 }) %>
+                </td>
+                <td>
+                  <%= pb_rails("card", props: {
+                    classname: "card",
+                    padding: "xxs",
+                    background: "light",
+                    border_none: true,
+                    border_radius: "sm"
+                  })  do %>
+                    <%= pb_rails("body", props: {
+                      classname: "kearning"
+                    }) do %>
+                        <%= value[:type] == "Enum" ? "array" : value[:type].downcase %>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td>
+                  <% if value[:values].present? %>
+                    <% value[:values].each do |item| %>
+                      <% if item != nil %>
+                        <%= pb_rails("card", props: {
+                          flex_direction: "row",
+                          classname: "card",
+                          padding: "xxs",
+                          background: "light",
+                          border_none: true,
+                          border_radius: "sm",
+                          margin: "xxs"
+                        })  do %>
+                          <%= pb_rails("body", props: {
+                              classname: "kearning"
+                          }) do %>
+                            <%= item %>
+                          <% end %>
+                        <% end %>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td>
+                  <% if value[:default].present? || value[:default].is_a?(TrueClass) || value[:default].is_a?(FalseClass) %>
+                    <%= pb_rails("card", props: {
+                            classname: "card",
+                            padding: "xxs",
+                            background: "light",
+                            border_none: true,
+                            border_radius: "sm"
+                      })  do %>
+                        <%= pb_rails("body", props: {
+                          classname: "kearning"
+                        }) do %>
+                            <%= value[:default] %>
+                        <% end %>
+                      <% end %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
@@ -4,15 +4,15 @@
 
 <% puts "===================#{local_prop_data}" %>
     <%= pb_rails("list", props: { xpadding: true }) do %>
-      <% local_prop_data.each do |hash|%>
-        <% hash.values.first.each do |subhash| %>
-          <% subhash.each do |value| %>
-            <%= pb_rails("list/item") do %>
-              <%= value %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
+      <%# <% local_prop_data.each do |hash|%> %>
+        <%# <% hash.values.first.each do |subhash| %> %>
+          <%# <% subhash.each do |value| %> %>
+            <%# <%= pb_rails("list/item") do %> %>
+              <%# <%= value %> %>
+            <%# <% end %> %>
+          <%# <% end %> %>
+        <%# <% end %> %>
+      <%# <% end %> %>
     <% end %>
   <% end %>
 </div>

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
@@ -1,12 +1,16 @@
 <div data-action="toggle" data-togglable="prop_example" class="pb--propsTable">
   <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm" }) %>
   <%= pb_rails("card", props: { padding: "none" }) do %>
-<% puts local_prop_data %>
-<% puts "===================" %>
+
+<% puts "===================#{local_prop_data}" %>
     <%= pb_rails("list", props: { xpadding: true }) do %>
-      <% kit_props.each do |key, _def| %>
-        <%= pb_rails("list/item") do %>
-          <%= key %>
+      <% local_prop_data.each do |hash|%>
+        <% hash.values.first.each do |subhash| %>
+          <% subhash.each do |value| %>
+            <%= pb_rails("list/item") do %>
+              <%= value %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.html.erb
@@ -1,6 +1,8 @@
 <div data-action="toggle" data-togglable="prop_example" class="pb--propsTable">
   <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm" }) %>
   <%= pb_rails("card", props: { padding: "none" }) do %>
+<% puts kit_local_props %>
+<% puts "===================" %>
     <%= pb_rails("list", props: { xpadding: true }) do %>
       <% kit_props.each do |key, _def| %>
         <%= pb_rails("list/item") do %>

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
@@ -16,7 +16,7 @@ module Playbook
       end
 
       def local_prop_data
-        local_props = []
+        local_props = {}
 
         kit_local_props.each do |key, _value|
           # Itterate over values
@@ -31,7 +31,8 @@ module Playbook
           # puts "THIS IS THE DEFAULT: ========== #{key[:value].instance_variable_get(:@values)}"
           values = key[:value].instance_variable_get(:@values)
 
-          local_props.push([{ key: "name", value: name }, { key: "type", value: type }, { key: "default", value: default }, { key: "values", value: values }])
+          # local_props.push([{ key: "name", value: name }, { key: "type", value: type }, { key: "default", value: default }, { key: "values", value: values }])
+          local_props[name.to_sym] = { "type": type, "default": default, "values": values }
           # local_props.push({ key: "type", value: type })
           # local_props.push({ key: "default", value: default })
           # local_props.push({ key: "values", value: values })

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
@@ -8,8 +8,6 @@ module Playbook
       def kit_local_props
         local = []
         kit_props.each do |key, value|
-          # puts key
-          # puts value
           value.kit != Playbook::KitBase && local.push({ key: key, value: value })
         end
         local
@@ -19,30 +17,11 @@ module Playbook
         local_props = {}
 
         kit_local_props.each do |key, _value|
-          # Itterate over values
-          # grab the: Name, Type, Default, Values
-          # puts key
-          # puts "THIS IS THE NAME: ========== #{key[:value].instance_variable_get(:@name)}"
           name = key[:value].instance_variable_get(:@name)
-          # puts "THIS IS THE TYPE: ========== #{key[:value]}"
           type = key[:value].class.to_s.split("::").last
-          # puts "THIS IS THE DEFAULT: ========== #{key[:value].instance_variable_get(:@default)}"
           default = key[:value].instance_variable_get(:@default)
-          # puts "THIS IS THE DEFAULT: ========== #{key[:value].instance_variable_get(:@values)}"
           values = key[:value].instance_variable_get(:@values)
-
-          # local_props.push([{ key: "name", value: name }, { key: "type", value: type }, { key: "default", value: default }, { key: "values", value: values }])
           local_props[name.to_sym] = { "type": type, "default": default, "values": values }
-          # local_props.push({ key: "type", value: type })
-          # local_props.push({ key: "default", value: default })
-          # local_props.push({ key: "values", value: values })
-
-          # puts Time.current
-          # key.each do |prop|
-          #   puts prop[:values]
-          # end
-          # puts key
-          # puts key[:value].instance_variable_get(:@values)
         end
         local_props
       end

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
@@ -6,14 +6,44 @@ module Playbook
       prop :kit, type: Playbook::Props::String, required: true
 
       def kit_local_props
-        # global = []
-
         local = []
-        # puts kit_props.class
         kit_props.each do |key, value|
-          value.kit == Playbook::PbButton::Button && local.push(key)
+          # puts key
+          # puts value
+          value.kit != Playbook::KitBase && local.push({ key: key, value: value })
         end
         local
+      end
+
+      def local_prop_data
+        local_props = []
+
+        kit_local_props.each do |key, _value|
+          # Itterate over values
+          # grab the: Name, Type, Default, Values
+          # puts key
+          # puts "THIS IS THE NAME: ========== #{key[:value].instance_variable_get(:@name)}"
+          name = key[:value].instance_variable_get(:@name)
+          # puts "THIS IS THE TYPE: ========== #{key[:value]}"
+          type = key[:value].class.to_s.split("::").last
+          # puts "THIS IS THE DEFAULT: ========== #{key[:value].instance_variable_get(:@default)}"
+          default = key[:value].instance_variable_get(:@default)
+          # puts "THIS IS THE DEFAULT: ========== #{key[:value].instance_variable_get(:@values)}"
+          values = key[:value].instance_variable_get(:@values)
+
+          local_props.push(name)
+          local_props.push(type)
+          local_props.push(default)
+          local_props.push(values)
+
+          # puts Time.current
+          # key.each do |prop|
+          #   puts prop[:values]
+          # end
+          # puts key
+          # puts key[:value].instance_variable_get(:@values)
+        end
+        local_props
       end
 
       def kit_props

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
@@ -31,10 +31,10 @@ module Playbook
           # puts "THIS IS THE DEFAULT: ========== #{key[:value].instance_variable_get(:@values)}"
           values = key[:value].instance_variable_get(:@values)
 
-          local_props.push(name)
-          local_props.push(type)
-          local_props.push(default)
-          local_props.push(values)
+          local_props.push([{ key: "name", value: name }, { key: "type", value: type }, { key: "default", value: default }, { key: "values", value: values }])
+          # local_props.push({ key: "type", value: type })
+          # local_props.push({ key: "default", value: default })
+          # local_props.push({ key: "values", value: values })
 
           # puts Time.current
           # key.each do |prop|

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_api.rb
@@ -5,6 +5,17 @@ module Playbook
     class KitApi < Playbook::KitBase
       prop :kit, type: Playbook::Props::String, required: true
 
+      def kit_local_props
+        # global = []
+
+        local = []
+        # puts kit_props.class
+        kit_props.each do |key, value|
+          value.kit == Playbook::PbButton::Button && local.push(key)
+        end
+        local
+      end
+
       def kit_props
         kit_class.props
       end

--- a/yarn.lock
+++ b/yarn.lock
@@ -10379,6 +10379,11 @@ pretty-format@^29.0.0, pretty-format@^29.3.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+prismjs@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -10732,6 +10737,11 @@ react-select@3.0.8:
     prop-types "^15.6.0"
     react-input-autosize "^2.2.2"
     react-transition-group "^2.2.1"
+
+react-simple-code-editor@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz#4514553fa132dcaffec33a6612c58f1613c52416"
+  integrity sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==
 
 react-transition-group@^2.2.1:
   version "2.9.0"


### PR DESCRIPTION
**What does this PR do?**
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-740)
* This PR improves how we show the props available to our kits. We pass the prop `name` `type` `value` and default` into a table. We are only showing the local kit props and not the global props. The Global props will come in a later story


**Screenshots:** 
<img width="1044" alt="Screen Shot 2023-04-20 at 10 30 38 AM" src="https://user-images.githubusercontent.com/73671109/233398735-5bba3270-4af8-427f-930c-afc714c31800.png">


**How to test?** Steps to confirm the desired behavior:
1. Go to any kit in playbook
2. Click on the rails side and scroll to the bottom
3. Check for the table showing all the kit props

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.