### PR TITLE
[PLAY-910] Adding children prop to Fixed Confirmation Toast

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
@@ -14,24 +14,26 @@ const iconMap = {
 };
 
 type FixedConfirmationToastProps = {
-  autoClose?: number;
-  className?: string;
-  closeable?: boolean;
-  data?: string;
-  horizontal?: "right" | "left" | "center";
-  id?: string;
-  multiLine?: boolean;
-  onClose?: () => void;
-  open?: boolean;
-  status?: "success" | "error" | "neutral" | "tip";
-  text: string;
-  vertical?: "top" | "bottom";
-};
+  autoClose?: number,
+  children?: React.ReactChild[] | React.ReactChild,
+  className?: string,
+  closeable?: boolean,
+  data?: string,
+  horizontal?: "right" | "left" | "center",
+  id?: string,
+  multiLine?: boolean,
+  onClose?: () => void,
+  open?: boolean,
+  status?: "success" | "error" | "neutral" | "tip",
+  text: string,
+  vertical?: "top" | "bottom",
+}
 
 const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   const [showToast, toggleToast] = useState(true);
   const {
     autoClose = 0,
+    children,
     className,
     closeable = false,
     horizontal,
@@ -75,13 +77,20 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
       {showToast && (
         <div className={css} onClick={handleClick}>
           {icon && <Icon className="pb_icon" fixedWidth icon={icon} />}
-          <Title
-            className="pb_fixed_confirmation_toast_text"
-            size={4}
-            text={text}
-          />
+
+          {
+            children && children ||
+            text && (
+              <Title
+                className="pb_fixed_confirmation_toast_text"
+                size={4}
+                text={text}
+              />
+            )
+          }
+
           {closeable && (
-            <Icon className="pb_icon" fixedWidth={false} icon="times" />
+            <Icon className="pb_icon" cursor="pointer" fixedWidth={false} icon="times" />
           )}
         </div>
       )}

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
@@ -25,7 +25,7 @@ type FixedConfirmationToastProps = {
   onClose?: () => void,
   open?: boolean,
   status?: "success" | "error" | "neutral" | "tip",
-  text: string,
+  text?: string,
   vertical?: "top" | "bottom",
 }
 

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.html.erb
@@ -1,0 +1,17 @@
+<%= pb_rails("fixed_confirmation_toast", props: {
+  padding_y: "none",
+  status: "success"
+}) do %>
+  <%= pb_rails("title", props: {
+    dark: true,
+    margin_left: "md",
+    text: "Design & Handoff Process was moved to UX Designer Learning Track.",
+    size: 4
+  }) %>
+  <%= pb_rails("button", props: {
+    dark: true,
+    padding_right: "none",
+    text: "Undo",
+    variant: "link"
+  }) %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import FixedConfirmationToast from '../_fixed_confirmation_toast'
+import Button from '../../pb_button/_button'
+import Title from '../../pb_title/_title'
+
+const FixedConfirmationToastChildren = (props) => {
+    return (
+        <>
+            <FixedConfirmationToast
+                paddingY="none"
+                status="success"
+                {...props}
+            >
+                <Title
+                    dark
+                    marginLeft="md"
+                    size={4}
+                    text="Design & Handoff Process was moved to UX Designer Learning Track."
+                />
+                <Button
+                    dark
+                    onClick={() => alert("button clicked!")}
+                    paddingRight="none"
+                    text="Undo"
+                    variant="link"
+                />
+            </FixedConfirmationToast>
+        </>
+    )
+}
+
+export default FixedConfirmationToastChildren

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.md
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.md
@@ -1,0 +1,3 @@
+Pass anything (including any of our kits) to the `children` prop to customize a fixed confirmation toast content.
+
+**NOTE:** passing `children` overrides any content passed to `text`

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.md
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_children.md
@@ -1,3 +1,3 @@
-Pass anything (including any of our kits) to the `children` prop to customize a fixed confirmation toast content.
+Pass anything (including any of our kits) to the `children` prop to customize the content of the fixed confirmation toast.
 
 **NOTE:** passing `children` overrides any content passed to `text`

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
@@ -5,6 +5,7 @@ examples:
   - fixed_confirmation_toast_multi_line: Multi Line
   - fixed_confirmation_toast_close: Click to Close
   - fixed_confirmation_toast_positions: Click to Show Positions
+  - fixed_confirmation_toast_children: Children
   
   react:
   - fixed_confirmation_toast_default: Default
@@ -12,3 +13,4 @@ examples:
   - fixed_confirmation_toast_close: Click to Close
   - fixed_confirmation_toast_positions: Click to Show Positions
   - fixed_confirmation_toast_auto_close: Click to Show Auto Close
+  - fixed_confirmation_toast_children: Children

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
@@ -3,3 +3,4 @@ export { default as FixedConfirmationToastMultiLine } from './_fixed_confirmatio
 export { default as FixedConfirmationToastClose } from './_fixed_confirmation_toast_close.jsx'
 export { default as FixedConfirmationToastPositions } from './_fixed_confirmation_toast_positions.jsx'
 export { default as FixedConfirmationToastAutoClose } from './_fixed_confirmation_toast_auto_close.jsx'
+export { default as FixedConfirmationToastChildren } from './_fixed_confirmation_toast_children.jsx'

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.html.erb
@@ -4,6 +4,12 @@
     data: object.data,
     class: object.classname) do %>
     <%= pb_rails("icon", props: { icon: object.icon_value, classname: "pb_icon", fixed_width: true }) %>
-    <%= pb_rails("title", props: { text: object.text, size: 4, classname: "pb_fixed_confirmation_toast_text" }) if object.show_text? %>
-    <%= pb_rails("icon", props: { icon: "times", classname: "pb_icon" }) if object.closeable %>
+
+    <% if content %>
+        <%= content %>
+    <% elsif object.show_text? %>
+        <%= pb_rails("title", props: { text: object.text, size: 4, classname: "pb_fixed_confirmation_toast_text" }) %>
+    <% end %>
+
+    <%= pb_rails("icon", props: { icon: "times", classname: "pb_icon", cursor: "pointer" }) if object.closeable %>
 <% end %>


### PR DESCRIPTION
**What does this PR do?**
Implements a children's prop to the Fixed Confirmation Toast kit, so I pass custom content (i.e., links) to my toasts.

**Screenshots:**
![image](https://github.com/powerhome/playbook/assets/2573205/e8272c41-9012-44db-bb97-4846a0b3d53c)

**How to test?**
1. Go to the Fixed Confirmation Toast kit doc page
2. Scroll down to the children example


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.