### PR TITLE
[PLAY-764] Adding styles tags to Body kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_body/_body.scss
+++ b/playbook/app/pb_kits/playbook/pb_body/_body.scss
@@ -28,6 +28,16 @@
       color: $text_lt_default;
     }
   }
+
+  em {
+    font-weight: $bold;
+  }
+
+  small {
+    font-size: $font_smaller;
+    letter-spacing: $lspace_loose;
+  }
+
   @each $status_name, $status_value in $pb_body_status {
     &[class*=#{$status_name}] {
       @include pb_body($status_value);

--- a/playbook/app/pb_kits/playbook/pb_body/docs/_body_styled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_body/docs/_body_styled.html.erb
@@ -6,4 +6,16 @@
     <br />
     <br />
     <a href="#">This text is using the <%="<a>"%> tag</a>
+    <br />
+    <br />
+    <i>This text is using an <%="<i>"%> tag</i>
+    <br />
+    <br />
+    This <em>word</em> is using an <%="<em>"%> tag.
+    <br />
+    <br />
+    <small>This text is using a <%="<small>"%> tag.</small>
+    <br />
+    <br />
+    <u>This text is using a <%="<u>"%> tag.</u>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_body/docs/_body_styled.jsx
+++ b/playbook/app/pb_kits/playbook/pb_body/docs/_body_styled.jsx
@@ -3,7 +3,7 @@ import { Body } from '../..'
 
 const BodyStyled = (props) => {
   return (
-    <div>
+    <>
       <Body {...props}>
         <b>{"This text is using the <b> tag"}</b>
         <br />
@@ -12,8 +12,20 @@ const BodyStyled = (props) => {
         <br />
         <br />
         <a href="#">{"This text is using the <a> tag"}</a>
+        <br />
+        <br />
+        <i>{"This text is using an <i> tag"}</i>
+        <br />
+        <br />
+        {"This "}<em>word</em>{" is using an <em> tag."}
+        <br />
+        <br />
+        <small>{"This text is using a <small> tag."}</small>
+        <br />
+        <br />
+        <u>{"This text is using a <u> tag."}</u>
       </Body>
-    </div>
+    </>
   )
 }
 

--- a/playbook/app/pb_kits/playbook/pb_body/docs/_body_styled.md
+++ b/playbook/app/pb_kits/playbook/pb_body/docs/_body_styled.md
@@ -1,1 +1,1 @@
-Playbook styles the `b`, `strong` and `a` tags within the body kit to match Playbook's design system.
+Playbook styles the `b`, `strong`, `a`. `i`, `em`, `small` and `u` tags within the body kit to match Playbook's design system.

--- a/playbook/app/pb_kits/playbook/pb_body/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_body/docs/example.yml
@@ -3,9 +3,9 @@ examples:
   - body_light: Default
   - body_block: Block
   - body_articles: Best settings for articles
-  - body_styled: Styled b/strong/a tags
+  - body_styled: Styled tags
   react:
   - body_light: Default
   - body_block: Block
   - body_articles: Best settings for articles
-  - body_styled: Styled b/strong/a tags
+  - body_styled: Styled tags


### PR DESCRIPTION
**What does this PR do?**
Adding styles to <em> and <small> tags in Playbook.

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-764)


**Screenshots:**
![image](https://user-images.githubusercontent.com/2573205/234691794-1d1764bd-648c-403c-8ef8-add7d1d05888.png)

**How to test?** Steps to confirm the desired behavior:
1. Go to Body kit on Playbook
2. Scroll down to the **Style Tags** example

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.