### PR TITLE
[PLAY-1119] Docs: add `xxl` as Max Width value

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
@@ -27,7 +27,7 @@ const MaxWidth = ({ example }: {example: string}) => (
       }}
       title="Max Width"
   >
-    {SIZES.map((size: string, index: number) => (
+    {SIZES.map((size: string) => (
       <Background
           backgroundColor="gradient"
           key={size}

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
@@ -5,11 +5,15 @@ import React from 'react'
 import {
   Background,
   Title,
+  Body,
+  Flex
 } from 'playbook-ui'
 
 import Example from '../Templates/Example'
 
-const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] //TODO: investigate using types
+const SIZES = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'] //TODO: investigate using types
+
+const pixels = ['360px', '540px', '720px', '960px', '1140px', '1320px']
 
 const MaxWidthDescription = () => (
   <>
@@ -26,7 +30,7 @@ const MaxWidth = ({ example }: {example: string}) => (
       }}
       title="Max Width"
   >
-    {SIZES.map((size: string) => (
+    {SIZES.map((size: string, index: number) => (
       <Background
           backgroundColor="gradient"
           key={size}
@@ -34,12 +38,21 @@ const MaxWidth = ({ example }: {example: string}) => (
           maxWidth={size}
           padding="xs"
       >
-        <Title
+                <Title
             dark
             size={4}
         >
           {size.toUpperCase()}
         </Title>
+        {/* <Flex align='center'>
+
+        <Body
+          dark
+          paddingLeft='xs'
+        >
+          {'-'}{pixels[index]}
+        </Body>
+        </Flex> */}
       </Background>
     ))}
   </Example>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
@@ -23,6 +23,7 @@ const MaxWidthDescription = () => (
 
 const MaxWidth = ({ example }: {example: string}) => (
   <Example
+      backgroundClass='maxwidth-class'
       description={<MaxWidthDescription />}
       example={example}
       globalProps={{
@@ -38,21 +39,13 @@ const MaxWidth = ({ example }: {example: string}) => (
           maxWidth={size}
           padding="xs"
       >
-                <Title
-            dark
-            size={4}
+        <Title
+          dark
+          size={4}
         >
           {size.toUpperCase()}
         </Title>
-        {/* <Flex align='center'>
 
-        <Body
-          dark
-          paddingLeft='xs'
-        >
-          {'-'}{pixels[index]}
-        </Body>
-        </Flex> */}
       </Background>
     ))}
   </Example>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
@@ -5,15 +5,11 @@ import React from 'react'
 import {
   Background,
   Title,
-  Body,
-  Flex
 } from 'playbook-ui'
 
 import Example from '../Templates/Example'
 
 const SIZES = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'] //TODO: investigate using types
-
-const pixels = ['360px', '540px', '720px', '960px', '1140px', '1320px']
 
 const MaxWidthDescription = () => (
   <>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Templates/Example.tsx
@@ -4,6 +4,7 @@
 import React from 'react'
 
 import {
+  Background,
   Body,
   Caption,
   Card,
@@ -18,6 +19,7 @@ import {
 import PropsValues from './PropsValues'
 
 type ExampleType = {
+  backgroundClass?: string,
   children?: React.ReactChild[] | React.ReactChild,
   // codesandboxExample? : boolean,
   customChildren?: boolean,
@@ -32,6 +34,7 @@ type ExampleType = {
 }
 
 const Example = ({
+  backgroundClass= '',
   children,
   // codesandboxExample,
   customChildren,
@@ -51,6 +54,11 @@ const Example = ({
     defaultTokensDescription = 'Make your own styles using Playbook tokens to keep your site consistent.'
 
   return (
+    <Background
+      backgroundColor="light"
+      className={`${backgroundClass} token-wrapper`}
+      padding="xl"
+    >
     <div id={title?.replace(/\s+/g, '')}>
       {title && (
         <Title
@@ -164,6 +172,7 @@ const Example = ({
         </Card>
       </Card>
     </div>
+    </Background>
   )
 }
 

--- a/playbook-website/app/javascript/site_styles/_visual_guidelines.scss
+++ b/playbook-website/app/javascript/site_styles/_visual_guidelines.scss
@@ -15,11 +15,11 @@
       max-width: 600px;
       margin: auto;
     }
-    @include break_at(breakpoint("sm")){    
+    @include break_at(breakpoint("sm")){
       padding: $space_xl !important;
     }
   }
-  
+
   // Main Sections
   .token-wrapper {
     max-width: 1242px;

--- a/playbook-website/app/javascript/site_styles/_visual_guidelines.scss
+++ b/playbook-website/app/javascript/site_styles/_visual_guidelines.scss
@@ -26,6 +26,10 @@
     margin: auto;
   }
 
+  .maxwidth-class {
+    max-width: 1320px !important;
+  }
+
   // General Code Round Bottom
   .border-bottom {
     border-radius: 0 0 6px 6px;

--- a/playbook-website/app/views/pages/visual_guidelines.html.erb
+++ b/playbook-website/app/views/pages/visual_guidelines.html.erb
@@ -1,5 +1,3 @@
 <div class="visual_guidelines">
-  <%= pb_rails("background", props: { classname: "token-wrapper", background_color: "light", padding: "xl" }) do %>
-    <%= react_component("VisualGuidelines", examples: @kit_examples_json) %>
-  <% end %>
+  <%= react_component("VisualGuidelines", examples: @kit_examples_json) %>
 </div>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Adds the `xxl` maxWidth global prop to the Visual guidelines doc examples. 
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1119)

In order to achieve this I had to remove the `Background` kit in the `visual_guidelines.html.erb` file and add it to the `Example.tsx`. I also added a new prop called `backgroundClass` to the Example component which is used to style the background component in the Example component and give it a width of 1320px, so that the `xxl` maxWidth prop value is visible on the page.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1904" alt="Screenshot 2023-12-26 at 2 55 55 PM" src="https://github.com/powerhome/playbook/assets/73671109/16376bbe-db0a-478c-8735-4940c2195d0d">


**How to test?** Steps to confirm the desired behavior:
1. Go to /visual_guidelines/max_width
2. Check that all maxWidth values are present


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.