### PR TITLE
[PLAY-1121] Docs: add `onClose` example or markdown to Quick Pick

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_on_change.md
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_on_change.md
@@ -1,3 +1,5 @@
 Your change handler function has access to two arguments: `dateStr` and `selectedDates`.
 
 The first, `dateStr`, is a string of the chosen date.  The second, `selectedDates`, is an array of selected date objects. In many use cases `selectedDates` will have only one value but you'll still need to access it from index 0.
+
+NOTE: On Change does not account for manual input by users, so if your date picker sets `allowInput`, you should use the `onClose` method instead.

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_on_close.md
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_on_close.md
@@ -1,3 +1,5 @@
 The `onClose` handler function has access to two arguments: `dateStr` and `selectedDates`.
 
 The first, `dateStr`, is a string of the chosen date.  The second, `selectedDates`, is an array of selected date objects. In many use cases `selectedDates` will have only one value but you'll still need to access it from index 0.
+
+NOTE: `onClose` is the ideal handler function to use when `allowInput` is enabled.

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_quick_pick_react.md
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_quick_pick_react.md
@@ -1,1 +1,1 @@
-Use the `onChange` handler function to access the startDate and endDate values. Check the [`onChange` example](https://playbook.powerapp.cloud/kits/date_picker/react#onchange) for more information.
+Because the Quick Pick variant has `allowInput` set to `true` by default, use the `onClose` handler function to access the startDate and endDate values. See the [`onClose` example](https://playbook.powerapp.cloud/kits/date_picker/react#onclose) for details.

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
@@ -1,56 +1,56 @@
 examples:
 
   rails:
-  - date_picker_default: Default
-  - date_picker_hide_icon: Hide Input Icon
-  - date_picker_default_date: Default Date
-  - date_picker_allow_input: Allow Input
-  - date_picker_input: Input Field
-  - date_picker_label: Label
-  - date_picker_range: Range
+  # - date_picker_default: Default
+  # - date_picker_hide_icon: Hide Input Icon
+  # - date_picker_default_date: Default Date
+  # - date_picker_allow_input: Allow Input
+  # - date_picker_input: Input Field
+  # - date_picker_label: Label
+  # - date_picker_range: Range
   - date_picker_quick_pick_rails: Range (Quick Pick)
-  - date_picker_quick_pick_range_limit: Range (Quick Pick w/ “This” Range limit)
-  - date_picker_quick_pick_custom: Custom Quick Pick Dates
-  - date_picker_quick_pick_custom_override: Custom Quick Pick Dates (append to defaults)
-  - date_picker_format: Format
-  - date_picker_disabled: Disabled Dates
-  - date_picker_min_max: Min Max
-  - date_picker_error: Error
-  - date_picker_flatpickr_methods: Flatpickr Methods
-  - date_picker_hooks: Hooks
-  - date_picker_year_range: Year Range
-  - date_picker_anti_patterns: Anti-Patterns
-  - date_picker_inline: Inline
-  - date_picker_month_and_year: Month & Year Only
-  - date_picker_week: Week
-  - date_picker_time: Time Selection
-  - date_picker_positions: Custom Positions
-  - date_picker_positions_element: Custom Position (based on element)
+  # - date_picker_quick_pick_range_limit: Range (Quick Pick w/ “This” Range limit)
+  # - date_picker_quick_pick_custom: Custom Quick Pick Dates
+  # - date_picker_quick_pick_custom_override: Custom Quick Pick Dates (append to defaults)
+  # - date_picker_format: Format
+  # - date_picker_disabled: Disabled Dates
+  # - date_picker_min_max: Min Max
+  # - date_picker_error: Error
+  # - date_picker_flatpickr_methods: Flatpickr Methods
+  # - date_picker_hooks: Hooks
+  # - date_picker_year_range: Year Range
+  # - date_picker_anti_patterns: Anti-Patterns
+  # - date_picker_inline: Inline
+  # - date_picker_month_and_year: Month & Year Only
+  # - date_picker_week: Week
+  # - date_picker_time: Time Selection
+  # - date_picker_positions: Custom Positions
+  # - date_picker_positions_element: Custom Position (based on element)
 
   react:
-  - date_picker_default: Default
-  - date_picker_hide_icon: Hide Input Icon
-  - date_picker_default_date: Default Date
-  - date_picker_allow_input: Allow Input
-  - date_picker_input: Input Field
-  - date_picker_label: Label
+  # - date_picker_default: Default
+  # - date_picker_hide_icon: Hide Input Icon
+  # - date_picker_default_date: Default Date
+  # - date_picker_allow_input: Allow Input
+  # - date_picker_input: Input Field
+  # - date_picker_label: Label
   - date_picker_on_change: onChange
   - date_picker_on_close: onClose
-  - date_picker_range: Range
+  # - date_picker_range: Range
   - date_picker_quick_pick_react: Range (Quick Pick)
-  - date_picker_quick_pick_range_limit: Range (Quick Pick w/ “This” Range limit)
-  - date_picker_quick_pick_custom: Custom Quick Pick Dates
-  - date_picker_quick_pick_custom_override: Custom Quick Pick Dates (append to defaults)
-  - date_picker_format: Format
-  - date_picker_disabled: Disabled Dates
-  - date_picker_min_max: Min Max
-  - date_picker_error: Error
-  - date_picker_flatpickr_methods: Flatpickr Methods
-  - date_picker_hooks: Hooks
-  - date_picker_year_range: Year Range
-  - date_picker_inline: Inline
-  - date_picker_month_and_year: Month & Year Only
-  - date_picker_week: Week
-  - date_picker_time: Time Selection
-  - date_picker_positions: Custom Positions
-  - date_picker_positions_element: Custom Position (based on element)
+  # - date_picker_quick_pick_range_limit: Range (Quick Pick w/ “This” Range limit)
+  # - date_picker_quick_pick_custom: Custom Quick Pick Dates
+  # - date_picker_quick_pick_custom_override: Custom Quick Pick Dates (append to defaults)
+  # - date_picker_format: Format
+  # - date_picker_disabled: Disabled Dates
+  # - date_picker_min_max: Min Max
+  # - date_picker_error: Error
+  # - date_picker_flatpickr_methods: Flatpickr Methods
+  # - date_picker_hooks: Hooks
+  # - date_picker_year_range: Year Range
+  # - date_picker_inline: Inline
+  # - date_picker_month_and_year: Month & Year Only
+  # - date_picker_week: Week
+  # - date_picker_time: Time Selection
+  # - date_picker_positions: Custom Positions
+  # - date_picker_positions_element: Custom Position (based on element)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Added new copy to the onClose, onChange and Range(quickpick) doc examples of the date picker kit
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1121)

**Screenshots:** Screenshots to visualize your addition/change
<img width="1396" alt="Screenshot 2023-12-27 at 3 06 32 PM" src="https://github.com/powerhome/playbook/assets/73671109/140ac213-d4e6-4b61-b46e-9e3c16364521">
<img width="1410" alt="Screenshot 2023-12-27 at 3 06 41 PM" src="https://github.com/powerhome/playbook/assets/73671109/e804abb9-f0b7-438f-a956-4250cc380360">
<img width="1405" alt="Screenshot 2023-12-27 at 3 06 55 PM" src="https://github.com/powerhome/playbook/assets/73671109/dac61299-e76b-45f0-b861-5857b1b1f668">


**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/date_picker/react
2. Check the onChange, onClose and Range(quickpick) Doc examples for the correct copy


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.