### PR TITLE
Fixes for broken code snippets

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_docs/kit_example.rb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_example.rb
@@ -41,8 +41,12 @@ module Playbook
     private
 
       def sanitize_code(stringified_code)
-        stringified_code = stringified_code.gsub(%r{'../.*}, "'playbook-ui'")
+        stringified_code = stringified_code.gsub('"../.."', '"playbook-ui"')
+                                           .gsub('"../../"', '"playbook-ui"')
+                                           .gsub("'../../'", "'playbook-ui'")
+                                           .gsub("'../..'", "'playbook-ui'")
                                            .gsub(%r{"../.*}, '"playbook-ui"')
+                                           .gsub(%r{from '../.*}, "from 'playbook-ui'")
         stringified_code = dark ? stringified_code.gsub("{...props}", "dark") : stringified_code.gsub(/\s*{...props}\s*\n/, "\n")
         if stringified_code.include?("props: { ")
           stringified_code = stringified_code.gsub("props: {", "props: {dark: true,") if type == "rails" && dark


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Code snippets were broken for certain kits, where "playbook-ui" was being needlessly injected into the code

![Screenshot 2023-04-26 at 10 44 21 AM](https://user-images.githubusercontent.com/73710701/234636757-bc14ac44-ee93-4740-ab37-ac6a95c2bb5e.png)


**Screenshots:** Screenshots to visualize your addition/change
Fixed:

<img width="561" alt="Screenshot 2023-04-26 at 12 12 48 PM" src="https://user-images.githubusercontent.com/73710701/234636886-4336a6f1-5c2c-443f-8eb3-f0b1290f3900.png">


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.