### PR TITLE
[PBIOS-231] Reaction Button Variant Docs

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_props_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_props_swift.md
@@ -9,3 +9,14 @@
 | **Icon** | `PBIcon` | Adds an icon to the Button | `nil` |  |
 | **Icon Position** | `IconPosition` | Adjusts the icon's position | `.left` | `.left` `.right` |
 | **Action** | `(() -> Void)` | Adds an action for the Button to perform | `{}` |  |
+
+### Reaction Button Props
+| Name | Type | Description | Default | Values |
+| --- | ----------- | --------- | --------- | --------- |
+| **count** | `Int` | Tracks number of times a reaction button has been pressed | `0` |  |
+| **isHighlighted** | `Bool` | Boolean for whether or not a reaction button has a highlight | ` false` | `true` `false` |
+| **isHovering** | `Bool` | Boolean for whether or not a mouse is hovering over the reaction button | `false` | `true` `false` |
+| **icon** | `String` | Allows user to use a unicode string for an emoji reaction button |  |  |
+| **pbIcon** | `PBIcon` | A PlayBook Icon option for reaction button | |  |
+| **isInteractive** | `Bool` | Boolean for whether or not a reaction button is interactive | `false` | `true` `false` |
+

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_reaction_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_reaction_swift.md
@@ -1,0 +1,26 @@
+![button-reaction](https://github.com/powerhome/playbook/assets/54749071/10d21ee2-4faf-4c18-ab72-242df8f837c4)
+
+```swift
+@State private var count: Int = 153
+@State private var count1: Int = 5
+
+HStack(alignment: .center, spacing: 12) {
+            PBReactionButton(
+              count: $count,
+              icon: "\u{1F389}",
+              isInteractive: true
+            )
+            PBReactionButton(
+              count: $count1,
+              icon: "1️⃣",
+              isInteractive: false
+            )
+            PBReactionButton(
+              isInteractive: false
+            )
+            PBReactionButton(
+              pbIcon: PBIcon(FontAwesome.user),
+              isInteractive: false
+            )
+}
+```

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_reaction_swift.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_reaction_swift.md
@@ -1,4 +1,4 @@
-![button-reaction](https://github.com/powerhome/playbook/assets/54749071/10d21ee2-4faf-4c18-ab72-242df8f837c4)
+![reaction-button](https://github.com/powerhome/playbook/assets/54749071/10d21ee2-4faf-4c18-ab72-242df8f837c4)
 
 ```swift
 @State private var count: Int = 153

--- a/playbook/app/pb_kits/playbook/pb_button/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/example.yml
@@ -32,4 +32,5 @@ examples:
   - button_icon_options_swift: Button Icon Options
   - button_circle_swift: Circle Button
   - button_size_swift: Button Size
+  - button_reaction_swift: Button Reaction
   - button_props_swift: ""


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Adds documentation for the reaction button variant in the button docs


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.