### PR TITLE
Title 2 Defaults to Bold

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_title/_title.scss
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.scss
@@ -12,6 +12,7 @@
   &[class*=_2] {
     @include pb_title_2;
     @include title_colors;
+    @include pb_title_bold;
   }
 
   &[class*=_3] {

--- a/playbook/app/pb_kits/playbook/pb_title/docs/_title_light_weight.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/_title_light_weight.html.erb
@@ -1,1 +1,2 @@
 <%= pb_rails("title", props: { text: "Title 1", tag: "h1", size: 1, bold: false }) %>
+<%= pb_rails("title", props: { text: "Title 2", tag: "h2", size: 2, bold: false }) %>

--- a/playbook/app/pb_kits/playbook/pb_title/docs/_title_light_weight.jsx
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/_title_light_weight.jsx
@@ -1,15 +1,20 @@
-import React from 'react'
+import React from "react"
 
-import Title from '../_title'
+import Title from "../_title"
 
 const TitleLightWeight = (props) => {
   return (
     <div>
-      <Title
-          bold={false}
+      <Title bold={false}
           size={1}
-          tag="h1"
-          text="Title 1"
+          tag='h1'
+          text='Title 1'
+          {...props}
+      />
+      <Title bold={false}
+          size={2}
+          tag='h2'
+          text='Title 2'
           {...props}
       />
     </div>

--- a/playbook/app/pb_kits/playbook/pb_title/docs/_title_light_weight.md
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/_title_light_weight.md
@@ -1,4 +1,4 @@
 ##### Prop
-Title `size 1` will use `font-weight: 700` by default, if you want a lighter font weight, use the `bold` prop set to `false`.
-Title `size 2` & `size 3` uses a light font weight by default and will not accept a bold font weight.
+Title `size 1` & `size 2` will use `font-weight: 700` by default, if you want a lighter font weight, use the `bold` prop set to `false`.
+Title `size 3` uses a light font weight by default and will not accept a bold font weight.
 Title `size 4` uses a heavy font weight by default and will not accept a lighter font weight.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This sets Title 2 to default to Bold now. 
This can still be turned off manually on an individual kit basis, as an escape hatch if need be. 

**Screenshots:** Screenshots to visualize your addition/change
Updated the copy as well to reflect the changes. 
<img width="960" alt="Screenshot 2023-05-15 at 1 43 41 PM" src="https://github.com/powerhome/playbook/assets/9158723/10730b02-5021-4888-a21e-e252bb86dce7">
<img width="1018" alt="Screenshot 2023-05-15 at 1 43 53 PM" src="https://github.com/powerhome/playbook/assets/9158723/02a6d10c-8b77-4828-ae55-cda2930d7cd4">

**How to test?** Steps to confirm the desired behavior:
1. Go to any title size=2 and see bold for rails/react.

#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~- [] **TESTS** I have added test coverage to my code.~