### PR TITLE
[PLAY-881] Fixing the map kit button height for Safari

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_map/_map.scss
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.scss
@@ -141,6 +141,10 @@
     .map-flyto-button {
       @include pb_map_button;
 
+      .pb_button_content {
+        height: $space_sm;
+      }
+
       svg {
         width: $space_xs + 6;
         height: $space_sm;


### PR DESCRIPTION
**What does this PR do?**
Fix the Map kit's nav buttons that are oversized and breaking their own layout in Safari.

**How to test?** Steps to confirm the desired behavior:
1. Go to Map kit in Safari
2. Check the map buttons


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.