### PR TITLE
[PBNTR-12] Adding check to empty filters

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_filter/Filter/CurrentFilters.tsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/Filter/CurrentFilters.tsx
@@ -27,7 +27,7 @@ const CurrentFilters = ({ dark, filters }: CurrentFiltersProps): React.ReactElem
             color="light"
             paddingLeft="xs"
             size={4}
-            tag="h4"
+            tag="span"
             text="No Filter Selected"
         />
       </div>

--- a/playbook/app/pb_kits/playbook/pb_filter/filter.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/filter.html.erb
@@ -9,22 +9,23 @@
           <div class="maskContainer">
             <div class="filters">
               <div class="left_gradient"></div>
-              <% object.filters.each do |filter| %>
-                <% if filter[:name] == "" %>
-                  <div>
-                    <%= pb_rails("body", props: {
-                      color: "light",
-                      padding_left: "xs",
-                      size: 4,
-                      tag:"h4",
-                      text: "No Filter Selected"
-                    }) %>
-                  </div>
-                <% else %>
-                <div class="filter">
-                  <%= pb_rails("caption", props: { text: filter[:name]}) %>
-                  <%= pb_rails("title", props: { size: 4, tag:"h4", text: filter[:value]}) %>
+              <% if object.filters&.none? { |filter| filter[:name].present? } %>
+                <div>
+                  <%= pb_rails("body", props: {
+                    color: "light",
+                    padding_left: "xs",
+                    size: 4,
+                    tag:"span",
+                    text: "No Filter Selected"
+                  }) %>
                 </div>
+              <% end %>
+              <% object.filters&.each do |filter| %>
+                <% if filter[:name].present? %>
+                  <div class="filter">
+                    <%= pb_rails("caption", props: { text: filter[:name]}) %>
+                    <%= pb_rails("title", props: { size: 4, tag:"h4", text: filter[:value]}) %>
+                  </div>
                 <% end %>
               <% end %>
               <div class="right_gradient"></div>


### PR DESCRIPTION
**What does this PR do?** 
We are replacing the `<h4>` in the PB Filter kit with a `<span>` tag and we are checking for empty filters in the Rails version since the current version is not checking for all the empty values the filters prop could have.

[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-12)


**How to test?** Steps to confirm the desired behavior:
1. Go to the Filters kit page in PB.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.