### PR TITLE
[PBIOS-182] Docs: Text Input

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
@@ -1,4 +1,4 @@
-
+![text-input-add-on](https://github.com/powerhome/playbook/assets/92755007/65a28e6a-9e65-4ca1-af8d-91dae6eac4f5)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
@@ -1,0 +1,35 @@
+
+
+```swift
+
+ PBTextInput(
+  "ADD ON WITH DEFAULTS",
+  text: $textAddOn,
+  style: .rightIcon(.user, divider: true)
+)
+
+PBTextInput(
+  "RIGHT-ALIGNED ADD ON WITH BORDER",
+  text: $textAddOnRight,
+  style: .rightIcon(.user, divider: true)
+)
+
+PBTextInput(
+  "RIGHT-ALIGNED ADD ON WITH NO BORDER",
+  text: $textAddOnRightNoBorder,
+  style: .rightIcon(.user, divider: false)
+)
+
+PBTextInput(
+  "LEFT-ALIGNED ADD ON WITH NO BORDER",
+  text: $textAddOnLeft,
+  style: .leftIcon(.user, divider: false)
+)
+
+PBTextInput(
+  "LEFT-ALIGNED ADD ON WITH BORDER",
+  text: $textAddOnLeftNoBorder,
+ style: .leftIcon(.user, divider: true)
+)
+
+```

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
@@ -29,7 +29,7 @@ PBTextInput(
 PBTextInput(
   "LEFT-ALIGNED ADD ON WITH BORDER",
   text: $textAddOnLeftNoBorder,
- style: .leftIcon(.user, divider: true)
+  style: .leftIcon(.user, divider: true)
 )
 
 ```

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_add_on_swift.md
@@ -2,7 +2,7 @@
 
 ```swift
 
- PBTextInput(
+PBTextInput(
   "ADD ON WITH DEFAULTS",
   text: $textAddOn,
   style: .rightIcon(.user, divider: true)

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default_swift.md
@@ -1,3 +1,4 @@
+![text-input-default](https://github.com/powerhome/playbook/assets/92755007/625a246e-9d5c-42ea-8c6e-7afcf0984c9a)
 
 
 ```swift

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default_swift.md
@@ -1,0 +1,45 @@
+
+
+```swift
+
+@State private var textFirstName: String = ""
+@State private var textLastName: String = ""
+@State private var textPhone: String = ""
+@State private var textEmail: String = ""
+@State private var textZip: String = ""
+
+PBTextInput(
+  "First name",
+  text: $textFirstName,
+  placeholder: "Enter first name"
+)
+
+PBTextInput(
+  "Last name",
+  text: $textLastName,
+  placeholder: "Enter last name"
+)
+
+PBTextInput(
+  "Phone number",
+  text: $textPhone,
+  placeholder: "Enter phone number",
+  keyboardType: .phonePad
+)
+
+PBTextInput(
+  "Email",
+  text: $textEmail,
+  placeholder: "Enter email address",
+  keyboardType: .emailAddress
+)
+
+PBTextInput(
+  "Zip code",
+  text: $textZip,
+  placeholder: "Enter zip code",
+  keyboardType: .numberPad
+)
+
+
+```

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default_swift.md
@@ -6,8 +6,6 @@
 @State private var textFirstName: String = ""
 @State private var textLastName: String = ""
 @State private var textPhone: String = ""
-@State private var textEmail: String = ""
-@State private var textZip: String = ""
 
 PBTextInput(
   "First name",
@@ -27,20 +25,5 @@ PBTextInput(
   placeholder: "Enter phone number",
   keyboardType: .phonePad
 )
-
-PBTextInput(
-  "Email",
-  text: $textEmail,
-  placeholder: "Enter email address",
-  keyboardType: .emailAddress
-)
-
-PBTextInput(
-  "Zip code",
-  text: $textZip,
-  placeholder: "Enter zip code",
-  keyboardType: .numberPad
-)
-
 
 ```

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_disabled_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_disabled_swift.md
@@ -1,3 +1,4 @@
+![text-input-disabled](https://github.com/powerhome/playbook/assets/92755007/0e08256e-dd76-4528-b748-826f38bbe6a0)
 
 
 ```swift

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_disabled_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_disabled_swift.md
@@ -1,0 +1,12 @@
+
+
+```swift
+
+PBTextInput(
+  "Last name",
+  text: $textDisabled,
+  placeholder: "Enter last name",
+  style: .disabled
+)
+
+```

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error_swift.md
@@ -1,0 +1,23 @@
+
+
+```swift
+
+@State private var textError: String = ""
+@State private var textConfirmError: String = ""
+
+PBTextInput(
+  "Email address",
+  text: $textError,
+  placeholder: "Enter email address",
+  error: (true, "Insert a valid email"),
+  style: .leftIcon(.user, divider: true)
+)
+
+PBTextInput(
+  "Confirm email address",
+  text: $textConfirmError,
+  placeholder: "Confirm email address",
+  style: .leftIcon(.user, divider: true)
+)
+
+```

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error_swift.md
@@ -1,3 +1,4 @@
+![text-input-error](https://github.com/powerhome/playbook/assets/92755007/7c664f75-1d7a-4a94-bc59-6f845a68ce19)
 
 
 ```swift

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_props_swift.md
@@ -1,0 +1,13 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **title** |  |  |  |  |
+| **placeholder** |  |  |  |  |
+| **error** |  |  |  |  |
+| **style** |  |  |  |  |
+| **onChange** |  |  |  |  |
+| **keyboardType** |  | (ios only) |  |  |
+| **text** |  |  |  |  |
+| **selected** |  |  |  |  |
+| **isHovering** |  |  |  |  |
+| **isIconHovering** |  |  |  |  |

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_props_swift.md
@@ -1,13 +1,13 @@
 ### Props
 | Name | Type | Description | Default | Values |
 | --- | ----------- | --------- | --------- | --------- |
-| **title** |  |  |  |  |
-| **placeholder** |  |  |  |  |
-| **error** |  |  |  |  |
-| **style** |  |  |  |  |
-| **onChange** |  |  |  |  |
-| **keyboardType** |  | (ios only) |  |  |
-| **text** |  |  |  |  |
-| **selected** |  |  |  |  |
-| **isHovering** |  |  |  |  |
-| **isIconHovering** |  |  |  |  |
+| **title** | `String` | Adds a title | `nil` |  |
+| **placeholder** | `String` | Adds placeholder text | `""` |  |
+| **error** | `(Bool, String)` | Changes the style of the Text Input | `nil` |  |
+| **style** | `Style` | Changes the style of the Text Input | `.default` | `.default` `.rightIcon` `.leftIcon` `.inline` `.disabled` |
+| **onChange** | `Bool` | Adds an event handler | `nil` |  |
+| **keyboardType** | `UIKeyboardType` | Speficies the keyboard type (ios only) | `.default` |  |
+| **text** | `String` | Sets the Text Input's text valye |  |  |
+| **selected** | `Bool` | Changes the style of the Text Input |  | `true` `false` |
+| **isHovering** | `Bool` | Changes the style of the Text Input | `false` | `true` `false` |
+| **isIconHovering** | `Bool` | Changes the style of the Text Input | `false` | `true` `false` |

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_props_swift.md
@@ -7,7 +7,7 @@
 | **style** | `Style` | Changes the style of the Text Input | `.default` | `.default` `.rightIcon` `.leftIcon` `.inline` `.disabled` |
 | **onChange** | `Bool` | Adds an event handler | `nil` |  |
 | **keyboardType** | `UIKeyboardType` | Speficies the keyboard type (ios only) | `.default` |  |
-| **text** | `String` | Sets the Text Input's text valye |  |  |
+| **text** | `String` | Sets the Text Input's text value |  |  |
 | **selected** | `Bool` | Changes the style of the Text Input |  | `true` `false` |
 | **isHovering** | `Bool` | Changes the style of the Text Input | `false` | `true` `false` |
 | **isIconHovering** | `Bool` | Changes the style of the Text Input | `false` | `true` `false` |

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/example.yml
@@ -16,3 +16,10 @@ examples:
   - text_input_add_on: Add On
   - text_input_inline: Inline
   - text_input_no_label: No Label
+
+  swift:
+    - text_input_default_swift: Default
+    - text_input_error_swift: With Error
+    - text_input_disabled_swift: Disabled
+    - text_input_add_on_swift: Add On
+    - text_input_props_swift: ""


### PR DESCRIPTION
[PBIOS-182](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-182)

Adds Text Input docs for Swift!


https://github.com/powerhome/playbook/assets/92755007/e32c10de-ca17-4f87-a29d-b5f1914d6e4d


**How to test?** Steps to confirm the desired behavior:
1. Pull branch locally and navigate to the Text Input kit.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.