### PR TITLE
[PLAY-1003] Misc Sidebar fixes

### DIFF
--- a/playbook-website/app/javascript/components/MainSidebar/NavComponents/KitsNavComponent.tsx
+++ b/playbook-website/app/javascript/components/MainSidebar/NavComponents/KitsNavComponent.tsx
@@ -6,7 +6,7 @@ const currentURL = window.location.pathname + window.location.search;
 
 export const kitsType = (type) => {
   if (type === null || type === undefined) {
-    return "rails";
+    return "react";
   } else {
     return type;
   }

--- a/playbook-website/app/javascript/site_styles/_site-style.scss
+++ b/playbook-website/app/javascript/site_styles/_site-style.scss
@@ -100,12 +100,12 @@ body {
       @include break_at($nav_breakpoint) {
         position: absolute;
         transform-origin: 0% 0%;
-        transform: translate(110%, 0);
+        transform: translate(-110%, 0);
         transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
         border-radius: $border_rad_heavier;
         box-shadow: $shadow_deepest;
         top: 100px;
-        right: 0;
+        left: 0;
         min-width: 200px;
         width: auto !important;
         z-index: 1000;
@@ -113,7 +113,7 @@ body {
     }
     &:checked ~ #{$selector}--sideNav {
       @include break_at($nav_breakpoint) {
-        transform: translate(-10%, 0);
+        transform: translate(10%, 0);
       }
     }
   }
@@ -159,6 +159,7 @@ body {
   }
 
   &--mobileNav {
+    position: relative;
     height: 100px;
     background-color: $white;
     width: 100%;


### PR DESCRIPTION
[Runway story](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1033)

This PR:

- Changes kits default to react if no type specified
- Z-index fix for mobile nav:

![Screenshot 2023-10-02 at 8 43 40 AM](https://github.com/powerhome/playbook/assets/73710701/e9a330ba-521d-4ad7-ad81-cdf81b2b7f94)

- Mobile sidebar to pop out from left instead of right:

![Screenshot 2023-10-02 at 8 44 21 AM](https://github.com/powerhome/playbook/assets/73710701/cd9a7af5-da12-49e8-b863-185c6a8c5a60)