### PR TITLE
[PBIOS-107] Swift Docs: Badge, Pill, Radio and Timestamp Kits

### DIFF
--- a/playbook-website/app/javascript/site_styles/_kits_show.scss
+++ b/playbook-website/app/javascript/site_styles/_kits_show.scss
@@ -24,6 +24,25 @@
   .card {
     max-width: fit-content;
   }
+  .kit_show_swift & {
+    p {
+      a {
+        background-color: $bg_light;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        border-radius: $border_radius_lg;
+        box-shadow: inset $shadow_deep;
+        img {
+          max-width: 250px;
+          height: auto;
+          position: relative;
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
 }
 
 .multi-kits-container {

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_colors_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_colors_swift.md
@@ -2,32 +2,32 @@
 
 ```swift
 HStack {
-    PBBadge(text: "1", rounded: true, variant: .chat)
-    PBBadge(text: "4", variant: .chat)
-    PBBadge(text: "1000", variant: .chat)
+  PBBadge(text: "1", rounded: true, variant: .chat)
+  PBBadge(text: "4", variant: .chat)
+  PBBadge(text: "1000", variant: .chat)
 
-    PBBadge(text: "1", rounded: true, variant: .error)
-    PBBadge(text: "4", variant: .error)
-    PBBadge(text: "1000", variant: .error)
+  PBBadge(text: "1", rounded: true, variant: .error)
+  PBBadge(text: "4", variant: .error)
+  PBBadge(text: "1000", variant: .error)
 
-    PBBadge(text: "1", rounded: true, variant: .info)
-    PBBadge(text: "4", variant: .info)
-    PBBadge(text: "1000", variant: .info)
+  PBBadge(text: "1", rounded: true, variant: .info)
+  PBBadge(text: "4", variant: .info)
+  PBBadge(text: "1000", variant: .info)
 
-    PBBadge(text: "1", rounded: true, variant: .neutral)
-    PBBadge(text: "4", variant: .neutral)
-    PBBadge(text: "1000", variant: .neutral)
+  PBBadge(text: "1", rounded: true, variant: .neutral)
+  PBBadge(text: "4", variant: .neutral)
+  PBBadge(text: "1000", variant: .neutral)
 
-    PBBadge(text: "1", rounded: true, variant: .primary)
-    PBBadge(text: "4", variant: .primary)
-    PBBadge(text: "1000", variant: .primary)
+  PBBadge(text: "1", rounded: true, variant: .primary)
+  PBBadge(text: "4", variant: .primary)
+  PBBadge(text: "1000", variant: .primary)
 
-    PBBadge(text: "1", rounded: true, variant: .success)
-    PBBadge(text: "4", variant: .success)
-    PBBadge(text: "1000", variant: .success)
+  PBBadge(text: "1", rounded: true, variant: .success)
+  PBBadge(text: "4", variant: .success)
+  PBBadge(text: "1000", variant: .success)
 
-    PBBadge(text: "1", rounded: true, variant: .warning)
-    PBBadge(text: "4", variant: .warning)
-    PBBadge(text: "1000", variant: .warning)
+  PBBadge(text: "1", rounded: true, variant: .warning)
+  PBBadge(text: "4", variant: .warning)
+  PBBadge(text: "1000", variant: .warning)
  }
 ```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_colors_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_colors_swift.md
@@ -1,0 +1,33 @@
+![badge-colors](https://github.com/powerhome/playbook/assets/92755007/52ce34ef-eb0d-48c0-9232-89edfff60cef)
+
+```swift
+HStack {
+    PBBadge(text: "1", rounded: true, variant: .chat)
+    PBBadge(text: "4", variant: .chat)
+    PBBadge(text: "1000", variant: .chat)
+
+    PBBadge(text: "1", rounded: true, variant: .error)
+    PBBadge(text: "4", variant: .error)
+    PBBadge(text: "1000", variant: .error)
+
+    PBBadge(text: "1", rounded: true, variant: .info)
+    PBBadge(text: "4", variant: .info)
+    PBBadge(text: "1000", variant: .info)
+
+    PBBadge(text: "1", rounded: true, variant: .neutral)
+    PBBadge(text: "4", variant: .neutral)
+    PBBadge(text: "1000", variant: .neutral)
+
+    PBBadge(text: "1", rounded: true, variant: .primary)
+    PBBadge(text: "4", variant: .primary)
+    PBBadge(text: "1000", variant: .primary)
+
+    PBBadge(text: "1", rounded: true, variant: .success)
+    PBBadge(text: "4", variant: .success)
+    PBBadge(text: "1000", variant: .success)
+
+    PBBadge(text: "1", rounded: true, variant: .warning)
+    PBBadge(text: "4", variant: .warning)
+    PBBadge(text: "1000", variant: .warning)
+ }
+```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_default_swift.md
@@ -2,8 +2,8 @@
 
 ```swift
 HStack {
-    PBBadge(text: "+1", variant: .primary)
-    PBBadge(text: "+4", variant: .primary)
-    PBBadge(text: "+1000", variant: .primary)
+  PBBadge(text: "+1", variant: .primary)
+  PBBadge(text: "+4", variant: .primary)
+  PBBadge(text: "+1000", variant: .primary)
  }
 ```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_default_swift.md
@@ -1,0 +1,9 @@
+![badge-rectangle](https://github.com/powerhome/playbook/assets/92755007/04188c68-84f0-475b-9764-7b9a325f73da)
+
+```swift
+HStack {
+    PBBadge(text: "+1", variant: .primary)
+    PBBadge(text: "+4", variant: .primary)
+    PBBadge(text: "+1000", variant: .primary)
+ }
+```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification_swift.md
@@ -2,8 +2,8 @@
 
 ```swift
 HStack {
-    PBBadge(text: "1", rounded: true, variant: .chat)
-    PBBadge(text: "4", variant: .chat)
-    PBBadge(text: "1000", variant: .chat)
+  PBBadge(text: "1", rounded: true, variant: .chat)
+  PBBadge(text: "4", variant: .chat)
+  PBBadge(text: "1000", variant: .chat)
  }
 ```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_notification_swift.md
@@ -1,0 +1,9 @@
+![badge-chat-notification](https://github.com/powerhome/playbook/assets/92755007/f769c3bc-6a63-465d-8538-3efb5f3ec0d3)
+
+```swift
+HStack {
+    PBBadge(text: "1", rounded: true, variant: .chat)
+    PBBadge(text: "4", variant: .chat)
+    PBBadge(text: "1000", variant: .chat)
+ }
+```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_props_swift.md
@@ -1,0 +1,6 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **text** | `String` | Specifies the value of the Badge |  |  |
+| **rounded** | `Bool` | Displays the rounded variant | `false` |  |
+| **variant** | `Variant` | Changes the color of the Badge | `.primary` | `.chat` `.error` `.info` `.neutral` `.primary` `.success` `.warning` |

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_rounded_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_rounded_swift.md
@@ -1,0 +1,9 @@
+![badge-rounded](https://github.com/powerhome/playbook/assets/92755007/775a906f-0108-4ee1-a277-e7b9f2715a2b)
+
+```swift
+HStack {
+    PBBadge(text: "+1", rounded: true, variant: .primary)
+    PBBadge(text: "+4", rounded: true, variant: .primary)
+    PBBadge(text: "+1000", rounded: true, variant: .primary)
+ }
+```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_rounded_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/_badge_rounded_swift.md
@@ -2,8 +2,8 @@
 
 ```swift
 HStack {
-    PBBadge(text: "+1", rounded: true, variant: .primary)
-    PBBadge(text: "+4", rounded: true, variant: .primary)
-    PBBadge(text: "+1000", rounded: true, variant: .primary)
+  PBBadge(text: "+1", rounded: true, variant: .primary)
+  PBBadge(text: "+4", rounded: true, variant: .primary)
+  PBBadge(text: "+1000", rounded: true, variant: .primary)
  }
 ```

--- a/playbook/app/pb_kits/playbook/pb_badge/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_badge/docs/example.yml
@@ -10,3 +10,10 @@ examples:
   - badge_rounded: Rounded
   - badge_colors: Colors
   - badge_notification: Notification
+
+  swift:
+  - badge_default_swift: Rectangle
+  - badge_rounded_swift: Rounded
+  - badge_colors_swift: Colors
+  - badge_notification_swift: Notification
+  - badge_props_swift: ""

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_default_swift.md
@@ -1,0 +1,5 @@
+![pill-default](https://github.com/powerhome/playbook/assets/92755007/608cb5dd-9400-45f4-afb2-ac1bbd972c3d)
+
+```swift
+PBPill("default")
+```

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_props_swift.md
@@ -1,0 +1,5 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **title** | `String` | Specifies the value of the Pill |  |  |
+| **variant** | `Variant` | Changes the color of the Pill | `.neutral` | `.error` `.info` `.neutral` `.primary` `.success` `.warning` |

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_variants_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_variants_swift.md
@@ -1,0 +1,10 @@
+![pill-variants](https://github.com/powerhome/playbook/assets/92755007/79ac4260-633e-4429-8b1f-0a97b8178a86)
+
+```swift
+PBPill("success", variant: .success)
+ PBPill("error", variant: .error)
+ PBPill("warning", variant: .warning)
+ PBPill("info", variant: .info)
+ PBPill("neutral", variant: .neutral)
+ PBPill("primary", variant: .primary)
+```

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/example.yml
@@ -11,3 +11,8 @@ examples:
   - pill_default: Default
   - pill_variants: Variants
   - pill_example: Example
+
+  swift:
+  - pill_default_swift: Default
+  - pill_variants_swift: Variants
+  - pill_props_swift: ""

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_alignment_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_alignment_swift.md
@@ -1,0 +1,16 @@
+![radio-alignment](https://github.com/powerhome/playbook/assets/92755007/04b84035-8391-4de1-a33e-8964999d5c0f)
+
+```swift
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Power"),
+      .init("Nitro"),
+      .init("Google")
+    ],
+    orientation: .horizontal,
+    textAlignment: .vertical,
+    selected: $selectedAlignment
+  )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_swift.md
@@ -1,0 +1,18 @@
+![radio-custom](https://github.com/powerhome/playbook/assets/92755007/3eab180b-0550-4d7e-b562-84a007690218)
+
+```swift
+VStack(alignment: .leading) {
+  if let selectedCustom = selectedCustom {
+    Text("Your choice is: \(selectedCustom.title)")
+  }
+  PBRadio(
+    items: [
+      PBRadioItem("Custom Power"),
+      .init("Custom Nitro"),
+      .init("Custom Google")
+    ],
+    orientation: .vertical,
+    selected: $selectedCustom
+  )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_default_swift.md
@@ -1,0 +1,15 @@
+![radio-default](https://github.com/powerhome/playbook/assets/92755007/be32852e-de70-4ae0-b8bb-c091f8cfa34b)
+
+```swift
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Power"),
+      .init("Nitro"),
+      .init("Google")
+    ],
+    orientation: .vertical,
+    selected: $selectedDefault
+  )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_error_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_error_swift.md
@@ -1,0 +1,14 @@
+![radio-error](https://github.com/powerhome/playbook/assets/92755007/425f499b-4daf-4093-82a7-230b01723287)
+
+```swift
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Power")
+    ],
+    orientation: .vertical,
+    selected: $selectedError,
+    errorState: true
+  )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_orientation_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_orientation_swift.md
@@ -1,0 +1,15 @@
+![radio-orientation](https://github.com/powerhome/playbook/assets/92755007/f1f8dac7-a7d5-43cf-ba93-92bd624a1016)
+
+```swift
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Power"),
+      .init("Nitro"),
+      .init("Google")
+    ],
+    orientation: .horizontal,
+    selected: $selectedOrientation
+  )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_padding_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_padding_swift.md
@@ -1,0 +1,31 @@
+![radio-padding](https://github.com/powerhome/playbook/assets/92755007/5cb123fb-791b-43f7-a57e-336f93c1bb3a)
+
+```swift
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Small")
+    ],
+    orientation: .vertical,
+    padding: Spacing.small,
+    selected: $selectedPadding
+  )
+  PBRadio(
+    items: [
+      PBRadioItem("Medium")
+    ],
+    orientation: .vertical,
+    padding: Spacing.medium,
+    selected: $selectedPadding
+  )
+  PBRadio(
+    items: [
+      PBRadioItem("Large")
+    ],
+    orientation: .vertical,
+    padding: Spacing.large,
+    selected: $selectedPadding
+  )
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_props_swift.md
@@ -1,0 +1,10 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **items** | `PBRadioItem` | Specifies the value of the Radio buttons | | |
+| **orientation** | `Orientation` | Changes between stacked or inline Radio items | `.vertical` | |
+| **textAlignment** | `Orientation` | Changes lable position | `.horizontal` | |
+| **spacing** | `CGFloat` | Applies padding around Radio and lable | `Spacing.xSmall` | `Spacing.none` `Spacing.xxSmall` `Spacing.xSmall` `Spacing.small` `Spacing.medium` `Spacing.large` `Spacing.xLarge` |
+| **padding** | `CGFloat` | Applies padding between Radio and lable | `Spacing.xSmall` | `Spacing.none` `Spacing.xxSmall` `Spacing.xSmall` `Spacing.small` `Spacing.medium` `Spacing.large` `Spacing.xLarge` |
+| **errorState** | `Bool` | Changes Radio to error styling | | |
+| **selected** | `PBRadioItem?` | Sets selected Radio item | | |

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_spacing_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_spacing_swift.md
@@ -1,0 +1,36 @@
+![radio-spacing](https://github.com/powerhome/playbook/assets/92755007/58d1bf02-0c79-4526-9e5c-ba2f631d1dfe)
+
+```swift
+HStack(alignment: .top) {
+  PBRadio(
+    items: [
+      PBRadioItem("Small"),
+      .init("Small Spacing"),
+      .init("Small Power")
+    ],
+    orientation: .vertical,
+    spacing: Spacing.small,
+    selected: $selectedSpacing
+  )
+  PBRadio(
+    items: [
+      PBRadioItem("Medium"),
+      .init("Medium Spacing"),
+      .init("Medium Power")
+    ],
+    orientation: .vertical,
+    spacing: Spacing.medium,
+    selected: $selectedSpacing
+  )
+  PBRadio(
+    items: [
+      PBRadioItem("Large"),
+      .init("Large Spacing"),
+      .init("Large Power")
+    ],
+    orientation: .vertical,
+    spacing: Spacing.large,
+    selected: $selectedSpacing
+  )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_subtitle_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_subtitle_swift.md
@@ -1,0 +1,13 @@
+![radio-subtitle](https://github.com/powerhome/playbook/assets/92755007/1244f4d4-0e87-4b5a-9b20-ac2223866321)
+
+```swift
+VStack(alignment: .leading) {
+  PBRadio(
+    items: [
+      PBRadioItem("Power", subtitle: "subtitle")
+    ],
+    selected: $selectedSubtitle
+  )
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/example.yml
@@ -12,3 +12,14 @@ examples:
   - radio_custom: Custom
   - radio_error: With Error
   - radio_alignment: Alignment
+
+  swift:
+  - radio_default_swift: Default
+  - radio_custom_swift: Custom
+  - radio_error_swift: With Error
+  - radio_orientation_swift: Orientation
+  - radio_alignment_swift: Alignment
+  - radio_spacing_swift: Spacing
+  - radio_padding_swift: Padding
+  - radio_subtitle_swift: Subtitle
+  - radio_props_swift: ""

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_align_swift.md
@@ -1,0 +1,45 @@
+![timestamp-align](https://github.com/powerhome/playbook/assets/92755007/9107e699-218e-4a15-a0f9-b1a8f4710c37)
+
+```swiftå
+VStack(alignment: .leading, spacing: Spacing.small) {
+  Group {
+    PBTimestamp(
+      Date(),
+      showDate: false
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+    PBTimestamp(Date())
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+    PBTimestamp(Date().addingTimeInterval(addThreeYear))
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+    PBTimestamp(Date().addingTimeInterval(subOneYear))
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+  }
+  Group {
+    PBTimestamp(
+      Date(),
+      showDate: false
+    )
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .center)
+    PBTimestamp(Date())
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .center)
+    PBTimestamp(Date().addingTimeInterval(addThreeYear))
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .center)
+    PBTimestamp(Date().addingTimeInterval(subOneYear))
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .center)
+  }
+  Group {
+    PBTimestamp(
+      Date(),
+      showDate: false
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .trailing)
+    PBTimestamp(Date())
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .trailing)
+    PBTimestamp(Date().addingTimeInterval(addThreeYear))
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .trailing)
+    PBTimestamp(Date().addingTimeInterval(subOneYear))
+      .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .trailing)
+  }
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_default_swift.md
@@ -1,0 +1,26 @@
+![timestamp-default](https://github.com/powerhome/playbook/assets/92755007/064c6a98-4bdd-4160-8f4b-589233762c80)
+
+```swift
+VStack(alignment: .leading, spacing: Spacing.small) {
+  PBTimestamp(
+    Date(),
+    showDate: false
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+  PBTimestamp(
+    Date()
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+  PBTimestamp(
+    Date().addingTimeInterval(addThreeYear)
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+  PBTimestamp(
+    Date().addingTimeInterval(subOneYear)
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed_swift.md
@@ -1,0 +1,25 @@
+![timestamp-elapsed](https://github.com/powerhome/playbook/assets/92755007/bb10a951-b536-41cc-aa6c-b343e826af20)
+
+```swift
+VStack(alignment: .leading, spacing: Spacing.small) {
+  PBTimestamp(
+    Date().addingTimeInterval(-10),
+    showUser: true,
+    text: "Maricris Nanota",
+        variant: .elapsed
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+  PBTimestamp(
+    Date().addingTimeInterval(-36000),
+        variant: .elapsed
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+  PBTimestamp(
+    Date().addingTimeInterval(-36000),
+        variant: .hideUserElapsed
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_props_swift.md
@@ -1,0 +1,10 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **amPmStyle** | `AmPmStyle` | Displays shortened or full version of "am" and "pm" | `.short` | `.short` `.full` |
+| **showDate** | `Bool` | Displays date | `true` |  |
+| **showTimeZone** | `Bool` | Displays time zone | `false` |  |
+| **showUser** | `Bool` | Displays user's name | `false` |  |
+| **text** | `String` | Specifies which user to display | `nil` |  |
+| **timeZone** | `String` | Specifies which time zone to display | `nil` |  |
+| **variant** | `Variant` | Specifies copy for last upadted | `.standard` | `.elapsed` `.standard`  `.updated` `.hideUserElapsed` |

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_timezones_swift.md
@@ -1,0 +1,67 @@
+![timestamp-timezones](https://github.com/powerhome/playbook/assets/92755007/119f0838-e912-473b-83de-626db1fd0d61)
+
+```swift
+VStack(alignment: .leading, spacing: Spacing.small) {
+  Group {
+    PBTimestamp(
+      Date(),
+      showDate: false,
+      showTimeZone: true,
+      timeZone: "America/New_York"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+    PBTimestamp(
+      Date(),
+      showTimeZone: true,
+      timeZone: "America/New_York"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+    PBTimestamp(
+      Date().addingTimeInterval(addThreeYear),
+      showTimeZone: true,
+      timeZone: "America/New_York"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+    PBTimestamp(
+      Date().addingTimeInterval(subOneYear),
+      showTimeZone: true,
+      timeZone: "America/New_York"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+  }
+
+  Group {
+    PBTimestamp(
+      Date(),
+      showDate: false,
+      showTimeZone: true,
+      timeZone: "Asia/Hong_Kong"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+    PBTimestamp(
+      Date(),
+      showTimeZone: true,
+      timeZone: "Asia/Hong_Kong"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+    PBTimestamp(
+      Date().addingTimeInterval(addThreeYear),
+      showTimeZone: true,
+      timeZone: "Asia/Hong_Kong"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+    PBTimestamp(
+      Date().addingTimeInterval(subOneYear),
+      showTimeZone: true,
+      timeZone: "Asia/Hong_Kong"
+    )
+    .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+  }
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated_swift.md
@@ -1,0 +1,19 @@
+![timestamp-updated](https://github.com/powerhome/playbook/assets/92755007/14717880-c584-4413-9d9b-c569392595b7)
+
+```swift
+VStack(alignment: .leading, spacing: Spacing.small) {
+  PBTimestamp(
+    Date().addingTimeInterval(-12),
+    showUser: true,
+    text: "Maricris Nanota",
+    variant: .updated
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+
+  PBTimestamp(
+    Date().addingTimeInterval(-12),
+    variant: .updated
+  )
+  .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/example.yml
@@ -13,3 +13,11 @@ examples:
   - timestamp_timezones: Timezones
   - timestamp_updated: Last Updated by
   - timestamp_elapsed: Time Ago
+  
+  swift:
+  - timestamp_default_swift: Default
+  - timestamp_align_swift: Alignments
+  - timestamp_timezones_swift: Timezones
+  - timestamp_updated_swift: Last Updated by
+  - timestamp_elapsed_swift: Time Ago
+  - timestamp_props_swift: ""


### PR DESCRIPTION
This PR adds swift docs for `badge`, `pill`, `radio`, and `timestamp`
[PBIOS-107](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-107)
[PBIOS-115](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-115)
[PBIOS-116](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-116)
[PBIOS-117](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-117)

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. You will need to pull down locally and go to the `badge`, `pill`, `radio`, and `timestamp` kits



#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.