### PR TITLE
[PLAY-937] Text Align Global Prop Docs

### DIFF
--- a/playbook-website/app/javascript/components/Sidebar/index.tsx
+++ b/playbook-website/app/javascript/components/Sidebar/index.tsx
@@ -16,6 +16,7 @@ export const MENU_ITEMS = [
   "Cursor",
   "Flex Box",
   "Hover",
+  "Text Align",
 ];
 
 const Sidebar = () => {

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -28,7 +28,7 @@ const Hover = ({ example }: { example: string }) => (
     />
     <Body
         paddingBottom="xxs"
-        text="Adding our hover prop is usefull for easily customizing UI for kit ineractions."
+        text="Adding our hover prop is useful for easily customizing UI for kit interactions."
     />
     <Button
         link="https://codesandbox.io/s/playbook-global-hover-prop-example-forked-mhssmm?file=/src/App.js"

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/TextAlign.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/TextAlign.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable flowtype/no-types-missing-file-annotation */
+
+import React from 'react'
+import Example from '../Templates/Example'
+
+const PROPVALUES = [
+  'left',
+  'right',
+  'center',
+  'justify',
+  'justify-all',
+  'start',
+  'end',
+  'match-parent',
+  'initial',
+  'inherit',
+]
+
+const screenSizeProps = {
+  display: ['xs', 'sm', 'md', 'lg', 'xl'],
+}
+
+const TextAlign = ({
+  example,
+}: {
+  example: string;
+}) => (
+  <>
+    <Example
+        example={example}
+        globalProps={{
+          textAlign: PROPVALUES,
+        }}
+        screenSizes={screenSizeProps}
+        title="Text Align"
+    />
+  </>
+)
+
+export default TextAlign

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -17,6 +17,7 @@ import Cursor from "../VisualGuidelines/Examples/Cursor";
 import FlexBox from "../VisualGuidelines/Examples/FlexBox";
 import Position from "../VisualGuidelines/Examples/Position";
 import Hover from "../VisualGuidelines/Examples/Hover";
+import TextAlign from "../VisualGuidelines/Examples/TextAlign";
 
 const VisualGuidelines = ({
   examples,
@@ -69,6 +70,8 @@ const VisualGuidelines = ({
                />;
       case "hover":
         return <Hover example={examples.hover_jsx}/>;
+      case "text_align":
+        return <TextAlign example={examples.text_align_jsx} />
 
       default:
         return <Colors/>;

--- a/playbook-website/app/views/pages/code_snippets/text_align_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/text_align_jsx.txt
@@ -1,0 +1,13 @@
+<Title
+    text="Default Title"
+    textAlign="center"
+/>
+
+<Title
+    text="Default Title"
+    textAlign={{
+      xs: "center",
+      sm: "left",
+      lg: "center",
+    }}
+/>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
- [Runway](https://nitro.powerhrg.com/runway/backlog_items/PLAY-937)
- Adds Text Align global prop docs
- Corrects spelling in Hover docs

**Screenshots:**
![Screenshot 2023-09-13 at 4 03 08 PM](https://github.com/powerhome/playbook/assets/47684670/bf70ad60-5389-4651-aa87-d120815f5652)

**How to test?** Steps to confirm the desired behavior:
1. Go to the "Design" tab in Playbook
2. Check out the Text Align docs

#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.