### PR TITLE
Fix for Broken bread_crumb Rails Page on Website

### DIFF
--- a/playbook-website/app/components/playbook/pb_docs/kit_api.html.erb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_api.html.erb
@@ -7,7 +7,7 @@
           <%= pb_rails("nav/item", props: { text: "Global Props", link: "#", active: true, dark: dark }) %>
         <% end %>
       <% end %>
-      <%= pb_rails("section_separator", dark: dark) %>
+      <%= pb_rails("section_separator", props:{ dark: dark }) %>
       <%= pb_rails("card/card_body", props: {}) do %>
         <%= pb_rails("table", props: {container: false, disable_hover: true, dark: dark }) do %>
           <thead>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

breadcrumbs rails page on the PB website is broken, follow this link to see error msg: https://playbook.powerapp.cloud/kits/bread_crumbs

This PR fixes this be adding the missing props:{} syntax to kit_api.html.erb page

**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2023-06-14 at 8 16 34 AM](https://github.com/powerhome/playbook/assets/73710701/71eaf0e9-e975-4bbd-b095-8b2e892d3e8a)



**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.