### PR TITLE
[PLAY-779] Implementing custom icons for Selectable Card Icon kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/_selectable_card_icon_custom.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/_selectable_card_icon_custom.html.erb
@@ -1,0 +1,11 @@
+<div class="pb--doc-demo-row">
+  <% svg_url = "https://upload.wikimedia.org/wikipedia/commons/3/3b/Wrench_font_awesome.svg" %>
+
+  <%= pb_rails("selectable_card_icon", props: {
+    custom_icon: svg_url,
+    title_text: "Customization", 
+    body_text: "Personalize everything",
+    input_id: 1,
+    checked: true,
+  }) %>
+</div>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/_selectable_card_icon_custom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/_selectable_card_icon_custom.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import SelectableCardIcon from '../_selectable_card_icon'
+
+const svg = {
+  newChat: (
+    <svg
+        ariaHidden="true"
+        focusable="false"
+        role="img"
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+          d="M448 0H64C28.7 0 0 28.7 0 64v288c0 35.3 28.7 64 64 64h96v84c0 7.1 5.8 12 12 12 2.4 0 4.9-.7 7.1-2.4L304 416h144c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64zm16 352c0 8.8-7.2 16-16 16H288l-12.8 9.6L208 428v-60H64c-8.8 0-16-7.2-16-16V64c0-8.8 7.2-16 16-16h384c8.8 0 16 7.2 16 16v288zM336 184h-56v-56c0-8.8-7.2-16-16-16h-16c-8.8 0-16 7.2-16 16v56h-56c-8.8 0-16 7.2-16 16v16c0 8.8 7.2 16 16 16h56v56c0 8.8 7.2 16 16 16h16c8.8 0 16-7.2 16-16v-56h56c8.8 0 16-7.2 16-16v-16c0-8.8-7.2-16-16-16z"
+          fill="currentColor"
+      />
+    </svg>
+  ),
+}
+
+const SelectableCardIconCustom = (props) => {
+  return (
+    <div className="pb--doc-demo-row">
+      <SelectableCardIcon
+          bodyText="Talk to someone you love"
+          checked
+          customIcon={svg.newChat}
+          inputId={1}
+          titleText="New Chat"
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default SelectableCardIconCustom

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/_selectable_card_icon_custom.md
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/_selectable_card_icon_custom.md
@@ -1,0 +1,19 @@
+# Tips for Custom Icons
+
+When using custom icons it is important to introduce a "clean" SVG. In order to ensure these custom icons perform as intended within your kit(s), ensure these things have been modified from the original SVG markup:
+
+Attributes must be React compatible e.g. <code>xmlns:xlink</code> should be <code>xmlnsXlink</code> and so on. <strong>There should be no hyphenated attributes and no semi-colons!.</strong>
+
+Fill colors with regards to <code>g</code> or <code>path</code> nodes, e.g. <code>fill="black"</code>, should be replaced with   <code>currentColor</code> ala <code>fill="currentColor"</code>. Your mileage may vary depending on the complexity of your SVG.
+
+Pay attention to your custom icon's dimensions and `viewBox` attribute. It is best to use a `viewBox="0 0 512 512"` starting point __when designing instead of trying to retrofit the viewbox afterwards__!
+
+You must source *your own SVG into component/view* you are working on. This can easily be done in programmatic and maintainable ways.
+
+### React
+
+So long as you have a valid React `<SVG>` node, you can send it as the `customIcon` prop and the kit will take care of the rest.
+
+### Rails
+
+Some Rails applications use only webpack(er) which means using `image_url` will be successful over `image_path` in most cases especially development where Webpack Dev Server is serving assets over HTTP. Rails applications still using Asset Pipeline may use `image_path` or `image_url`. Of course, YMMV depending on any custom configurations in your Rails application.

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/example.yml
@@ -5,10 +5,10 @@ examples:
   - selectable_card_icon_checkmark: Checkmark
   - selectable_card_icon_single_select: Single Select
   - selectable_card_icon_options: With Options
-
-
+  - selectable_card_icon_custom: Custom Icon
 
   react:
   - selectable_card_icon_default: Default
   - selectable_card_icon_checkmark: Checkmark
   - selectable_card_icon_single_select: Single Select
+  - selectable_card_icon_custom: Custom Icon

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/docs/index.js
@@ -1,3 +1,4 @@
 export { default as SelectableCardIconDefault } from './_selectable_card_icon_default.jsx'
 export { default as SelectableCardIconCheckmark } from './_selectable_card_icon_checkmark.jsx'
 export { default as SelectableCardIconSingleSelect } from './_selectable_card_icon_single_select.jsx'
+export { default as SelectableCardIconCustom } from './_selectable_card_icon_custom.jsx'

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.html.erb
@@ -8,12 +8,14 @@
     value: object.value,
     checked: object.checked,
     disabled: object.disabled,
+    custom_icon: object.custom_icon,
     icon: object.checkmark,
     multi: object.multi,
     dark: object.dark,
     input_options: object.input_options
   }) do %>
     <%= pb_rails("selectable_icon", props: {
+      custom_icon: object.custom_icon,
       icon: object.icon,
       inputs: "disabled",
       text: object.title_text,

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.rb
@@ -4,6 +4,8 @@ module Playbook
   module PbSelectableCardIcon
     class SelectableCardIcon < Playbook::KitBase
       # Icon and text props
+      prop :custom_icon, type: Playbook::Props::String,
+                         default: nil
       prop :icon, type: Playbook::Props::String
       prop :title_text, type: Playbook::Props::String
       prop :body_text, type: Playbook::Props::String

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.html.erb
@@ -5,7 +5,7 @@
 
     <% if object.inputs == "disabled" %>
 
-      <%= pb_rails("icon", props: { icon: object.icon, size: "2x" }) %>
+      <%= pb_rails("icon", props: { custom_icon: object.custom_icon, icon: object.icon, size: "2x" }) %>
       <%= pb_rails("title", props: { text: object.text, tag: "h4", size: 4 }) %>
 
     <% else %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.rb
@@ -4,6 +4,8 @@ module Playbook
   module PbSelectableIcon
     class SelectableIcon < Playbook::KitBase
       # Icon props
+      prop :custom_icon, type: Playbook::Props::String,
+                         default: nil
       prop :icon, type: Playbook::Props::String
       # Title text
       prop :text, type: Playbook::Props::String


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Implementing custom icons for the Selectable Card Icon kit.
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-779)

**Screenshots:** Screenshots to visualize your addition/change
![image](https://github.com/powerhome/playbook/assets/2573205/f8628117-2e90-4518-b5e3-c7b135f873be)

**How to test?** Steps to confirm the desired behavior:
1. Go to the Selectable Card Icon kit
2. Go to the Custom Icon example

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.