### PR TITLE
[PBNTR-65] Center Align Text for Status Dialogs

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
@@ -7,359 +7,356 @@
 @import "../tokens/animation-curves";
 @import "../tokens/positioning";
 
-
-
-// Dialog Animations
-// Dialog Animations for fading in and out from the center
+// Dialog animations
+// Dialog animations for fading in and out from the center
 @keyframes modalFadeIn {
-	from {
-		transform: translate3d(0, -100%, 0);
-		opacity: 0;
-	}
-	to {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
+  from {
+    transform: translate3d(0, -100%, 0);
+    opacity: 0;
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
 }
 
 @keyframes modalFadeOut {
-	from {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
-	to {
-		transform: translate3d(0, -50%, 0);
-		opacity: 0;
-	}
+  from {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+  to {
+    transform: translate3d(0, -50%, 0);
+    opacity: 0;
+  }
 }
 
-// Dialog Animations for fading in and out from the left side
+// Dialog animations for fading in and out from the left side
 @keyframes modalFadeInLeft {
-	from {
-		transform: translate3d(-100%, 0, 0);
-		opacity: 0;
-	}
-	to {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
+  from {
+    transform: translate3d(-100%, 0, 0);
+    opacity: 0;
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
 }
 
 @keyframes modalFadeOutLeft {
-	from {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
-	to {
-		transform: translate3d(-50%, 0, 0);
-		opacity: 0;
-	}
+  from {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+  to {
+    transform: translate3d(-50%, 0, 0);
+    opacity: 0;
+  }
 }
 
 
-// Dialog Animations for fading in and out from the right side
+// Dialog animations for fading in and out from the right side
 @keyframes modalFadeInRight {
-	from {
-		transform: translate3d(100%, 0, 0);
-		opacity: 0;
-	}
-	to {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
+  from {
+    transform: translate3d(100%, 0, 0);
+    opacity: 0;
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
 }
 
 @keyframes modalFadeOutRight {
-	from {
-		transform: translate3d(0, 0, 0);
-		opacity: 1;
-	}
-	to {
-		transform: translate3d(50%, 0, 0);
-		opacity: 0;
-	}
+  from {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+  to {
+    transform: translate3d(50%, 0, 0);
+    opacity: 0;
+  }
 }
 
 @keyframes overlayFade {
-	from {
-		opacity: 0;
-		transform: translateY(0);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes overlayFadeOut {
-	from {
-		opacity: 1;
-	}
-	to {
-		opacity: 0;
-	}
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 // Dialog Styles
-
 .pb_dialog {
 
-	// Local Variables
-	$gutter: $space_lg;
-	$small: 300px;
-	$status_size: 375px;
-	$medium: 500px;
-	$large: 800px;
-	$xlarge: 1150px;
-	$animation-duration: .2s;
-	$z-index: 100;
-	$opacity_visible: 1;
-	$opacity_hidden: 0;
+  // Local Variables
+  $gutter: $space_lg;
+  $small: 300px;
+  $status_size: 375px;
+  $medium: 500px;
+  $large: 800px;
+  $xlarge: 1150px;
+  $animation-duration: .2s;
+  $z-index: 100;
+  $opacity_visible: 1;
+  $opacity_hidden: 0;
 
-	.dialog_sticky_header {
-		position: sticky;
-		top: 0;
-		background-color: $white;
-		z-index: $z_8;
-	}
+  .dialog_sticky_header {
+    position: sticky;
+    top: 0;
+    background-color: $white;
+    z-index: $z_8;
+  }
 
-	.dialog_status_text_align {
-		text-align: center;
-	}
+  .dialog_status_text_align {
+    text-align: center;
+  }
 
-	// @include pb_card;
-	background-color: $white;
-	box-shadow: $shadow_deepest;
-	border: 0;
-	border-radius: $border_radius_md;
-	max-height: calc(100vh - #{$gutter * 2});
-	max-width: calc(100vw - #{$gutter * 2});
-	overflow: auto;
-	animation-name: modalFadeIn;
-	animation-duration: $animation-duration;
-	outline: none;
-	animation-timing-function: $easeInOutQuint;
+  // @include pb_card;
+  background-color: $white;
+  box-shadow: $shadow_deepest;
+  border: 0;
+  border-radius: $border_radius_md;
+  max-height: calc(100vh - #{$gutter * 2});
+  max-width: calc(100vw - #{$gutter * 2});
+  overflow: auto;
+  animation-name: modalFadeIn;
+  animation-duration: $animation-duration;
+  outline: none;
+  animation-timing-function: $easeInOutQuint;
 
-	&[class*="_left"] {
-		animation-name: modalFadeInLeft;
-		&[class*="_before_close"] {
-			animation-name: modalFadeOutLeft;
-			animation-duration: $animation-duration;
-			opacity: $opacity_hidden;
-		}
-	}
+  &[class*="_left"] {
+    animation-name: modalFadeInLeft;
+    &[class*="_before_close"] {
+      animation-name: modalFadeOutLeft;
+      animation-duration: $animation-duration;
+      opacity: $opacity_hidden;
+    }
+  }
 
-	&[class*="_right"] {
-		animation-name: modalFadeInRight;
-		&[class*="_before_close"] {
-			animation-name: modalFadeOutRight;
-			animation-duration: $animation-duration;
-			opacity: $opacity_hidden;
-		}
-	}
+  &[class*="_right"] {
+    animation-name: modalFadeInRight;
+    &[class*="_before_close"] {
+      animation-name: modalFadeOutRight;
+      animation-duration: $animation-duration;
+      opacity: $opacity_hidden;
+    }
+  }
 
-	&[class*="_status_size"] {
-		width: $status_size;
-	}
+  &[class*="_status_size"] {
+    width: $status_size;
+  }
 
-	&[class*="_sm"] {
-		width: $small;
-	}
+  &[class*="_sm"] {
+    width: $small;
+  }
 
-	&[class*="_md"] {
-		width: $medium;
-	}
+  &[class*="_md"] {
+    width: $medium;
+  }
 
+  &[class*="_lg"] {
+    width: $large;
+  }
 
-	&[class*="_lg"] {
-		width: $large;
-	}
+  &_body_open {
+    overflow: hidden;
+  }
 
-	&_body_open {
-		overflow: hidden;
-	}
+  &_after_open {
+    opacity: $opacity_visible;
+  }
 
-	&_after_open {
-		opacity: $opacity_visible;
-	}
+  &[class*="_before_close"] {
+    animation-name: modalFadeOut;
+    animation-duration: $animation-duration;
+    opacity: $opacity_hidden;
+  }
 
-	&[class*="_before_close"] {
-		animation-name: modalFadeOut;
-		animation-duration: $animation-duration;
-		opacity: $opacity_hidden;
-	}
+  &_close_icon {
+    cursor: pointer;
+  }
 
-	&_close_icon {
-		cursor: pointer;
-	}
+  &_overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba($bg_dark, $opacity_4);
+    z-index: $z-index;
+    animation-name: overlayFade;
+    animation-duration: $animation-duration;
 
-	&_overlay {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background-color: rgba($bg_dark, $opacity_4);
-		z-index: $z-index;
-		animation-name: overlayFade;
-		animation-duration: $animation-duration;
+    &_after_open {
+      opacity: $opacity_visible;
+    }
+    &_before_close {
+      animation-name: overlayFadeOut;
+      animation-duration: $animation-duration;
+      opacity: $opacity_hidden;
+    }
+    &[class*="full_height"] {
+      &[class*="_left"]{
+        justify-content: flex-start;
+      }
 
-		&_after_open {
-			opacity: $opacity_visible;
-		}
-		&_before_close {
-			animation-name: overlayFadeOut;
-			animation-duration: $animation-duration;
-			opacity: $opacity_hidden;
-		}
-		&[class*="full_height"] {
-			&[class*="_left"]{
-				justify-content: flex-start;
-			}
+      &[class*="_center"]{
+        justify-content: center;
+      }
 
-			&[class*="_center"]{
-				justify-content: center;
-			}
+      &[class*="_right"]{
+        justify-content: flex-end;
+      }
 
-			&[class*="_right"]{
-				justify-content: flex-end;
-			}
+      .pb_dialog {
+        border-radius: 0;
+        height: 100%;
+        max-height: 100%;
+        max-width: none;
+        // This empty div only has height when dialog is full height
+        // Fix for dialog body content disappearing behind sticky footer
+        .dialog-pseudo-footer {
+          height: $space_xl * 2;
+        }
+        .dialog_footer {
+          position:fixed;
+          bottom: 0;
+          background-color: $white;
+        }
 
-			.pb_dialog {
-				border-radius: 0;
-				height: 100%;
-				max-height: 100%;
-				max-width: none;
-				//this empty div only has height when dialog is full height.
-				//fix for dialog body content disappearing behind sticky footer
-				.dialog-pseudo-footer {
-					height: $space_xl * 2;
-				}
-				.dialog_footer {
-					position:fixed;
-					bottom: 0;
-					background-color: $white;
-				}
-
-				&[class*="_sm"] {
-					width: $medium;
-					.dialog_footer {
-						width: $medium;
-					}
-				}
-				&[class*="_md"] {
-					width: $large;
-					.dialog_footer {
-						width: $large;
-					}
-				}
-				&[class*="_lg"] {
-					width: $xlarge;
-					.dialog_footer {
-						width: $xlarge;
-					}
-				}
-			}
-		}
-	}
+        &[class*="_sm"] {
+          width: $medium;
+          .dialog_footer {
+            width: $medium;
+          }
+        }
+        &[class*="_md"] {
+          width: $large;
+          .dialog_footer {
+            width: $large;
+          }
+        }
+        &[class*="_lg"] {
+          width: $xlarge;
+          .dialog_footer {
+            width: $xlarge;
+          }
+        }
+      }
+    }
+  }
 }
 
-// styles specific to rails version of kit
-// rails version has own wrapper because of the way the overlay functions for the HTML dialog used to create this
+// Styles specific to Rails version of kit
+// Rails version has own wrapper because of the way the overlay functions for the HTML dialog used to create this
 .pb_dialog_wrapper_rails {
-	$medium: 500px;
-	$large: 800px;
-	$xlarge: 1150px;
+  $medium: 500px;
+  $large: 800px;
+  $xlarge: 1150px;
 
-	.dialog_status_text_align {
-		text-align: center;
-	}
+  .dialog_status_text_align {
+    text-align: center;
+  }
 
-	&[class*="full_height"] {
-		&[class*="_left"]{
-			.pb_dialog_rails {
-				margin: unset !important;
-				margin-right: auto !important;
-			}
-		}
+  &[class*="full_height"] {
+    &[class*="_left"]{
+      .pb_dialog_rails {
+        margin: unset !important;
+        margin-right: auto !important;
+      }
+    }
 
-		&[class*="_center"]{
-			justify-content: center;
-		}
+    &[class*="_center"]{
+      justify-content: center;
+    }
 
-		&[class*="_right"]{
-			.pb_dialog_rails {
-				margin: unset !important;
-				margin-left: auto !important;
-			}
-		}
+    &[class*="_right"]{
+      .pb_dialog_rails {
+        margin: unset !important;
+        margin-left: auto !important;
+      }
+    }
 
-		.pb_dialog {
-			border-radius: 0;
-			height: 100% !important;
-			max-height: 100% !important;
-			max-width: 100%;
-			//this empty div only has height when dialog is full height.
-			//fix for dialog body content disappearing behind sticky footer
-			.dialog-pseudo-footer {
-				height: $space_xl * 2;
-			}
-			.dialog_footer {
-				position:fixed;
-				bottom: 0;
-				background-color: $white;
-			}
-			&[class*="_sm"] {
-				width: $medium;
-				.dialog_footer {
-					width: $medium;
-				}
-			}
-			&[class*="_md"] {
-				width: $large;
-				.dialog_footer {
-					width: $large;
-				}
-			}
-			&[class*="_lg"] {
-				width: $xlarge;
-				.dialog_footer {
-					width: $xlarge;
-				}
-			}
-		}
-	}
+    .pb_dialog {
+      border-radius: 0;
+      height: 100% !important;
+      max-height: 100% !important;
+      max-width: 100%;
+      // This empty div only has height when dialog is full height.
+      // Fix for dialog body content disappearing behind sticky footer
+      .dialog-pseudo-footer {
+        height: $space_xl * 2;
+      }
+      .dialog_footer {
+        position:fixed;
+        bottom: 0;
+        background-color: $white;
+      }
+      &[class*="_sm"] {
+        width: $medium;
+        .dialog_footer {
+          width: $medium;
+        }
+      }
+      &[class*="_md"] {
+        width: $large;
+        .dialog_footer {
+          width: $large;
+        }
+      }
+      &[class*="_lg"] {
+        width: $xlarge;
+        .dialog_footer {
+          width: $xlarge;
+        }
+      }
+    }
+  }
 
-	// fixes for stylesheets in nitro that were conflicting with our kit. DO NOT REMOVE.
-	//conflicts were only apparent in nitro, not in playbook local env
-	.pb_dialog_rails {
-		position: fixed !important;
-		top: 0 !important;
-		padding: unset !important;
-		margin: auto;
+  // Fixes for stylesheets in nitro that were conflicting with our kit. DO NOT REMOVE.
+  // Conflicts were only apparent in nitro, not in playbook local env
+  .pb_dialog_rails {
+    position: fixed !important;
+    top: 0 !important;
+    padding: unset !important;
+    margin: auto;
 
-	}
-	//overlay for rails kit
-	dialog::backdrop {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background-color: rgba($bg_dark, $opacity_4);
-		animation-name: overlayFade;
-		animation-duration: 0.2s;
-	}
+  }
 
-	.dialog-button-class {
-		background-color: unset;
-		border: none;
-		cursor: pointer;
-	}
+  // Overlay for rails kit
+  dialog::backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba($bg_dark, $opacity_4);
+    animation-name: overlayFade;
+    animation-duration: 0.2s;
+  }
+
+  .dialog-button-class {
+    background-color: unset;
+    border: none;
+    cursor: pointer;
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
@@ -270,9 +270,9 @@
 // styles specific to rails version of kit
 // rails version has own wrapper because of the way the overlay functions for the HTML dialog used to create this
 .pb_dialog_wrapper_rails {
-		$medium: 500px;
-    $large: 800px;
-    $xlarge: 1150px;
+	$medium: 500px;
+	$large: 800px;
+	$xlarge: 1150px;
 
 	.dialog_status_text_align {
 		text-align: center;

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
@@ -117,10 +117,14 @@
 	$opacity_hidden: 0;
 
 	.dialog_sticky_header {
-	position: sticky;
-	top: 0;
-	background-color: $white;
-	z-index: $z_8;
+		position: sticky;
+		top: 0;
+		background-color: $white;
+		z-index: $z_8;
+	}
+
+	.dialog_status_text_align {
+		text-align: center;
 	}
 
 	// @include pb_card;
@@ -135,7 +139,7 @@
 	animation-duration: $animation-duration;
 	outline: none;
 	animation-timing-function: $easeInOutQuint;
-	
+
 	&[class*="_left"] {
 		animation-name: modalFadeInLeft;
 		&[class*="_before_close"] {
@@ -153,7 +157,7 @@
 			opacity: $opacity_hidden;
 		}
 	}
-	
+
 	&[class*="_status_size"] {
 		width: $status_size;
 	}
@@ -165,7 +169,7 @@
 	&[class*="_md"] {
 		width: $medium;
 	}
-	
+
 
 	&[class*="_lg"] {
 		width: $large;
@@ -215,7 +219,7 @@
 			&[class*="_left"]{
 				justify-content: flex-start;
 			}
-			
+
 			&[class*="_center"]{
 				justify-content: center;
 			}
@@ -229,7 +233,7 @@
 				height: 100%;
 				max-height: 100%;
 				max-width: none;
-				//this empty div only has height when dialog is full height. 
+				//this empty div only has height when dialog is full height.
 				//fix for dialog body content disappearing behind sticky footer
 				.dialog-pseudo-footer {
 					height: $space_xl * 2;
@@ -239,7 +243,7 @@
 					bottom: 0;
 					background-color: $white;
 				}
-				
+
 				&[class*="_sm"] {
 					width: $medium;
 					.dialog_footer {
@@ -258,17 +262,21 @@
 						width: $xlarge;
 					}
 				}
-			} 
+			}
 		}
-	}	
+	}
 }
 
-//styles specific to rails version of kit
+// styles specific to rails version of kit
 // rails version has own wrapper because of the way the overlay functions for the HTML dialog used to create this
 .pb_dialog_wrapper_rails {
-	$medium: 500px;
+		$medium: 500px;
     $large: 800px;
     $xlarge: 1150px;
+
+	.dialog_status_text_align {
+		text-align: center;
+	}
 
 	&[class*="full_height"] {
 		&[class*="_left"]{
@@ -277,7 +285,7 @@
 				margin-right: auto !important;
 			}
 		}
-		
+
 		&[class*="_center"]{
 			justify-content: center;
 		}
@@ -294,7 +302,7 @@
 			height: 100% !important;
 			max-height: 100% !important;
 			max-width: 100%;
-			//this empty div only has height when dialog is full height. 
+			//this empty div only has height when dialog is full height.
 			//fix for dialog body content disappearing behind sticky footer
 			.dialog-pseudo-footer {
 				height: $space_xl * 2;
@@ -322,17 +330,17 @@
 					width: $xlarge;
 				}
 			}
-		} 
+		}
 	}
 
-	// fixes for stylesheets in nitro that were conflicting with our kit. DO NOT REMOVE. 
+	// fixes for stylesheets in nitro that were conflicting with our kit. DO NOT REMOVE.
 	//conflicts were only apparent in nitro, not in playbook local env
 	.pb_dialog_rails {
 		position: fixed !important;
 		top: 0 !important;
 		padding: unset !important;
 		margin: auto;
-	
+
 	}
 	//overlay for rails kit
 	dialog::backdrop {
@@ -346,7 +354,7 @@
 		justify-content: center;
 		background-color: rgba($bg_dark, $opacity_4);
 		animation-name: overlayFade;
-		animation-duration: 0.2s;	
+		animation-duration: 0.2s;
 	}
 
 	.dialog-button-class {

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
@@ -181,7 +181,10 @@ const Dialog = (props: DialogProps) => {
             {title && !status ? <Dialog.Header>{title}</Dialog.Header> : null}
             {!status && text ? <Dialog.Body>{text}</Dialog.Body> : null}
             {status && (
-              <Dialog.Body padding="md">
+              <Dialog.Body
+                  className="dialog_status_text_align"
+                  padding="md"
+              >
                 <Flex align="center" orientation="column">
                   <IconCircle
                     icon={sweetAlertStatus[status].icon}
@@ -197,17 +200,17 @@ const Dialog = (props: DialogProps) => {
             )}
             {cancelButton && confirmButton ? (
               <Dialog.Footer>
-                  <Button 
-                    loading={loading} 
-                    onClick={onConfirm} 
-                    htmlType="button" 
+                  <Button
+                    loading={loading}
+                    onClick={onConfirm}
+                    htmlType="button"
                     variant="primary">
                     {confirmButton}
                   </Button>
-                  <Button 
-                    id="cancel-button" 
-                    onClick={onCancel} 
-                    variant="link" 
+                  <Button
+                    id="cancel-button"
+                    onClick={onCancel}
+                    variant="link"
                     htmlType="button">
                     {cancelButton}
                   </Button>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -5,38 +5,38 @@
         id: object.id,
         class: object.classname) do %>
             <% if object.status === "" && object.title %>
-                <%= pb_rails("dialog/dialog_header", props: {title: object.title, id: object.id }) %>
+                <%= pb_rails("dialog/dialog_header", props: { title: object.title, id: object.id }) %>
             <% end %>
             <% if object.status === "" && object.text %>
                 <%= pb_rails("dialog/dialog_body", props: { text: object.text }) %>
             <% end %>
             <% if object.status != "" %>
-                <%= pb_rails("dialog/dialog_body", props: {padding: "md"}) do %>
-                    <%= pb_rails("flex", props: {align: "center", orientation: "column"}) do %>
+                <%= pb_rails("dialog/dialog_body", props: { classname: "dialog_status_text_align" ,padding: "md" }) do %>
+                    <%= pb_rails("flex", props: { align: "center", orientation: "column" }) do %>
                         <%= pb_rails("icon_circle", props: {
                                 icon: object.status_alerts[0],
                                 variant: object.status_alerts[1],
                                 size: "lg"
                             }) %>
                         <%= pb_rails("title", props: { text: object.title, tag: "h1", size: 3, margin_top: "sm" }) %>
-                        <%= pb_rails("body", props: {text: object.text, margin_top: "sm"}) %>
+                        <%= pb_rails("body", props: { text: object.text, margin_top: "sm" }) %>
                     <% end %>
                 <% end %>
             <% end %>
             <% if object.cancel_button && object.confirm_button %>
                         <%= pb_rails("dialog/dialog_footer", props: {
-                            cancel_button: object.cancel_button, 
+                            cancel_button: object.cancel_button,
                             confirm_button: object.confirm_button,
                             id: object.id
                         }) %>
             <% end %>
-            
+
             <%= content %>
     <% end %>
 </div>
 
 <%= javascript_tag do %>
-    window.addEventListener("DOMContentLoaded", () => {      
+    window.addEventListener("DOMContentLoaded", () => {
         dialogHelper()
     })
-  <% end %>
+<% end %>


### PR DESCRIPTION
**What does this PR do?**
- [Runway](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-65)
- Centers the text for status dialogs by adding a class name: [`dialog_status_text_align`](https://github.com/powerhome/playbook/compare/PBNTR-65-Dialog-Title-Body?expand=1#diff-e0614f355c6addc50e729055d662c40e0486bf3b34ee83d2578a9cff2790ffa4R185)

**Screenshots:**
| Before | After |
|--------|--------|
| ![Screenshot 2023-07-20 at 12 38 20 PM](https://github.com/powerhome/playbook/assets/47684670/5d30d256-eb6c-41c3-8eb0-b67daefde495) | ![Screenshot 2023-07-20 at 12 30 31 PM](https://github.com/powerhome/playbook/assets/47684670/3d526e7b-8936-49eb-8074-3c142c192f6d) |

**How to test?** Steps to confirm the desired behavior:
1. Go to the Dialog kit
2. Open a status Dialog variant
3. Put in some long text - it should be centered

#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.