### PR TITLE
[PLAY-816] Convert WeekdayStacked to TS + Jest Tests

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_weekday_stacked/_weekday_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_weekday_stacked/_weekday_stacked.tsx
@@ -12,18 +12,17 @@ import DateTime from '../pb_kit/dateTime'
 
 type WeekdayStackedProps = {
   align?: "left" | "center" | "right",
-  aria?: object,
+  aria?: {[key:string]:string },
   className?: string,
   dark?: boolean,
   data?: object,
-  date: date,
+  date: Date,
   id?: string,
   variant?: "day_only" | "month_day" | "expanded",
   compact?: boolean,
-  id?: string,
 }
 
-const getDayOfWeek = (value, compact) => {
+const getDayOfWeek = (value: Date | string, compact: boolean) => {
   const dateTime = new DateTime({ value })
   if (compact) {
     return dateTime.toDayAbbr()
@@ -32,7 +31,7 @@ const getDayOfWeek = (value, compact) => {
   }
 }
 
-const getFormattedDate = (value, variant) => {
+const getFormattedDate = (value: Date | string, variant: "day_only" | "month_day" | "expanded") => {
   const dateTime = new DateTime({ value })
   if (variant === 'day_only') {
     return dateTime.toDay()

--- a/playbook/app/pb_kits/playbook/pb_weekday_stacked/weekday_stacked.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_weekday_stacked/weekday_stacked.test.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, screen } from "../utilities/test-utils";
+
+import WeekdayStacked from "./_weekday_stacked";
+
+const TEST_DATE = "01/01/2020 00:00:000 GMT-0500";
+jest.setSystemTime(new Date(TEST_DATE));
+const testId = "weekdaystacked-kit";
+const realDate = Date;
+
+beforeEach(() => {
+  global.Date.now = jest.fn(() => new Date(TEST_DATE));
+});
+
+afterEach(() => {
+  global.Date = realDate;
+});
+
+describe("WeekdayStacked Kit", () => {
+  test("renders className", () => {
+    render(
+      <WeekdayStacked 
+          data={{ testid: testId }} 
+      />
+    );
+
+    const kit = screen.getByTestId(testId);
+    expect(kit).toHaveClass("pb_weekday_stacked_kit_left");
+  });
+
+  test("renders Caption with weekday", () => {
+    render(
+      <WeekdayStacked 
+          data={{ testid: testId }}
+      />
+    );
+
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_md");
+    expect(text.textContent).toEqual("Wed") 
+  });
+
+  test("renders Title with date", () => {
+    render(
+      <WeekdayStacked 
+          data={{ testid: testId }}
+      />
+    );
+
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_title_kit_size_4");
+    expect(text.textContent).toEqual("1/1") 
+  });
+
+  test("renders compact prop", () => {
+    render(
+      <WeekdayStacked 
+          compact
+          data={{ testid: testId }}
+      />
+    );
+
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_caption_kit_md");
+    expect(text.textContent).toEqual("W") 
+  });
+
+  test("renders align prop", () => {
+    render(
+        <WeekdayStacked 
+            align="left"
+            data={{ testid: testId }}
+        />
+    );
+      
+    const kit = screen.getByTestId(testId);
+    expect(kit).toHaveClass("pb_weekday_stacked_kit_left")
+  });
+
+  test("renders day_only variant prop", () => {
+    render(
+        <WeekdayStacked 
+            data={{ testid: testId }}
+            variant="day_only"
+        />
+    );
+      
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_title_kit_size_4");
+    expect(text.textContent).toEqual("1") 
+  });
+
+  test("renders expanded variant prop", () => {
+    render(
+        <WeekdayStacked 
+            data={{ testid: testId }}
+            variant="expanded"
+        />
+    );
+      
+    const kit = screen.getByTestId(testId);
+    const text = kit.querySelector(".pb_title_kit_size_4");
+    expect(text.textContent).toEqual("Jan 1") 
+  });
+});


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Converts WeekdayStacked to TS + adds jest tests
[Runway story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-816)

**Screenshots:** Screenshots to visualize your addition/change
<img width="791" alt="Screenshot 2023-05-18 at 10 08 22 AM" src="https://github.com/powerhome/playbook/assets/73710701/4d8c9fcf-eecb-41ed-bd31-36db6a58410e">


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.