### PR TITLE
[PLAY-878] Add CSS for Changelog Dates

### DIFF
--- a/playbook-website/app/javascript/site_styles/docs/_markdown.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_markdown.scss
@@ -30,11 +30,12 @@
     margin: 1.9rem 0 0 0;
   }
   h3 {
-    font-size: $text_large;
-    line-height: $text_large;
-    font-weight: $bolder;
-    letter-spacing: $lspace_tight;
-    margin: 1.7rem 0 0 0;
+    font-size: $font_smaller;
+    font-weight: $bold;
+    color: $text_lt_light;
+    text-transform: uppercase;
+    letter-spacing: $lspace_looser;
+    margin: 1rem 0 0 0;
   }
   h4, h5, h6 {
     font-size: $text_base;
@@ -138,7 +139,7 @@
   &.dark {
     color: $text_dk_default ;
     h1,h2,h3,h4,h5,h6 {
-     color: $text_dk_default;
+      color: $text_dk_default;
     }
     a {
       color: $active_dark;

--- a/playbook-website/app/javascript/site_styles/docs/_markdown.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_markdown.scss
@@ -2,6 +2,7 @@
 @import "playbook-ui/dist/tokens/typography";
 @import "playbook-ui/dist/tokens/spacing";
 @import "playbook-ui/dist/tokens/colors";
+@import "playbook-ui/app/pb_kits/playbook/pb_caption/_caption_mixin.scss";
 
 .markdown_title {
   @include pb_title_1;
@@ -30,14 +31,16 @@
     margin: 1.9rem 0 0 0;
   }
   h3 {
-    font-size: $font_smaller;
-    font-weight: $bold;
-    color: $text_lt_light;
-    text-transform: uppercase;
-    letter-spacing: $lspace_looser;
-    margin: 1rem 0 0 0;
+    font-size: $text_large;
+    line-height: $text_large;
+    font-weight: $bolder;
+    letter-spacing: $lspace_tight;
+    margin: 1.7rem 0 0 0;
   }
-  h4, h5, h6 {
+  h5 {
+    @include caption;
+  }
+  h4, h6 {
     font-size: $text_base;
     line-height: $text_base;
     letter-spacing: $lspace_tight;

--- a/playbook-website/app/views/guides/design_guidelines/example_markdown_styling.md
+++ b/playbook-website/app/views/guides/design_guidelines/example_markdown_styling.md
@@ -11,6 +11,7 @@ Headings are an essential component of any design system. They help organize con
 ## H2: Headings
 ### H3: Subheadings
 #### H4: Sub-Subheadings
+##### H5: Changelog Dates
 
 ![](https://p-a6FbDk.t4.n0.cdn.getcloudapp.com/items/jkuAW48D/e1e18232-8a66-47d4-abd9-5bee15b49961.jpg?source=client&v=4821b53656635fa27dfb8c37e23969a7)
 
@@ -57,7 +58,7 @@ Click here to learn more about design systems.
 **Bold** and _underline_ are used to *highlight specific words* or phrases within ~~a block of~~ text. They help draw the user’s attention to important information. Here’s an example: *Design systems are* a collection of **reusable components**, **guidelines**, and **assets** that help ensure _consistency across all of your design work_.
 
 ### Code Blocks and Inline Code
-Code blocks and `inline code` are used to display and highlight code within a block of text. This is especially useful for developers who need to reference code snippets in their work. 
+Code blocks and `inline code` are used to display and highlight code within a block of text. This is especially useful for developers who need to reference code snippets in their work.
 
 Here’s an example:
 

--- a/playbook/CHANGELOG.md
+++ b/playbook/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Styling typography just got easier!
+##### June 13, 2023
 
 ![12 25 0](https://github.com/powerhome/playbook/assets/73710701/6db5b3e0-f499-446d-965a-0e00b0c31931)
 
@@ -18,7 +19,8 @@ You can now wrap our Date kit with any of our typography kits (Title, Body, Capt
 - Changelog Improvements [\#2591](https://github.com/powerhome/playbook/pull/2591) ([jasoncypret](https://github.com/jasoncypret))
 - Separation of Markdown & PBDocs Dependencies from Playbook Library [\#2527](https://github.com/powerhome/playbook/pull/2527) ([jasoncypret](https://github.com/jasoncypret))
 
-# Responsive Components in Rapid Time: Introducing Global Responsive Spacing Props for React and Rails Components. 
+# Responsive Components in Rapid Time: Introducing Global Responsive Spacing Props for React and Rails Components.
+##### May 26, 2023
 
 ![titleboldandresponsivespacing](https://github.com/powerhome/playbook/assets/9158723/9741a86c-5439-4081-b197-0101079c8575)
 
@@ -637,7 +639,7 @@ Give it a try and let us know what you think!
 **Kit Enhancements:**
 
 - Update Error Color Token [\#2226](https://github.com/powerhome/playbook/pull/2226) ([nidaqg](https://github.com/nidaqg))
-- New psuedo border on hover: + Table.scss file cleanup [\#2189](https://github.com/powerhome/playbook/pull/2189) ([jasoncypret](https://github.com/jasoncypret), [carloslimasd](https://github.com/carloslimasd), [Israel-Molestina](https://github.com/Israel-Molestina)), 
+- New psuedo border on hover: + Table.scss file cleanup [\#2189](https://github.com/powerhome/playbook/pull/2189) ([jasoncypret](https://github.com/jasoncypret), [carloslimasd](https://github.com/carloslimasd), [Israel-Molestina](https://github.com/Israel-Molestina)),
 
 **Fixed Bugs:**
 
@@ -1039,7 +1041,7 @@ Give it a try and let us know what you think!
 ## [11.2.7](https://github.com/powerhome/playbook/compare/11.2.6...11.2.7) (2022-08-17)
 
 **Fixed Bugs:**
-- Dialog Title Patch [\#2017](https://github.com/powerhome/playbook/pull/2017)([augustomallmann](https://github.com/augustomallmann)) 
+- Dialog Title Patch [\#2017](https://github.com/powerhome/playbook/pull/2017)([augustomallmann](https://github.com/augustomallmann))
 
 ## [11.2.6](https://github.com/powerhome/playbook/compare/11.2.5...11.2.6) (2022-08-12)
 
@@ -1063,7 +1065,7 @@ Give it a try and let us know what you think!
 
 **Kit Enhancements:**
 - Convert Avatar Action Button to Typescript [\#1975](https://github.com/powerhome/playbook/pull/1975) ([augustomallmann](https://github.com/augustomallmann))
-- Typescript Conversion: Bread Crumbs [\#1976](https://github.com/powerhome/playbook/pull/1976) ([augustomallmann](https://github.com/augustomallmann)) 
+- Typescript Conversion: Bread Crumbs [\#1976](https://github.com/powerhome/playbook/pull/1976) ([augustomallmann](https://github.com/augustomallmann))
 
 ## [11.2.2](https://github.com/powerhome/playbook/compare/11.2.1...11.2.2) (2022-08-04)
 **Fixed Bugs:**
@@ -1077,8 +1079,8 @@ Give it a try and let us know what you think!
 
 [Full Changelog](https://github.com/powerhome/playbook/compare/11.1.2...11.2.0)
 
-**New Kits** 
-- \[PLAY-158\] Lightbox Kit [\#1772](https://github.com/powerhome/playbook/pull/1772) ([jasperfurniss](https://github.com/jasperfurniss), [thestephenmarshall](https://github.com/thestephenmarshall), 
+**New Kits**
+- \[PLAY-158\] Lightbox Kit [\#1772](https://github.com/powerhome/playbook/pull/1772) ([jasperfurniss](https://github.com/jasperfurniss), [thestephenmarshall](https://github.com/thestephenmarshall),
 [Ivancandido11](https://github.com/Ivancandido11))
 
 **Kit Enhancements:**

--- a/playbook/CHANGELOG.md
+++ b/playbook/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Detail Kit Unleashed: Supercharge Data Display in Your UI
-##### June 23, 2023
+##### June 22, 2023
 
 ![12-26-0](https://github.com/powerhome/playbook/assets/73710701/2daca1f7-8d62-4f78-97e9-465767566ee1)
 
@@ -25,7 +25,7 @@ Need to display a wealth of information without cluttering your UI? Look no furt
 [Full Changelog](https://github.com/powerhome/playbook/compare/12.25.0...12.26.0)
 
 # Styling typography just got easier!
-##### June 13, 2023
+##### June 9, 2023
 
 ![12 25 0](https://github.com/powerhome/playbook/assets/73710701/6db5b3e0-f499-446d-965a-0e00b0c31931)
 


### PR DESCRIPTION
**What does this PR do?**
- [Runway](https://nitro.powerhrg.com/runway/backlog_items/PLAY-878)
- In the changelog's markdown file, use `h5` for the date below the title (see screenshots)
  - CSS is the same as the Caption kit
- Add changelog dates to `12.24` and `12.25` and update the Example Markdown Styling page with the `h5` description
- Redcarpet adds a copy link on hover to all headers, but this is a quick ship story

**Screenshots:**

**Add Changelog Dates**

<img width="419" alt="Screenshot 2023-06-25 at 8 48 27 PM" src="https://github.com/powerhome/playbook/assets/47684670/96cb3f30-67aa-4ddd-9c37-e8d7d235aef7">

<img width="840" alt="Screenshot 2023-06-25 at 8 48 01 PM" src="https://github.com/powerhome/playbook/assets/47684670/2f2b45f8-27c6-40a9-b9f2-f6322a6a5428">

**Add h5 Description to Example Markdown Styling Page**

<img width="731" alt="Screenshot 2023-06-25 at 8 52 40 PM" src="https://github.com/powerhome/playbook/assets/47684670/6034c86a-99e3-41d5-9a38-5e911d950f7f">

**How to test?** Steps to confirm the desired behavior:
1. Go to `/changelog`
  - In the changelog file, add a `h5` right below the `h1` title.
2. Go to `/guides/design_guidelines/example_markdown_styling`
  - View the added `h5` description for changelog dates

#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.