### PR TITLE
[PLAY-928] Fixed Text Input Options Prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_options.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_options.html.erb
@@ -1,0 +1,12 @@
+<%= pb_rails("text_input", props: {
+  placeholder: "Placeholder", 
+  input_options: {
+    id: "testing-one-time-code",
+    autocomplete: "one-time-code",
+    name:"auth-token",
+    inputmode:"numeric",
+    pattern:"[0-9]*",
+    type: "text"
+  }
+}) %>
+

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/example.yml
@@ -7,6 +7,7 @@ examples:
   - text_input_add_on: Add On
   - text_input_inline: Inline
   - text_input_no_label: No Label
+  - text_input_options: Input Options
   react:
   - text_input_default: Default
   - text_input_error: With Error

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -60,7 +60,7 @@ module Playbook
           required: required,
           type: type,
           value: value,
-        }
+        }.merge(input_options)
       end
 
       def validation_message

--- a/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Playbook::PbTextInput::TextInput do
   it { is_expected.to define_prop(:placeholder) }
   it { is_expected.to define_prop(:value) }
   it { is_expected.to define_prop(:type).with_default("text") }
-  it { is_expected.to define_prop(:input_options).of_type(Playbook::Props::Hash).with_default({}) }
+  it { is_expected.to define_hash_prop(:input_options).with_default({}) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do


### PR DESCRIPTION
**What does this PR do?** 

https://nitro.powerhrg.com/runway/backlog_items/PLAY-928
We've had the input_options prop for a long time, but it wasn't connected correctly. We just needed a simple merge to be able to leverage any values that the end user passes in. 

✅  Fixed Broken Input Options Prop. 
✅  Simplified Rspec by Using Matcher


**Screenshots:** Screenshot

<img width="1370" alt="Screenshot 2023-08-07 at 9 26 52 AM" src="https://github.com/powerhome/playbook/assets/9158723/a188b66b-f975-4db7-9a6a-3f8f032caab9">
s to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:

1. Go to Input Options example in the rails docs.
2. Inspect the page, and look directly at the <input />
3. See attributes being added because of the input_options prop fix.


#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [X] **TESTS** I have added test coverage to my code.