### PR TITLE
[PBIOS-170] Docs: Multiple Users

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
@@ -1,4 +1,6 @@
+![PBIOS-170](https://github.com/powerhome/playbook/assets/92755007/73dffd55-14f7-468e-b6ea-4e700980183d)
 ```swift
+
 
 PBDoc(title: "xSmall") {
   PBMultipleUsers(users: twoUsers, size: .xSmall)

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
@@ -2,6 +2,8 @@
 
 ```swift
 
+let twoUsers = [andrew, picAndrew]
+
 PBDoc(title: "xSmall") {
   PBMultipleUsers(users: twoUsers, size: .xSmall)
 }

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
@@ -1,0 +1,7 @@
+```swift
+
+PBDoc(title: "xSmall") {
+  PBMultipleUsers(users: twoUsers, size: .xSmall)
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_default_swift.md
@@ -1,6 +1,6 @@
-![PBIOS-170](https://github.com/powerhome/playbook/assets/92755007/73dffd55-14f7-468e-b6ea-4e700980183d)
-```swift
+![mulitple-users-default](https://github.com/powerhome/playbook/assets/92755007/73dffd55-14f7-468e-b6ea-4e700980183d)
 
+```swift
 
 PBDoc(title: "xSmall") {
   PBMultipleUsers(users: twoUsers, size: .xSmall)

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_props_swift.md
@@ -1,0 +1,7 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **Users** | `[PBUser]` | Sets the user's avatar |  |  |
+| **Size** | `AvatarSize` | Changes the size of the avatar  | `.small` | `.xSmall` `.small` |
+| **Reversed** | `Bool` | Changes the order of the avatars | `false` | `true` `false` |
+| **Max Displayed Users** | `Int` | Limits the number of avatars displayed | `4` |  |

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_props_swift.md
@@ -1,7 +1,7 @@
 ### Props
 | Name | Type | Description | Default | Values |
 | --- | ----------- | --------- | --------- | --------- |
-| **Users** | `[PBUser]` | Sets the user's avatar |  |  |
-| **Size** | `AvatarSize` | Changes the size of the avatar  | `.small` | `.xSmall` `.small` |
+| **Users** | `[PBUser]` | Sets the user's avatars |  |  |
+| **Size** | `AvatarSize` | Changes the size of the avatars  | `.small` | `.xSmall` `.small` |
 | **Reversed** | `Bool` | Changes the order of the avatars | `false` | `true` `false` |
 | **Max Displayed Users** | `Int` | Limits the number of avatars displayed | `4` |  |

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_reverse_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_reverse_swift.md
@@ -2,6 +2,9 @@
 
 ```swift
 
+let multipleUsers = [andrew, picAndrew, andrew, andrew]
+let twoUsers = [andrew, picAndrew]
+
 VStack(alignment: .leading, spacing: Spacing.small) {
   PBMultipleUsers(users: multipleUsers, size: .small, reversed: true)
   PBMultipleUsers(users: twoUsers, size: .small, reversed: true)

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_reverse_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_reverse_swift.md
@@ -1,0 +1,8 @@
+```swift
+
+VStack(alignment: .leading, spacing: Spacing.small) {
+  PBMultipleUsers(users: multipleUsers, size: .small, reversed: true)
+  PBMultipleUsers(users: twoUsers, size: .small, reversed: true)
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_reverse_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_reverse_swift.md
@@ -1,3 +1,5 @@
+![multiple-users-reverse](https://github.com/powerhome/playbook/assets/92755007/be3f6f7d-f699-40f2-bbb6-8a99144a8744)
+
 ```swift
 
 VStack(alignment: .leading, spacing: Spacing.small) {

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
@@ -1,0 +1,7 @@
+```swift
+
+PBDoc(title: "Small") {
+  PBMultipleUsers(users: multipleUsers, size: .small)
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
@@ -1,4 +1,5 @@
 ![mulitple-users-size](https://github.com/powerhome/playbook/assets/92755007/5c15b862-fb32-4e0a-a826-bc25b1db555e)
+
 ```swift
 
 PBDoc(title: "Small") {

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
@@ -1,3 +1,4 @@
+![mulitple-users-size](https://github.com/powerhome/playbook/assets/92755007/5c15b862-fb32-4e0a-a826-bc25b1db555e)
 ```swift
 
 PBDoc(title: "Small") {

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/_multiple_users_size_swift.md
@@ -2,6 +2,8 @@
 
 ```swift
 
+let multipleUsers = [andrew, picAndrew, andrew, andrew]
+
 PBDoc(title: "Small") {
   PBMultipleUsers(users: multipleUsers, size: .small)
 }

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/docs/example.yml
@@ -10,3 +10,9 @@ examples:
   - multiple_users_default: Default
   - multiple_users_reverse: Reverse
   - multiple_users_size: Size
+
+  swift:
+  - multiple_users_default_swift: Default
+  - multiple_users_reverse_swift: Reverse
+  - multiple_users_size_swift: Small
+  - multiple_users_props_swift: ""


### PR DESCRIPTION
[PBIOS-170](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-170)

Adds Multiple Users docs for Swift!

<img width="1720" alt="Screenshot 2023-11-14 at 3 12 04 PM" src="https://github.com/powerhome/playbook/assets/92755007/0d763662-0d71-4d2f-a6a1-c42d4755a405">

<img width="1720" alt="Screenshot 2023-11-14 at 3 12 15 PM" src="https://github.com/powerhome/playbook/assets/92755007/c8f35fd2-a9ab-499d-958b-aaf19e18291f">

<img width="1720" alt="Screenshot 2023-11-14 at 3 12 22 PM" src="https://github.com/powerhome/playbook/assets/92755007/06282f2e-b860-43aa-9869-f606c3155199">

**How to test?** Steps to confirm the desired behavior:
1. Pull branch down locally and navigate to the Multiple Users kit

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.