### PR TITLE
[PBIOS-172] Docs: Multiple Users Stacked

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_default_swift.md
@@ -1,4 +1,4 @@
-
+![mulitple-users-stacked-default](https://github.com/powerhome/playbook/assets/92755007/180e1275-3eb6-4b28-b1ef-bdde45ab3c2e)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_default_swift.md
@@ -1,0 +1,11 @@
+
+
+```swift
+
+HStack(spacing: Spacing.xSmall) {
+  PBMultipleUsersStacked(users: oneUser, size: .default)
+  PBMultipleUsersStacked(users: twoUsers, size: .default)
+  PBMultipleUsersStacked(users: multipleUsers, size: .default)
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_default_swift.md
@@ -2,6 +2,10 @@
 
 ```swift
 
+let oneUser = [andrew]
+let twoUsers = [andrew, picAndrew]
+let multipleUsers = [andrew, picAndrew, andrew, andrew]
+
 HStack(spacing: Spacing.xSmall) {
   PBMultipleUsersStacked(users: oneUser, size: .default)
   PBMultipleUsersStacked(users: twoUsers, size: .default)

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_props_swift.md
@@ -1,0 +1,5 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **Users** | `[PBUser]` | Sets the user's avatars |  |  |
+| **Size** | `Size` | Changes the size of the avatars | `.small` | `.default` `.small` `.xSmall` |

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_small_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_small_swift.md
@@ -2,6 +2,10 @@
 
 ```swift
 
+let oneUser = [andrew]
+let twoUsers = [andrew, picAndrew]
+let multipleUsers = [andrew, picAndrew, andrew, andrew]
+
 HStack(spacing: Spacing.xSmall) {
   PBMultipleUsersStacked(users: oneUser)
   PBMultipleUsersStacked(users: twoUsers)

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_small_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_small_swift.md
@@ -1,4 +1,4 @@
-
+![mulitple-users-stacked-small](https://github.com/powerhome/playbook/assets/92755007/277fd685-6302-462e-a02a-18a8fcb57715)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_small_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_small_swift.md
@@ -1,0 +1,11 @@
+
+
+```swift
+
+HStack(spacing: Spacing.xSmall) {
+  PBMultipleUsersStacked(users: oneUser)
+  PBMultipleUsersStacked(users: twoUsers)
+  PBMultipleUsersStacked(users: multipleUsers)
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_xsmall_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_xsmall_swift.md
@@ -1,4 +1,4 @@
-
+![mulitple-users-stacked-xsmall](https://github.com/powerhome/playbook/assets/92755007/4f31976f-a41b-4923-9230-5015f6ad75f8)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_xsmall_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_xsmall_swift.md
@@ -1,0 +1,11 @@
+
+
+```swift
+
+ HStack(spacing: Spacing.xSmall) {
+  PBMultipleUsersStacked(users: oneUser, size: .xSmall)
+  PBMultipleUsersStacked(users: twoUsers, size: .xSmall)
+  PBMultipleUsersStacked(users: multipleUsers, size: .xSmall)
+}
+
+```

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_xsmall_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_xsmall_swift.md
@@ -2,6 +2,10 @@
 
 ```swift
 
+let oneUser = [andrew]
+let twoUsers = [andrew, picAndrew]
+let multipleUsers = [andrew, picAndrew, andrew, andrew]
+
  HStack(spacing: Spacing.xSmall) {
   PBMultipleUsersStacked(users: oneUser, size: .xSmall)
   PBMultipleUsersStacked(users: twoUsers, size: .xSmall)

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/example.yml
@@ -6,3 +6,9 @@ examples:
 
   react:
   - multiple_users_stacked_default: Default
+
+  swift: 
+  - multiple_users_stacked_default_swift: Default
+  - multiple_users_stacked_small_swift: Small
+  - multiple_users_stacked_xsmall_swift: xSmall
+  - multiple_users_stacked_props_swift: ""


### PR DESCRIPTION
[PBIOS-172](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-172)

<img width="1720" alt="Screenshot 2023-11-15 at 2 05 38 PM" src="https://github.com/powerhome/playbook/assets/92755007/44aad7f6-4331-4b08-b2ff-1ee179a7228f">

<img width="1720" alt="Screenshot 2023-11-15 at 2 05 45 PM" src="https://github.com/powerhome/playbook/assets/92755007/03ad4a3c-d6ba-4a70-b52f-7133fd007a9d">

<img width="1720" alt="Screenshot 2023-11-15 at 2 05 52 PM" src="https://github.com/powerhome/playbook/assets/92755007/23d88fe8-c755-4fd1-b2ef-ef2f761e7094">

**How to test?** Steps to confirm the desired behavior:
1. Pull branch locally and navigate to the Multiple users Stacked kit


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.