### PR TITLE
[PLAY-1087] Scripts for Quicker Release Formatting

### DIFF
--- a/playbook/changelog.rb
+++ b/playbook/changelog.rb
@@ -44,3 +44,4 @@ formatted_release.gsub!(/-\s+/, "- ")
 
 # Write the new changelog to a file
 File.write("new-changelog.md", formatted_release)
+puts "🎉 Latest release formatted for Github and saved to new-changelog.md 🎉"

--- a/playbook/changelog.rb
+++ b/playbook/changelog.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "date"
+
+## Function to capitalize words except for certain articles
+def titleize(sentence)
+  lowercase_words = %w[a an the and but or for nor on at to from by]
+  sentence.split.each_with_index.map { |w, i| lowercase_words.include?(w.downcase) && i.positive? ? w : w.capitalize }.join(" ")
+end
+
+# Read the changelog content from a file
+raw_changelog = File.read("changelog.md")
+
+# Extract the latest release section
+latest_release_boundary = /\n(?=## \[\d+\.\d+\.\d+\])|\n(?=# )/
+latest_release = raw_changelog.split(latest_release_boundary).first
+
+# Define placeholders
+fancy_title = "# Awesome Release Title Here!"
+image_placeholder = "![Image Description](image_url)"
+current_date = "##### #{Date.today.strftime('%B %d, %Y')}"
+feature_description = "Your feature description goes here."
+
+# Format the latest release
+formatted_release = latest_release
+formatted_release.sub!(/^## \[\d+\.\d+\.\d+\]\(.*?\) \(\d{4}-\d{2}-\d{2}\)/, "#{fancy_title}\n\n#{current_date}\n\n#{image_placeholder}\n\n#{feature_description}")
+
+# Move the full changelog link to the end of the section
+full_changelog_link = formatted_release.match(/\[Full Changelog\]\(.+\)/).to_s
+formatted_release.gsub!(/\[Full Changelog\]\(.+\)/, "")
+formatted_release << "\n\n#{full_changelog_link}" unless full_changelog_link.empty?
+
+# Remove ticket numbers, emojis, and PR number/user references
+formatted_release.gsub!(/\\\[\w+-\d+\\\]\s?/, "") # Remove ticket numbers
+formatted_release.gsub!(/[\u{1F300}-\u{1F5FF}\u{1F600}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/, "") # Remove Unicode emojis
+formatted_release.gsub!(/\[\#\d+\].*?\)\s+\(\[.*?\]\)/, "") # Remove PR number and user references
+
+# Apply titleize to each PR title in the release notes
+formatted_release.gsub!(/(?<=-\s).+/) { |match| titleize(match) }
+
+# Remove leading spaces from each PR title after bullet points
+# Adjusted to also remove any leading spaces after bullet point and emoji/number removal
+formatted_release.gsub!(/-\s+/, "- ")
+
+# Write the new changelog to a file
+File.write("new-changelog.md", formatted_release)

--- a/playbook/connect.rb
+++ b/playbook/connect.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "date"
+
+# Function to capitalize words except for certain articles
+def titleize(sentence)
+  lowercase_words = %w[a an the and but or for nor on at to from by]
+  sentence.split.each_with_index.map { |w, i| lowercase_words.include?(w.downcase) && i.positive? ? w : w.capitalize }.join(" ")
+end
+
+# Read the original changelog content
+raw_changelog = File.read("CHANGELOG.md")
+
+# Extract the latest release section
+latest_release_boundary = /\n(?=## \[\d+\.\d+\.\d+\])|\n(?=# )/
+latest_release = raw_changelog.split(latest_release_boundary).first
+
+# Format for connect
+connect_formatted = latest_release
+connect_formatted.gsub!(/\\\[\w+-\d+\\\]\s?/, "") # Remove ticket numbers
+connect_formatted.gsub!(/[\u{1F300}-\u{1F5FF}\u{1F600}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/, "") # Remove Unicode emojis
+connect_formatted.gsub!(%r{\s+\[.*?\]\(https://github\.com/.*?\)\s+\(\[.*?\]\)}, "") # Remove PR number and user references
+connect_formatted.gsub!(/(?<=-\s).+/) { |match| titleize(match) }
+connect_formatted.gsub!(/-\s+/, "- ")
+connect_formatted.gsub!(/^\*\*Merged pull requests:\*\*.*?(?=^\*\*|$)/m, "") # Remove "Merged pull requests" section
+
+# Replace section titles with emojis
+connect_formatted.gsub!(/^\*\*Kit Enhancements:\*\*/, "✨ Kit Enhancements:")
+connect_formatted.gsub!(/^\*\*Fixed Bugs:\*\*/, "🐛 Fixed Bugs:")
+connect_formatted.gsub!(/^\*\*Improvements:\*\*/, "🔥 Improvements:")
+
+connect_formatted.gsub!(/\[.*?\]\(.*?\)\s*/, "") # Remove links and trailing space
+
+connect_formatted.gsub!(/\(\s*\)/, "")
+
+# Append link to full changelog
+full_changelog_link = "See [here](https://playbook.powerapp.cloud/changelog) for full Changelog"
+connect_formatted << "\n\n#{full_changelog_link}"
+
+# Write the formatted content for connect
+File.write("connect_message_formatted.md", connect_formatted)
+
+puts "🎉 Connect message formatted and saved to connect_message_formatted.md 🎉"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This adds two scripts that we can run like so:
```
cd playbook
ruby changelog.rb
ruby connect.rb
```

A success message shows and the playbook release team member should copy both separately away and remove the generated new-changelog.md & connect_message_formatted.md.

Next steps: 
- Add more automation for updating the original changelog.md

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.