### PR TITLE
[PBIOS-116] Docs: Radio

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_alignment_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_alignment_swift.md
@@ -1,14 +1,14 @@
 ```swift
- VStack(alignment: .leading) {
-      PBRadio(
-        items: [
-          PBRadioItem("Power"),
-          .init("Nitro"),
-          .init("Google")
-        ],
-        orientation: .horizontal,
-        textAlignment: .vertical,
-        selected: $selectedAlignment
-      )
-    }
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Power"),
+      .init("Nitro"),
+      .init("Google")
+    ],
+    orientation: .horizontal,
+    textAlignment: .vertical,
+    selected: $selectedAlignment
+  )
+}
 ```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_alignment_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_alignment_swift.md
@@ -1,0 +1,14 @@
+```swift
+ VStack(alignment: .leading) {
+      PBRadio(
+        items: [
+          PBRadioItem("Power"),
+          .init("Nitro"),
+          .init("Google")
+        ],
+        orientation: .horizontal,
+        textAlignment: .vertical,
+        selected: $selectedAlignment
+      )
+    }
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_swift.md
@@ -1,0 +1,16 @@
+```swift
+ VStack(alignment: .leading) {
+      if let selectedCustom = selectedCustom {
+        Text("Your choice is: \(selectedCustom.title)")
+      }
+      PBRadio(
+        items: [
+          PBRadioItem("Custom Power"),
+          .init("Custom Nitro"),
+          .init("Custom Google")
+        ],
+        orientation: .vertical,
+        selected: $selectedCustom
+      )
+    }
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_swift.md
@@ -1,16 +1,16 @@
 ```swift
- VStack(alignment: .leading) {
-      if let selectedCustom = selectedCustom {
-        Text("Your choice is: \(selectedCustom.title)")
-      }
-      PBRadio(
-        items: [
-          PBRadioItem("Custom Power"),
-          .init("Custom Nitro"),
-          .init("Custom Google")
-        ],
-        orientation: .vertical,
-        selected: $selectedCustom
-      )
-    }
+VStack(alignment: .leading) {
+  if let selectedCustom = selectedCustom {
+    Text("Your choice is: \(selectedCustom.title)")
+  }
+  PBRadio(
+    items: [
+      PBRadioItem("Custom Power"),
+      .init("Custom Nitro"),
+      .init("Custom Google")
+    ],
+    orientation: .vertical,
+    selected: $selectedCustom
+  )
+  }
 ```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_default_swift.md
@@ -1,0 +1,13 @@
+```swift
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Power"),
+      .init("Nitro"),
+      .init("Google")
+    ],
+    orientation: .vertical,
+    selected: $selectedDefault
+  )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_error_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_error_swift.md
@@ -1,12 +1,12 @@
 ```swift
 VStack(alignment: .leading) {
-      PBRadio(
-        items: [
-          PBRadioItem("Power")
-        ],
-        orientation: .vertical,
-        selected: $selectedError,
-        errorState: true
-      )
+  PBRadio(
+    items: [
+      PBRadioItem("Power")
+    ],
+    orientation: .vertical,
+    selected: $selectedError,
+    errorState: true
+  )
 }
 ```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_error_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_error_swift.md
@@ -1,0 +1,12 @@
+```swift
+VStack(alignment: .leading) {
+      PBRadio(
+        items: [
+          PBRadioItem("Power")
+        ],
+        orientation: .vertical,
+        selected: $selectedError,
+        errorState: true
+      )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_props_swift.md
@@ -1,0 +1,13 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **title** | `String` | Description | | |
+| **subtitle** | `String` | Description | | |
+| **items** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **orientation** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **textAlignment** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **spacing** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **padding** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **errorState** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **selected** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **errorState** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_props_swift.md
@@ -1,13 +1,10 @@
 ### Props
 | Name | Type | Description | Default | Values |
 | --- | ----------- | --------- | --------- | --------- |
-| **title** | `String` | Description | | |
-| **subtitle** | `String` | Description | | |
-| **items** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
-| **orientation** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
-| **textAlignment** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
-| **spacing** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
-| **padding** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
-| **errorState** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
-| **selected** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
-| **errorState** | `type` | Description | `defaultValue` | `all` `other` `accepted` `values` |
+| **items** | `` | Specifies the value of the Radio buttons | | |
+| **orientation** | `` | Changes between stacked or inline Radio items | `.vertical` | |
+| **textAlignment** | `` | Changes lable position | `.horizontal` | |
+| **spacing** | `CGFloat` | Applies padding around Radio and lable | `Spacing.xSmall` | `Spacing.none` `Spacing.xxSmall` `Spacing.xSmall` `Spacing.small` `Spacing.medium` `Spacing.large` `Spacing.xLarge` |
+| **padding** | `CGFloat` | Applies padding between Radio and lable | `Spacing.xSmall` | `Spacing.none` `Spacing.xxSmall` `Spacing.xSmall` `Spacing.small` `Spacing.medium` `Spacing.large` `Spacing.xLarge` |
+| **errorState** | `Bool` | Changes Radio to error styling | | |
+| **selected** | `` | Sets selected Radio item | | |

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/example.yml
@@ -12,3 +12,10 @@ examples:
   - radio_custom: Custom
   - radio_error: With Error
   - radio_alignment: Alignment
+
+  swift:
+  - radio_default_swift: Default
+  - radio_custom_swift: Custom
+  - radio_error_swift: With Error
+  - radio_alignment_swift: Alignment
+  - radio_props_swift: ""


### PR DESCRIPTION
[PBIOS-116](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-116)

This story adds Swift docs for the Radio kit


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.