### PR TITLE
[PLAY-916] 🧬📄 Hover global prop docs

### DIFF
--- a/playbook-website/app/javascript/components/Sidebar/index.tsx
+++ b/playbook-website/app/javascript/components/Sidebar/index.tsx
@@ -15,6 +15,7 @@ export const MENU_ITEMS = [
   "Display",
   "Cursor",
   "Flex Box",
+  "Hover",
 ];
 
 const Sidebar = () => {
@@ -34,7 +35,7 @@ const Sidebar = () => {
     </Nav>
     </>
   )
-  
+
 };
 
 export default Sidebar;

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -13,6 +13,9 @@ import Example from '../Templates/Example'
 
 const ZINDEX = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
+const shadowArr = ['deep', 'deeper', 'deepest']
+const scaleObj = { 'sm': '@1.05', 'md': '@1.10', 'lg': '@1.15' }
+
 const hoverDescription = (
   <>
     <Body
@@ -51,15 +54,14 @@ const Hover = ({ example }: { example: string }) => (
     />
 
     <Card
-        marginTop="sm"
+        marginTop="md"
         shadow="deep"
     >
       <Flex
-          gap="sm"
           orientation="column"
           wrap
       >
-        <FlexItem>
+        <FlexItem paddingBottom="xs">
           <Caption
               text="Visual Guide"
           />
@@ -67,6 +69,60 @@ const Hover = ({ example }: { example: string }) => (
         <FlexItem>
           <Body
               text="Hover over any card below to view hover property."
+          />
+        </FlexItem>
+        <FlexItem paddingY="sm">
+          <Flex
+              gap="sm"
+              wrap
+          >
+            <Card
+                hover={{ background: 'success_subtle' }}
+                padding="xs"
+            >
+              <Body
+                  text="background color*"
+              />
+            </Card>
+            {shadowArr.map((value) => {
+              return (
+                <Card
+                    hover={{ shadow: value }}
+                    key={value}
+                    padding="xs"
+                >
+                  <Body
+                      text={`shadow ${value}`}
+                  />
+                </Card>
+              )
+            })}
+            {Object.entries(scaleObj).map(([key, value]) => {
+              return (
+                <Card
+                    hover={{ scale: key }}
+                    key={key}
+                    padding="xs"
+                >
+                  <Flex align="center">
+                    <Body
+                        paddingRight="xxs"
+                        text={`scale ${key}`}
+                    />
+                    <Caption
+                        size="xs"
+                        text={value}
+                    />
+                  </Flex>
+                </Card>
+              )
+            })}
+          </Flex>
+        </FlexItem>
+        <FlexItem>
+          <Caption
+              size="xs"
+              text="*background accepts any color token"
           />
         </FlexItem>
       </Flex>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import {
+  Body,
+  Button,
+  Caption,
+  Card,
+  Flex,
+  FlexItem,
+  Icon,
+} from 'playbook-ui'
+
+import Example from '../Templates/Example'
+
+const ZINDEX = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+const hoverDescription = (
+  <>
+    <Body
+        text="Adding our hover prop is usefull for easily customizing UI for kit ineractions."
+    />
+    <Button
+        link="https://codesandbox.io/s/playbook-global-hover-prop-example-forked-mhssmm?file=/src/App.js"
+        newWindow
+        padding="none"
+        tabIndex={0}
+        variant="link"
+    >
+      <Body
+          variant="link"
+      >
+        {'See this prop in action in our sample UI'}
+        <Icon
+            fixedWidth
+            icon="angle-right"
+        />
+      </Body>
+    </Button>
+  </>
+)
+
+const Hover = ({ example }: { example: string }) => (
+  <React.Fragment>
+    <Example
+        description={hoverDescription}
+        example={example}
+        globalProps={{
+          hover: ZINDEX,
+        }}
+        // globalPropsDescription={globalPropsDescription}
+        title="Hover"
+    />
+
+    <Card
+        marginTop="sm"
+        shadow="deep"
+    >
+      <Flex
+          gap="sm"
+          orientation="column"
+          wrap
+      >
+        <FlexItem>
+          <Caption
+              text="Visual Guide"
+          />
+        </FlexItem>
+        <FlexItem>
+          <Body
+              text="Hover over any card below to view hover property."
+          />
+        </FlexItem>
+      </Flex>
+    </Card>
+  </React.Fragment>
+)
+
+export default Hover

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -7,18 +7,27 @@ import {
   Flex,
   FlexItem,
   Icon,
+  Pill,
+  SectionSeparator,
+  Table,
+  Title,
 } from 'playbook-ui'
 
 import Example from '../Templates/Example'
 
-const ZINDEX = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
 const shadowArr = ['deep', 'deeper', 'deepest']
 const scaleObj = { 'sm': '@1.05', 'md': '@1.10', 'lg': '@1.15' }
 
-const hoverDescription = (
-  <>
+const Hover = ({ example }: { example: string }) => (
+  <React.Fragment>
+    <Title
+        marginBottom="sm"
+        size={1}
+        tag="h1"
+        text="Hover"
+    />
     <Body
+        paddingBottom="xxs"
         text="Adding our hover prop is usefull for easily customizing UI for kit ineractions."
     />
     <Button
@@ -38,20 +47,122 @@ const hoverDescription = (
         />
       </Body>
     </Button>
-  </>
-)
-
-const Hover = ({ example }: { example: string }) => (
-  <React.Fragment>
-    <Example
-        description={hoverDescription}
-        example={example}
-        globalProps={{
-          hover: ZINDEX,
-        }}
-        // globalPropsDescription={globalPropsDescription}
-        title="Hover"
+    <Title
+        marginBottom="xs"
+        marginTop="md"
+        size={4}
+        tag="h4"
+        text="Global Props"
     />
+    <Body
+        marginBottom="md"
+        text="Available in every kit. These are added globally as they are most flexible when developing."
+    />
+    <Example
+        customChildren
+        example={example}
+    >
+      <Flex
+          paddingBottom="sm"
+          vertical="stretch"
+      >
+        <Card.Body
+            marginRight="xl"
+            paddingRight="xl"
+        >
+          <Caption
+              marginBottom="sm"
+              text="Props"
+          />
+          <Pill
+              text="hover"
+              textTransform="none"
+          />
+        </Card.Body>
+        <SectionSeparator
+            marginBottom="xs"
+            marginLeft="xl"
+            marginTop="md"
+            orientation="vertical"
+            paddingLeft="xl"
+            variant="card"
+        />
+        <Table
+            container={false}
+            dataTable
+            marginTop="sm"
+            marginX="sm"
+            size="sm"
+        >
+          <thead>
+            <tr>
+              <th>{'options'}</th>
+              <th>{'values'}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <Pill
+                    text="background"
+                    textTransform="none"
+                    variant="warning"
+                />
+              </td>
+              <td>
+                <Pill
+                    text="${color}"
+                    textTransform="none"
+                    variant="warning"
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <Pill
+                    text="shadow"
+                    textTransform="none"
+                    variant="warning"
+                />
+              </td>
+              <td>
+                {shadowArr.map((value) => {
+                  return (
+                    <Pill
+                        key={value}
+                        text={value}
+                        textTransform="none"
+                        variant="warning"
+                    />
+                  )
+                })}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <Pill
+                    text="scale"
+                    textTransform="none"
+                    variant="warning"
+                />
+              </td>
+              <td>
+                {Object.entries(scaleObj).map(([key]) => {
+                  return (
+                    <Pill
+                        key={key}
+                        text={key}
+                        textTransform="none"
+                        variant="warning"
+                    />
+                  )
+                })}
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      </Flex>
+    </Example>
 
     <Card
         marginTop="md"

--- a/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
@@ -21,7 +21,7 @@ type ExampleType = {
   children?: React.ReactChild[] | React.ReactChild,
   // codesandboxExample? : boolean,
   customChildren?: boolean,
-  description?: React.ReactChild[] | React.ReactChild | string,
+  description?: React.ReactChild[] | React.ReactChild | string | (() => JSX.Element),
   example?: string,
   globalProps?: { [key: string]: string[] | number[] },
   globalPropsDescription?: React.ReactElement | React.ReactElement[] | string,

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -16,6 +16,7 @@ import Display from "../VisualGuidelines/Examples/Display";
 import Cursor from "../VisualGuidelines/Examples/Cursor";
 import FlexBox from "../VisualGuidelines/Examples/FlexBox";
 import Position from "../VisualGuidelines/Examples/Position";
+import Hover from "../VisualGuidelines/Examples/Hover";
 
 const VisualGuidelines = ({
   examples,
@@ -48,7 +49,7 @@ const VisualGuidelines = ({
                    tokensExample={examples.shadow_erb}
                />;
       case "spacing":
-        return <Spacing 
+        return <Spacing
                   example={examples.spacing_global_props_jsx}
                   tokensExample={examples.spacing_tokens_jsx}
                />;
@@ -66,6 +67,8 @@ const VisualGuidelines = ({
         return <Position example={examples.position_jsx}
                    tokensExample={examples.position_token}
                />;
+      case "hover":
+        return <Hover example={examples.hover_jsx}/>;
 
       default:
         return <Colors/>;

--- a/playbook-website/app/views/pages/code_snippets/hover_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/hover_jsx.txt
@@ -1,0 +1,11 @@
+<Button
+  hover={{ shadow: "deep" }}
+  onClick={() => alert("button clicked!")}
+  text='Shadow Deep'
+/>
+
+<Message
+    hover={{ background: "success_subtle" }}
+    label='Anna Black'
+    message='How can we assist you today?'
+/>

--- a/playbook-website/app/views/pages/code_snippets/hover_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/hover_jsx.txt
@@ -4,6 +4,12 @@
   text='Shadow Deep'
 />
 
+<Button
+  hover={{ scale: "lg" }}
+  onClick={() => alert("button clicked!")}
+  text='Shadow Deep'
+/>
+
 <Message
     hover={{ background: "success_subtle" }}
     label='Anna Black'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Create Hover Global Prop docs in our Playbook Wesbite
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-916)


**Screenshots:** Screenshots to visualize your addition/change
<img width="1278" alt="Screenshot 2023-07-24 at 2 43 29 PM" src="https://github.com/powerhome/playbook/assets/73671109/b614fc1d-9188-4c4d-b08f-92b7811e5d36">
<img width="1203" alt="Screenshot 2023-07-24 at 2 43 41 PM" src="https://github.com/powerhome/playbook/assets/73671109/01b44589-d0ea-4bb8-b29e-03c10d5c3b77">


**How to test?** Steps to confirm the desired behavior:
1. Go to Playbook Website
2. Click on Design in the upper right hand corner
3. Click on Hover on the left hand side bar
4. See addition of Hover Global Props


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.