### PR TITLE
Fixed misalignment on passphrase icon in firefox

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.scss
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.scss
@@ -70,7 +70,6 @@
   @-moz-document url-prefix() {
     .passphrase-popover {
       position: relative;
-      top: $space_sm;
       left: -($space_xs * 1.5);
     }
   }


### PR DESCRIPTION
Fix misalignment of passphrase icon in firefox. 

## Before
<img width="729" alt="screenshot-2023-08-22-at-5-11-41-pm" src="https://github.com/powerhome/playbook/assets/73710701/dbb27b58-c960-4457-aeef-db5f7786e120">

## After 

![Screenshot 2023-08-23 at 7 53 57 AM](https://github.com/powerhome/playbook/assets/73710701/0c608f7c-b037-421f-bf6f-09c2b7b90b4d)
