### PR TITLE
[PBIOS-229] Docs: HomeStreetAddress

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default_swift.md
@@ -1,0 +1,18 @@
+
+
+```swift
+
+PBHomeAddressStreet(
+  address: "70 Prospect Ave",
+  withBullet: true,
+  houseStyle: "Colonial",
+  addressCont: "Apt M18",
+  city: "West Chester",
+  homeId: "8250263",
+  homeUrl: "https://powerhrg.com/",
+  state: "PA",
+  territory: "PHL",
+  zipcode: "19382"
+)
+
+```

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_default_swift.md
@@ -1,4 +1,4 @@
-
+![home-address-street-default](https://github.com/powerhome/playbook/assets/92755007/a4c97536-a402-4cc2-90be-4eeda3b57f6d)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
@@ -1,4 +1,4 @@
-![home-street-address-emphasis](https://github.com/powerhome/playbook/assets/92755007/338ed5f9-7e06-4e4c-b71e-d0a348f7a6d6)
+![home-address-street-emphasis](https://github.com/powerhome/playbook/assets/92755007/338ed5f9-7e06-4e4c-b71e-d0a348f7a6d6)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
@@ -12,6 +12,21 @@ PBHomeAddressStreet(
   homeUrl: "https://powerhrg.com/",
   state: "PA",
   territory: "PHL",
+  zipcode: "19382"
+)
+
+Spacer(minLength: Spacing.medium)
+
+PBHomeAddressStreet(
+  address: "70 Prospect Ave",
+  withBullet: true,
+  houseStyle: "Colonial",
+  addressCont: "Apt M18",
+  city: "West Chester",
+  homeId: "8250263",
+  homeUrl: "https://powerhrg.com/",
+  state: "PA",
+  territory: "PHL",
   zipcode: "19382",
   emphasize: .city
 )

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
@@ -1,0 +1,19 @@
+
+
+```swift
+
+PBHomeAddressStreet(
+  address: "70 Prospect Ave",
+  withBullet: true,
+  houseStyle: "Colonial",
+  addressCont: "Apt M18",
+  city: "West Chester",
+  homeId: "8250263",
+  homeUrl: "https://powerhrg.com/",
+  state: "PA",
+  territory: "PHL",
+  zipcode: "19382",
+  emphasize: .city
+)
+
+```

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis_swift.md
@@ -1,4 +1,4 @@
-
+![home-street-address-emphasis](https://github.com/powerhome/playbook/assets/92755007/338ed5f9-7e06-4e4c-b71e-d0a348f7a6d6)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_link_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_link_swift.md
@@ -1,0 +1,18 @@
+
+
+```swift
+
+PBHomeAddressStreet(
+  address: "70 Prospect Ave",
+  withBullet: true,
+  houseStyle: "Colonial",
+  addressCont: "Apt M18",
+  city: "West Chester",
+  homeId: "8250263",
+  homeUrl: "https://powerhrg.com/",
+  state: "PA",
+  territory: "PHL",
+  zipcode: "19382"
+)
+
+```

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_link_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_link_swift.md
@@ -1,4 +1,4 @@
-![address-street-home-link](https://github.com/powerhome/playbook/assets/92755007/890a61d9-896b-45a1-aa7c-c78783f3ac54)
+![home-address-street-link](https://github.com/powerhome/playbook/assets/92755007/890a61d9-896b-45a1-aa7c-c78783f3ac54)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_link_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_link_swift.md
@@ -1,4 +1,4 @@
-
+![address-street-home-link](https://github.com/powerhome/playbook/assets/92755007/890a61d9-896b-45a1-aa7c-c78783f3ac54)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
@@ -1,4 +1,4 @@
-![home-address-srteet-modified](https://github.com/powerhome/playbook/assets/92755007/32e16708-896f-41c8-ae06-7bea00225b4f)
+![home-address-street-modified](https://github.com/powerhome/playbook/assets/92755007/32e16708-896f-41c8-ae06-7bea00225b4f)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
@@ -1,0 +1,13 @@
+
+
+```swift
+
+PBHomeAddressStreet(
+  address: "70 Prospect Ave",
+  city: "West Chester",
+  state: "PA",
+  territory: "PHL",
+  zipcode: "19382"
+)
+
+```

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
@@ -1,4 +1,4 @@
-
+![home-address-steet-modified](https://github.com/powerhome/playbook/assets/92755007/32e16708-896f-41c8-ae06-7bea00225b4f)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_modified_swift.md
@@ -1,4 +1,4 @@
-![home-address-steet-modified](https://github.com/powerhome/playbook/assets/92755007/32e16708-896f-41c8-ae06-7bea00225b4f)
+![home-address-srteet-modified](https://github.com/powerhome/playbook/assets/92755007/32e16708-896f-41c8-ae06-7bea00225b4f)
 
 ```swift
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_props_swift.md
@@ -1,14 +1,14 @@
 ### Props
 | Name | Type | Description | Default | Values |
 | --- | ----------- | --------- | --------- | --------- |
-| **address** | `String` |  |  |  |
-| **withBullet** | `Bool` |  | `false` |  |
-| **houseStyle** | `String` |  | `nil` |  |
-| **addressCont** | `String` |  | `nil` |  |
-| **city** | `String` |  |  |  |
-| **homeId** | `String` |  | `nil` |  |
-| **homeUrl** | `String` |  | `nil` |  |
-| **state** | `String` |  |  |  |
-| **territory** | `String` |  |  |  |
-| **zipcode** |  `String` |  |  |  |
-| **emphasize** | `Emphasize` |  | `.address` | `.address` `.city`  `.cityWithZipcode` |
+| **address** | `String` | Sets the address |  |  |
+| **withBullet** | `Bool` | Adds a bullet after the address | `false` | `false` `true` |
+| **houseStyle** | `String` | Sets the house style | `nil` |  |
+| **addressCont** | `String` | Sets additional address text | `nil` |  |
+| **city** | `String` | Sets the city |  |  |
+| **homeId** | `String` | Sets the home ID | `nil` |  |
+| **homeUrl** | `String` | Adds a URL to the homeID | `nil` |  |
+| **state** | `String` | Sets the state |  |  |
+| **territory** | `String` | Sets the territory |  |  |
+| **zipcode** |  `String` | Sets the zipcode |  |  |
+| **emphasize** | `Emphasize` | Changes text to bold | `.address` | `.address` `.city`  `.cityWithZipcode` |

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_props_swift.md
@@ -1,0 +1,14 @@
+### Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **address** | `String` |  |  |  |
+| **withBullet** | `Bool` |  | `false` |  |
+| **houseStyle** | `String` |  | `nil` |  |
+| **addressCont** | `String` |  | `nil` |  |
+| **city** | `String` |  |  |  |
+| **homeId** | `String` |  | `nil` |  |
+| **homeUrl** | `String` |  | `nil` |  |
+| **state** | `String` |  |  |  |
+| **territory** | `String` |  |  |  |
+| **zipcode** |  `String` |  |  |  |
+| **emphasize** | `Emphasize` |  | `.address` | `.address` `.city`  `.cityWithZipcode` |

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
@@ -12,3 +12,9 @@ examples:
   - home_address_street_modified: Modified
   - home_address_street_link: Link
 
+  swift:
+  - home_address_street_default_swift: Default
+  - home_address_street_emphasis_swift: Emphasis
+  - home_address_street_modified_swift: Modified
+  - home_address_street_link_swift: Link
+  - home_address_street_props_swift: ""


### PR DESCRIPTION
[PBIOS-229](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-229)

Adds Swift docs for the `Home Address Street` kit.

![Screenshot 2023-12-13 at 3 31 56 PM](https://github.com/powerhome/playbook/assets/92755007/6b3e89b9-a98b-42d3-9df4-018ad4ad7787)

![Screenshot 2023-12-13 at 3 32 05 PM](https://github.com/powerhome/playbook/assets/92755007/2b87590f-676b-40bc-8e2d-5e911643667b)

![Screenshot 2023-12-13 at 3 32 13 PM](https://github.com/powerhome/playbook/assets/92755007/21eec712-7158-4500-9afa-70e2a3a9caa3)

![Screenshot 2023-12-13 at 3 32 21 PM](https://github.com/powerhome/playbook/assets/92755007/ee73e2ee-4590-4058-acb7-b01142a01fee)


**How to test?** Steps to confirm the desired behavior:
1. Pull branch locally and navigate to the home address street kit.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.