### PR TITLE
[PLAY-834] Fixes for darkmode Styling of TextInput

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -2,8 +2,7 @@
 @import "../tokens/titles";
 @import "../tokens/colors";
 
-
-[class^=pb_text_input_kit] {
+[class^="pb_text_input_kit"] {
   margin-bottom: $space_sm;
   .pb_text_input_kit_label {
     margin-bottom: $space_xs;
@@ -22,8 +21,8 @@
       overflow: hidden;
     }
     input:hover,
-    .text_input:hover{
-      background-color: rgba($focus_input_light,$opacity_5);
+    .text_input:hover {
+      background-color: rgba($focus_input_light, $opacity_5);
     }
     input:focus,
     .text_input:focus,
@@ -32,7 +31,7 @@
       @include pb_textarea_focus;
       @include transition_default;
       border-color: $primary;
-      background-color: rgba($focus_input_light,$opacity_5);
+      background-color: rgba($focus_input_light, $opacity_5);
     }
   }
   &.dark {
@@ -52,15 +51,16 @@
       .text_input .placeholder {
         @include pb_body_light_dark;
       }
-      input, .text_input {
+      input,
+      .text_input {
         @include pb_textarea_dark;
         @include pb_body_dark;
         overflow: hidden;
-        background-color: rgba($white,$opacity_1);
+        background-color: rgba($white, $opacity_1);
         border-color: rgba($white, 0.15);
       }
       input:hover,
-      .text_input:hover{
+      .text_input:hover {
         background-color: rgba($white, 0.15);
       }
       input:focus,
@@ -73,7 +73,8 @@
     }
     &.error {
       .text_input_wrapper {
-        input, .text_input {
+        input,
+        .text_input {
           border-color: $error_dark;
         }
       }
@@ -81,10 +82,11 @@
   }
   &.error {
     .text_input_wrapper {
-      [class*=pb_body_kit] {
+      [class*="pb_body_kit"] {
         margin-top: $space_xs / 2;
       }
-      input, .text_input {
+      input,
+      .text_input {
         border-color: $error;
       }
     }
@@ -151,90 +153,92 @@
       }
     }
   }
-}
 
-.text_input_wrapper_add_on {
-  & > [class^=pb_text_input_kit]:not(:last-child) {
-    .text_input_wrapper_add_on input, [class^=pb_text_input_kit] .text_input_wrapper_add_on .text_input {
-      border-bottom-right-radius: 0;
-      border-top-right-radius: 0;
-      border-right-width: 0;
-    }
-  }
-  .section-separator span {
-    padding: 0;
-  }
-
-  .add-on {
-    &-card {
-      height: 45px;
-      margin: 0;
-      padding: 0 !important;
-      align-items: center;
-      justify-content: center;
-      width: 45px;
-    }
-    &-icon {
-      color: $text_lt_lighter;
-    }
-    &-card-dark {
-      background-color: $bg-dark;
-    }
-    &-left {
-      .text_input {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-      }
-    }
-
-    &-right {
-      .text_input{
-        border-top-right-radius: 0;
+  .text_input_wrapper_add_on {
+    & > [class^="pb_text_input_kit"]:not(:last-child) {
+      .text_input_wrapper_add_on input,
+      [class^="pb_text_input_kit"] .text_input_wrapper_add_on .text_input {
         border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+        border-right-width: 0;
       }
     }
-  }
-  .text_input:focus ~ .add-on-card-dark {
-    background-color: $focus_input_dark;
-    border-width: 0px;
-  }
-  .card-left-aligned {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
+    .section-separator span {
+      padding: 0;
+    }
 
-  .card-right-aligned {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
+    .add-on {
+      &-card {
+        height: 45px;
+        margin: 0;
+        padding: 0 !important;
+        align-items: center;
+        justify-content: center;
+        width: 45px;
+      }
+      &-icon {
+        color: $text_lt_lighter;
+      }
+      &-card-dark {
+        background-color: rgba($white, $opacity_1);
+        border-color: rgba($white, 0.15);
+      }
+      &-left {
+        .text_input {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+      }
 
-  .border {
-    &_right_off {
-      .card-left-aligned {
-        border-right: 0;
-      }
-      .text_input {
-        border-left: 0;
-        padding-left: 16px;
+      &-right {
+        .text_input {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
       }
     }
-    &_left_on {
-      .card-right-aligned {
-        border-left: 0;
-      }
+    .text_input:focus ~ .add-on-card-dark {
+      background-color: $focus_input_dark;
+      border-width: 0px;
     }
-    &_right_on {
-      .card-left-aligned {
-        border-right: 0;
-      }
+    .card-left-aligned {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
     }
-    &_left_off {
-      .card-right-aligned {
-        border-left: 0;
+
+    .card-right-aligned {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+
+    .border {
+      &_right_off {
+        .card-left-aligned {
+          border-right: 0;
+        }
+        .text_input {
+          border-left: 0;
+          padding-left: 16px;
+        }
       }
-      .text_input {
-        border-right: 0;
-        padding-right: 0;
+      &_left_on {
+        .card-right-aligned {
+          border-left: 0;
+        }
+      }
+      &_right_on {
+        .card-left-aligned {
+          border-right: 0;
+        }
+      }
+      &_left_off {
+        .card-right-aligned {
+          border-left: 0;
+        }
+        .text_input {
+          border-right: 0;
+          padding-right: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This PR fixes broken dark mode styling for TextInput with icon add on.

[PLAY-834](https://nitro.powerhrg.com/runway/backlog_items/PLAY-834)

**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2023-05-21 at 10 44 23 AM](https://github.com/powerhome/playbook/assets/73710701/744239f1-381f-4cc0-a0b2-776c7c4cb2e4)


**How to test?** Steps to confirm the desired behavior:
1. Go to TextInput in dark mode and scroll to 'Add on' doc example


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.