### PR TITLE
No CPU Limits + Increase Memory in Production

### DIFF
--- a/playbook-website/config/deploy/production/values.yaml
+++ b/playbook-website/config/deploy/production/values.yaml
@@ -3,6 +3,7 @@ ingress:
 resourceAllocation:
   playbook:
     limits:
-      cpu: 0.5
+      memory: 512Mi
     requests:
       cpu: 0.5
+      memory: 512Mi

--- a/playbook-website/config/deploy/templates/deployment.yaml.erb
+++ b/playbook-website/config/deploy/templates/deployment.yaml.erb
@@ -64,7 +64,6 @@ spec:
             timeoutSeconds: 10
           <<: <%= partial "resources", component: "playbook", defaults: {
             "limits" => {
-              "cpu" => "0.3",
               "memory" => "256Mi",
               "ephemeral-storage" => "100Mi"
             },


### PR DESCRIPTION
I made these changes during Create and it seemed to eliminate pod restarts, which are the cause of the 500 errors.

I believe there is some request queueing going on with Puma, and the constrained resources don't allow the queue to be worked fast enough. I recommend implementing some puma metrics to analyze the queue. But these changes should help a  bunch.