### PR TITLE
[PLAY-901] Adding new dashed section separator

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
@@ -45,6 +45,13 @@ $section_colors_dark: (
     }
   }
 
+  &[class*=_dashed] {
+    &::before, &::after {
+      border: 1px dashed $border_light;
+      background: none;
+    }
+  }
+
   // Dark =========================
 
   &.dark {

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
@@ -8,10 +8,12 @@ import Caption from '../pb_caption/_caption'
 
 type SectionSeparatorProps = {
   aria?: { [key: string]: string; },
+  children?: React.ReactChild[] | React.ReactChild,
   className?: string,
   dark?: boolean,
   data?: { [key: string]: string; },
   id?: string,
+  lineStyle?: "solid" | "dashed",
   orientation?: "horizontal" | "vertical",
   text?: string,
   variant?: "card" | "background",
@@ -20,9 +22,11 @@ type SectionSeparatorProps = {
 const SectionSeparator = (props: SectionSeparatorProps) => {
   const {
     aria = {},
+    children,
     className,
     data = {},
     id,
+    lineStyle = 'solid',
     orientation = 'horizontal',
     text,
     dark = false,
@@ -30,21 +34,22 @@ const SectionSeparator = (props: SectionSeparatorProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const classes = classnames(buildCss('pb_section_separator_kit', variant, orientation), globalProps(props), className)
+  const classes = classnames(buildCss('pb_section_separator_kit', variant, orientation, lineStyle === "dashed" ? lineStyle : ""), globalProps(props), className)
 
   return (
 
     <div
-        {...ariaProps}
-        {...dataProps}
-        className={classes}
-        id={id}
+      {...ariaProps}
+      {...dataProps}
+      className={classes}
+      id={id}
     >
       {
+        children && children ||
         text && (
           <span>
-          <Caption text={text} dark={dark}/>
-        </span>
+            <Caption text={text} dark={dark} />
+          </span>
         )
       }
     </div>

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.html.erb
@@ -1,0 +1,14 @@
+<%= pb_rails("section_separator", props: { line_style: "dashed" }) do %>
+    <%= pb_rails("card", props: {
+        border_radius: "rounded",
+        justify_content: "center",
+        padding: "none"
+    })  do %>
+        <%= pb_rails("caption", props: {
+            text: "TODAY",
+            size: "xs",
+            padding_left: "xs",
+            padding_right: "xs" 
+        }) %>
+    <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.jsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { SectionSeparator, Card, Caption } from '../../'
+
+const children = (
+    <Card
+        borderRadius="rounded"
+        justifyContent="center"
+        padding="none"
+    >
+        <Caption
+            paddingLeft="xs"
+            paddingRight="xs"
+            size="xs"
+            text="TODAY"
+        />
+    </Card>
+)
+
+const SectionSeparatorChildren = (props) => {
+    return (
+        <SectionSeparator
+            {...props}
+            lineStyle='dashed'
+        >
+            {children}
+        </SectionSeparator>
+    )
+}
+
+export default SectionSeparatorChildren

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.md
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.md
@@ -1,0 +1,2 @@
+Pass anything (including any of our kits) to the `children` prop to customize a separator's content. 
+NOTE: passing `children` overrides any content passed to `text`

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.md
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_children.md
@@ -1,2 +1,3 @@
-Pass anything (including any of our kits) to the `children` prop to customize a separator's content. 
-NOTE: passing `children` overrides any content passed to `text`
+Pass anything (including any of our kits) to the `children` prop to customize a separator's content.
+
+**NOTE:** passing `children` overrides any content passed to `text`

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_dashed.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_dashed.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("section_separator", props: { line_style: "dashed" }) %>

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_dashed.jsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_dashed.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { SectionSeparator } from '../../'
+
+const SectionSeparatorDashed = (props) => {
+    return (
+        <SectionSeparator
+            {...props}
+            lineStyle='dashed'
+        />
+    )
+}
+
+export default SectionSeparatorDashed

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.html.erb
@@ -1,1 +1,1 @@
-<%= pb_rails("section_separator", props: { text: "Title Separator" }) %>
+<%= pb_rails("section_separator", props: { text: "Text Separator" }) %>

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.jsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_text.jsx
@@ -5,7 +5,7 @@ const SectionSeparatorText = (props) => {
   return (
     <SectionSeparator
         {...props}
-        text="Title Separator"
+        text="Text Separator"
     />
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/example.yml
@@ -1,12 +1,15 @@
 examples:
 
   rails:
-  - section_separator_text: Text Separator
   - section_separator_line: Line Separator
+  - section_separator_dashed: Dashed Separator
+  - section_separator_text: Text Separator
   - section_separator_vertical: Vertical
-
+  - section_separator_children: Children
 
   react:
-  - section_separator_text: Text Separator
   - section_separator_line: Line Separator
+  - section_separator_dashed: Dashed Separator
+  - section_separator_text: Text Separator
   - section_separator_vertical: Vertical
+  - section_separator_children: Children

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/index.js
@@ -1,3 +1,5 @@
 export { default as SectionSeparatorLine } from './_section_separator_line.jsx'
 export { default as SectionSeparatorText } from './_section_separator_text.jsx'
 export { default as SectionSeparatorVertical } from './_section_separator_vertical.jsx'
+export { default as SectionSeparatorDashed } from './_section_separator_dashed.jsx'
+export { default as SectionSeparatorChildren } from './_section_separator_children.jsx'

--- a/playbook/app/pb_kits/playbook/pb_section_separator/section_separator.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/section_separator.html.erb
@@ -4,9 +4,11 @@
     data: object.data,
     class: object.classname) do %>
     <% if object.orientation === 'horizontal' %>
-        <% if object.text %>
+        <% if content %>
+            <%= content %>
+        <% elsif object.text %>
             <span><%= pb_rails("caption", props: { text: object.text }) %></span>
-        <%end%>
+        <% end %>
     <% end %>
     <% if object.orientation === 'vertical' %>
         <%= pb_rails("flex", props: { orientation: "column"}) do %>

--- a/playbook/app/pb_kits/playbook/pb_section_separator/section_separator.rb
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/section_separator.rb
@@ -12,9 +12,12 @@ module Playbook
                          default: "horizontal"
       prop :dark, type: Playbook::Props::Boolean,
                   default: false
+      prop :line_style, type: Playbook::Props::Enum,
+                        values: %w[dashed solid],
+                        default: "solid"
 
       def classname
-        generate_classname("pb_section_separator_kit", variant, orientation)
+        generate_classname("pb_section_separator_kit", variant, orientation, line_style == "dashed" ? "dashed" : nil)
       end
 
     private

--- a/playbook/spec/pb_kits/playbook/kits/section_seperator_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/section_seperator_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Playbook::PbSectionSeparator::SectionSeparator do
       expect(subject.new(variant: "background", classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_background_horizontal additional_class dark"
       expect(subject.new(orientation: "vertical", classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_card_vertical additional_class dark"
       expect(subject.new(classname: "additional_class", dark: true).classname).to eq "pb_section_separator_kit_card_horizontal additional_class dark"
+      expect(subject.new(line_style: "dashed").classname).to eq "pb_section_separator_kit_card_horizontal_dashed"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Make the kit accept children, and users are now able to use a dashed separator.

**Screenshots:**
![image](https://github.com/powerhome/playbook/assets/2573205/7043e8fd-818e-44c7-8fa5-5b603d3dd1ce)
![image](https://github.com/powerhome/playbook/assets/2573205/f283e689-63f5-4de6-a576-e7a8e51b05d4)

**How to test?**
1. Go to the Section Separator kit


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.