### PR TITLE
[PBIOS-228] Docs: Contact

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default_swift.md
@@ -1,4 +1,3 @@
-
 ![contact-default](https://github.com/powerhome/playbook/assets/92755007/4226a1e0-5f31-4445-a536-57e95b83768a)
 
 ```swift

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default_swift.md
@@ -1,0 +1,14 @@
+
+
+```swift
+
+VStack(alignment: .leading, spacing: Spacing.small) {
+  PBContact(type: .cell, value: "3491859988")
+  PBContact(value: "5555555555")
+  PBContact(type: .email, value: "email@example.com")
+  PBContact(type: .work, value: "3245627482")
+  PBContact(type: .workCell, value: "3245627482")
+}
+
+
+```

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default_swift.md
@@ -1,4 +1,5 @@
 
+![contact-default](https://github.com/powerhome/playbook/assets/92755007/4226a1e0-5f31-4445-a536-57e95b83768a)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_props_swift.md
@@ -1,6 +1,6 @@
 ### Props
 | Name | Type | Description | Default | Values |
 | --- | ----------- | --------- | --------- | --------- |
-| **detail** | `Bool` | Displays text describing the Contact's type  |  | `true` `false` |
-| **contactValue** | `String` | Sets the Contact's text value  |  |  |
+| **detail** | `Bool` | Displays text describing the Contact's type |  | `true` `false` |
+| **contactValue** | `String` | Sets the Contact's text value |  |  |
 | **type** | `ContactType` | Sets the icon |  | `cell` `email` `home` `work` `workCell` `wrongPhone` `ext` `custom` |

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_props_swift.md
@@ -1,0 +1,6 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **detail** | `Bool` | Displays text describing the Contact's type  |  | `true` `false` |
+| **contactValue** | `String` | Sets the Contact's text value  |  |  |
+| **type** | `ContactType` | Sets the icon |  | `cell` `email` `home` `work` `workCell` `wrongPhone` `ext` `custom` |

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_props_swift.md
@@ -1,6 +1,6 @@
 ### Props
 | Name | Type | Description | Default | Values |
 | --- | ----------- | --------- | --------- | --------- |
-| **detail** | `Bool` | Displays text describing the Contact's type |  | `true` `false` |
+| **detail** | `Bool` | Displays text describing the Contact's type | `false` | `true` `false` |
 | **contactValue** | `String` | Sets the Contact's text value |  |  |
-| **type** | `ContactType` | Sets the icon |  | `cell` `email` `home` `work` `workCell` `wrongPhone` `ext` `custom` |
+| **type** | `ContactType` | Sets the icon | `.home` | `cell` `email` `home` `work` `workCell` `wrongPhone` `ext` `custom` |

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail_swift.md
@@ -1,3 +1,4 @@
+![contact-detail-indicator](https://github.com/powerhome/playbook/assets/92755007/2a29d4b5-6e7b-43ff-8e7c-0dbeec11627e)
 
 
 ```swift

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail_swift.md
@@ -1,6 +1,5 @@
 ![contact-detail-indicator](https://github.com/powerhome/playbook/assets/92755007/2a29d4b5-6e7b-43ff-8e7c-0dbeec11627e)
 
-
 ```swift
 
 VStack(alignment: .leading, spacing: Spacing.small) {

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail_swift.md
@@ -1,0 +1,14 @@
+
+
+```swift
+
+VStack(alignment: .leading, spacing: Spacing.small) {
+  PBContact(type: .cell, value: "3491859988", detail: true)
+  PBContact(value: "5555555555", detail: true)
+  PBContact(type: .email, value: "email@example.com", detail: true)
+  PBContact(type: .work, value: "3245627482", detail: true)
+  PBContact(type: .ext, value: "1234", detail: true)
+}
+
+
+```

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/example.yml
@@ -8,3 +8,9 @@ examples:
   react:
   - contact_default: Default
   - contact_with_detail: Detail Indicator
+
+
+  swift:
+  - contact_default_swift: Default
+  - contact_with_detail_swift: Detail Indicator
+  - contact_props_swift: ""


### PR DESCRIPTION
[PBIOS-228](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-228)

Adds swift docs for the Contact kit

![Screenshot 2023-12-07 at 2 53 28 PM](https://github.com/powerhome/playbook/assets/92755007/73c6f734-caf7-439f-9be6-b765d2272299)

![Screenshot 2023-12-07 at 2 55 59 PM](https://github.com/powerhome/playbook/assets/92755007/510600b3-674d-4b98-b28d-220a2d06f6bf)

**How to test?** Steps to confirm the desired behavior:
1.  pull branch locally and navigate to the Contact kit


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.