### PR TITLE
[PLAY-912]  🌐 kit_collection: add kit + global props table to Rails page

### DIFF
--- a/playbook-website/app/views/pages/kit_collection.html.erb
+++ b/playbook-website/app/views/pages/kit_collection.html.erb
@@ -9,9 +9,9 @@
   <div class="multi-kits-container">
     <% if @type == "rails" %>
       <%= pb_kit(kit: @selected_kit, dark_mode: dark_mode?) %>
+      <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
     <% elsif @type == "react" %>
       <%= pb_kit(kit: @selected_kit, type: "react", dark_mode: dark_mode?) %>
     <% end %>
-    <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
   </div>
 <% end %>

--- a/playbook-website/app/views/pages/kit_collection.html.erb
+++ b/playbook-website/app/views/pages/kit_collection.html.erb
@@ -12,5 +12,6 @@
     <% elsif @type == "react" %>
       <%= pb_kit(kit: @selected_kit, type: "react", dark_mode: dark_mode?) %>
     <% end %>
+    <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
   </div>
 <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Added the Rails kit and global props table to the rails kit mash up page
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-912)


**Screenshots:** Screenshots to visualize your addition/change
<img width="1754" alt="Screenshot 2023-07-20 at 2 34 27 PM" src="https://github.com/powerhome/playbook/assets/73671109/ea751876-b4d8-440f-bcd1-cc21e4b6206c">


**How to test?** Steps to confirm the desired behavior:
1. Go to https://playbook.powerapp.cloud/kit_collection/title&card&nav
2. Scroll to the bottom
3. Ensure both kit and global prop tables are functioning correctly
4. Change between different kits and ensure that the tables show up as they should for each kit.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.