### PR TITLE
[PLAY-1108] Fix Telemetry Links

### DIFF
--- a/milano.production.yml
+++ b/milano.production.yml
@@ -13,8 +13,8 @@ rollback:
   <<: *deploy
 
 links:
-  logs: "https://logging-hq.powerapp.cloud/app/kibana#/discover?_g=(refreshInterval:(pause:!f,value:5000),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!((meta:(alias:!n,disabled:!f,index:c42b1680-dbc1-11e9-a5cd-5d6d0e6547e8,key:kubernetes.namespace,negate:!f,params:(query:playbook-$ENVIRONMENT,type:phrase),type:phrase,value:playbook-$ENVIRONMENT),query:(match:(kubernetes.namespace:(query:playbook-$ENVIRONMENT,type:phrase))))),index:c42b1680-dbc1-11e9-a5cd-5d6d0e6547e8,interval:auto,query:(language:lucene,query:''),sort:!('@timestamp',desc))"
-  metrics: "https://grafana-hq.powerapp.cloud/d/hYTBQhQiz/pod-resource-usage?orgId=1&refresh=10s&var-namespace=playbook-$ENVIRONMENT&var-filter=.%2B&var-pod=All"
+  logs: "https://logging.prod.hq.powerapp.cloud/app/kibana#/discover?_g=()&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:c18d3bb0-80c3-11ed-928d-67e2505d2bc3,key:kubernetes.namespace_name,negate:!f,params:(query:playbook-$ENVIRONMENT,type:phrase),type:phrase,value:playbook-$ENVIRONMENT),query:(match:(kubernetes.namespace_name:(query:playbook-$ENVIRONMENT,type:phrase))))),index:c18d3bb0-80c3-11ed-928d-67e2505d2bc3,interval:auto,query:(language:lucene,query:''),sort:!(time,desc))"
+  metrics: "https://metrics.powerapp.cloud/d/s9c8D_K7k/pod-resource-usage?orgId=1&refresh=10s&var-datasource=prometheus-app-prod-hq&var-namespace=playbook-$ENVIRONMENT&var-filter=.%2B&var-pod=All"
 
 ci:
   require:

--- a/milano.staging.yml
+++ b/milano.staging.yml
@@ -13,8 +13,8 @@ rollback:
   <<: *deploy
 
 links:
-  logs: "https://logging-hq.powerapp.cloud/app/kibana#/discover?_g=(refreshInterval:(pause:!f,value:5000),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!((meta:(alias:!n,disabled:!f,index:c42b1680-dbc1-11e9-a5cd-5d6d0e6547e8,key:kubernetes.namespace,negate:!f,params:(query:playbook-$ENVIRONMENT,type:phrase),type:phrase,value:playbook-$ENVIRONMENT),query:(match:(kubernetes.namespace:(query:playbook-$ENVIRONMENT,type:phrase))))),index:c42b1680-dbc1-11e9-a5cd-5d6d0e6547e8,interval:auto,query:(language:lucene,query:''),sort:!('@timestamp',desc))"
-  metrics: "https://grafana-hq.powerapp.cloud/d/hYTBQhQiz/pod-resource-usage?orgId=1&refresh=10s&var-namespace=playbook-$ENVIRONMENT&var-filter=.%2B&var-pod=All"
+  logs: "https://logging.beta.hq.powerapp.cloud/app/kibana#/discover?_g=()&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:de342080-dbc1-11e9-a185-dd3f9223feeb,key:kubernetes.namespace_name,negate:!f,params:(query:$ENVIRONMENT,type:phrase),type:phrase,value:$ENVIRONMENT),query:(match:(kubernetes.namespace_name:(query:$ENVIRONMENT,type:phrase))))),index:de342080-dbc1-11e9-a185-dd3f9223feeb,interval:auto,query:(language:kuery,query:''),sort:!('@timestamp',desc))"
+  metrics: "https://metrics.powerapp.cloud/d/s9c8D_K7k/pod-resource-usage?orgId=1&refresh=10s&var-datasource=prometheus-app-beta-hq&var-namespace=$ENVIRONMENT&var-filter=.%2B&var-pod=All"
 
 ci:
   require:


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Fixes the telemetry links displayed in Milano environments for staging and production.

**Screenshots:** Screenshots to visualize your addition/change

N/A

**How to test?** Steps to confirm the desired behavior:

### Staging:

1. Visit https://milano.powerapp.cloud/powerhome/playbook/staging
2. Click on "More" 
3. Click on "Metrics" 
4. Observe that the linked dashboard does not exist. 
5. Visit https://milano.powerapp.cloud/powerhome/playbook/staging 
6. Click on "More" 
7. Click on "Logs" 
8. Observe that there are no logs

### Production:

Visit https://milano.powerapp.cloud/powerhome/playbook/production

1. Click on "More"
2. Click on "Metrics"
3. Observe that the linked dashboard does not exist.
4. Visit https://milano.powerapp.cloud/powerhome/playbook/production
5. Click on "More"
6. Click on "Logs"
7. Observe that there are no logs


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.