### PR TITLE
[PLAY-902] Adding Badge notification variant

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_badge/_badge.scss
+++ b/playbook/app/pb_kits/playbook/pb_badge/_badge.scss
@@ -37,6 +37,11 @@
     border-radius: $pb_badge_height / 2;
   }
 
+  &[class*=_notification] {
+    background: $primary;
+    color: $white;
+  }
+
   &.dark {
     border-width: 0;
 

--- a/playbook/app/pb_kits/playbook/pb_badge/_badge.tsx
+++ b/playbook/app/pb_kits/playbook/pb_badge/_badge.tsx
@@ -24,7 +24,7 @@ type BadgeProps = {
   removeOnClick?: React.MouseEventHandler<HTMLSpanElement>,
   rounded?: boolean,
   text?: string,
-  variant?: "error" | "info" | "neutral" | "primary" | "success" | "warning",
+  variant?: "error" | "info" | "neutral" | "notification" | "primary" | "success" | "warning",
 } & GlobalProps
 const Badge = (props: BadgeProps) => {
   const {

--- a/playbook/app/pb_kits/playbook/pb_badge/badge.rb
+++ b/playbook/app/pb_kits/playbook/pb_badge/badge.rb
@@ -6,7 +6,7 @@ module Playbook
       prop :rounded, type: Playbook::Props::Boolean, default: false
       prop :text
       prop :variant, type: Playbook::Props::Enum,
-                     values: %w[success warning error info neutral primary],
+                     values: %w[success warning error info neutral notification primary],
                      default: "neutral"
 
       def classname

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification.html.erb
@@ -1,0 +1,12 @@
+<div>
+  <%= pb_rails("badge", props: {
+    text: "1",
+    variant: "notification",
+    rounded: true
+  }) %>
+
+  <%= pb_rails("badge", props: {
+    text: "4",
+    variant: "notification"
+  }) %>
+</div>

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification.jsx
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import Badge from '../_badge'
+
+const BadgeNotification = (props) => {
+  return (
+    <>
+      <Badge
+          rounded
+          text="1"
+          variant="notification"
+          {...props}
+      />
+
+      &nbsp;
+
+      <Badge
+          text="4"
+          variant="notification"
+          {...props}
+      />
+    </>
+  )
+}
+
+export default BadgeNotification

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/example.yml
@@ -3,9 +3,10 @@ examples:
   - badge_default: Rectangle
   - badge_rounded: Rounded
   - badge_colors: Colors
- 
+  - badge_notification: Notification
 
   react:
   - badge_default: Rectangle
   - badge_rounded: Rounded
   - badge_colors: Colors
+  - badge_notification: Notification

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/index.js
@@ -1,3 +1,4 @@
 export { default as BadgeDefault } from './_badge_default'
 export { default as BadgeRounded } from './_badge_rounded'
 export { default as BadgeColors } from './_badge_colors'
+export { default as BadgeNotification } from './_badge_notification'


### PR DESCRIPTION
**What does this PR do?**
Adds to the Badge kit a variant with a solid background for notifications.

**Screenshots:**
![image](https://github.com/powerhome/playbook/assets/2573205/21e81dcd-130e-4ab5-9527-4b8f7847e4d4)

**How to test?**
1. Go to the Badge kit page
2. Scroll down to **Notification** example


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.