### PR TITLE
[PLAY-1028] Add Global htmlOptions Prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar/_avatar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar/_avatar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 import Image from '../pb_image/_image'
@@ -12,6 +12,7 @@ export type AvatarProps = {
   className?: string,
   data?: {[key: string]: string},
   dark?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   imageAlt?: string,
   imageUrl?: string,
@@ -30,6 +31,7 @@ const Avatar = (props: AvatarProps): React.ReactElement => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     name = null,
     id = '',
     imageAlt = '',
@@ -40,6 +42,7 @@ const Avatar = (props: AvatarProps): React.ReactElement => {
   } = props
   const dataProps: {[key: string]: any} = buildDataProps(data)
   const ariaProps: {[key: string]: any} = buildAriaProps(aria)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const classes = classnames(
     buildCss('pb_avatar_kit', `size_${size}`),
     globalProps(props),
@@ -58,6 +61,7 @@ const Avatar = (props: AvatarProps): React.ReactElement => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.tsx
@@ -6,8 +6,8 @@ import classnames from 'classnames'
 import {
   buildAriaProps,
   buildCss,
-  buildDataProps,
-} from '../utilities/props'
+  buildDataProps, 
+  buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Avatar from '../pb_avatar/_avatar'
@@ -20,6 +20,7 @@ type AvatarActionButtonProps = {
   className?: string,
   dark?: boolean,
   data?: Object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   imageAlt?: string,
   imageUrl?: string,
@@ -38,6 +39,7 @@ const AvatarActionButton = (props: AvatarActionButtonProps) => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     id,
     imageAlt = '',
     imageUrl,
@@ -50,6 +52,7 @@ const AvatarActionButton = (props: AvatarActionButtonProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(buildCss(
     'pb_avatar_action_button_kit',
@@ -68,6 +71,7 @@ const AvatarActionButton = (props: AvatarActionButtonProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_background/_background.tsx
+++ b/playbook/app/pb_kits/playbook/pb_background/_background.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 
 type BackgroundProps = {
@@ -23,6 +23,7 @@ type BackgroundProps = {
   className?: string,
   customColor?: string,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   padding?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl',
   tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'div' | 'tr' | 'th' | 'td' | 'thead' | 'col',
@@ -74,6 +75,7 @@ const Background = (props: BackgroundProps) => {
     className,
     customColor,
     data = {},
+    htmlOptions = {},
     id,
     imageUrl = '',
     tag = 'div',
@@ -113,6 +115,7 @@ const Background = (props: BackgroundProps) => {
     imageUrl: resImageUrl,
   } = responsiveProps;
 
+
   // Build CSS classes and styles using responsive values.
   const classes = classnames(
     buildCss('pb_background_kit'),
@@ -137,16 +140,17 @@ const Background = (props: BackgroundProps) => {
   const Tag: React.ReactElement | any = `${tag}`;
   const ariaProps = buildAriaProps(aria);
   const dataProps = buildDataProps(data);
-
- 
+  const htmlProps = buildHtmlProps(htmlOptions);
+  
   return (
     <Tag
-      alt={alt}
-      style={backgroundStyle}
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
+      alt={alt}
       className={classes}
       id={id}
+      style={backgroundStyle}
     >
       {children}
     </Tag>

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_light.jsx
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_light.jsx
@@ -3,10 +3,14 @@ import { Background } from '../..'
 
 const BackgroundLight = (props) => (
   <Background
+      tag="td"
       backgroundColor="light"
       padding="xl"
+      htmlOptions={{ align: "left", colSpan: 12 }}
       {...props}
-  />
+  >
+    hi
+  </Background>
 )
 
 export default BackgroundLight

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_light.jsx
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_light.jsx
@@ -3,14 +3,10 @@ import { Background } from '../..'
 
 const BackgroundLight = (props) => (
   <Background
-      tag="td"
       backgroundColor="light"
       padding="xl"
-      htmlOptions={{ align: "left", colSpan: 12 }}
       {...props}
-  >
-    hi
-  </Background>
+  />
 )
 
 export default BackgroundLight

--- a/playbook/app/pb_kits/playbook/pb_badge/_badge.tsx
+++ b/playbook/app/pb_kits/playbook/pb_badge/_badge.tsx
@@ -6,7 +6,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-} from '../utilities/props'
+  buildHtmlProps } from '../utilities/props'
 
 import Icon from '../pb_icon/_icon'
 
@@ -19,6 +19,7 @@ type BadgeProps = {
     onTouchEnd?: React.TouchEventHandler<HTMLSpanElement>,
   },
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   removeIcon?: boolean,
   removeOnClick?: React.MouseEventHandler<HTMLSpanElement>,
@@ -32,6 +33,7 @@ const Badge = (props: BadgeProps) => {
     className,
     closeProps = {},
     data = {},
+    htmlOptions = {},
     id,
     removeIcon = false,
     removeOnClick,
@@ -41,6 +43,7 @@ const Badge = (props: BadgeProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const css = classnames(
     buildCss('pb_badge_kit', variant === "success" ? "success_sm" : variant, rounded ? 'rounded' : null),
     globalProps(props),
@@ -51,6 +54,7 @@ const Badge = (props: BadgeProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { globalProps } from "../utilities/globalProps";
-import { buildAriaProps, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildDataProps, buildHtmlProps } from "../utilities/props";
 
 import HighchartsReact from "highcharts-react-official";
 import Highcharts from "highcharts";
@@ -19,6 +19,7 @@ type BarGraphProps = {
   yAxisMax: number;
   chartData: { name: string; data: number[] }[];
   className?: string;
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id: any;
   pointStart: number | any;
   subTitle?: string;
@@ -46,6 +47,7 @@ const BarGraph = ({
   chartData,
   className = "pb_bar_graph",
   colors,
+  htmlOptions = {},
   id,
   pointStart,
   subTitle,
@@ -64,7 +66,8 @@ const BarGraph = ({
   ...props
 }: BarGraphProps): React.ReactElement => {
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const setupTheme = () => {
     dark
       ? Highcharts.setOptions(highchartsDarkTheme)
@@ -135,6 +138,7 @@ const BarGraph = ({
           id: id,
           ...ariaProps,
           ...dataProps,
+          ...htmlProps
         }}
         highcharts={Highcharts}
         options={options}

--- a/playbook/app/pb_kits/playbook/pb_body/_body.tsx
+++ b/playbook/app/pb_kits/playbook/pb_body/_body.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, globalProps, GlobalProps } from '../utilities/globalProps'
 
 import Highlight from '../pb_highlight/_highlight'
@@ -15,6 +15,7 @@ type BodyProps = {
   data?: {[key: string]: string},
   highlightedText?: string[],
   highlighting?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   status?: 'neutral' | 'negative' | 'positive',
   tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'div',
@@ -33,6 +34,7 @@ const Body = (props: BodyProps): React.ReactElement => {
     data = {},
     highlightedText = [],
     highlighting = false,
+    htmlOptions = {},
     id = '',
     status = null,
     tag = 'div',
@@ -43,6 +45,7 @@ const Body = (props: BodyProps): React.ReactElement => {
 
   const ariaProps: {[key: string]: any} = buildAriaProps(aria)
   const dataProps: {[key: string]: any} = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const isTruncated = truncate ? `truncate_${truncate}` : ''
   const classes = classnames(
     buildCss('pb_body_kit', color, variant, status, isTruncated),
@@ -56,6 +59,7 @@ const Body = (props: BodyProps): React.ReactElement => {
     <Tag
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
@@ -8,7 +8,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-, buildHtmlProps } from '../utilities/props'
+  buildHtmlProps } from '../utilities/props'
 
 type BreadCrumbItemProps = {
   aria?: {[key: string]: string},

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
@@ -8,12 +8,13 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-} from '../utilities/props'
+, buildHtmlProps } from '../utilities/props'
 
 type BreadCrumbItemProps = {
   aria?: {[key: string]: string},
   className?: string,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   component?: "a" | "span",
   [x:string]: any;
@@ -25,12 +26,14 @@ const BreadCrumbItem = (props: BreadCrumbItemProps) => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
     component = 'a',
     ...rest
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const Component = component || 'span';
   const css = classnames(
     buildCss('pb_bread_crumb_item_kit'),
@@ -42,6 +45,7 @@ const BreadCrumbItem = (props: BreadCrumbItemProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.tsx
@@ -1,5 +1,3 @@
-/* @flow */
-
 import React from 'react'
 import classnames from 'classnames'
 import { globalProps } from '../utilities/globalProps'
@@ -8,12 +6,14 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
+  buildHtmlProps
 } from '../utilities/props'
 
 type BreadCrumbsProps = {
   aria?: {[key: string]: string},
   className?: string,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   text?: string,
   children?: React.ReactChild[] | React.ReactNode,
@@ -23,11 +23,13 @@ const BreadCrumbs = (props: BreadCrumbsProps) => {
     aria = { label: 'Breadcrumb Navigation' },
     className,
     data = {},
+    htmlOptions = {},
     id,
     children,
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const css = classnames(
     buildCss('pb_bread_crumbs_kit'),
     globalProps(props),
@@ -38,6 +40,7 @@ const BreadCrumbs = (props: BreadCrumbsProps) => {
     <nav
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_button/_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 import { isValidEmoji } from '../utilities/validEmojiChecker'
 
@@ -21,6 +21,7 @@ type ButtonPropTypes = {
   form?: string,
   fullWidth?: boolean,
   highlight?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   icon?: string,
   iconRight?: boolean,
   id?: string,
@@ -73,6 +74,7 @@ const Button = (props: ButtonPropTypes) => {
     count,
     data = {},
     disabled,
+    htmlOptions = {},
     icon = null,
     iconRight = false,
     id,
@@ -91,6 +93,8 @@ const Button = (props: ButtonPropTypes) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   const css = classnames(
     buttonClassName(props),
     globalProps(props),
@@ -148,6 +152,7 @@ const Button = (props: ButtonPropTypes) => {
         <a
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={css}
           href={link}
           id={id}
@@ -164,6 +169,7 @@ const Button = (props: ButtonPropTypes) => {
         <button
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={css}
           disabled={disabled}
           form={form}
@@ -199,6 +205,7 @@ const Button = (props: ButtonPropTypes) => {
         <button
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={css}
           disabled={disabled}
           form={form}

--- a/playbook/app/pb_kits/playbook/pb_button_toolbar/_button_toolbar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_button_toolbar/_button_toolbar.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import { globalProps } from '../utilities/globalProps'
 
@@ -13,6 +13,7 @@ type ButtonToolbarProps = {
   className?: string,
   connected?: boolean,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   onClick?: React.MouseEventHandler<HTMLSpanElement>,
   orientation?: "horizontal" | "vertical",
@@ -26,6 +27,7 @@ const ButtonToolbar  = (props: ButtonToolbarProps) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     id,
     orientation = 'horizontal',
     text,
@@ -34,6 +36,7 @@ const ButtonToolbar  = (props: ButtonToolbarProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(
     buildCss('pb_button_toolbar_kit', orientation, variant),
@@ -45,6 +48,7 @@ const ButtonToolbar  = (props: ButtonToolbarProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_caption/_caption.tsx
+++ b/playbook/app/pb_kits/playbook/pb_caption/_caption.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, globalProps, GlobalProps } from '../utilities/globalProps'
 
 type CaptionProps = {
@@ -9,6 +9,7 @@ type CaptionProps = {
   className?: string,
   color?: "default" | "light" | "lighter" | "success" | "error" | "link",
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   size?: "xs" | "sm" | "md" | "lg" | "xl",
   tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span" | "div" | "caption",
@@ -24,6 +25,7 @@ const Caption = (props: CaptionProps): React.ReactElement => {
     className,
     color,
     data = {},
+    htmlOptions = {},
     id,
     size = 'md',
     tag = 'div',
@@ -47,6 +49,8 @@ const Caption = (props: CaptionProps): React.ReactElement => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   const css = classnames(
     buildCss('pb_caption_kit', size, variant, color),
     globalProps(props),
@@ -57,6 +61,7 @@ const Caption = (props: CaptionProps): React.ReactElement => {
     <Tag
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_card/_card.tsx
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { get } from 'lodash'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 import type { ProductColors, CategoryColors, BackgroundColors } from '../types/colors'
 
@@ -16,6 +16,7 @@ type CardPropTypes = {
   children: React.ReactChild[] | React.ReactChild | number,
   className?: string,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   highlight?: {
     position?: "side" | "top",
     color?: string,
@@ -78,6 +79,7 @@ const Card = (props: CardPropTypes) => {
     className,
     data = {},
     highlight = {},
+    htmlOptions = {},
     selected = false,
     tag = 'div',
   } = props
@@ -90,6 +92,7 @@ const Card = (props: CardPropTypes) => {
   })
   const ariaProps: {[key: string]: string} = buildAriaProps(aria)
   const dataProps: {[key: string]: string} = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
 
   // coerce to array
   const cardChildren = React.Children.toArray(children)
@@ -113,6 +116,7 @@ const Card = (props: CardPropTypes) => {
     <Tag
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classnames(cardCss, globalProps(props), className)}
     >
       {subComponentTags('Header')}

--- a/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import Body from '../pb_body/_body'
 import Icon from '../pb_icon/_icon'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import classnames from 'classnames'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
@@ -13,6 +13,7 @@ type CheckboxProps = {
   dark?: boolean,
   data?: {[key: string]: string},
   error?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   indeterminate?: boolean,
   name?: string,
@@ -31,6 +32,7 @@ const Checkbox = (props: CheckboxProps): JSX.Element => {
     dark = false,
     data = {},
     error = false,
+    htmlOptions = {},
     id,
     indeterminate = false,
     name = '',
@@ -41,8 +43,10 @@ const Checkbox = (props: CheckboxProps): JSX.Element => {
   } = props
 
   const checkRef = useRef(null)
-  const dataProps = buildDataProps(data)
   const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   const classes = classnames(
     buildCss('pb_checkbox_kit', checked ? 'checked' : null, error ? 'error' : null, indeterminate? 'indeterminate' : null),
     globalProps(props),
@@ -76,6 +80,7 @@ const Checkbox = (props: CheckboxProps): JSX.Element => {
     <label
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
@@ -9,7 +9,7 @@ import { highchartsTheme } from "../pb_dashboard/pbChartsLightTheme";
 import { highchartsDarkTheme } from "../pb_dashboard/pbChartsDarkTheme";
 import mapColors from "../pb_dashboard/pbChartsColorsHelper";
 import { globalProps } from "../utilities/globalProps";
-import { buildAriaProps, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildDataProps, buildHtmlProps } from "../utilities/props";
 
 type CircleChartProps = {
   align?: "left" | "right" | "center";
@@ -23,6 +23,7 @@ type CircleChartProps = {
   dataLabelHtml?: string;
   dataLabels?: boolean;
   height?: string;
+  htmlOptions?: { [key: string]: string | number | boolean | Function };
   id?: string;
   innerSize?: "sm" | "md" | "lg" | "none";
   legend?: boolean;
@@ -71,6 +72,7 @@ const CircleChart = ({
   dataLabelHtml = "<div>{point.name}</div>",
   dataLabels = false,
   height,
+  htmlOptions = {},
   id,
   innerSize = "md",
   legend = false,
@@ -89,7 +91,8 @@ const CircleChart = ({
   ...props
 }: CircleChartProps) => {
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   highchartsMore(Highcharts);
 
   const setupTheme = () => {
@@ -182,6 +185,7 @@ const CircleChart = ({
               id: id,
               ...ariaProps,
               ...dataProps,
+              ...htmlProps,
             }}
             highcharts={Highcharts}
             options={options}
@@ -195,6 +199,7 @@ const CircleChart = ({
             id: id,
             ...ariaProps,
             ...dataProps,
+            ...htmlProps,
           }}
           highcharts={Highcharts}
           options={options}

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
-
-import { noop } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, noop } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Button from '../pb_button/_button'
@@ -15,6 +13,7 @@ type CircleIconButtonProps = {
   data?: { [key: string]: string },
   disabled?: boolean,
   icon: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   link?: string,
   onClick?: React.MouseEventHandler<HTMLElement>,
@@ -30,6 +29,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
     dark,
     data = {},
     disabled,
+    htmlOptions = {},
     icon,
     id,
     onClick = noop,
@@ -41,6 +41,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_circle_icon_button_kit'),
     globalProps(props),
@@ -51,6 +52,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_collapsible/_collapsible.tsx
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/_collapsible.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 import  useCollapsible from './useCollapsible'
 
 import { globalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import CollapsibleContent from './child_kits/CollapsibleContent'
 import CollapsibleMain from './child_kits/CollapsibleMain'
@@ -22,6 +22,7 @@ type CollapsibleProps = {
   iconSize?: IconSizes,
   onIconClick?: ()=> void,
   onClick?: ()=> void,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
 }
 
@@ -33,6 +34,7 @@ const Collapsible = ({
   children = [],
   collapsed = true,
   data = {},
+  htmlOptions = {},
   icon,
   iconColor = 'default',
   iconSize,
@@ -60,6 +62,7 @@ const Collapsible = ({
   const { children: contentChildren, ...contentProps } = Content.props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_collapsible_kit'),
     globalProps(props),
@@ -70,6 +73,7 @@ const Collapsible = ({
       <div
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={classes}
           id={id}
       >

--- a/playbook/app/pb_kits/playbook/pb_contact/_contact.tsx
+++ b/playbook/app/pb_kits/playbook/pb_contact/_contact.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -51,6 +51,7 @@ type ContactProps = {
   contactType?: string,
   contactValue: string,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
 }
 
@@ -62,9 +63,11 @@ const Contact = (props: ContactProps) => {
     contactType,
     contactValue,
     data = {},
+    htmlOptions = {},
     id } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_contact_kit'),
     globalProps(props),
@@ -74,6 +77,7 @@ const Contact = (props: ContactProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_currency/_currency.tsx
+++ b/playbook/app/pb_kits/playbook/pb_currency/_currency.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { globalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import Body from '../pb_body/_body'
 import Caption from '../pb_caption/_caption'
@@ -18,6 +18,7 @@ type CurrencyProps = {
   data?: {[key:string]:string},
   decimals?: 'default' | 'matching',
   emphasized?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   label?: string,
   size?: 'sm' | 'md' | 'lg',
@@ -42,6 +43,7 @@ const Currency = (props: CurrencyProps) => {
     data = {},
     decimals = 'default',
     emphasized = true,
+    htmlOptions = {},
     id,
     unit,
     className,
@@ -65,6 +67,7 @@ const Currency = (props: CurrencyProps) => {
   const [whole, decimal = '00'] = amount.split('.')
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_currency_kit', align, size),
     globalProps(props),
@@ -96,6 +99,7 @@ const Currency = (props: CurrencyProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dashboard_value/_dashboard_value.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -12,6 +12,7 @@ type DashboardValueProps = {
   aria?: { [key: string]: string },
   className?: string,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   statChange?: {
     change? : 'increase' | 'decrease' | 'neutral',
@@ -30,6 +31,7 @@ const DashboardValue = (props: DashboardValueProps): React.ReactElement => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
     statChange = {},
     statLabel,
@@ -38,6 +40,7 @@ const DashboardValue = (props: DashboardValueProps): React.ReactElement => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_dashboard_value_kit', align),
     globalProps(props),
@@ -48,6 +51,7 @@ const DashboardValue = (props: DashboardValueProps): React.ReactElement => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_date/_date.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date/_date.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
 import DateTime from '../pb_kit/dateTime';
 
@@ -15,6 +15,7 @@ type PbDateProps = {
   aria?: { [key: string]: string };
   className?: string;
   data?: { [key: string]: string };
+  htmlOptions?: { [key: string]: string | number | boolean | Function };
   id?: string;
   showDayOfWeek?: boolean;
   showIcon?: boolean;
@@ -29,6 +30,7 @@ const PbDate = (props: PbDateProps) => {
     alignment = "left",
     className,
     data = {},
+    htmlOptions = {},
     id,
     showDayOfWeek = false,
     showIcon = false,
@@ -43,8 +45,9 @@ const PbDate = (props: PbDateProps) => {
   const year = DateTime.toYear(value);
   const currentYear = new Date().getFullYear();
 
-  const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(
     buildCss("pb_date_kit", alignment),
@@ -53,10 +56,12 @@ const PbDate = (props: PbDateProps) => {
   );
 
   return (
-    <div {...ariaProps}
-        {...dataProps}
-        className={classes}
-        id={id}
+    <div 
+      {...ariaProps}
+      {...dataProps}
+      {...htmlProps}
+      className={classes}
+      id={id}
     >
       {unstyled
         ? <>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, globalProps, GlobalProps } from '../utilities/globalProps'
 
 import datePickerHelper from './date_picker_helper'
@@ -25,6 +25,7 @@ type DatePickerProps = {
   format?: string,
   hideIcon?: boolean,
   hideLabel?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   inLine?: boolean,
   inputAria?: { [key: string]: string },
@@ -67,6 +68,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     format = 'm/d/Y',
     hideIcon = false,
     hideLabel = false,
+    htmlOptions = {},
     id,
     inLine = false,
     inputAria = {},
@@ -95,6 +97,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const inputAriaProps = buildAriaProps(inputAria)
   const inputDataProps = buildDataProps(inputData)
 
@@ -158,6 +161,7 @@ useEffect(() => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import classnames from "classnames";
 
 import { globalProps } from "../utilities/globalProps";
-import { buildCss, buildDataProps } from "../utilities/props";
+import { buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import DateTime from '../pb_kit/dateTime';
 
 import Body from "../pb_body/_body";
@@ -16,6 +16,7 @@ type DateRangeInlineProps = {
   align?: "left" | "center" | "vertical";
   size?: "sm" | "xs";
   dark?: boolean;
+  htmlOptions?: {[key: string]: string | number | boolean | Function};
   icon?: boolean;
   startDate?: Date;
   endDate?: Date;
@@ -40,6 +41,7 @@ const DateRangeInline = (props: DateRangeInlineProps) => {
     size = "sm",
     align = "left",
     data = {},
+    htmlOptions = {},
     startDate,
     endDate,
     className,
@@ -79,6 +81,7 @@ const DateRangeInline = (props: DateRangeInlineProps) => {
 
   const dateRangeClasses = buildCss("pb_date_range_inline_kit", align);
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const renderTime = (date: Date) => {
     return (
       <time dateTime={dateTimeIso(date)}>
@@ -94,6 +97,7 @@ const DateRangeInline = (props: DateRangeInlineProps) => {
   return (
     <div
         {...dataProps}
+        {...htmlProps}
         className={classnames(dateRangeClasses, globalProps(props), className)}
     >
       <div className="pb_date_range_inline_wrapper">

--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/_date_range_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/_date_range_stacked.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss, buildDataProps } from '../utilities/props'
+import { buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -15,6 +15,7 @@ type DateRangeStackedProps = {
   data?: string,
   dark?: boolean,
   endDate: Date,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   startDate: Date,
 }
@@ -26,10 +27,13 @@ const DateRangeStacked = (props: DateRangeStackedProps) => {
     globalProps(props),
     className
   )
-  const dataProps = buildDataProps(data)
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
-    <div {...dataProps}
+    <div 
+        {...dataProps}
+        {...htmlProps}
         className={css}
     >
       <Flex vertical="center">

--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/_date_range_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/_date_range_stacked.tsx
@@ -21,7 +21,14 @@ type DateRangeStackedProps = {
 }
 
 const DateRangeStacked = (props: DateRangeStackedProps) => {
-  const { className, dark = false, endDate, startDate, data={} } = props
+  const { 
+    className, 
+    dark = false, 
+    endDate, 
+    htmlOptions={},
+    startDate, 
+    data={},
+  } = props
   const css = classnames(
     buildCss('pb_date_range_stacked'),
     globalProps(props),

--- a/playbook/app/pb_kits/playbook/pb_date_stacked/_date_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_stacked/_date_stacked.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import classnames from "classnames";
-import { buildCss, buildDataProps } from "../utilities/props";
+import { buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
 import DateTime from '../pb_kit/dateTime';
 
@@ -15,6 +15,7 @@ type DateStackedProps = {
   dark?: boolean;
   data?: string;
   date: Date;
+  htmlOptions?: { [key: string]: string | number | boolean | Function };
   size?: "sm" | "md";
   id?: string;
   reverse?: boolean;
@@ -34,6 +35,7 @@ const DateStacked = (props: DateStackedProps) => {
     dark = false,
     date,
     data={},
+    htmlOptions={},
     size = "sm",
   } = props;
   const classes = classnames(
@@ -48,12 +50,15 @@ const DateStacked = (props: DateStackedProps) => {
   const currentYear = new Date().getFullYear()
   const inputYear = DateTime.toYear(date);
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
     <>
       {bold == false ? (
-        <div {...dataProps}
-            className={classes}
+        <div 
+          {...dataProps}
+          {...htmlProps}
+          className={classes}
         >
           <div className="pb_date_stacked_day_month">
             <Caption text={DateTime.toMonth(date).toUpperCase()} />
@@ -66,8 +71,10 @@ const DateStacked = (props: DateStackedProps) => {
           {currentYear != inputYear && <Caption size="xs">{inputYear}</Caption>}
         </div>
       ) : (
-          <div {...dataProps}
-              className={classes}
+          <div 
+            {...dataProps}
+            {...htmlProps}
+            className={classes}
           >
             <div className="pb_date_stacked_day_month">
               <Title

--- a/playbook/app/pb_kits/playbook/pb_date_time/_date_time.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_time/_date_time.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Flex from '../pb_flex/_flex'
@@ -14,6 +14,7 @@ type DateTimeProps = {
   className?: string,
   data?: { [key: string]: string; },
   datetime: Date,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   size?: "sm" | "md",
   showDayOfWeek: boolean,
@@ -27,6 +28,7 @@ const DateTime = (props: DateTimeProps) => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     showDayOfWeek = false,
     datetime,
     id,
@@ -37,6 +39,7 @@ const DateTime = (props: DateTimeProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_date_time', size),
     globalProps(props),
@@ -47,6 +50,7 @@ const DateTime = (props: DateTimeProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_date_time_stacked/_date_time_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_time_stacked/_date_time_stacked.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react'
 
-import { buildCss } from '../utilities/props'
+import { buildCss, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, globalProps } from '../utilities/globalProps'
 
 import Flex from '../pb_flex/_flex'
@@ -11,6 +11,7 @@ import TimeStacked from '../pb_time_stacked/_time_stacked'
 import DateStacked from '../pb_date_stacked/_date_stacked'
 
 type DateTimeStackedProps = {
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   date: Date,
   datetime: Date,

--- a/playbook/app/pb_kits/playbook/pb_date_time_stacked/_date_time_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_time_stacked/_date_time_stacked.tsx
@@ -26,15 +26,18 @@ const DateTimeStacked = (props: DateTimeStackedProps): React.ReactElement => {
     date,
     datetime,
     dark,
+    htmlOptions = {},
     timeZone = 'America/New_York',
   } = props
 
   const classes = buildCss('pb_date_time_stacked_kit', globalProps(props))
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
     <Flex
         inline={false}
         vertical="stretch"
+        {...htmlProps}
         {...props}
     >
       <FlexItem>

--- a/playbook/app/pb_kits/playbook/pb_date_year_stacked/_date_year_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_year_stacked/_date_year_stacked.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss, buildDataProps } from '../utilities/props'
+import { buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import DateTime from '../pb_kit/dateTime';
 
@@ -14,6 +14,7 @@ type DateYearStackedProps = {
   dark?: boolean,
   data?: string,
   date: Date,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
 }
 
@@ -24,10 +25,13 @@ const DateYearStacked = (props: DateYearStackedProps) => {
     globalProps(props),
     className
   )
-  const dataProps = buildDataProps(data)
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
-    <div {...dataProps}
+    <div 
+        {...dataProps}
+        {...htmlProps}
         className={css}
     >
       <Title

--- a/playbook/app/pb_kits/playbook/pb_date_year_stacked/_date_year_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_year_stacked/_date_year_stacked.tsx
@@ -19,7 +19,14 @@ type DateYearStackedProps = {
 }
 
 const DateYearStacked = (props: DateYearStackedProps) => {
-  const { align = 'left', className, dark = false, date, data={} } = props
+  const { 
+    align = 'left', 
+    className, 
+    dark = false, 
+    date, 
+    data={},
+    htmlOptions = {}, 
+  } = props
   const css = classnames(
     buildCss('pb_date_year_stacked', align),
     globalProps(props),

--- a/playbook/app/pb_kits/playbook/pb_detail/_detail.tsx
+++ b/playbook/app/pb_kits/playbook/pb_detail/_detail.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 type DetailProps = {

--- a/playbook/app/pb_kits/playbook/pb_detail/_detail.tsx
+++ b/playbook/app/pb_kits/playbook/pb_detail/_detail.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 type DetailProps = {
@@ -11,6 +11,7 @@ type DetailProps = {
   color?: 'light' | 'default' | 'lighter' | 'link' | 'error' | 'success',
   dark?: boolean,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'div',
   text?: string,
@@ -24,6 +25,7 @@ const Detail = (props: DetailProps) => {
     className,
     color = 'light',
     data = {},
+    htmlOptions = {},
     id = '',
     tag = 'div',
     text= ''
@@ -31,6 +33,7 @@ const Detail = (props: DetailProps) => {
 
   const ariaProps: {[key: string]: any} = buildAriaProps(aria)
   const dataProps: {[key: string]: any} = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const isBold = bold ? "bold" : null
   const classes = classnames(
     buildCss('pb_detail_kit', color),
@@ -44,6 +47,7 @@ const Detail = (props: DetailProps) => {
     <Tag
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
@@ -26,6 +26,7 @@ type DialogProps = {
   closeable: boolean;
   confirmButton?: string;
   data?: object;
+  htmlOptions?: { [key: string]: string | number | boolean | Function };
   id?: string;
   fullHeight?: boolean;
   loading?: boolean;

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import classnames from "classnames";
 import Modal from "react-modal";
 
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
 
 import Body from "../pb_body/_body";
@@ -51,6 +51,7 @@ const Dialog = (props: DialogProps) => {
     confirmButton,
     className,
     data = {},
+    htmlOptions = {},
     id,
     size = "md",
     children,
@@ -69,7 +70,8 @@ const Dialog = (props: DialogProps) => {
     trigger,
   } = props;
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions);
   const dialogClassNames = {
     base: classnames("pb_dialog", buildCss("pb_dialog", size, placement)),
     afterOpen: "pb_dialog_after_open",
@@ -164,7 +166,12 @@ const Dialog = (props: DialogProps) => {
 
   return (
     <DialogContext.Provider value={api}>
-      <div {...ariaProps} {...dataProps} className={classes}>
+      <div 
+        {...ariaProps} 
+        {...dataProps}
+        {...htmlProps} 
+        className={classes}
+      >
         <Modal
           ariaHideApp={false}
           className={dialogClassNames}

--- a/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_footer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_footer.tsx
@@ -13,6 +13,7 @@ type DialogFooterProps = {
   children: React.ReactChild[] | React.ReactChild | string,
   className?: string,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   padding?: string,
   paddingBottom?: string,

--- a/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_footer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss } from '../../utilities/props'
+import { buildCss, buildHtmlProps } from '../../utilities/props'
 import { GlobalProps, globalProps } from '../../utilities/globalProps'
 
 import Flex from '../../pb_flex/_flex'
@@ -27,15 +27,19 @@ const DialogFooter = (props: DialogFooterProps) => {
   const {
     children,
     className,
+    htmlOptions = {},
     spacing = "between",
     separator = false,
   } = props
 
   const footerCSS = buildCss("dialog_footer")
   const footerSpacing = globalProps(props)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
-    <>
+    <div 
+      {...htmlProps}
+    >
       {separator &&
         <SectionSeparator />
       }
@@ -47,7 +51,7 @@ const DialogFooter = (props: DialogFooterProps) => {
       >
         {children}
       </Flex>
-    </>
+    </div>
   )
 }
 

--- a/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_header.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_header.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../../utilities/props'
 import { globalProps, GlobalProps } from '../../utilities/globalProps'
 
 import { CloseIcon } from '../_close_icon'
@@ -14,6 +14,7 @@ type DialogHeaderProps = {
   className?: string,
   closeable?: boolean,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   padding?: string,
   separator?: boolean,
@@ -28,6 +29,7 @@ const DialogHeader = (props: DialogHeaderProps) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     spacing = "between",
     closeable = true,
     separator = true,
@@ -35,6 +37,7 @@ const DialogHeader = (props: DialogHeaderProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const api = useContext(DialogContext)
   const headerCSS = buildCss("dialog_header")
   const headerSpacing = globalProps(props)
@@ -46,6 +49,7 @@ const DialogHeader = (props: DialogHeaderProps) => {
       <Flex
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={classnames(headerCSS, headerSpacing, className)}
           spacing={spacing}
       >

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { globalProps } from '../utilities/globalProps'
+import { buildHtmlProps } from '../utilities/props'
 
 type DistributionBarProps = {
   className?: string,
@@ -34,14 +35,19 @@ const barValues = (normalizedValues: number[], colors: []) => {
 
 const DistributionBar = (props: DistributionBarProps) => {
   const {
+    htmlOptions = {},
     size = 'lg',
     widths = [1],
     colors = [],
   } = props
   const normalizedValues = normalizeCharacters(widths)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
-    <div className={classnames(`pb_distribution_bar_${size}`, globalProps(props))}>
+    <div 
+      className={classnames(`pb_distribution_bar_${size}`, globalProps(props))}  
+      {...htmlProps}
+    >
       {barValues(normalizedValues, colors)}
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/_distribution_bar.tsx
@@ -6,6 +6,7 @@ type DistributionBarProps = {
   className?: string,
   colors: [],
   data?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   size?: "lg" | "sm",
   widths?: number[],

--- a/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.tsx
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, useRef } from 'react'
 import { useDropzone, DropzoneInputProps, DropzoneRootProps } from 'react-dropzone'
 import classnames from 'classnames'
 
-import { buildCss, buildDataProps, noop } from '../utilities/props'
+import { buildCss, buildDataProps, noop, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import type { Callback } from '../types'
 
@@ -14,6 +14,7 @@ type FileUploadProps = {
   className?: string,
   customMessage?: string,
   data?: {[key: string]: string | number},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   acceptedFilesDescription?: string,
   maxSize?: number,
   onFilesAccepted: Callback<File, File>,
@@ -31,6 +32,7 @@ const FileUpload = (props: FileUploadProps): React.ReactElement => {
     className,
     customMessage,
     data = {},
+    htmlOptions = {},
     maxSize,
     onFilesAccepted = noop,
     onFilesRejected = noop,
@@ -76,7 +78,8 @@ const FileUpload = (props: FileUploadProps): React.ReactElement => {
     })
   }
 
-  const dataProps = buildDataProps(data)
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions)
 
   const getDescription = () => {
     return customMessage
@@ -88,6 +91,7 @@ const FileUpload = (props: FileUploadProps): React.ReactElement => {
     <div
         className={classnames(buildCss('pb_file_upload_kit'), globalProps(props), className)}
         {...dataProps}
+        {...htmlProps}
         {...getRootProps()}
     >
       <Card>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
@@ -20,6 +20,7 @@ type FixedConfirmationToastProps = {
   closeable?: boolean,
   data?: string,
   horizontal?: "right" | "left" | "center",
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   multiLine?: boolean,
   onClose?: () => void,

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import classnames from "classnames";
 
 import { globalProps } from "../utilities/globalProps";
+import { buildHtmlProps } from '../utilities/props'
 
 import Icon from "../pb_icon/_icon";
 import Title from "../pb_title/_title";
@@ -38,6 +39,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
     className,
     closeable = false,
     horizontal,
+    htmlOptions = {},
     multiLine = false,
     onClose = () => { },
     open = true,
@@ -53,6 +55,8 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
     className
   );
   const icon = iconMap[status];
+
+  const htmlProps = buildHtmlProps(htmlOptions);
 
   const autoCloseToast = () => {
     if (autoClose && open) {
@@ -76,7 +80,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps) => {
   return (
     <>
       {showToast && (
-        <div className={css} onClick={handleClick}>
+        <div className={css} onClick={handleClick} {...htmlProps}>
           {icon && <Icon className="pb_icon" fixedWidth icon={icon} />}
 
           {

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex.tsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 import { Sizes } from '../types'
 

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex.tsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildCss, buildDataProps } from '../utilities/props'
+import { buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 import { Sizes } from '../types'
 
@@ -10,6 +10,7 @@ type FlexProps = {
   data?: object,
   horizontal?: "left" | "center" | "right" | "stretch" | "none",
   justify?: "start" | "center" | "end" | "around" | "between" | "evenly" | "none",
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   inline?: boolean,
   orientation?: "row" | "column",
@@ -32,6 +33,7 @@ const Flex = (props: FlexProps) => {
     data = {},
     inline = false,
     horizontal = 'left',
+    htmlOptions = {},
     justify = 'none',
     orientation = 'row',
     spacing = 'none',
@@ -58,6 +60,8 @@ const Flex = (props: FlexProps) => {
   const reverseClass = reverse === true ? 'reverse' : ''
   const alignSelfClass = alignSelf !== 'none' ? `align_self_${alignSelf}` : ''
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
 
   return (
     <div
@@ -80,6 +84,7 @@ const Flex = (props: FlexProps) => {
         className
       )}
         {...dataProps}
+        {...htmlProps}
     >
       {children}
     </div>

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex_item.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildCss } from '../utilities/props'
+import { buildCss, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 type FlexItemPropTypes = {
   children: React.ReactNode[] | React.ReactNode,
   fixedSize?: string,
   grow?: boolean,
+  htmlOptions?: { [key: string]: string | number | boolean | Function },
   shrink?: boolean,
   className?: string,
   order?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 'first' | 'none',
@@ -19,6 +20,7 @@ const FlexItem = (props: FlexItemPropTypes): React.ReactElement => {
     className,
     fixedSize,
     grow,
+    htmlOptions = {},
     shrink,
     flex = 'none',
     order = 'none',
@@ -34,8 +36,11 @@ const FlexItem = (props: FlexItemPropTypes): React.ReactElement => {
     fixedSize !== undefined ? { flexBasis: `${fixedSize}` } : null
   const orderClass = order !== 'none' ? `order_${order}` : null
 
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   return (
     <div
+        {...htmlProps}
         className={classnames(buildCss('pb_flex_item_kit', growClass, shrinkClass, flexClass, displayFlexClass), orderClass, alignSelfClass, globalProps(props), className)}
         style={fixedStyle}
     >

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type FormGroupProps = {

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type FormGroupProps = {
@@ -9,6 +9,7 @@ type FormGroupProps = {
   className?: string,
   data?: object,
   fullWidth?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
 }
 
@@ -18,17 +19,20 @@ const FormGroup = (props: FormGroupProps) => {
     className,
     data = {},
     fullWidth = false,
+    htmlOptions = {},
     id,
     children,
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_form_group_kit', { full: fullWidth }), globalProps(props), className)
   return (
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
@@ -5,6 +5,7 @@ import Title from '../pb_title/_title'
 import Icon from '../pb_icon/_icon'
 import Avatar from '../pb_avatar/_avatar'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
+import { buildHtmlProps } from '../utilities/props'
 
 type FormPillProps = {
   className?: string,
@@ -26,6 +27,7 @@ type FormPillProps = {
 const FormPill = (props: FormPillProps) => {
   const {
     className,
+    htmlOptions = {},
     id,
     text,
     name,
@@ -42,8 +44,11 @@ const FormPill = (props: FormPillProps) => {
     size === 'small' ? 'small' : null,
     textTransform,
   )
+
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   return (
-    <div className={css} id={id}>
+    <div className={css} id={id} {...htmlProps}>
         {name &&
         <>
         <Avatar

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
@@ -8,6 +8,7 @@ import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 type FormPillProps = {
   className?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   text: string,
   name?: string,

--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.tsx
@@ -10,7 +10,7 @@ import solidGauge from "highcharts/modules/solid-gauge";
 import defaultColors from "../tokens/exports/_colors.scss";
 import typography from "../tokens/exports/_typography.scss";
 
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
 
 type GaugeProps = {
@@ -22,6 +22,7 @@ type GaugeProps = {
   disableAnimation?: boolean;
   fullCircle?: boolean;
   height?: string;
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string;
   max?: number;
   min?: number;
@@ -45,6 +46,7 @@ const Gauge = ({
   disableAnimation = false,
   fullCircle = false,
   height = null,
+  htmlOptions = {},
   id,
   max = 100,
   min = 0,
@@ -61,7 +63,8 @@ const Gauge = ({
   ...props
 }: GaugeProps) => {
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+ const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   highchartsMore(Highcharts);
   solidGauge(Highcharts);
   const setupTheme = () => {
@@ -192,6 +195,7 @@ const Gauge = ({
         id: id,
         ...ariaProps,
         ...dataProps,
+        ...htmlProps,
       }}
       highcharts={Highcharts}
       options={options}

--- a/playbook/app/pb_kits/playbook/pb_hashtag/_hashtag.tsx
+++ b/playbook/app/pb_kits/playbook/pb_hashtag/_hashtag.tsx
@@ -4,7 +4,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 import Badge from '../pb_badge/_badge'
@@ -14,6 +14,7 @@ type HashtagProps = {
   className?: string,
   dark?: boolean,
   data?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   newWindow?: boolean,
   rel?: string,
@@ -35,6 +36,7 @@ const Hashtag = (props: HashtagProps) => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     id,
     newWindow,
     rel,
@@ -45,12 +47,14 @@ const Hashtag = (props: HashtagProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_hashtag_kit'), globalProps(props), className)
 
   return (
     <span
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_highlight/_highlight.tsx
+++ b/playbook/app/pb_kits/playbook/pb_highlight/_highlight.tsx
@@ -3,10 +3,12 @@ import Highlighter from 'react-highlight-words'
 import React from 'react'
 import classnames from 'classnames'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
+import { buildHtmlProps, buildHtmlProps } from '../utilities/props'
 
 type HighlightProps = {
   className?: string,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   children?: React.ReactChild[] | React.ReactChild | string,
   text?: string,
@@ -19,10 +21,12 @@ const Highlight = (props: HighlightProps): React.ReactElement => {
     className = 'pb_highlight_kit',
     data = {},
     highlightedText = ['highlight'],
+    htmlOptions = {},
     id = '',
     text = '',
   } = props
 
+  const htmlProps = buildHtmlProps(htmlOptions)
   const highlightContent: any = text || children;
 
   return (
@@ -34,6 +38,7 @@ const Highlight = (props: HighlightProps): React.ReactElement => {
         id={id}
         searchWords={highlightedText}
         textToHighlight={highlightContent}
+        {...htmlProps}
     />
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_highlight/_highlight.tsx
+++ b/playbook/app/pb_kits/playbook/pb_highlight/_highlight.tsx
@@ -3,7 +3,7 @@ import Highlighter from 'react-highlight-words'
 import React from 'react'
 import classnames from 'classnames'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
-import { buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildHtmlProps } from '../utilities/props'
 
 type HighlightProps = {
   className?: string,

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
@@ -7,7 +7,7 @@ import { globalProps } from '../utilities/globalProps'
 import Body from '../pb_body/_body'
 import Hashtag from '../pb_hashtag/_hashtag'
 import Title from '../pb_title/_title'
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 type HomeAddressStreetProps = {
   aria?: { [key: string]: string },
@@ -18,6 +18,7 @@ type HomeAddressStreetProps = {
   data?: { [key: string]: string },
   dark?: boolean,
   emphasis: "street" | "city",
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   homeId: string,
   houseStyle: string,
   homeUrl: string,
@@ -37,6 +38,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps) => {
     data = {},
     dark = false,
     emphasis = 'street',
+    htmlOptions = {},
     homeId,
     homeUrl,
     newWindow,
@@ -58,9 +60,14 @@ const HomeAddressStreet = (props: HomeAddressStreetProps) => {
 
   const dataProps: { [key: string]: any } = buildDataProps(data)
   const ariaProps: { [key: string]: any } = buildAriaProps(aria)
-  
+  const htmlProps = buildHtmlProps(htmlOptions)
   return (
-    <div className={classes(className, dark)} {...ariaProps} {...dataProps}>
+    <div 
+      className={classes(className, dark)} 
+      {...ariaProps} 
+      {...dataProps}
+      {...htmlProps}
+    >
       {emphasis == 'street' && 
         <div>
           <Title

--- a/playbook/app/pb_kits/playbook/pb_icon/_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon/_icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 import { isValidEmoji } from '../utilities/validEmojiChecker'
 
@@ -28,6 +28,7 @@ type IconProps = {
   fixedWidth?: boolean,
   flip?: "horizontal" | "vertical" | "both" | "none",
   icon: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   inverse?: boolean,
   listItem?: boolean,
@@ -55,6 +56,7 @@ const Icon = (props: IconProps) => {
     data = {},
     fixedWidth = true,
     flip = "none",
+    htmlOptions = {},
     icon,
     id,
     inverse = false,
@@ -104,6 +106,7 @@ const Icon = (props: IconProps) => {
   aria.label ? null : aria.label = `${icon} icon`
   const ariaProps: {[key: string]: any} = buildAriaProps(aria)
   const dataProps: {[key: string]: any} = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   // Add a conditional here to show only the SVG if custom
   const displaySVG = (customIcon: any) => {
@@ -113,6 +116,7 @@ const Icon = (props: IconProps) => {
           {
             React.cloneElement(customIcon, {
               ...dataProps,
+              ...htmlProps,
               className: classes,
               id,
             })
@@ -124,6 +128,7 @@ const Icon = (props: IconProps) => {
         <>
           <span
               {...dataProps}
+              {...htmlProps}
               className={classesEmoji}
               id={id}
           >
@@ -137,6 +142,7 @@ const Icon = (props: IconProps) => {
         <>
           <i
               {...dataProps}
+              {...htmlProps}
               className={classes}
               id={id}
           />

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Icon from '../pb_icon/_icon'
@@ -13,6 +13,7 @@ type IconCircleProps = {
   dark?: boolean,
   data?: {[key:string]: string},
   icon: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   size?: "base" | "xs" | "sm" | "md" | "lg" | "xl",
   variant?: | "default"
@@ -32,6 +33,7 @@ const IconCircle = (props: IconCircleProps) => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     icon,
     id,
     size = 'md',
@@ -40,6 +42,7 @@ const IconCircle = (props: IconCircleProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_icon_circle_kit', size, variant), globalProps(props), className)
 
 
@@ -47,6 +50,7 @@ const IconCircle = (props: IconCircleProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_icon_stat_value/_icon_stat_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_stat_value/_icon_stat_value.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -16,6 +16,7 @@ type IconStatValueProps = {
   data?: object,
   dark?: boolean,
   icon: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   orientation?: "vertical" | "horizontal",
   size?: "sm" | "md" | "lg",
@@ -39,6 +40,7 @@ const IconStatValue = (props: IconStatValueProps) => {
     className,
     data = {},
     dark = false,
+    htmlOptions = {},
     icon,
     id,
     orientation = 'horizontal',
@@ -50,6 +52,7 @@ const IconStatValue = (props: IconStatValueProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_icon_stat_value_kit', orientation, size, variant), globalProps(props),
     className
@@ -89,6 +92,7 @@ const IconStatValue = (props: IconStatValueProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_icon_value/_icon_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_value/_icon_value.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -14,6 +14,7 @@ type IconValueProps = {
   dark?: boolean,
   data?: object,
   icon: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   text: string,
 }
@@ -25,12 +26,14 @@ const IconValue = (props: IconValueProps) => {
     className,
     dark,
     data = {},
+    htmlOptions = {},
     icon,
     id,
     text,
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_icon_value_kit', align),
     globalProps(props),
@@ -41,6 +44,7 @@ const IconValue = (props: IconValueProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_image/_image.tsx
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 type ImageType = {
   alt?: string,

--- a/playbook/app/pb_kits/playbook/pb_image/_image.tsx
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import classnames from 'classnames'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 
 type ImageType = {
   alt?: string,
   aria?: {[key: string]: string},
   className?: string,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   onError?: () => void,
   size?: "xs" | "sm" | "md" | "lg" | "xl",
@@ -22,6 +23,7 @@ const Image = (props: ImageType): React.ReactElement => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
     onError = null,
     rounded = false,
@@ -40,11 +42,14 @@ const Image = (props: ImageType): React.ReactElement => {
     className
   )
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
 
   return (
     <img
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         alt={alt}
         className={classes}
         data-src={url}

--- a/playbook/app/pb_kits/playbook/pb_label_pill/_label_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_label_pill/_label_pill.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 import { globalProps } from '../utilities/globalProps'
 
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import Pill from '../pb_pill/_pill'
 import Caption from '../pb_caption/_caption'
@@ -11,6 +11,7 @@ type LabelPillProps = {
   aria?: {[key: string]:string},
   className?: string,
   data?: {[key: string]:string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   label?: string,
   pillValue?: string,
@@ -22,6 +23,7 @@ const LabelPill = (props: LabelPillProps) => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
     label,
     pillValue,
@@ -29,6 +31,7 @@ const LabelPill = (props: LabelPillProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const css = classnames(
     'pb_label_pill_kit',
     globalProps(props),
@@ -39,6 +42,7 @@ const LabelPill = (props: LabelPillProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_label_value/_label_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_label_value/_label_value.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classnames from "classnames";
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
 import DateTime from '../pb_kit/dateTime';
 
@@ -17,6 +17,7 @@ type LabelValueProps = {
   dark?: boolean;
   data?: object;
   date?: Date;
+  htmlOptions?: {[key: string]: string | number | boolean | Function};
   id?: string;
   label: string;
   value?: string;
@@ -42,6 +43,7 @@ const LabelValue = (props: LabelValueProps) => {
     data = {},
     date,
     description,
+    htmlOptions = {},
     icon,
     id,
     label,
@@ -51,7 +53,8 @@ const LabelValue = (props: LabelValueProps) => {
   } = props;
 
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const variantClass = variant === "details" ? "details" : "";
   const classes = classnames(
     buildCss("pb_label_value_kit", variantClass),
@@ -63,6 +66,7 @@ const LabelValue = (props: LabelValueProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
         title={title}

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import { globalProps } from '../utilities/globalProps'
 

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 
 import { globalProps } from '../utilities/globalProps'
 
@@ -12,6 +12,7 @@ type LayoutPropTypes = {
   dark?: boolean,
   data?: object,
   full?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   position?: "left" | "right",
   responsive?: boolean,
   size?: "xs" | "sm" | "md" | "base" | "lg" | "xl",
@@ -106,6 +107,7 @@ const Layout = (props: LayoutPropTypes) => {
     dark = false,
     data = {},
     full = false,
+    htmlOptions = {},
     position = 'left',
     responsive = false,
     size = 'md',
@@ -116,6 +118,8 @@ const Layout = (props: LayoutPropTypes) => {
   const responsiveClass = responsive ? '_responsive' : ''
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   const layoutCss =
     layout == 'collection'
       ? `pb_layout_kit_${layout}`
@@ -159,6 +163,7 @@ const Layout = (props: LayoutPropTypes) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classnames(
         layoutCss,
         layoutCollapseCss,

--- a/playbook/app/pb_kits/playbook/pb_legend/_legend.tsx
+++ b/playbook/app/pb_kits/playbook/pb_legend/_legend.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -13,6 +13,7 @@ type LegendProps = {
   color?: string,
   dark?: boolean,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   prefixText?: string,
   text: string,
@@ -25,6 +26,7 @@ const Legend = (props: LegendProps) => {
     color = 'data_1',
     dark = false,
     data = {},
+    htmlOptions = {},
     id,
     prefixText,
     text,
@@ -32,6 +34,7 @@ const Legend = (props: LegendProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const customColor = color.charAt(0) === '#' && color
 
@@ -50,6 +53,7 @@ const Legend = (props: LegendProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={bodyCss}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_lightbox/Header/_lightbox_header.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/Header/_lightbox_header.tsx
@@ -6,6 +6,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
+  buildHtmlProps,
 } from "../../utilities/props";
 import { globalProps, GlobalProps } from "../../utilities/globalProps";
 import { LightboxContext } from "../_lightbox_context";
@@ -23,6 +24,7 @@ type LightboxHeaderProps = {
   className?: string;
   closeable?: boolean;
   data?: { [key: string]: string | number };
+  htmlOptions?: { [key: string]: string | number | boolean | Function };
   icon?: string;
   id?: string;
   onClickRight?: () => void;
@@ -38,6 +40,7 @@ const LightboxHeader = (props: LightboxHeaderProps): React.ReactElement => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     onClickRight,
     spacing = "between",
     text,
@@ -48,7 +51,8 @@ const LightboxHeader = (props: LightboxHeaderProps): React.ReactElement => {
   } = props;
 
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const api: any = useContext(LightboxContext);
   const headerCSS = buildCss("lightbox_header");
   const headerSpacing = globalProps(props, { paddingY: "sm" });
@@ -112,6 +116,7 @@ const LightboxHeader = (props: LightboxHeaderProps): React.ReactElement => {
       <Flex
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classnames(headerCSS, headerSpacing, className)}
         spacing={spacing}
       >

--- a/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
@@ -36,6 +36,7 @@ const Lightbox = (props: LightboxType): React.ReactNode => {
     currentPhotoIndex,
     data = {},
     description,
+    htmlOptions = {},
     id = '',
     initialPhoto = 0,
     photos,

--- a/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_lightbox/_lightbox.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useMemo, useRef, useState, useEffect } from 'react'
 import { useKbdControls } from './hooks/useKbdControls'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import LightboxHeader from './Header/_lightbox_header'
 import { LightboxContext } from './_lightbox_context'
@@ -15,6 +15,7 @@ type LightboxType = {
   currentPhotoIndex?: number,
   data?: {[key: string]: string | number},
   description?: string | any,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   photos: [],
   initialPhoto?: number,
@@ -60,6 +61,7 @@ const Lightbox = (props: LightboxType): React.ReactNode => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_lightbox_kit'),
     globalProps(props),
@@ -96,6 +98,7 @@ const Lightbox = (props: LightboxType): React.ReactNode => {
         <div
             {...ariaProps}
             {...dataProps}
+            {...htmlProps}
             className={classes}
             id={id}
             ref={lightboxRef}

--- a/playbook/app/pb_kits/playbook/pb_line_graph/_line_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/_line_graph.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import classnames from "classnames";
 import { globalProps } from "../utilities/globalProps";
-import { buildAriaProps, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildDataProps, buildHtmlProps } from "../utilities/props";
 
 import HighchartsReact from "highcharts-react-official";
 import Highcharts from "highcharts";
@@ -22,6 +22,7 @@ type LineGraphProps = {
     data: number[];
   }[];
   gradient?: boolean;
+  htmlOptions?: {[key: string]: string | number | boolean | Function};
   id: string;
   pointStart: number;
   subTitle?: string;
@@ -47,6 +48,7 @@ const LineGraph = ({
   dark = false,
   gradient = false,
   type = "line",
+  htmlOptions = {},
   id,
   legend = false,
   toggleLegendClick = true,
@@ -66,8 +68,11 @@ const LineGraph = ({
   colors = [],
   ...props
 }: LineGraphProps) => {
-  const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   const setupTheme = () => {
     dark
       ? Highcharts.setOptions(highchartsDarkTheme)
@@ -138,6 +143,7 @@ const LineGraph = ({
         id: id,
         ...ariaProps,
         ...dataProps,
+        ...htmlProps
       }}
       highcharts={Highcharts}
       options={options}

--- a/playbook/app/pb_kits/playbook/pb_list/_list.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classnames from "classnames";
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
 
 type ListProps = {
@@ -10,6 +10,7 @@ type ListProps = {
   children: React.ReactNode[] | React.ReactNode;
   dark?: boolean;
   data?: object;
+  htmlOptions?: {[key: string]: string | number | boolean | Function};
   id?: string;
   layout?: "" | "left" | "right";
   ordered?: boolean;
@@ -29,6 +30,7 @@ const List = (props: ListProps) => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     id,
     layout = "",
     ordered = false,
@@ -53,7 +55,8 @@ const List = (props: ListProps) => {
     }
   );
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions);
   const classes = classnames(
     buildCss("pb_list_kit", layoutClass[layout], size, {
       dark: dark,
@@ -71,6 +74,7 @@ const List = (props: ListProps) => {
         <ol
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={className}
           id={id}
           role={role}
@@ -82,6 +86,7 @@ const List = (props: ListProps) => {
         <ul
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={className}
           id={id}
           role={role}

--- a/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type ListItemProps = {
@@ -8,6 +8,7 @@ type ListItemProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   tabIndex?: number,
 }
@@ -18,12 +19,14 @@ const ListItem = (props: ListItemProps) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     id,
     tabIndex,
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_item_kit'),
     globalProps(props),
@@ -35,6 +38,7 @@ const ListItem = (props: ListItemProps) => {
       <li
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={classes}
           id={id}
           tabIndex={tabIndex}

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/_loading_inline.tsx
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/_loading_inline.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -12,6 +12,7 @@ type LoadingInlineProps = {
   aria?: { [key: string]: string },
   className?: string,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
 }
 
@@ -21,11 +22,13 @@ const LoadingInline = (props: LoadingInlineProps) => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss(`pb_loading_inline_kit_${align}`),
     globalProps(props),
@@ -36,6 +39,7 @@ const LoadingInline = (props: LoadingInlineProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_map/_map.tsx
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 import MapControls from './_map_controls';

--- a/playbook/app/pb_kits/playbook/pb_map/_map.tsx
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 import MapControls from './_map_controls';
@@ -10,6 +10,7 @@ type MapProps = {
   children?: React.ReactChild[] | React.ReactNode,
   className?: string,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   zoomBtns?: boolean,
   flyTo?: boolean, 
@@ -24,6 +25,7 @@ const Map = (props: MapProps) => {
   children,
   className,
   data = {},
+  htmlOptions = {},
   id,
   zoomBtns = false,
   flyTo = false,
@@ -34,12 +36,15 @@ const Map = (props: MapProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   const classes = classnames(buildCss('pb_map'), globalProps(props), className)
 
   return (
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_message/_message.tsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Avatar from '../pb_avatar/_avatar'
@@ -21,6 +21,7 @@ type MessageProps = {
   children?: React.ReactChild[] | React.ReactChild,
   className?: string,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   label?: string,
   message: string,
@@ -39,6 +40,7 @@ const Message = (props: MessageProps) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     id,
     label,
     message,
@@ -49,6 +51,7 @@ const Message = (props: MessageProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const shouldDisplayAvatar = avatarUrl || avatarName
   const baseClassName = shouldDisplayAvatar
     ? 'pb_message_kit_avatar'
@@ -64,6 +67,7 @@ const Message = (props: MessageProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_message/_message_mention.tsx
+++ b/playbook/app/pb_kits/playbook/pb_message/_message_mention.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type MessageMentionProps = {
@@ -8,6 +8,7 @@ type MessageMentionProps = {
   children?: React.ReactChild[] | React.ReactChild,
   className?: string,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   variant: 'user' | 'self',
 }
@@ -18,11 +19,13 @@ const MessageMention = (props: MessageMentionProps) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     id,
     variant = 'user',
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_message_mention', variant),
     globalProps(props),
@@ -33,6 +36,7 @@ const MessageMention = (props: MessageMentionProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react"
 import classnames from "classnames"
 import { globalProps, GlobalProps } from "../utilities/globalProps"
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props"
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props"
 import Checkbox from "../pb_checkbox/_checkbox"
 import Radio from "../pb_radio/_radio"
 import Body from "../pb_body/_body"
@@ -40,6 +40,7 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
     inputDisplay = "pills",
     inputName,
@@ -53,6 +54,7 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss("pb_multi_level_select"),
     globalProps(props),
@@ -418,6 +420,7 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -24,6 +24,7 @@ type MultiLevelSelectProps = {
   aria?: { [key: string]: string }
   className?: string
   data?: { [key: string]: string }
+  htmlOptions?: {[key: string]: string | number | boolean | Function}
   id?: string
   inputDisplay?: "pills" | "none"
   inputName?: string

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Avatar from '../pb_avatar/_avatar'
@@ -13,6 +13,7 @@ type MultipleUsersProps = {
   className?: string,
   dark?: boolean,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   maxDisplayedUsers?: number,
   reverse?: boolean,
@@ -26,6 +27,7 @@ const MultipleUsers = (props: MultipleUsersProps): React.ReactElement => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     id,
     maxDisplayedUsers = 4,
     reverse = false,
@@ -41,6 +43,7 @@ const MultipleUsers = (props: MultipleUsersProps): React.ReactElement => {
   const avatarSizeClass = size === 'xxs' ? 'xxs' : 'xs'
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_multiple_users_kit', reverseClass),
     globalProps(props),
@@ -56,6 +59,7 @@ const MultipleUsers = (props: MultipleUsersProps): React.ReactElement => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { globalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import Avatar from '../pb_avatar/_avatar'
 import Badge from '../pb_badge/_badge'
@@ -12,6 +12,7 @@ type MultipleUsersStackedProps = {
   className?: string,
   dark?: boolean,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   users: Array<{ [key: string]: string }>,
 }
@@ -22,6 +23,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     id,
     users,
   } = props
@@ -33,6 +35,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
   }
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss(
     'pb_multiple_users_stacked_kit',
     { single: onlyOne }), globalProps(props), className)
@@ -85,6 +88,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_nav/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_nav/_item.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps, GlobalProps } from "../utilities/globalProps";
 
 import Icon from "../pb_icon/_icon";
@@ -21,6 +21,7 @@ type NavItemProps = {
   data?: object;
   dark?: boolean;
   fontSize?: "normal" | "small";
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   iconLeft?: string;
   iconRight?: string | string[];
   onIconRightClick?: () => void;
@@ -67,6 +68,7 @@ const NavItem = (props: NavItemProps) => {
     data = {},
     dark = false,
     fontSize = "normal",
+    htmlOptions = {},
     iconLeft,
     iconRight,
     onIconRightClick,
@@ -158,7 +160,8 @@ const { filteredPadding, filteredMargin } = filterItemSpacing(itemSpacing);
   const fontWeightClass = fontWeightMapping[fontWeight];
 
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
 
   const tagClasses = classnames(
     collapsible ? "pb_nav_list_item_link_collapsible" : "pb_nav_list_item_link",
@@ -216,6 +219,7 @@ const { filteredPadding, filteredMargin } = filterItemSpacing(itemSpacing);
               <Tag
                 {...ariaProps}
                 {...dataProps}
+                {...htmlProps}
                 className={classes}
                 id={id}
                 href={link}
@@ -256,6 +260,7 @@ const { filteredPadding, filteredMargin } = filterItemSpacing(itemSpacing);
         <Tag
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
           className={classes}
           id={id}
           href={link}

--- a/playbook/app/pb_kits/playbook/pb_nav/_nav.tsx
+++ b/playbook/app/pb_kits/playbook/pb_nav/_nav.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 import Caption from '../pb_caption/_caption'
@@ -15,6 +15,7 @@ type NavProps = {
   data?: object,
   dark?: boolean,
   highlight?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   onClick?: React.MouseEventHandler<HTMLElement>,
   orientation?: "vertical" | "horizontal",
@@ -33,6 +34,7 @@ const Nav = (props: NavProps) => {
     data = {},
     dark = false,
     highlight = true,
+    htmlOptions = {},
     id,
     link = '#',
     onClick = () => { },
@@ -44,6 +46,7 @@ const Nav = (props: NavProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const cardCss = classnames(
     buildCss('pb_nav_list', variant, orientation, {
       highlight: highlight,
@@ -70,6 +73,7 @@ const childrenWithProps = React.Children.map(children, (child) => {
     <nav
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={cardCss}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_online_status/_online_status.tsx
+++ b/playbook/app/pb_kits/playbook/pb_online_status/_online_status.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import classnames from 'classnames'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 
 type OnlineStatusProps = {
   aria?: {[key: string]: string},
   className?: string,
   data?: {[key: string]: string | number},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   status?: "online" | "offline" | "away",
 } & GlobalProps
@@ -17,6 +18,7 @@ const OnlineStatus = (props: OnlineStatusProps) => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
     status = 'offline',
   } = props
@@ -25,12 +27,14 @@ const OnlineStatus = (props: OnlineStatusProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_online_status_kit', status), globalProps(props), className)
 
   return (
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     />

--- a/playbook/app/pb_kits/playbook/pb_online_status/_online_status.tsx
+++ b/playbook/app/pb_kits/playbook/pb_online_status/_online_status.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 
-import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 type OnlineStatusProps = {
   aria?: {[key: string]: string},

--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useMemo, useState } from "react"
 import classnames from "classnames"
 
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props"
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props"
 import { globalProps } from "../utilities/globalProps"
 
 import Body from '../pb_body/_body'
@@ -20,6 +20,7 @@ type PassphraseProps = {
   className?: string,
   data?: object,
   dark?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   inputProps?: {},
   label?: string,
@@ -37,6 +38,7 @@ const Passphrase = (props: PassphraseProps) => {
     confirmation = false,
     data = {},
     dark = false,
+    htmlOptions = {},
     id,
     inputProps = {},
     label = confirmation ? "Confirm Passphrase" : "Passphrase",
@@ -82,7 +84,8 @@ const Passphrase = (props: PassphraseProps) => {
     globalProps(props),
     className
   )
-  const dataProps = buildDataProps(data)
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions)
 
   const popoverReference = (
     <CircleIconButton
@@ -98,6 +101,7 @@ const Passphrase = (props: PassphraseProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_person/_person.tsx
+++ b/playbook/app/pb_kits/playbook/pb_person/_person.tsx
@@ -6,7 +6,8 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-, buildHtmlProps } from '../utilities/props'
+  buildHtmlProps
+} from '../utilities/props'
 
 import Body from '../pb_body/_body'
 import Title from '../pb_title/_title'

--- a/playbook/app/pb_kits/playbook/pb_person/_person.tsx
+++ b/playbook/app/pb_kits/playbook/pb_person/_person.tsx
@@ -6,7 +6,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-} from '../utilities/props'
+, buildHtmlProps } from '../utilities/props'
 
 import Body from '../pb_body/_body'
 import Title from '../pb_title/_title'
@@ -16,6 +16,7 @@ type PersonProps = {
   className?: string | string[],
   data?: { [key: string]: string },
   firstName: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   lastName: string,
 }
@@ -25,12 +26,14 @@ const Person = (props: PersonProps): React.ReactElement => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     firstName,
     id,
     lastName } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_person_kit'),
     globalProps(props),
@@ -41,6 +44,7 @@ const Person = (props: PersonProps): React.ReactElement => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_person_contact/_person_contact.tsx
+++ b/playbook/app/pb_kits/playbook/pb_person_contact/_person_contact.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Caption from '../pb_caption/_caption'
@@ -19,6 +19,7 @@ type PersonContactProps = {
   className?: string | string[],
   data?: object,
   firstName: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   lastName: string,
   contacts?: ContactItem[],
@@ -31,12 +32,14 @@ const PersonContact = (props: PersonContactProps) => {
     contacts = [],
     data = {},
     firstName,
+    htmlOptions = {},
     id,
     lastName,
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_person_contact_kit'),
     globalProps(props),
@@ -59,6 +62,7 @@ const PersonContact = (props: PersonContactProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -5,7 +5,7 @@ import intlTelInput from 'intl-tel-input'
 import 'intl-tel-input/build/css/intlTelInput.css'
 import 'intl-tel-input/build/js/utils.js'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import TextInput from '../pb_text_input/_text_input'
@@ -25,6 +25,7 @@ type PhoneNumberInputProps = {
   data?: { [key: string]: string },
   disabled?: boolean,
   error?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   initialCountry?: string,
   isValid?: (valid: boolean) => void,
@@ -71,6 +72,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
     dark = false,
     data = {},
     disabled = false,
+    htmlOptions = {},
     id = "",
     initialCountry = "",
     isValid = () => {
@@ -90,6 +92,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss("pb_phone_number_input"),
     globalProps(props),
@@ -256,7 +259,10 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
   if (required) textInputProps.required = true
 
   return (
-    <div {...wrapperProps}>
+    <div 
+      {...wrapperProps} 
+      {...htmlProps}
+    >
       <TextInput
           ref={
             inputNode => {

--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 
 import classnames from 'classnames'
 import Title from '../pb_title/_title'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 
 type PillProps = {
   aria?: {[key: string]: string},
   className?: string,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   text: string,
   variant?: "success" | "warning" | "error" | "info" | "neutral" | "primary",
@@ -20,6 +21,7 @@ const Pill = (props: PillProps) => {
     aria = {},
     className,
     data = {},
+    htmlOptions = {},
     id,
     text,
     variant = 'neutral',
@@ -28,12 +30,14 @@ const Pill = (props: PillProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_pill_kit', variant, textTransform), globalProps(props), className)
 
   return (
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
@@ -12,6 +12,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
+  buildHtmlProps,
   noop,
 } from "../utilities/props";
 
@@ -24,6 +25,7 @@ type PbPopoverProps = {
   className?: string;
   closeOnClick?: "outside" | "inside" | "any";
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string;
   offset?: boolean;
   reference: PopperReference & any;
@@ -63,6 +65,7 @@ const Popover = (props: PbPopoverProps) => {
     className,
     children,
     data = {},
+    htmlOptions = {},
     id,
     modifiers,
     offset,
@@ -92,7 +95,8 @@ const Popover = (props: PbPopoverProps) => {
     );
   };
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const classes = classnames(
     buildCss("pb_popover_kit"),
     globalProps(props),
@@ -110,6 +114,7 @@ const Popover = (props: PbPopoverProps) => {
           <div
               {...ariaProps}
               {...dataProps}
+              {...htmlProps}
               className={classes}
               data-placement={placement}
               id={id}

--- a/playbook/app/pb_kits/playbook/pb_progress_pills/_progress_pills.tsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/_progress_pills.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -13,6 +13,7 @@ type ProgressPillsProps = {
   className?: string,
   data?: { [key: string]: string },
   dark?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   steps?: number,
   title?: string,
@@ -43,6 +44,7 @@ const ProgressPills = (props: ProgressPillsProps) => {
     aria = { hidden: 'true' },
     className,
     data = {},
+    htmlOptions = {},
     id,
     steps = 3,
     title,
@@ -52,12 +54,14 @@ const ProgressPills = (props: ProgressPillsProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_progress_pills_kit'), globalProps(props), className)
 
   return (
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.tsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.tsx
@@ -24,6 +24,7 @@ const ProgressSimple = (props: ProgressSimpleProps) => {
     className,
     dark = false,
     data ={},
+    htmlOptions = {},
     max,
     muted = false,
     percent = '',
@@ -35,8 +36,8 @@ const ProgressSimple = (props: ProgressSimpleProps) => {
     width: width,
   }
 
-   const dataProps = buildDataProps(data)
-   const htmlProps = buildHtmlProps(htmlOptions)
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const variantStyle = variant == 'default' ? '' : variant
 
   const valueStyles = {

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.tsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildCss, buildDataProps } from '../utilities/props'
+import { buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type ProgressSimpleProps = {
@@ -8,6 +8,7 @@ type ProgressSimpleProps = {
   className?: string | string[],
   dark?: boolean,
   data?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   max?: number,
   muted: boolean,
@@ -34,7 +35,8 @@ const ProgressSimple = (props: ProgressSimpleProps) => {
     width: width,
   }
 
-  const dataProps = buildDataProps(data)
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions)
   const variantStyle = variant == 'default' ? '' : variant
 
   const valueStyles = {
@@ -53,8 +55,11 @@ const ProgressSimple = (props: ProgressSimpleProps) => {
   )
 
   return (
-    <div {...dataProps}
-      className={wrapperClass}>
+    <div 
+      {...dataProps}
+      {...htmlProps}
+      className={wrapperClass}
+    >
       <div
           className={kitClass}
           data-value={value}

--- a/playbook/app/pb_kits/playbook/pb_progress_step/_progress_step.tsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/_progress_step.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type ProgressStepProps = {
   aria?: { [key: string]: string },
   className?: string,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   children?: React.ReactChild[] | React.ReactChild,
   orientation?: "horizontal" | "vertical",
@@ -24,6 +25,7 @@ const ProgressStep = (props: ProgressStepProps): React.ReactElement => {
     color,
     data = {},
     orientation = 'horizontal',
+    htmlOptions = {},
     icon = false,
     showIcon = false,
     variant,
@@ -31,6 +33,7 @@ const ProgressStep = (props: ProgressStepProps): React.ReactElement => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const iconStyle = icon === true || showIcon === true ? 'icon' : ''
   const progressStepCss = buildCss(
     'pb_progress_step_kit',
@@ -44,6 +47,7 @@ const ProgressStep = (props: ProgressStepProps): React.ReactElement => {
     <ul
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classnames(progressStepCss, globalProps(props), className)}
     >
       {children}

--- a/playbook/app/pb_kits/playbook/pb_progress_step/_progress_step_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/_progress_step_item.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss, buildDataProps } from '../utilities/props'
+import { buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import Icon from '../pb_icon/_icon'
 
@@ -10,6 +10,7 @@ type ProgressStepItemProps = {
   data?: { [key: string]: string },
   status?: "complete" | "active" | "inactive" | "hidden",
   children?: React.ReactNode | React.ReactNode[],
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   icon?: string,
 }
 
@@ -19,15 +20,18 @@ const ProgressStepItem = (props: ProgressStepItemProps): React.ReactElement => {
     data = {},
     status = 'inactive',
     children,
+    htmlOptions = {},
     icon = 'check',
   } = props
 
   const progressStepItem = buildCss('pb_progress_step_item', status)
-  const dataProps = buildDataProps(data)
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
     <li 
         {...dataProps}
+        {...htmlProps}
         className={classnames(progressStepItem, className)}
     >
       <div className="box">

--- a/playbook/app/pb_kits/playbook/pb_radio/_radio.tsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/_radio.tsx
@@ -3,7 +3,7 @@
 import React, { forwardRef } from 'react'
 import Body from '../pb_body/_body'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 type RadioProps = {
@@ -15,6 +15,7 @@ type RadioProps = {
   dark?: boolean,
   data?: {[key: string]: string},
   error?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   label: string,
   name?: string,
@@ -31,6 +32,7 @@ const Radio = ({
   dark = false,
   data = {},
   error = false,
+  htmlOptions = {},
   id,
   label,
   name = 'radio_name',
@@ -41,6 +43,7 @@ const Radio = ({
 }: RadioProps, ref: any) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_radio_kit', alignment ),
     dark ? 'dark': null, error ? 'error': null,
@@ -68,6 +71,7 @@ const Radio = ({
     <label
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         htmlFor={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames'
 import inlineFocus from './inlineFocus'
 import useFocus from './useFocus'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildDataProps, noop } from '../utilities/props'
+import { buildAriaProps, buildDataProps, noop, buildHtmlProps } from '../utilities/props'
 
 try {
   const Trix = require('trix')
@@ -35,6 +35,7 @@ type RichTextEditorProps = {
   className?: string,
   data?: { [key: string]: string },
   focus?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   inline?: boolean, 
   extensions?: { [key: string]: string }[],
@@ -58,6 +59,7 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     className,
     data = {},
     focus = false,
+    htmlOptions = {},
     inline = false,
     extensions,
     name,
@@ -74,8 +76,11 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     dataProps = buildDataProps(data),
     [editor, setEditor] = useState<Editor>()
 
+  const htmlProps = buildHtmlProps(htmlOptions)
+  
   const handleOnEditorReady = (editorInstance: Editor) => setEditor(editorInstance),
     element = editor?.element
+
 
   // DOM manipulation must wait for editor to be ready
   if (editor) {
@@ -161,6 +166,7 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={css}
     >
       {

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Caption from '../pb_caption/_caption'
@@ -12,6 +12,7 @@ type SectionSeparatorProps = {
   className?: string,
   dark?: boolean,
   data?: { [key: string]: string; },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   lineStyle?: "solid" | "dashed",
   orientation?: "horizontal" | "vertical",
@@ -25,6 +26,7 @@ const SectionSeparator = (props: SectionSeparatorProps) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     id,
     lineStyle = 'solid',
     orientation = 'horizontal',
@@ -34,6 +36,7 @@ const SectionSeparator = (props: SectionSeparatorProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_section_separator_kit', variant, orientation, lineStyle === "dashed" ? lineStyle : ""), globalProps(props), className)
 
   return (
@@ -41,6 +44,7 @@ const SectionSeparator = (props: SectionSeparatorProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_select/_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps, domSafeProps } from '../utilities/globalProps'
 import type { InputCallback } from '../types'
 
@@ -24,6 +24,7 @@ type SelectProps = {
   data?: { [key: string]: string },
   disabled?: boolean,
   error?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   includeBlank?: string,
   inline?: boolean,
@@ -58,6 +59,7 @@ const Select = ({
   disabled = false,
   error,
   label,
+  htmlOptions = {},
   inline = false,
   multiple = false,
   name,
@@ -69,6 +71,7 @@ const Select = ({
 }: SelectProps, ref: React.LegacyRef<HTMLSelectElement>) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const optionsList = createOptions(options)
 
   const inlineClass = inline ? 'inline' : null
@@ -89,6 +92,7 @@ const Select = ({
     if (children) return children
     return (
       <select
+          {...htmlOptions}
           {...domSafeProps(props)}
           disabled={disabled}
           id={name}
@@ -109,6 +113,7 @@ const Select = ({
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
     >
       {label &&

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.tsx
@@ -9,7 +9,7 @@ import {
   buildCss,
   buildDataProps,
   noop,
-} from '../utilities/props'
+  buildHtmlProps } from '../utilities/props'
 
 import Icon from '../pb_icon/_icon'
 import Checkbox from '../pb_checkbox/_checkbox'
@@ -28,8 +28,9 @@ type SelectableCardProps = {
   disabled?: boolean,
   error?: boolean,
   icon?: boolean,
-  id?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   inputId?: string,
+  id?: string,
   multi?: boolean,
   name?: string,
   onChange: (event: React.FormEvent<HTMLInputElement>) => void,
@@ -48,6 +49,7 @@ const SelectableCard = (props: SelectableCardProps) => {
     data = {},
     disabled = false,
     error = false,
+    htmlOptions = {},
     icon = false,
     inputId = null,
     multi = true,
@@ -59,6 +61,7 @@ const SelectableCard = (props: SelectableCardProps) => {
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(buildCss('pb_selectable_card_kit',
     {
@@ -109,6 +112,7 @@ const SelectableCard = (props: SelectableCardProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
     >
       <input

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/_selectable_card_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/_selectable_card_icon.tsx
@@ -6,7 +6,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-} from '../utilities/props'
+, buildHtmlProps } from '../utilities/props'
 
 import Body from '../pb_body/_body'
 import SelectableCard from '../pb_selectable_card/_selectable_card'
@@ -21,6 +21,7 @@ type SelectableCardIconProps = {
   dark?: boolean,
   data?: { [key: string]: string },
   disabled?: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   icon?: string,
   inputId?: string,
   multi?: boolean,
@@ -41,6 +42,7 @@ const SelectableCardIcon = (props: SelectableCardIconProps) => {
     dark = false,
     data = {},
     disabled = false,
+    htmlOptions = {},
     icon,
     inputId,
     multi = true,
@@ -53,6 +55,7 @@ const SelectableCardIcon = (props: SelectableCardIconProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(
     buildCss('pb_selectable_card_icon_kit', {
@@ -68,6 +71,7 @@ const SelectableCardIcon = (props: SelectableCardIconProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
     >
       <SelectableCard

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/_selectable_card_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/_selectable_card_icon.tsx
@@ -6,7 +6,8 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-, buildHtmlProps } from '../utilities/props'
+  buildHtmlProps,
+} from '../utilities/props'
 
 import Body from '../pb_body/_body'
 import SelectableCard from '../pb_selectable_card/_selectable_card'

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/_selectable_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/_selectable_icon.tsx
@@ -6,6 +6,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
+  buildHtmlProps 
 } from '../utilities/props'
 import Icon from '../pb_icon/_icon'
 import Title from '../pb_title/_title'
@@ -17,6 +18,7 @@ type SelectableIconProps = {
   customIcon?: {[key: string] :SVGElement},
   disabled?: boolean,
   data?: Object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   icon: string,
   inputId: string,
   inputs: string,
@@ -33,6 +35,7 @@ const SelectableIcon = ({
   customIcon,
   data = {},
   disabled = false,
+  htmlOptions = {},
   icon,
   inputId,
   inputs = 'enabled',
@@ -44,6 +47,7 @@ const SelectableIcon = ({
 }: SelectableIconProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(
     buildCss('pb_selectable_icon_kit', {
@@ -62,6 +66,7 @@ const SelectableIcon = ({
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
     >
       {inputs === 'disabled' && (

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import classnames from "classnames";
 
-import { buildAriaProps, buildCss, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
 
 import Checkbox from "../pb_checkbox/_checkbox";
@@ -15,6 +15,7 @@ export type SelectableListItemProps = {
   className?: string;
   data?: object;
   defaultChecked?: boolean;
+  htmlOptions?: { [key: string]: string | number | boolean | Function };
   id?: string;
   label?: string;
   text?: string;
@@ -31,6 +32,7 @@ const SelectableListItem = ({
   className,
   data = {},
   defaultChecked,
+  htmlOptions = {},
   id,
   label,
   text = "",
@@ -41,7 +43,8 @@ const SelectableListItem = ({
   ...props
 }: SelectableListItemProps) => {
   const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions);
   const classes = classnames(
     buildCss("pb_selectable_list_item_kit"),
     globalProps(props),
@@ -61,7 +64,12 @@ const SelectableListItem = ({
       {...props}
       className={classnames(checkedState ? "checked_item" : "", className)}
     >
-      <div {...ariaProps} {...dataProps} className={classes}>
+      <div 
+        {...ariaProps} 
+        {...dataProps}
+        {...htmlProps} 
+        className={classes}
+      >
         {variant == "checkbox" && (
           <>
             <Checkbox

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import { SelectableListItemProps } from './_item.js'
 
@@ -13,6 +13,7 @@ type SelectableListProps = {
   children?: React.ReactElement[],
   className?: string,
   data?: object,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   variant?: 'checkbox' | 'radio',
 }
@@ -23,12 +24,14 @@ const SelectableList = (props: SelectableListProps) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     id,
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const classes = classnames(buildCss('pb_selectable_list_kit'), globalProps(props), className)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const isRadio = props.variant === "radio"
   const defaultCheckedRadioValue = children.filter((item: {props:SelectableListItemProps} ) => item.props.defaultChecked)[0]?.props?.value
 
@@ -58,6 +61,7 @@ const SelectableList = (props: SelectableListProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_source/_source.tsx
+++ b/playbook/app/pb_kits/playbook/pb_source/_source.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildDataProps, buildAriaProps } from '../utilities/props'
+import { buildDataProps, buildAriaProps, buildHtmlProps } from '../utilities/props'
 import { titleize } from '../utilities/text'
 
 import Avatar, { AvatarProps } from '../pb_avatar/_avatar'
@@ -15,6 +15,7 @@ type SourceProps = {
   className?: string,
   data?: { [key: string]: string },
   hideIcon: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   source?: string,
   type: "events" | "inbound" | "outbound" | "prospecting" | "referral" | "retail" | "user",
@@ -26,12 +27,14 @@ const Source = ({
   className,
   data = {},
   hideIcon = false,
+  htmlOptions = {},
   id,
   source,
   type = 'inbound',
   user = {},
 }: SourceProps) => {
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const ariaProps = buildAriaProps(aria)
 
   const css = classnames([
@@ -71,6 +74,7 @@ const Source = ({
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={css}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_star_rating/_star_rating.tsx
+++ b/playbook/app/pb_kits/playbook/pb_star_rating/_star_rating.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import classnames from "classnames"
 
-import { buildAriaProps, buildDataProps } from "../utilities/props"
+import { buildAriaProps, buildDataProps, buildHtmlProps } from "../utilities/props"
 
 import Icon from "../pb_icon/_icon"
 
@@ -11,6 +11,7 @@ type StarRatingProps = {
   data?: object,
   fixedWidth?: boolean,
   hideRating: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   icon?: string,
   id?: string,
   rating: number,
@@ -20,12 +21,14 @@ const StarRating = ({
   aria = {},
   className,
   data = {},
+  htmlOptions = {},
   hideRating = false,
   id,
   rating = 0,
 }: StarRatingProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const css = classnames([
     "pb_star_rating_kit", className,
   ])
@@ -42,6 +45,7 @@ const StarRating = ({
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_stat_change/_stat_change.tsx
+++ b/playbook/app/pb_kits/playbook/pb_stat_change/_stat_change.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss } from '../utilities/props'
+import { buildCss, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -22,6 +22,7 @@ type StatChangeProps = {
   change?: 'increase' | 'decrease' | 'neutral',
   className?: string,
   icon?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   value?: string | number,
 }

--- a/playbook/app/pb_kits/playbook/pb_stat_change/_stat_change.tsx
+++ b/playbook/app/pb_kits/playbook/pb_stat_change/_stat_change.tsx
@@ -28,12 +28,22 @@ type StatChangeProps = {
 }
 
 const StatChange = (props: StatChangeProps): React.ReactElement => {
-  const { change = 'neutral', className, icon, id, value } = props
+  const { 
+    change = 'neutral', 
+    className, 
+    htmlOptions = {},
+    icon, 
+    id, 
+    value 
+  } = props
+
   const status = statusMap[change as keyof typeof statusMap]
   let returnedIcon = iconMap[change as keyof typeof iconMap]
   if (icon) {
     returnedIcon = icon
   }
+
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
     <>
@@ -45,6 +55,7 @@ const StatChange = (props: StatChangeProps): React.ReactElement => {
               className
               )}
             id={id}
+            {...htmlProps}
         >
           <Body status={status}>
             {returnedIcon &&

--- a/playbook/app/pb_kits/playbook/pb_stat_value/_stat_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/_stat_value.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { globalProps } from '../utilities/globalProps'
+import { buildHtmlProps } from '../utilities/props'
 import Title from '../pb_title/_title'
 
 type StatValueProps = {
@@ -15,10 +16,13 @@ type StatValueProps = {
 const StatValue = (props: StatValueProps): React.ReactElement => {
   const {
     className,
+    htmlOptions = {},
     id,
     unit,
     value = 0,
   } = props
+
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const displayValue = function(value: string | number) {
     if (value || value === 0) {
@@ -48,6 +52,7 @@ const StatValue = (props: StatValueProps): React.ReactElement => {
     <div
         className={classnames('pb_stat_value_kit', globalProps(props), className)}
         id={id}
+        {...htmlProps}
     >
       <div className="pb_stat_value_wrapper">
         {displayValue(value)}

--- a/playbook/app/pb_kits/playbook/pb_stat_value/_stat_value.tsx
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/_stat_value.tsx
@@ -6,6 +6,7 @@ import Title from '../pb_title/_title'
 
 type StatValueProps = {
   className?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   unit?: string,
   value: string | number,

--- a/playbook/app/pb_kits/playbook/pb_table/_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_table/_table.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import PbTable from '.'
 
@@ -14,6 +14,7 @@ type TableProps = {
   data?: { [key: string]: string },
   dataTable: boolean,
   disableHover: boolean,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   responsive: "collapse" | "scroll" | "none",
   singleLine: boolean,
@@ -43,6 +44,7 @@ const Table = (props: TableProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const tableCollapseCss = responsive !== 'none' ? `table-collapse-${collapse}` : ''
   const verticalBorderCss = verticalBorder ? 'vertical-border' : ''
 
@@ -55,6 +57,7 @@ const Table = (props: TableProps) => {
     <table
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classnames(
         'pb_table',
         `table-${size}`,

--- a/playbook/app/pb_kits/playbook/pb_table/_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_table/_table.tsx
@@ -34,6 +34,7 @@ const Table = (props: TableProps) => {
     data = {},
     dataTable = false,
     disableHover = false,
+    htmlOptions = {},
     id,
     responsive = 'collapse',
     singleLine = false,

--- a/playbook/app/pb_kits/playbook/pb_table/_table_row.tsx
+++ b/playbook/app/pb_kits/playbook/pb_table/_table_row.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 type TableRowPropTypes = {
@@ -8,6 +8,7 @@ type TableRowPropTypes = {
   children: React.ReactNode[] | React.ReactNode,
   className: string,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   sideHighlightColor: string,
 }
@@ -18,12 +19,14 @@ const TableRow = (props: TableRowPropTypes) => {
     children,
     className,
     data = {},
+    htmlOptions = {},
     id,
     sideHighlightColor = 'windows',
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const sideHighlightClass =
     sideHighlightColor != '' ? `side_highlight_${sideHighlightColor}` : null
   const classes = classnames(buildCss('pb_table_row_kit', sideHighlightClass), globalProps(props), className)
@@ -32,6 +35,7 @@ const TableRow = (props: TableRowPropTypes) => {
     <tr
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import classnames from 'classnames'
 
 import { globalProps, GlobalProps, domSafeProps } from '../utilities/globalProps'
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import Flex from '../pb_flex/_flex'
 import Card from '../pb_card/_card'
@@ -17,6 +17,7 @@ type TextInputProps = {
   dark?: boolean,
   disabled?: boolean,
   error?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   inline?: boolean,
   name: string,
@@ -43,6 +44,7 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
     data = {},
     disabled,
     error,
+    htmlOptions = {},
     id,
     inline = false,
     name,
@@ -57,6 +59,7 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const { alignment, border, icon } = addOn
   const addOnAlignment = alignment === 'left' ? 'left' : 'right'
@@ -138,6 +141,7 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
     >
       {label && 

--- a/playbook/app/pb_kits/playbook/pb_textarea/_textarea.tsx
+++ b/playbook/app/pb_kits/playbook/pb_textarea/_textarea.tsx
@@ -6,7 +6,7 @@ import classnames from 'classnames'
 import PbTextarea from '.'
 import type { InputCallback } from '../types'
 
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -22,6 +22,7 @@ type TextareaProps = {
   data?: {[key: string]: string},
   disabled?: boolean,
   error?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   inline?: boolean,
   object?: string,
@@ -44,6 +45,7 @@ const Textarea = ({
   children,
   data = {},
   disabled,
+  htmlOptions = {},
   inline = false,
   resize = 'none',
   error,
@@ -71,7 +73,7 @@ const Textarea = ({
   const noCount = typeof characterCount !== 'undefined'
   const ariaProps: {[key: string]: any} = buildAriaProps(aria)
   const dataProps: {[key: string]: any} = buildDataProps(data)
-
+  const htmlProps = buildHtmlProps(htmlOptions)
   const characterCounter = () => {
     return maxCharacters && characterCount ? `${checkIfZero(characterCount)} / ${maxCharacters}` : `${checkIfZero(characterCount)}`
   }
@@ -84,6 +86,7 @@ const Textarea = ({
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
     >
       <Caption text={label} />

--- a/playbook/app/pb_kits/playbook/pb_time/_time.tsx
+++ b/playbook/app/pb_kits/playbook/pb_time/_time.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 
-import { buildCss } from "../utilities/props";
+import { buildCss, buildHtmlProps } from "../utilities/props";
 import { globalProps, GlobalProps } from "../utilities/globalProps";
 import DateTime from '../pb_kit/dateTime';
 
@@ -16,6 +16,7 @@ type TimeProps = {
   date: Date;
   dark?: boolean;
   id?: string;
+  htmlOptions?: {[key: string]: string | number | boolean | Function};
   showIcon?: boolean;
   size?: "md" | "sm";
   showTimezone?: boolean;
@@ -28,6 +29,7 @@ const Time = (props: TimeProps) => {
     align,
     className,
     date,
+    htmlOptions = {},
     showIcon,
     size,
     timeZone,
@@ -41,8 +43,13 @@ const Time = (props: TimeProps) => {
     className
   );
 
+  const htmlProps = buildHtmlProps(htmlOptions);
+
   return (
-    <div className={classes}>
+    <div 
+      {...htmlProps}
+      className={classes} 
+    >
       {showIcon && (
         unstyled
           ? (

--- a/playbook/app/pb_kits/playbook/pb_time_range_inline/_time_range_inline.tsx
+++ b/playbook/app/pb_kits/playbook/pb_time_range_inline/_time_range_inline.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { globalProps, GlobalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 import DateTime from '../pb_kit/dateTime';
 
 import Body from '../pb_body/_body'
@@ -12,6 +12,7 @@ import Icon from '../pb_icon/_icon'
 type TimeRangeInlineProps = {
   aria?: { [key: string]: string },
   className?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   data?: { [key: string]: string },
   alignment?: "left" | "center" | "vertical",
@@ -41,6 +42,7 @@ const TimeRangeInline = (props: TimeRangeInlineProps) => {
     className,
     data = {},
     alignment = 'left',
+    htmlOptions = {},
     size = 'sm',
     dark = false,
     icon = false,
@@ -52,6 +54,7 @@ const TimeRangeInline = (props: TimeRangeInlineProps) => {
 
   const dataProps: { [key: string]: string } = buildDataProps(data)
   const ariaProps: { [key: string]: string } = buildAriaProps(aria)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const separator = (
     <Body color="light">
@@ -87,6 +90,7 @@ const TimeRangeInline = (props: TimeRangeInlineProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classnames('pb_time_range_inline_kit_' + alignment, globalProps(props), className)}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_time_stacked/_time_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_time_stacked/_time_stacked.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss, buildDataProps } from '../utilities/props'
+import { buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, globalProps } from '../utilities/globalProps'
 import DateTime from '../pb_kit/dateTime';
 
@@ -14,6 +14,7 @@ type TimeStackedProps = {
   dark?: boolean,
   data?: { [key: string]: string },
   date?: Date,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   time?: number | Date,
   timeZone?: string,
@@ -28,6 +29,7 @@ const TimeStackedDefault = (props: TimeStackedProps): React.ReactElement => {
     dark,
     data = {},
     date,
+    htmlOptions = {},
     time,
     timeZone,
   } = props
@@ -37,12 +39,14 @@ const TimeStackedDefault = (props: TimeStackedProps): React.ReactElement => {
     globalProps(props),
     className
   )
-  const dataProps = buildDataProps(data)
+   const dataProps = buildDataProps(data)
+   const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
     <div
         className={classes}
         {...dataProps}
+        {...htmlProps}
     >
       <Body
           className={classnames('pb_time_stacked', 'time-spacing')}

--- a/playbook/app/pb_kits/playbook/pb_timeline/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_item.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildCss } from '../utilities/props'
+import { buildCss, buildHtmlProps } from '../utilities/props'
 
 import DateStacked from '../pb_date_stacked/_date_stacked'
 import IconCircle from '../pb_icon_circle/_icon_circle'

--- a/playbook/app/pb_kits/playbook/pb_timeline/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_item.tsx
@@ -10,6 +10,7 @@ type ItemProps = {
   className?: string,
   children?: React.ReactNode[] | React.ReactNode,
   date?: Date,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   icon?: string,
   iconColor?: 'default' | 'royal' | 'blue' | 'purple' | 'teal' | 'red' | 'yellow' | 'green',
   lineStyle?: 'solid' | 'dotted',
@@ -19,6 +20,7 @@ const TimelineItem = ({
   className,
   children,
   date,
+  htmlOptions = {},
   icon = 'user',
   iconColor = 'default',
   lineStyle = 'solid',
@@ -26,8 +28,13 @@ const TimelineItem = ({
 }: ItemProps) => {
   const timelineItemCss = buildCss('pb_timeline_item_kit', lineStyle)
 
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   return (
-    <div className={classnames(timelineItemCss, className)}>
+    <div 
+      {...htmlProps}
+      className={classnames(timelineItemCss, className)}
+    >
       <div className="pb_timeline_item_left_block">
         {date &&
           <DateStacked

--- a/playbook/app/pb_kits/playbook/pb_timeline/_timeline.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_timeline.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import TimelineItem from './_item'
 
@@ -10,6 +10,7 @@ type TimelineProps = {
   children?: React.ReactChild[] | React.ReactChild,
   className?: string,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   orientation?: string,
   showDate?: boolean,
@@ -20,18 +21,21 @@ const Timeline = ({
   className,
   children,
   data = {},
+  htmlOptions = {},
   id,
   orientation = 'horizontal',
   showDate = false,
 }: TimelineProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const dateStyle = showDate === true ? '_with_date' : ''
   const timelineCss = buildCss('pb_timeline_kit', `_${orientation}`, dateStyle)
   return (
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classnames(timelineCss, className)}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import DateTime from '../pb_kit/dateTime';
 
@@ -16,6 +16,7 @@ type TimestampProps = {
   text: string,
   timestamp: Date | string,
   timezone: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   showDate?: boolean,
   showUser?: boolean,
@@ -32,6 +33,7 @@ const Timestamp = (props: TimestampProps): React.ReactElement => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     text,
     timezone,
     timestamp,
@@ -45,6 +47,7 @@ const Timestamp = (props: TimestampProps): React.ReactElement => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_timestamp_kit', align, {
       dark: dark,
@@ -101,6 +104,7 @@ const Timestamp = (props: TimestampProps): React.ReactElement => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
     >
       <div className="pb_timestamp_kit">

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, GlobalProps, globalProps } from '../utilities/globalProps'
 
 type SizeType = 1 | 2 | 3 | 4 | "1" | "2" | "3" | "4"

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, GlobalProps, globalProps } from '../utilities/globalProps'
 
 type SizeType = 1 | 2 | 3 | 4 | "1" | "2" | "3" | "4"
@@ -13,6 +13,7 @@ type TitleProps = {
   className?: string,
   color?: "default" | "light" | "lighter" | "success" | "error" | "link",
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   size?: SizeType | SizeResponsiveType,
   tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div" | "span",
@@ -29,6 +30,7 @@ const Title = (props: TitleProps): React.ReactElement => {
     className,
     color,
     data = {},
+    htmlOptions = {},
     id,
     size = 3,
     bold = true,
@@ -40,6 +42,7 @@ const Title = (props: TitleProps): React.ReactElement => {
 
   const ariaProps: {[key: string]: string | number} = buildAriaProps(aria)
   const dataProps: {[key: string]: string | number} = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const getBold = bold ? '' : 'thin'
   const isTruncated = truncate ? `truncate-${truncate}` : null
   const isSizeNumberOrString = typeof size === "number" || typeof size === "string"
@@ -68,6 +71,7 @@ const Title = (props: TitleProps): React.ReactElement => {
     <Tag
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_title_count/_title_count.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title_count/_title_count.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Body from '../pb_body/_body'
@@ -16,6 +16,7 @@ type TitleCountProps = {
   count?: number,
   dark?: boolean,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   title?: string,
   size?: "lg" | "sm",
@@ -28,12 +29,14 @@ const TitleCount = (props: TitleCountProps): React.ReactElement => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     count,
     id,
     title,
     size = 'sm' } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const css = classnames(
     buildCss('pb_title_count_kit', align, size),
@@ -47,6 +50,7 @@ const TitleCount = (props: TitleCountProps): React.ReactElement => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={css}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_title_detail/_title_detail.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title_detail/_title_detail.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { GlobalProps, globalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import Body from '../pb_body/_body'
 import Title from '../pb_title/_title'
@@ -13,20 +13,33 @@ type TitleDetailProps = {
   className?: string,
   data?: { [key: string]: string },
   detail: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   title: string,
 } & GlobalProps
 
 const TitleDetail = (props: TitleDetailProps) => {
-  const { align = 'left', aria = {}, className, data = {}, detail, id, title } = props
+  const {
+    align = "left",
+    aria = {},
+    className,
+    data = {},
+    detail,
+    htmlOptions = {},
+    id,
+    title,
+  } = props
+  
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
-  const pbCss = buildCss('pb_title_detail_kit', align)
+  const htmlProps = buildHtmlProps(htmlOptions)
+  const pbCss = buildCss("pb_title_detail_kit", align)
 
   return (
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classnames(pbCss, globalProps(props), className)}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
@@ -6,7 +6,7 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-  buildHtmlProps
+  buildHtmlProps,
 } from '../utilities/props'
 
 import { GlobalProps, globalProps } from '../utilities/globalProps'

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
@@ -6,7 +6,8 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-} from '../utilities/props'
+  buildHtmlProps
+, buildHtmlProps } from '../utilities/props'
 
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 
@@ -16,6 +17,7 @@ type Props = {
   children?: React.ReactNode | React.ReactNode[],
   className?: string,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   name?: string,
   onChange?: InputCallback<HTMLInputElement>,
@@ -30,6 +32,7 @@ const Toggle = ({
   className,
   data = {},
   id,
+  htmlOptions = {},
   name,
   onChange = () => { },
   size = 'sm',
@@ -38,6 +41,7 @@ const Toggle = ({
 }: Props) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const css = classnames(
     buildCss('pb_toggle_kit',
       size,
@@ -51,6 +55,7 @@ const Toggle = ({
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classnames(css, globalProps(props), className)}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
@@ -7,7 +7,7 @@ import {
   buildCss,
   buildDataProps,
   buildHtmlProps
-, buildHtmlProps } from '../utilities/props'
+} from '../utilities/props'
 
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 

--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -14,7 +14,7 @@ import {
 
 import classnames from "classnames"
 import { GlobalProps, globalProps } from "../utilities/globalProps"
-import { buildAriaProps, buildDataProps } from "../utilities/props"
+import { buildAriaProps, buildDataProps, buildHtmlProps } from "../utilities/props"
 import Flex from "../pb_flex/_flex"
 
 type TooltipProps = {
@@ -23,6 +23,7 @@ type TooltipProps = {
   children: JSX.Element,
   data?: { [key: string]: string },
   delay?: number | Partial<{open: number; close: number}>,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   icon?: string,
   interaction?: boolean,
   placement?: Placement,
@@ -38,6 +39,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
     children,
     data = {},
     delay = 0,
+    htmlOptions = {},
     icon = null,
     interaction = false,
     placement: preferredPlacement = "top",
@@ -50,6 +52,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
 
   const dataProps: { [key: string]: any } = buildDataProps(data)
   const ariaProps: { [key: string]: any } = buildAriaProps(aria)
+  const htmlProps = buildHtmlProps(htmlOptions)
   
   const css = classnames(
     globalProps({...rest}),
@@ -127,6 +130,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
           style={{ display: "inline-flex" }}
           {...ariaProps}
           {...dataProps}
+          {...htmlProps}
       >
         {children}
       </div>

--- a/playbook/app/pb_kits/playbook/pb_treemap_chart/_treemap_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_treemap_chart/_treemap_chart.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import classnames from "classnames";
 
 import { globalProps } from "../utilities/globalProps";
-import { buildAriaProps, buildDataProps } from "../utilities/props";
+import { buildAriaProps, buildDataProps, buildHtmlProps } from "../utilities/props";
 
 import HighchartsReact from "highcharts-react-official";
 import Highcharts from "highcharts";
@@ -25,6 +25,7 @@ type TreemapChartProps = {
   drillable: boolean;
   grouped: boolean;
   height?: string;
+  htmlOptions?: {[key: string]: string | number | boolean | Function};
   id: number | string;
   title?: string;
   tooltipHtml: string;
@@ -42,14 +43,18 @@ const TreemapChart = ({
   drillable = false,
   grouped = false,
   height,
+  htmlOptions = {},
   id,
   title = "",
   tooltipHtml = '<span style="font-weight: bold; color:{point.color};">●</span>{point.name}: <b>{point.value}</b>',
   type = "treemap",
   ...props
 }: TreemapChartProps) => {
-  const ariaProps = buildAriaProps(aria);
-  const dataProps = buildDataProps(data);
+  
+  const ariaProps = buildAriaProps(aria)
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
+
   const setupTheme = () => {
     dark
       ? Highcharts.setOptions(highchartsDarkTheme)
@@ -101,6 +106,7 @@ const TreemapChart = ({
         id: id,
         ...ariaProps,
         ...dataProps,
+        ...htmlProps
       }}
       highcharts={Highcharts}
       options={options}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -16,7 +16,7 @@ import Option from './components/Option'
 import Placeholder from './components/Placeholder'
 import ValueContainer from './components/ValueContainer'
 
-import { noop, buildDataProps } from '../utilities/props'
+import { noop, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { Noop } from '../types'
 
 /**
@@ -34,6 +34,7 @@ type TypeaheadProps = {
   dark?: boolean,
   data?: { [key: string]: string },
   error?: string,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   label?: string,
   loadOptions?: string | Noop,
@@ -68,6 +69,7 @@ const Typeahead = ({
   data = {},
   getOptionLabel,
   getOptionValue,
+  htmlOptions = {},
   id,
   loadOptions = noop,
   ...props
@@ -125,6 +127,7 @@ const Typeahead = ({
   }
 
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     'pb_typeahead_kit react-select',
     globalProps(props),
@@ -134,7 +137,9 @@ const Typeahead = ({
   const inlineClass = selectProps.inline ? 'inline' : null
 
   return (
-    <div {...dataProps}
+    <div 
+      {...dataProps}
+      {...htmlProps}
       className={classnames(classes, inlineClass)}
     >
       <Tag

--- a/playbook/app/pb_kits/playbook/pb_user/_user.tsx
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { GlobalProps, globalProps } from '../utilities/globalProps'
 
 import Avatar from '../pb_avatar/_avatar'
@@ -16,6 +16,7 @@ type UserProps = {
   className?: string,
   dark?: boolean,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   name?: string,
   orientation?: "horizontal" | "vertical",
@@ -34,6 +35,7 @@ const User = (props: UserProps) => {
     className,
     dark = false,
     data = {},
+    htmlOptions = {},
     id,
     name,
     orientation = 'horizontal',
@@ -45,6 +47,7 @@ const User = (props: UserProps) => {
 
   const dataProps: {[key: string]: string} = buildDataProps(data)
   const ariaProps: {[key: string]: string} = buildAriaProps(aria)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(
     buildCss('pb_user_kit', align, orientation, size),
@@ -58,6 +61,7 @@ const User = (props: UserProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_user_badge/_user_badge.tsx
+++ b/playbook/app/pb_kits/playbook/pb_user_badge/_user_badge.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import Veteran from './badges/veteran'
 import MillionDollar from './badges/million-dollar';
@@ -10,6 +10,7 @@ type UserBadgeProps = {
   badge?: "million-dollar" | "veteran",
   className?: string,
   data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   size?: "sm" | "md" | "lg",
 }
@@ -20,6 +21,7 @@ const UserBadge = (props: UserBadgeProps) => {
     badge = 'million-dollar',
     className,
     data = {},
+    htmlOptions = {},
     id,
     size = 'md',
   } = props
@@ -27,6 +29,7 @@ const UserBadge = (props: UserBadgeProps) => {
   const image = badge === "million-dollar" ? <MillionDollar /> : <Veteran />
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_user_badge_kit', size),
     globalProps(props),
@@ -37,6 +40,7 @@ const UserBadge = (props: UserBadgeProps) => {
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_walkthrough/_walkthrough.tsx
+++ b/playbook/app/pb_kits/playbook/pb_walkthrough/_walkthrough.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 import Joyride, { TooltipRenderProps } from 'react-joyride'
 import Button from '../pb_button/_button'
@@ -14,6 +14,7 @@ type WalkthroughProps = {
   className?: string,
   continuous?: boolean,
   data?: { [key: string]: string },
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   run?: boolean,
   steps?: [],
@@ -150,6 +151,7 @@ const Walkthrough = (props: WalkthroughProps) => {
     floaterProps = {
       offset: 50,
     },
+    htmlOptions = {},
     id,
     run = false,
     steps,
@@ -163,12 +165,14 @@ const Walkthrough = (props: WalkthroughProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss('pb_walkthrough'), globalProps(props), className)
 
   return (
     <div
       {...ariaProps}
       {...dataProps}
+      {...htmlProps}
       className={classes}
       id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_weekday_stacked/_weekday_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_weekday_stacked/_weekday_stacked.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { globalProps } from '../utilities/globalProps'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 
 import Caption from '../pb_caption/_caption'
 import Title from '../pb_title/_title'
@@ -16,6 +16,7 @@ type WeekdayStackedProps = {
   dark?: boolean,
   data?: object,
   date: Date,
+  htmlOptions?: {[key: string]: string | number | boolean | Function},
   id?: string,
   variant?: "day_only" | "month_day" | "expanded",
   compact?: boolean,
@@ -46,6 +47,7 @@ const WeekdayStacked = (props: WeekdayStackedProps) => {
     dark = false,
     data = {},
     date = new Date(),
+    htmlOptions = {},
     id,
     variant = 'month_day',
     compact = false,
@@ -53,6 +55,7 @@ const WeekdayStacked = (props: WeekdayStackedProps) => {
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     buildCss('pb_weekday_stacked_kit', align),
     globalProps(props),
@@ -63,6 +66,7 @@ const WeekdayStacked = (props: WeekdayStackedProps) => {
     <div
         {...ariaProps}
         {...dataProps}
+        {...htmlProps}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/utilities/props.ts
+++ b/playbook/app/pb_kits/playbook/utilities/props.ts
@@ -49,3 +49,19 @@ export const buildDataProps = (data: {[key: string]: any}) => buildPrefixedProps
  */
 export const buildCss = (...rules: (string | { [x: string]: string | boolean; })[]): string => classnames(rules).replace(/\s/g, '_')
 
+/**
+ * Maps a given data object into HTML valid attributes and their values.
+ * This is a more general version of what buildAriaProps and buildDataProps do.
+ * It is used to map any arbitrary prop into a valid HTML attribute.
+ *  
+ * @returns {Object} an object holding the HTML valid props and their values.
+ */
+
+export const buildHtmlProps = (htmlOptions: { [key: string]: string | number | boolean | Function }) => {
+  const htmlProps: { [attr: string]: string | number | boolean | Function } = {}
+  Object.keys(htmlOptions).forEach((key) => {
+    htmlProps[key] = htmlOptions[key]
+  })
+  return htmlProps
+}
+


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://nitro.powerhrg.com/runway/backlog_items/PLAY-1028

Adds a new global prop for react kits called `htmlOptions`. 

There will be follow-up stories, where we add specific implementations that will be more useful for kits/components such as form-related components or components where a dev really wants to be able to tweak certain inner elements of a kit. 


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.