### PR TITLE
[PLAY-823] Global Prop Overflow

### DIFF
--- a/playbook-website/app/javascript/components/Sidebar/index.tsx
+++ b/playbook-website/app/javascript/components/Sidebar/index.tsx
@@ -17,6 +17,7 @@ export const MENU_ITEMS = [
   "Flex Box",
   "Hover",
   "Text Align",
+  "Overflow"
 ];
 
 const Sidebar = () => {

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Overflow.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Overflow.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import Example from '../Templates/Example'
+import SpacingProps from '../Templates/SpacingProps'
+
+const OVERFLOW = ["visible", "hidden", "scroll", "auto"]
+const PROPNAMES = ['overflow', 'overflowX', 'overflowY']
+const TOKENS = {
+'$visible': 'visible',
+'$hidden': 'hidden',
+'$scroll': 'scroll',
+'$auto': 'auto'
+}
+
+const Overflow = ({ example, tokensExample }: { example: string, tokensExample?: string }) => (
+  <React.Fragment>
+    <Example
+      description="Control over the overflow of a container can be useful for your UI. The overflow prop can be used to override default overflow behavior and apply any of the tokens: "
+      example={example}
+      title="Overflow"
+    >
+    <SpacingProps propValues={OVERFLOW} propNames={PROPNAMES} />
+    </Example>
+    <Example
+      example={tokensExample}
+      tokens={TOKENS}
+    />
+  </React.Fragment>
+)
+
+export default Overflow

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Overflow.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Overflow.tsx
@@ -14,7 +14,7 @@ const TOKENS = {
 const Overflow = ({ example, tokensExample }: { example: string, tokensExample?: string }) => (
   <React.Fragment>
     <Example
-      description="Control over the overflow of a container can be useful for your UI. The overflow prop can be used to override default overflow behavior and apply any of the tokens: "
+      description="The Overflow prop allows you to specify if and how a container's contents are visible when they exceed (i.e., overflow) the container's borders."
       example={example}
       title="Overflow"
     >

--- a/playbook-website/app/javascript/components/VisualGuidelines/Templates/SpacingProps.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Templates/SpacingProps.tsx
@@ -18,7 +18,7 @@ import {
 type Props = {
   propValues: string[];
   propNames: string[];
-  screenSizes: { [key: string]: string[] | number[] },
+  screenSizes?: { [key: string]: string[] | number[] },
 };
 
 const SpacingProps = ({ propNames, propValues, screenSizes }: Props): React.ReactElement => {
@@ -42,27 +42,30 @@ const SpacingProps = ({ propNames, propValues, screenSizes }: Props): React.Reac
           ))}
         </Card.Body>
       </FlexItem>
-      <SectionSeparator
-        marginBottom="md"
-        marginTop="md"
-        orientation="vertical"
-        variant="card"
-      />
-
-      <FlexItem flex={1}>
-        <Card.Body>
-          <Caption marginBottom="sm" text="Screen Size" />
-          {Object.values(screenSizes)[0].map((value) => (
-            <Pill
-              key={value}
-              text={value}
-              marginRight="xs"
-              textTransform="none"
-              variant="warning"
-            />
-          ))}
-        </Card.Body>
-      </FlexItem>
+      {screenSizes ? (
+        <>
+          <SectionSeparator
+            marginBottom="md"
+            marginTop="md"
+            orientation="vertical"
+            variant="card"
+          />
+          <FlexItem flex={1}>
+            <Card.Body>
+              <Caption marginBottom="sm" text="Screen Size" />
+              {Object.values(screenSizes)[0].map((value) => (
+                <Pill
+                  key={value}
+                  text={value}
+                  marginRight="xs"
+                  textTransform="none"
+                  variant="warning"
+                />
+              ))}
+            </Card.Body>
+          </FlexItem>
+        </>
+      ) : null}
       <SectionSeparator
         marginBottom="md"
         marginTop="md"

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -18,6 +18,7 @@ import FlexBox from "../VisualGuidelines/Examples/FlexBox";
 import Position from "../VisualGuidelines/Examples/Position";
 import Hover from "../VisualGuidelines/Examples/Hover";
 import TextAlign from "../VisualGuidelines/Examples/TextAlign";
+import Overflow from "./Examples/Overflow";
 
 const VisualGuidelines = ({
   examples,
@@ -72,6 +73,10 @@ const VisualGuidelines = ({
         return <Hover example={examples.hover_jsx}/>;
       case "text_align":
         return <TextAlign example={examples.text_align_jsx} />
+        case "overflow":
+          return <Overflow example={examples.overflow_jsx} 
+                    tokensExample={examples.overflow_token}
+                 />
 
       default:
         return <Colors/>;

--- a/playbook-website/app/views/pages/code_snippets/overflow_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/overflow_jsx.txt
@@ -1,0 +1,1 @@
+<Card overflow="hidden">{'Card content'}</Card>

--- a/playbook-website/app/views/pages/code_snippets/overflow_token.txt
+++ b/playbook-website/app/views/pages/code_snippets/overflow_token.txt
@@ -1,0 +1,5 @@
+@import "tokens/overflow
+
+.selector {
+    overflow-x: $visible;
+}

--- a/playbook/app/pb_kits/playbook/_playbook.scss
+++ b/playbook/app/pb_kits/playbook/_playbook.scss
@@ -113,5 +113,6 @@
 @import './utilities/border_radius';
 @import './utilities/hover';
 @import './utilities/text_align';
+@import './utilities/overflow';
 
 @import 'pb_multi_level_select/multi_level_select';

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex_item.scss
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex_item.scss
@@ -44,14 +44,6 @@
     order: -1;
   }
 
-  $overflow_values: auto, hidden, inherit, initial, scroll, visible;
-
-  @each $value in $overflow_values {
-    &.overflow_#{$value} {
-      overflow: #{$value}
-    }
-  }
-
   @for $i from 0 through 12 {
     &[class*=_flex_#{$i}]{
       flex: $i;

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex_item.tsx
@@ -8,7 +8,6 @@ type FlexItemPropTypes = {
   grow?: boolean,
   shrink?: boolean,
   className?: string,
-  // overflow?: "auto" | "hidden" | "initial" | "inherit" | "scroll" | "visible",
   order?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 'first' | 'none',
   alignSelf?: "start" | "end" | "center" | "stretch" | null,
   displayFlex?: boolean

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex_item.tsx
@@ -8,7 +8,7 @@ type FlexItemPropTypes = {
   grow?: boolean,
   shrink?: boolean,
   className?: string,
-  overflow?: "auto" | "hidden" | "initial" | "inherit" | "scroll" | "visible",
+  // overflow?: "auto" | "hidden" | "initial" | "inherit" | "scroll" | "visible",
   order?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 'first' | 'none',
   alignSelf?: "start" | "end" | "center" | "stretch" | null,
   displayFlex?: boolean
@@ -20,7 +20,6 @@ const FlexItem = (props: FlexItemPropTypes): React.ReactElement => {
     className,
     fixedSize,
     grow,
-    overflow = null,
     shrink,
     flex = 'none',
     order = 'none',
@@ -30,7 +29,6 @@ const FlexItem = (props: FlexItemPropTypes): React.ReactElement => {
   const growClass = grow === true ? 'grow' : ''
   const displayFlexClass = displayFlex === true ? `display_flex_${displayFlex}` : ''
   const flexClass = flex !== 'none' ? `flex_${flex}` : ''
-  const overflowClass = overflow ? `overflow_${overflow}` : ''
   const shrinkClass = shrink === true ? 'shrink' : ''
   const alignSelfClass = alignSelf ? `align_self_${alignSelf}` : ''
   const fixedStyle =
@@ -39,7 +37,7 @@ const FlexItem = (props: FlexItemPropTypes): React.ReactElement => {
 
   return (
     <div
-        className={classnames(buildCss('pb_flex_item_kit', growClass, shrinkClass, flexClass, displayFlexClass), overflowClass, orderClass, alignSelfClass, globalProps(props), className)}
+        className={classnames(buildCss('pb_flex_item_kit', growClass, shrinkClass, flexClass, displayFlexClass), orderClass, alignSelfClass, globalProps(props), className)}
         style={fixedStyle}
     >
       {children}

--- a/playbook/app/pb_kits/playbook/pb_flex/flex_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_flex/flex_item.rb
@@ -9,10 +9,6 @@ module Playbook
       prop :shrink, type: Playbook::Props::Boolean,
                     default: false
 
-      prop :overflow, type: Playbook::Props::Enum,
-                      values: %w[auto hidden inherit initial scroll visible] + [nil],
-                      default: nil
-
       prop :align_self, type: Playbook::Props::Enum,
                         values: %w[start center end stretch] + [nil],
                         default: nil
@@ -21,7 +17,7 @@ module Playbook
                           default: false
 
       def classname
-        generate_classname("pb_flex_item_kit", fixed_size_class, grow_class, shrink_class, display_flex_class) + overflow_class + align_self_class
+        generate_classname("pb_flex_item_kit", fixed_size_class, grow_class, shrink_class, display_flex_class) + align_self_class
       end
 
       def style_value
@@ -44,10 +40,6 @@ module Playbook
 
       def grow_class
         grow ? "grow" : nil
-      end
-
-      def overflow_class
-        overflow ? " overflow_#{overflow}" : ""
       end
 
       def shrink_class

--- a/playbook/app/pb_kits/playbook/tokens/_overflow.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_overflow.scss
@@ -1,10 +1,10 @@
-$oveflow_visible: visible;
-$overflow_hidden: hidden;
-$overflow_scroll: scroll;
-$overflow_auto: auto;
+$visible: visible;
+$hidden: hidden;
+$scroll: scroll;
+$auto: auto;
 $overflow: (
-    overflow_visible: $overflow_visible,
-    overflow_hidden: $overflow_hidden,
-    overflow_scroll: $overflow_scroll,
-    overflow_auto:$overflow_auto,
+  visible: $visible,
+  hidden: $hidden,
+  scroll: $scroll,
+  auto: $auto,
 );

--- a/playbook/app/pb_kits/playbook/tokens/_overflow.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_overflow.scss
@@ -1,7 +1,7 @@
-$visible: visible;
-$hidden: hidden;
-$scroll: scroll;
-$auto: auto;
+$visible: visible !default;
+$hidden: hidden !default;
+$scroll: scroll !default;
+$auto: auto !default;
 $overflow: (
   visible: $visible,
   hidden: $hidden,

--- a/playbook/app/pb_kits/playbook/tokens/_overflow.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_overflow.scss
@@ -1,0 +1,10 @@
+$oveflow_visible: visible;
+$overflow_hidden: hidden;
+$overflow_scroll: scroll;
+$overflow_auto: auto;
+$overflow: (
+    overflow_visible: $overflow_visible,
+    overflow_hidden: $overflow_hidden,
+    overflow_scroll: $overflow_scroll,
+    overflow_auto:$overflow_auto,
+);

--- a/playbook/app/pb_kits/playbook/utilities/_overflow.scss
+++ b/playbook/app/pb_kits/playbook/utilities/_overflow.scss
@@ -1,0 +1,9 @@
+@import "../tokens/overflow";
+
+$overflow_classes: (
+    visible: $overflow_visible,
+    hidden: $overflow_hidden,
+    scroll: $overflow_scroll,
+    auto:$overflow_auto,
+);
+

--- a/playbook/app/pb_kits/playbook/utilities/_overflow.scss
+++ b/playbook/app/pb_kits/playbook/utilities/_overflow.scss
@@ -1,9 +1,22 @@
 @import "../tokens/overflow";
 
 $overflow_classes: (
-    visible: $overflow_visible,
-    hidden: $overflow_hidden,
-    scroll: $overflow_scroll,
-    auto:$overflow_auto,
+  visible: $visible,
+  hidden: $hidden,
+  scroll: $scroll,
+  auto: $auto,
 );
 
+$variants: (
+  overflow_x: "overflow-x",
+  overflow_y: "overflow-y",
+  overflow: "overflow",
+);
+
+@each $variant_name, $variant_property in $variants {
+  @each $class_name, $overflow_value in $overflow_classes {
+    .#{$variant_name}_#{$class_name} {
+      #{$variant_property}: #{$overflow_value} !important;
+    }
+  }
+}

--- a/playbook/app/pb_kits/playbook/utilities/globalProps.ts
+++ b/playbook/app/pb_kits/playbook/utilities/globalProps.ts
@@ -128,6 +128,13 @@ type TextAlign = {
   textAlign?: "start" | "end" | "left" | "right" | "center" | "justify" | "justifyAll" | "matchParent",
 }
 
+type OverflowTypes = "scroll" | "visible" | "hidden" | "auto"
+type Overflow = {
+overflowX?: OverflowTypes,
+overflowY?: OverflowTypes,
+overflow?: OverflowTypes
+}
+
 type ZIndexType = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
 type ZIndexResponsiveType = {[key: string]: ZIndexType}
 type ZIndex = {
@@ -138,7 +145,7 @@ type ZIndex = {
 export type GlobalProps = AlignContent & AlignItems & AlignSelf &
   BorderRadius & Cursor & Dark & Display & DisplaySizes & Flex & FlexDirection &
   FlexGrow & FlexShrink & FlexWrap & JustifyContent & JustifySelf &
-  LineHeight & Margin & MaxWidth & NumberSpacing & Order & Padding &
+  LineHeight & Margin & MaxWidth & NumberSpacing & Order & Overflow & Padding &
   Position & Shadow & TextAlign & ZIndex & { hover?: string };
 
 const getResponsivePropClasses = (prop: {[key: string]: string}, classPrefix: string) => {
@@ -255,6 +262,14 @@ const PROP_CATEGORIES: {[key:string]: (props: {[key: string]: any}) => string} =
     css += borderRadius ? `border_radius_${borderRadius} ` : ''
     return css
   },
+  overflowProps: ({ overflow, overflowX, overflowY }: Overflow) => {
+    let css = ''
+    css += overflow ? `overflow_${overflow}` : ''
+    css += overflowX ? `overflow_x_${overflowX}` : ''
+    css += overflowY ? `overflow_y_${overflowY}` : ''
+    return css
+  },
+
   darkProps: ({ dark }: Dark) => dark ? 'dark' : '',
   numberSpacingProps: ({ numberSpacing }: NumberSpacing) => {
     let css = ''

--- a/playbook/lib/playbook/classnames.rb
+++ b/playbook/lib/playbook/classnames.rb
@@ -35,6 +35,7 @@ module Playbook
         hover_props,
         border_radius_props,
         text_align_props,
+        overflow_props,
       ].compact.join(" ")
     end
 

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -23,6 +23,7 @@ require "playbook/position"
 require "playbook/hover"
 require "playbook/border_radius"
 require "playbook/text_align"
+require "playbook/overflow"
 
 module Playbook
   class KitBase < ViewComponent::Base
@@ -51,6 +52,7 @@ module Playbook
     include Playbook::Hover
     include Playbook::BorderRadius
     include Playbook::TextAlign
+    include Playbook::Overflow
 
     prop :id
     prop :data, type: Playbook::Props::Hash, default: {}

--- a/playbook/lib/playbook/overflow.rb
+++ b/playbook/lib/playbook/overflow.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Playbook
+  module Overflow
+    def self.included(base)
+      base.prop :overflow
+      base.prop :overflow_x
+      base.prop :overflow_y
+    end
+
+    def overflow_values
+      %w[visible hidden scroll auto]
+    end
+
+    def overflow_options
+      {
+        overflow: "overflow",
+        overflow_x: "overflow_x",
+        overflow_y: "overflow_y",
+      }
+    end
+
+    def overflow_props
+      selected_props = overflow_options.keys.select { |sk| try(sk) }
+      return nil unless selected_props.present?
+
+      selected_props.map do |k|
+        overflow_value = send(k)
+        "#{overflow_options[k]}_#{overflow_value}" if overflow_values.include? overflow_value
+      end.compact.join(" ")
+    end
+  end
+end

--- a/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Playbook::PbFlex::FlexItem do
       expect(subject.new(shrink: true).classname).to eq "pb_flex_item_kit_shrink"
       expect(subject.new(flex: "1").classname).to eq "pb_flex_item_kit flex_1"
       expect(subject.new(fixed_size: "250px").classname).to eq "pb_flex_item_kit_fixed_size"
-      expect(subject.new(overflow: "hidden").classname).to eq "pb_flex_item_kit overflow_hidden"
     end
   end
 end

--- a/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/flex_item_spec.rb
@@ -5,11 +5,6 @@ require_relative "../../../../app/pb_kits/playbook/pb_flex/flex_item"
 RSpec.describe Playbook::PbFlex::FlexItem do
   subject { Playbook::PbFlex::FlexItem }
 
-  it {
-    is_expected.to define_enum_prop(:overflow)
-      .with_default(nil)
-      .with_values("auto", "hidden", "initial", "inherit", "scroll", "visible", nil)
-  }
   it { is_expected.to define_boolean_prop(:shrink).with_default(false) }
   it { is_expected.to define_boolean_prop(:grow).with_default(false) }
   it { is_expected.to define_string_prop(:fixed_size) }
@@ -21,6 +16,7 @@ RSpec.describe Playbook::PbFlex::FlexItem do
       expect(subject.new(shrink: true).classname).to eq "pb_flex_item_kit_shrink"
       expect(subject.new(flex: "1").classname).to eq "pb_flex_item_kit flex_1"
       expect(subject.new(fixed_size: "250px").classname).to eq "pb_flex_item_kit_fixed_size"
+      expect(subject.new(overflow: "hidden").classname).to eq "pb_flex_item_kit overflow_hidden"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**

- Creates the new overflow global prop
- Caters to overflow, overflowX/overflow_x and overflowY/overflow_y
- Created docs on visual guidelines page
- Removed the overflow prop on flexitem since it was doing same thing our global prop does now and there was no default in the kit