### PR TITLE
Upgrade deprecated kube resource API versions

### DIFF
--- a/playbook-website/config/deploy/templates/ingress.yaml.erb
+++ b/playbook-website/config/deploy/templates/ingress.yaml.erb
@@ -25,7 +25,7 @@ spec:
     - host: <%= url.host %>
       http:
         paths:
-          - path: <%= url.path %>
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/playbook-website/config/deploy/templates/ingress.yaml.erb
+++ b/playbook-website/config/deploy/templates/ingress.yaml.erb
@@ -1,5 +1,5 @@
 <% urls = ingress["hosts"].map { |host| URI.parse(host) } %>
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: playbook
@@ -26,7 +26,10 @@ spec:
       http:
         paths:
           - path: <%= url.path %>
+            pathType: Prefix
             backend:
-              serviceName: playbook
-              servicePort: 80
+              service:
+                name: playbook
+                port:
+                  number: 80
     <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Part of: https://nitro.powerhrg.com/runway/backlog_items/FVR-77

Address deprecated resource API utilization. This prepares the application for future Kubernetes upgrades in PAC. The upgraded APIs have been available since 1.19.0 and are removed in 1.22.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.