### PR TITLE
[PLAY-1109] 🐞 Display prop responsive arguments are blocking font color

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_detail/_detail.scss
+++ b/playbook/app/pb_kits/playbook/pb_detail/_detail.scss
@@ -6,13 +6,13 @@
   @include pb_detail;
 
   @each $color_name, $color_value in $pb_detail_colors {
-    &[class*=pb_detail_kit_#{$color_name}] {
+    &[class*=color_#{$color_name}] {
       @include pb_detail($color_value);
     }
   }
 
   @each $dark_color_name, $dark_color_value in $pb_dark_detail_colors{
-    &[class*=pb_detail_kit_#{$dark_color_name}][class*=dark]{
+    &[class*=color_#{$dark_color_name}][class*=dark]{
       @include pb_detail($dark_color_value)
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_detail/_detail.scss
+++ b/playbook/app/pb_kits/playbook/pb_detail/_detail.scss
@@ -6,13 +6,13 @@
   @include pb_detail;
 
   @each $color_name, $color_value in $pb_detail_colors {
-    &[class*=_#{$color_name}] {
+    &[class*=pb_detail_kit_#{$color_name}] {
       @include pb_detail($color_value);
     }
   }
 
   @each $dark_color_name, $dark_color_value in $pb_dark_detail_colors{
-    &[class*=_#{$dark_color_name}][class*=dark]{
+    &[class*=pb_detail_kit_#{$dark_color_name}][class*=dark]{
       @include pb_detail($dark_color_value)
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_detail/_detail.tsx
+++ b/playbook/app/pb_kits/playbook/pb_detail/_detail.tsx
@@ -11,7 +11,7 @@ type DetailProps = {
   color?: 'light' | 'default' | 'lighter' | 'link' | 'error' | 'success',
   dark?: boolean,
   data?: { [key: string]: string },
-  htmlOptions?: {[key: string]: string | number | boolean | Function},
+  htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'div',
   text?: string,
@@ -36,7 +36,7 @@ const Detail = (props: DetailProps) => {
   const htmlProps = buildHtmlProps(htmlOptions);
   const isBold = bold ? "bold" : null
   const classes = classnames(
-    buildCss('pb_detail_kit', color),
+    buildCss('pb_detail_kit', `color`, color),
     isBold,
     globalProps(props),
     className

--- a/playbook/app/pb_kits/playbook/pb_detail/detail.rb
+++ b/playbook/app/pb_kits/playbook/pb_detail/detail.rb
@@ -14,7 +14,7 @@ module Playbook
       prop :text
 
       def classname
-        generate_classname("pb_detail_kit", color) + is_bold
+        generate_classname("pb_detail_kit", "color", color) + is_bold
       end
 
       def content

--- a/playbook/app/pb_kits/playbook/pb_detail/detail.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_detail/detail.test.jsx
@@ -12,7 +12,7 @@ test('returns namespaced class name', () => {
   )
 
   const kit = screen.getByTestId('primary-test')
-  expect(kit).toHaveClass('pb_detail_kit_light')
+  expect(kit).toHaveClass('pb_detail_kit_color_light')
 })
 
 test('with colors', () => {
@@ -28,7 +28,7 @@ test('with colors', () => {
     )
 
     const kit = screen.getByTestId(testId)
-    expect(kit).toHaveClass(`pb_detail_kit_${color}`)
+    expect(kit).toHaveClass(`pb_detail_kit_color_${color}`)
   })
 })
 

--- a/playbook/spec/pb_kits/playbook/kits/detail_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/detail_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe Playbook::PbDetail::Detail do
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
-      expect(subject.new({}).classname).to eq "pb_detail_kit_light"
-      expect(subject.new(classname: "additional_class").classname).to eq "pb_detail_kit_light additional_class"
-      expect(subject.new(dark: true).classname).to eq "pb_detail_kit_light dark"
-      expect(subject.new(dark: true, color: "link").classname).to eq "pb_detail_kit_link dark"
-      expect(subject.new(bold: true).classname).to eq "pb_detail_kit_light bold"
+      expect(subject.new({}).classname).to eq "pb_detail_kit_color_light"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_detail_kit_color_light additional_class"
+      expect(subject.new(dark: true).classname).to eq "pb_detail_kit_color_light dark"
+      expect(subject.new(dark: true, color: "link").classname).to eq "pb_detail_kit_color_link dark"
+      expect(subject.new(bold: true).classname).to eq "pb_detail_kit_color_light bold"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fixes bug in detail kit where addition of global responsive display prop overrides our default color
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1109)

**Screenshots:** Screenshots to visualize your addition/change
n/a

**How to test?** Steps to confirm the desired behavior:
1. Use our detail kit in a codesandbox
2. Add our global responsive display props
3. See that it does not change the default color of the detail kit


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.