### PR TITLE
[PLAY-889] Fixed Expanded State to Load From TreeData

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -51,8 +51,25 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
   const dropdownRef = useRef(null)
 
 
-  //state for expanded property
-  const [expanded, setExpanded] = useState([])
+  const getExpandedItems = (treeData: { [key: string]: string }[]) => {
+    let expandedItems: any[] = [];
+    
+    const traverse = (items: string | any[]) => {
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.expanded) {
+          expandedItems.push(item.id);
+        }
+        if (Array.isArray(item.children)) {
+          traverse(item.children);
+        }
+      }
+    }
+  
+    traverse(treeData);
+    return expandedItems;
+  }
+
   //state for whether dropdown is open or closed
   const [isClosed, setIsClosed] = useState(true)
   //state from onchange for textinput, to use for filtering to create typeahead
@@ -63,6 +80,10 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
   const [formattedData, setFormattedData] = useState([])
   //state for return for default
   const [defaultReturn, setDefaultReturn] = useState([])
+  // Get expanded items from treeData.
+  const initialExpandedItems = getExpandedItems(treeData);
+  // Initialize state with expanded items.
+  const [expanded, setExpanded] = useState(initialExpandedItems);
 
 
   useEffect(() => {
@@ -153,11 +174,13 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     return tree
   }
 
+
+
   //function to map over data and add parent_id + depth property to each item
   const addCheckedAndParentProperty = (
     treeData: { [key: string]: any }[],
     parent_id: string = null,
-    depth: number = 0
+    depth: number = 0,
   ) => {
     if (!Array.isArray(treeData)) {
       return
@@ -294,6 +317,8 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
       </ul>
     )
   }
+
+
 
   return (
     <div {...ariaProps} {...dataProps} className={classes} id={id}>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_default.jsx
@@ -12,6 +12,7 @@ const treeData = [
         label: "People",
         value: "People",
         id: "people1",
+        expanded: true,
         children: [
           {
             label: "Talent Acquisition",


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fixes the expanded, so that the database can recall your expanded selections upon page reload. 

https://github.com/powerhome/playbook/assets/9158723/2ab329e3-e89d-4e1c-ba73-1f0dd3541e1d


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to MultiLevel and see the data coming from the tree structure for expanded states.


#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~- [X] **TESTS** I have added test coverage to my code.~