### PR TITLE
[PBNTR-149] Update Filter Docs for "No Filter Selected"

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.md
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.md
@@ -1,0 +1,1 @@
+To display the "No Filters Selected" text, the `filters` prop must be `null`. As a suggestion, check the values of each key in your filters object. If they are all falsy, return `null`.


### PR DESCRIPTION
**What does this PR do?**

- [Runway](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-149)
- Update the default filter kit docs instructing devs how to get "No Filter Selected" to appear
  - There are areas in Nitro that just have blank text when no filters are selected and the lack of docs could be why

#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.