### PR TITLE
[PLAY-753] Anchors Linking 

### DIFF
--- a/playbook-website/app/javascript/packs/application.js
+++ b/playbook-website/app/javascript/packs/application.js
@@ -25,6 +25,18 @@ import PbKitReact from '../components/PbKitReact'
 import PbKitFetch from '../components/PbKitFetch'
 import PbKitPlayground from '../components/PbKitPlayground'
 import AvailableProps from '../components/AvailableProps'
+import AnchorJS from 'anchor-js'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const anchors = new AnchorJS()
+  anchors.add('.pb--kit-example > .pb_caption_kit_md:first-child')
+  anchors.add('.changelog-card-collection h2')
+  const propsTableAnchors = new AnchorJS()
+  propsTableAnchors.options = {
+    class: 'props-table-anchor',
+  }
+  propsTableAnchors.add('.pb--propsTable > .pb_title_kit_3')
+})
 
 WebpackerReact.setup({
   DarkModeToggle,

--- a/playbook-website/app/javascript/packs/application.js
+++ b/playbook-website/app/javascript/packs/application.js
@@ -30,7 +30,6 @@ import AnchorJS from 'anchor-js'
 document.addEventListener('DOMContentLoaded', () => {
   const anchors = new AnchorJS()
   anchors.add('.pb--kit-example > .pb_caption_kit_md:first-child')
-  anchors.add('.changelog-card-collection h2')
   const propsTableAnchors = new AnchorJS()
   propsTableAnchors.options = {
     class: 'props-table-anchor',

--- a/playbook-website/app/javascript/site_styles/_changelog.scss
+++ b/playbook-website/app/javascript/site_styles/_changelog.scss
@@ -1,4 +1,5 @@
 @import "playbook-ui/dist/tokens/spacing";
+@import "playbook-ui/dist/tokens/typography";
 
 .changelog-card-collection {
   max-width: 650px;
@@ -8,5 +9,10 @@
     &:first-child {
       margin-top: 0;
     }
+  }
+  .markdown-header-anchor-icon {
+    font-size: $font_base;
+    position: relative;
+    bottom: $space_xxs / 2;
   }
 }

--- a/playbook-website/app/javascript/site_styles/docs/_all.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_all.scss
@@ -7,3 +7,4 @@
 @import "color_utilities";
 
 @import "markdown";
+@import "links"

--- a/playbook-website/app/javascript/site_styles/docs/_links.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_links.scss
@@ -1,0 +1,10 @@
+.anchorjs-link {
+  font-size: 2em !important;
+  position: relative;
+  top: $space_xxs;
+}
+.anchorjs-link.props-table-anchor {
+  position: relative;
+  top: $space_xxs;
+  font-size: 1.3em !important;
+}

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -95,9 +95,11 @@
     <br>
     <%= pb_rails("docs/kit_api", props: { kit: @kit }) %>
   <% else %>
-    <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm", margin_top: "sm" }) %>
-    <%= react_component("AvailableProps",
-      source: Playbook::PbDocs::KitExample.new(kit: @kit, example_title: "Default", example_key: @kit, type: "react").tsx_source )
-    %>
+    <div data-action="toggle" data-togglable="prop_example" class="pb--propsTable">
+      <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm", margin_top: "sm" }) %>
+      <%= react_component("AvailableProps",
+        source: Playbook::PbDocs::KitExample.new(kit: @kit, example_title: "Default", example_key: @kit, type: "react").tsx_source )
+      %>
+    </div>
   <% end %>
 </div>

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -15,6 +15,7 @@
     "@tiptap/pm": "^2.0.2",
     "@tiptap/react": "^2.0.2",
     "@tiptap/starter-kit": "^2.0.2",
+    "anchor-js": "^5.0.0",
     "maplibre-gl": "^2.4.0",
     "playbook-ui": ">= 1",
     "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2964,6 +2964,11 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
 
+anchor-js@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/anchor-js/-/anchor-js-5.0.0.tgz#e096bb1c6b76c31b41f8ff0966289af26fae87e7"
+  integrity sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA==
+
 ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Adds anchor links to all kit card examples on hover.
Also updates the size of the anchors on the changelog page. 

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2023-05-10 at 9 28 03 AM](https://github.com/powerhome/playbook/assets/9158723/2009838c-8b48-47d6-84bd-4af9968769fa)


**How to test?** Steps to confirm the desired behavior:
1. Go to a card example.
2. Hover near the caption and see a clickable anchor link icon.


#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~- [ ] **TESTS** I have added test coverage to my code.~