### PR TITLE
Refactor Dialog Kit Close on Outside Click

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
@@ -26,10 +26,9 @@ const dialogHelper = () => {
       if (dialogParentDataset.overlayClick === "overlay_close") return
 
       const clickedOutsideDialogBox = event.target.classList.contains("pb_dialog_rails")
-      const closeDialog = () => dialogElement.close()
 
       if (clickedOutsideDialogBox) {
-        closeDialog()
+        dialogElement.close()
       }
     })
   })

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
@@ -29,6 +29,7 @@ const dialogHelper = () => {
 
       if (clickedOutsideDialogBox) {
         dialogElement.close()
+        event.stopPropagation()
       }
     })
   })

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
@@ -1,6 +1,7 @@
 const dialogHelper = () => {
   const openTrigger = document.querySelectorAll("[data-open-dialog]");
   const closeTrigger = document.querySelectorAll("[data-close-dialog]");
+  const dialogs = document.querySelectorAll(".pb_dialog_rails")
 
   openTrigger.forEach((open) => {
     open.addEventListener("click", () => {
@@ -8,21 +9,6 @@ const dialogHelper = () => {
       var targetDialog = document.getElementById(openTriggerData)
       if (targetDialog.open) return;
       targetDialog.showModal();
-
-      //the following allows you to close dialog by clicking on overlay
-      targetDialog.addEventListener('click',((event) => {
-        var dialogContainerData = targetDialog.parentElement.dataset
-         if (dialogContainerData.overlayClick === "overlay_close") return;
-          let rect = event.target.getBoundingClientRect();
-                if (rect.left > event.clientX ||
-              rect.right < event.clientX ||
-              rect.top > event.clientY ||
-              rect.bottom < event.clientY
-          ) {
-              targetDialog.close();
-          }
-        })
-      );
     });
   });
 
@@ -32,6 +18,21 @@ const dialogHelper = () => {
       document.getElementById(closeTriggerData).close();
     });
   });
+
+  // Close dialog box on outside click
+  dialogs.forEach((dialogElement) => {
+    dialogElement.addEventListener("click", (event) => {
+      const dialogParentDataset = dialogElement.parentElement.dataset
+      if (dialogParentDataset.overlayClick === "overlay_close") return
+
+      const clickedOutsideDialogBox = event.target.classList.contains("pb_dialog_rails")
+      const closeDialog = () => dialogElement.close()
+
+      if (clickedOutsideDialogBox) {
+        closeDialog()
+      }
+    })
+  })
 };
 
 export default dialogHelper;


### PR DESCRIPTION
**What does this PR do?**
- Refactors the Dialog Rails kit's "click outside to close" feature to not be dependent on the `data-open-dialog` attribute
- If not improved, this could block the SweetAlert replacement ([see POC: PBNTR-62](https://github.com/powerhome/nitro-web/pull/33256))

**How to test?**
1. Go to the Dialog Rails kit
2. Open a dialog, then click outside to close
3. Go to the "Overlay Click" example. You should NOT be able to close.

#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.