### PR TITLE
[PLAY-909] Implementing Responsive Title

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_title/_title.scss
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.scss
@@ -1,5 +1,6 @@
 @import "../tokens/titles";
 @import "../tokens/colors";
+@import "../tokens/screen_sizes";
 @import './title_mixin';
 
 [class^=pb_title_kit]{
@@ -32,5 +33,22 @@
 
   &[class*=_thin] {
     @include pb_title_thin;
+  }
+
+  @each $size, $size_value in $breakpoints_grid {
+    @each $title_size_value in [1, 2, 3, 4] {
+        $min_size: map-get($size_value, "min");
+        $max_size: map-get($size_value, "max");
+        &[class*=_#{$size}_#{$title_size_value}] {
+          @include break_on($min_size, $max_size) {
+            @if $title_size_value == 1 { @include pb_title_1; }
+            @else if $title_size_value == 2 { @include pb_title_2; }
+            @else if $title_size_value == 3 { @include pb_title_3; }
+            @else if $title_size_value == 4 { @include pb_title_4; }
+            @include title_colors;
+            @if $title_size_value != 4 { @include pb_title_bold; }
+          }
+        }
+    }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -3,6 +3,9 @@ import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
 import { deprecatedProps, GlobalProps, globalProps } from '../utilities/globalProps'
 
+type SizeType = 1 | 2 | 3 | 4 | "1" | "2" | "3" | "4"
+type SizeResponsiveType = {[key: string]: SizeType}
+
 type TitleProps = {
   aria?: {[key: string]: string},
   bold?: boolean,
@@ -11,7 +14,7 @@ type TitleProps = {
   color?: "default" | "light" | "lighter" | "success" | "error" | "link",
   data?: {[key: string]: string},
   id?: string,
-  size?: 1 | 2| 3| 4 | "1" | "2" | "3" | "4",
+  size?: SizeType | SizeResponsiveType,
   tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div" | "span",
   text?: string,
   variant?: null | "link",
@@ -36,9 +39,24 @@ const Title = (props: TitleProps): React.ReactElement => {
   const ariaProps: {[key: string]: string | number} = buildAriaProps(aria)
   const dataProps: {[key: string]: string | number} = buildDataProps(data)
   const getBold = bold ? '' : 'thin'
+  const isSizeNumberOrString = typeof size === "number" || typeof size === "string"
+
+  const buildResponsiveSizeCss = () => {
+    let css = ''
+    
+    if (!isSizeNumberOrString) {
+      Object.entries(size).forEach((sizeObj) => {
+        css += `pb_title_kit_${sizeObj[0]}_${sizeObj[1]} `
+      })
+    }
+
+    return css.trim()
+  }
+
   const classes = classnames(
-    buildCss('pb_title_kit', `size_${size}`, variant, color, getBold),
+    buildCss('pb_title_kit', isSizeNumberOrString ? `size_${size}` : "", variant, color, getBold),
     globalProps(props),
+    buildResponsiveSizeCss(),
     className
   )
   const Tag: React.ReactElement | any = `${tag}`

--- a/playbook/app/pb_kits/playbook/pb_title/docs/_title_responsive.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/_title_responsive.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("title", props: { text: "Responsive Title", tag: "h1", size: {xs: 3, sm: 2, md: 1} }) %>

--- a/playbook/app/pb_kits/playbook/pb_title/docs/_title_responsive.jsx
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/_title_responsive.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Title from '../_title'
+
+const TitleResponsive = (props) => {
+  return (
+    <>
+      <Title
+          size={{xs: "3", sm: "2", md: "1"}}
+          text="Responsive Title"
+          {...props}
+      />
+    </>
+  )
+}
+
+export default TitleResponsive

--- a/playbook/app/pb_kits/playbook/pb_title/docs/_title_responsive.md
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/_title_responsive.md
@@ -1,0 +1,1 @@
+The `size` prop supports responsive sizes. To use them, pass an object to the size prop containing your size values relative to responsive break points (show code below). To test this here, resize your browser window to responsively change this Title's size.

--- a/playbook/app/pb_kits/playbook/pb_title/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/example.yml
@@ -3,8 +3,10 @@ examples:
   - title_default: Default UI
   - title_light_weight: Light Weight UI
   - title_colors: Colors
+  - title_responsive: Responsive
 
   react:
   - title_default: Default UI
   - title_light_weight: Light Weight UI
   - title_colors: Colors
+  - title_responsive: Responsive

--- a/playbook/app/pb_kits/playbook/pb_title/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_title/docs/index.js
@@ -1,3 +1,4 @@
 export { default as TitleDefault } from './_title_default.jsx'
 export { default as TitleLightWeight } from './_title_light_weight.jsx'
 export { default as TitleColors } from './_title_colors.jsx'
+export { default as TitleResponsive } from './_title_responsive.jsx'

--- a/playbook/app/pb_kits/playbook/pb_title/title.rb
+++ b/playbook/app/pb_kits/playbook/pb_title/title.rb
@@ -6,9 +6,7 @@ module Playbook
       prop :color, type: Playbook::Props::Enum,
                    values: [nil, "default", "light", "lighter", "success", "error", "link"],
                    default: nil
-      prop :size, type: Playbook::Props::Enum,
-                  values: [1, 2, 3, 4],
-                  default: 3
+      prop :size, default: 3
       prop :tag, type: Playbook::Props::Enum,
                  values: %w[h1 h2 h3 h4 h5 h6 p div span],
                  default: "h3"
@@ -20,11 +18,30 @@ module Playbook
       prop :bold, type: Playbook::Props::Boolean, default: true
 
       def classname
-        generate_classname("pb_title_kit", size, variant, color, is_bold)
+        if is_size_responsive
+          generate_classname("pb_title_kit", variant, color, is_bold) + generate_responsive_size_classname
+        else
+          generate_classname("pb_title_kit", size, variant, color, is_bold)
+        end
       end
 
       def is_bold
         bold ? nil : "thin"
+      end
+
+      def is_size_responsive
+        try(:size).is_a?(::Hash)
+      end
+
+      def generate_responsive_size_classname
+        css = ""
+        if is_size_responsive
+          size.each do |key, value|
+            css += " pb_title_kit_#{key}_#{value}"
+          end
+        end
+
+        css unless css.blank?
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_title/title.test.js
+++ b/playbook/app/pb_kits/playbook/pb_title/title.test.js
@@ -4,39 +4,52 @@ import { render, screen } from '../utilities/test-utils'
 import Title from './_title'
 
 test('returns namespaced class name', () => {
-  render(
-    <Title
-        data={{ testid: 'primary-test' }}
-        text="Test colors"
-    />
-  )
+    render(
+        <Title
+            data={{ testid: 'primary-test' }}
+            text="Test colors"
+        />
+    )
 
-  const kit = screen.getByTestId('primary-test')
-  expect(kit).toHaveClass('pb_title_kit_size_3')
+    const kit = screen.getByTestId('primary-test')
+    expect(kit).toHaveClass('pb_title_kit_size_3')
 })
 
 test('with thin font weight', () => {
-  render(
-    <Title
-        bold={false}
-        data={{ testid: 'primary-test' }}
-        text="Test thin font weight"
-    />
-  )
+    render(
+        <Title
+            bold={false}
+            data={{ testid: 'primary-test' }}
+            text="Test thin font weight"
+        />
+    )
 
-  const kit = screen.getByTestId('primary-test')
-  expect(kit).toHaveClass('pb_title_kit_size_3_thin')
+    const kit = screen.getByTestId('primary-test')
+    expect(kit).toHaveClass('pb_title_kit_size_3_thin')
 })
 
 test('with colors', () => {
-  render(
-    <Title
-        color="success"
-        data={{ testid: 'primary-test' }}
-        text="Test colors"
-    />
-  )
+    render(
+        <Title
+            color="success"
+            data={{ testid: 'primary-test' }}
+            text="Test colors"
+        />
+    )
 
-  const kit = screen.getByTestId('primary-test')
-  expect(kit).toHaveClass('pb_title_kit_size_3_success')
+    const kit = screen.getByTestId('primary-test')
+    expect(kit).toHaveClass('pb_title_kit_size_3_success')
+})
+
+test('with responsive title', () => {
+    render(
+        <Title
+            data={{ testid: 'primary-test' }}
+            size={{ xs: "3", sm: "2", md: "1" }}
+            text="Responsive Title"
+        />
+    )
+
+    const kit = screen.getByTestId('primary-test')
+    expect(kit).toHaveClass('pb_title_kit pb_title_kit_xs_3 pb_title_kit_sm_2 pb_title_kit_md_1')
 })

--- a/playbook/spec/pb_kits/playbook/kits/title_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/title_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Playbook::PbTitle::Title do
     is_expected.to define_boolean_prop(:dark)
       .with_default(false)
   }
-  it { is_expected.to define_prop(:size).of_type(Playbook::Props::Enum).with_default(3) }
+  it { is_expected.to define_prop(:size).with_default(3) }
   it {
     is_expected.to define_enum_prop(:tag)
       .with_values("h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "span")
@@ -38,6 +38,7 @@ RSpec.describe Playbook::PbTitle::Title do
       expect(subject.new(tag: "h3").classname).to eq "pb_title_kit_3"
       expect(subject.new(size: 4, color: "link").classname).to eq "pb_title_kit_4_link"
       expect(subject.new(bold: false).classname).to eq "pb_title_kit_3_thin"
+      expect(subject.new(size: { xs: 3, sm: 2, md: 1 }).classname).to eq "pb_title_kit pb_title_kit_xs_3 pb_title_kit_sm_2 pb_title_kit_md_1"
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**
It implements responsive Title sizes so that we can dynamically change Title sizes based on screen size.

**Screenshots:**
![image](https://github.com/powerhome/playbook/assets/2573205/076ab312-cb60-400d-a3c3-dadf6fc6fa0f)

**How to test?** 
1. Go to Title Kit on Playbook Website
2. Scroll down to **Responsive** example


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.