### PR TITLE
[PLAY-1085] Linter implementation: kits P - S

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
@@ -13,25 +13,26 @@ import Flex from '../pb_flex/_flex'
 import Icon from '../pb_icon/_icon'
 import PbReactPopover from '../pb_popover/_popover'
 import TextInput from '../pb_text_input/_text_input'
+import { GenericObject } from "../types"
 
 type PassphraseProps = {
   aria?: { [key: string]: string },
   confirmation?: boolean,
   className?: string,
-  data?: object,
+  data?: GenericObject,
   dark?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
-  inputProps?: {},
+  inputProps?: GenericObject,
   label?: string,
-  onChange: (inputValue: String) => void,
+  onChange: (inputValue: string) => void,
   showTipsBelow?: "always" | "xs" | "sm" | "md" | "lg" | "xl",
   tips?: Array<string>,
   uncontrolled?: boolean,
   value: string,
 }
 
-const Passphrase = (props: PassphraseProps) => {
+const Passphrase = (props: PassphraseProps): React.ReactElement => {
   const {
     aria = {},
     className,
@@ -42,7 +43,7 @@ const Passphrase = (props: PassphraseProps) => {
     id,
     inputProps = {},
     label = confirmation ? "Confirm Passphrase" : "Passphrase",
-    onChange = () => { },
+    onChange = () => undefined,
     showTipsBelow = "always",
     tips = [],
     uncontrolled = false,
@@ -84,60 +85,60 @@ const Passphrase = (props: PassphraseProps) => {
     globalProps(props),
     className
   )
-   const dataProps = buildDataProps(data)
-   const htmlProps = buildHtmlProps(htmlOptions)
+  const dataProps = buildDataProps(data)
+  const htmlProps = buildHtmlProps(htmlOptions)
 
   const popoverReference = (
     <CircleIconButton
-      className={tipClass}
-      dark={dark}
-      icon="info-circle"
-      onClick={toggleShowPopover}
-      variant="link"
+        className={tipClass}
+        dark={dark}
+        icon="info-circle"
+        onClick={toggleShowPopover}
+        variant="link"
     />
   )
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classes}
-      id={id}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classes}
+        id={id}
     >
       <label>
         <Flex align="baseline">
           <Caption
-            className="passphrase-label"
-            text={label}
+              className="passphrase-label"
+              text={label}
           />
           {tips.length > 0 && !confirmation &&
             <PbReactPopover
-              className="passphrase-tips"
-              closeOnClick="outside"
-              placement="right"
-              reference={popoverReference}
-              shouldClosePopover={handleShouldClosePopover}
-              show={showPopover}
+                className="passphrase-tips"
+                closeOnClick="outside"
+                placement="right"
+                reference={popoverReference}
+                shouldClosePopover={handleShouldClosePopover}
+                show={showPopover}
             >
               <Flex
-                align="center"
-                orientation="column"
+                  align="center"
+                  orientation="column"
               >
                 <Caption
-                  marginBottom="xs"
-                  text="Tips for a good passphrase"
+                    marginBottom="xs"
+                    text="Tips for a good passphrase"
                 />
                 <div>
                   {tips.map((tip, i) => (
                     <Caption
-                      key={i}
-                      marginBottom="xs"
-                      size="xs"
+                        key={i}
+                        marginBottom="xs"
+                        size="xs"
                     >
                       <Icon
-                        icon="shield-check"
-                        marginRight="xs"
+                          icon="shield-check"
+                          marginRight="xs"
                       />
                       {tip}
                     </Caption>
@@ -149,30 +150,30 @@ const Passphrase = (props: PassphraseProps) => {
         </Flex>
         <div className="passphrase-text-input-wrapper">
           <TextInput
-            className="passphrase-text-input"
-            dark={dark}
-            marginBottom="xs"
-            onChange={handleChange}
-            placeholder="Enter a passphrase..."
-            type={showPassphrase ? "text" : "password"}
-            value={displayValue}
-            {...inputProps}
+              className="passphrase-text-input"
+              dark={dark}
+              marginBottom="xs"
+              onChange={handleChange}
+              placeholder="Enter a passphrase..."
+              type={showPassphrase ? "text" : "password"}
+              value={displayValue}
+              {...inputProps}
           />
           <span
-            className="show-passphrase-icon"
-            onClick={toggleShowPassphrase}
+              className="show-passphrase-icon"
+              onClick={toggleShowPassphrase}
           >
             <Body
-              className={showPassphrase ? "hide-icon" : ""}
-              color="light"
-              dark={dark}
+                className={showPassphrase ? "hide-icon" : ""}
+                color="light"
+                dark={dark}
             >
               <Icon icon="eye-slash" />
             </Body>
             <Body
-              className={showPassphrase ? "" : "hide-icon"}
-              color="light"
-              dark={dark}
+                className={showPassphrase ? "" : "hide-icon"}
+                color="light"
+                dark={dark}
             >
               <Icon icon="eye" />
             </Body>

--- a/playbook/app/pb_kits/playbook/pb_person_contact/_person_contact.tsx
+++ b/playbook/app/pb_kits/playbook/pb_person_contact/_person_contact.tsx
@@ -7,6 +7,7 @@ import { globalProps } from '../utilities/globalProps'
 import Caption from '../pb_caption/_caption'
 import Contact from '../pb_contact/_contact'
 import Person from '../pb_person/_person'
+import { GenericObject } from '../types'
 
 type ContactItem = {
   contactType: string,
@@ -17,7 +18,7 @@ type ContactItem = {
 type PersonContactProps = {
   aria?: { [key: string]: string },
   className?: string | string[],
-  data?: object,
+  data?: GenericObject,
   firstName: string,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
@@ -25,7 +26,7 @@ type PersonContactProps = {
   contacts?: ContactItem[],
 }
 
-const PersonContact = (props: PersonContactProps) => {
+const PersonContact = (props: PersonContactProps): React.ReactElement => {
   const {
     aria = {},
     className,
@@ -60,35 +61,35 @@ const PersonContact = (props: PersonContactProps) => {
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classes}
-      id={id}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classes}
+        id={id}
     >
       <Person
-        firstName={firstName}
-        lastName={lastName}
+          firstName={firstName}
+          lastName={lastName}
       />
       {validContacts().map((contactObject, index) => (
         <Contact
-          contactDetail={contactObject.contactDetail}
-          contactType={contactObject.contactType}
-          contactValue={contactObject.contactValue}
-          key={`valid-contact-${index}`}
+            contactDetail={contactObject.contactDetail}
+            contactType={contactObject.contactType}
+            contactValue={contactObject.contactValue}
+            key={`valid-contact-${index}`}
         />
       ))}
       {wrongContacts().map((contactObject, index) => (
         <div key={`wrong-contact-caption-wrapper-${index}`}>
           <Caption
-            className="wrong_numbers"
-            key={`wrong-contact-caption-${index}`}
-            text="wrong number"
+              className="wrong_numbers"
+              key={`wrong-contact-caption-${index}`}
+              text="wrong number"
           />
           <Contact
-            contactType={contactObject.contactType}
-            contactValue={contactObject.contactValue}
-            key={`wrong-contact-${index}`}
+              contactType={contactObject.contactType}
+              contactValue={contactObject.contactValue}
+              key={`wrong-contact-${index}`}
           />
         </div>
       ))}

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -62,6 +62,7 @@ const formatAllCountries = () => {
 formatAllCountries()
 
 const containOnlyNumbers = (value: string) => {
+  // eslint-disable-next-line no-useless-escape
   return /^[()+\-\ .\d]*$/g.test(value)
 }
 
@@ -259,9 +260,9 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
   if (required) textInputProps.required = true
 
   return (
-    <div 
-      {...wrapperProps} 
-      {...htmlProps}
+    <div
+        {...wrapperProps}
+        {...htmlProps}
     >
       <TextInput
           ref={

--- a/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import {
@@ -54,7 +55,7 @@ const popoverModifiers = ({
   offset,
 }: {
   modifiers: Modifier<any> & any;
-  offset: {};
+  offset: boolean;
 }) => {
   return offset ? modifiers.concat([POPOVER_MODIFIERS.offset]) : modifiers;
 };
@@ -143,7 +144,7 @@ const Popover = (props: PbPopoverProps) => {
   );
 };
 
-const PbReactPopover = (props: PbPopoverProps) => {
+const PbReactPopover = (props: PbPopoverProps): React.ReactElement => {
   const [targetId] = useState(_uniqueId('id-'))
   const {
     className,
@@ -226,9 +227,10 @@ const PbReactPopover = (props: PbPopoverProps) => {
           <PopperReference>
             {({ ref }) => (
               <span
-                  id={"reference-" + targetId}
                   className="pb_popover_reference_wrapper"
-                  ref={ref}>
+                  id={"reference-" + targetId}
+                  ref={ref}
+              >
                 <reference.type {...reference.props} />
               </span>
             )}

--- a/playbook/app/pb_kits/playbook/pb_progress_pills/_progress_pills.tsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/_progress_pills.tsx
@@ -20,6 +20,14 @@ type ProgressPillsProps = {
   value?: string,
 }
 
+const ProgressPill = ({ active, dark, steps: step }: ProgressPillsProps) => (
+  <div
+      className={`pb_progress_pill${step <= active ? '_active' : '_inactive'}${dark ? ' dark' : ''
+      }`}
+      key={step}
+  />
+)
+
 const showSteps = (steps: number, active: number, dark: boolean) => {
   const items = []
 
@@ -29,14 +37,6 @@ const showSteps = (steps: number, active: number, dark: boolean) => {
 
   return items
 }
-
-const ProgressPill = ({ active, dark, steps: step }: ProgressPillsProps) => (
-  <div
-    className={`pb_progress_pill${step <= active ? '_active' : '_inactive'}${dark ? ' dark' : ''
-      }`}
-    key={step}
-  />
-)
 
 const ProgressPills = (props: ProgressPillsProps) => {
   const {
@@ -59,24 +59,24 @@ const ProgressPills = (props: ProgressPillsProps) => {
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classes}
-      id={id}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classes}
+        id={id}
     >
       {title &&
         <div className="progress_pills_status">
           <Title
-            dark={dark}
-            size={4}
-            tag="h4"
-            text={title}
+              dark={dark}
+              size={4}
+              tag="h4"
+              text={title}
           />
           <Body
-            color="light"
-            dark={dark}
-            text={value}
+              color="light"
+              dark={dark}
+              text={value}
           />
         </div>}
       <div className="progress_pills">{showSteps(steps, active, dark)}</div>

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.tsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.tsx
@@ -18,7 +18,7 @@ type ProgressSimpleProps = {
   width: string,
 }
 
-const ProgressSimple = (props: ProgressSimpleProps) => {
+const ProgressSimple = (props: ProgressSimpleProps): React.ReactElement => {
   const {
     align,
     className,
@@ -57,9 +57,9 @@ const ProgressSimple = (props: ProgressSimpleProps) => {
 
   return (
     <div 
-      {...dataProps}
-      {...htmlProps}
-      className={wrapperClass}
+        {...dataProps}
+        {...htmlProps}
+        className={wrapperClass}
     >
       <div
           className={kitClass}

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/EditorButton.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/EditorButton.tsx
@@ -7,7 +7,7 @@ import Tooltip from "../../pb_tooltip/_tooltip";
 
 type EditorButtonProps = {
   classname?: string,
-  onclick?: () => {} | void,
+  onclick?: () => undefined | void,
   icon?: string;
   text?: string;
   disable?: boolean
@@ -19,29 +19,31 @@ const EditorButton = ({
   onclick,
   icon,
   text,
-}: EditorButtonProps) => {
+}: EditorButtonProps): React.ReactElement => {
   return (
-    <Tooltip 
-      delay={{
+    <Tooltip
+        delay={{
         open: 2000
       }}
-      interaction 
-      placement="top" 
-      text={text}
+        interaction
+        placement="top"
+        text={text}
     >
       <button
-        className={classname}
-        disabled={disable}
-        onClick={onclick}
-        role="button"
-        type="button"
+          className={classname}
+          disabled={disable}
+          onClick={onclick}
+          role="button"
+          type="button"
       >
-        <Flex 
-          align="center"
-          className="toolbar_button_icon"
-          justify="center"
+        <Flex
+            align="center"
+            className="toolbar_button_icon"
+            justify="center"
         >
-          <Icon icon={icon} size="lg" />
+          <Icon icon={icon}
+              size="lg"
+          />
         </Flex>
       </button>
     </Tooltip>

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/EditorTypes.ts
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/EditorTypes.ts
@@ -3,7 +3,7 @@ export type ToolbarTypes = {
     icon?: string,
     isActive?: string | null,
     text?: string,
-    onclick?: () => {}
+    onclick?: () => undefined
     classname?: string
     disable?: boolean
 }

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/MoreExtensionsDropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/MoreExtensionsDropdown.tsx
@@ -20,17 +20,19 @@ const MoreExtensionsDropdown = ({extensions}: any) => {
 
 const popoverReference = (
     <button
-      className="toolbar_button"
-      onClick={handleTogglePopover}
-      role="button"
-      type="button"
+        className="toolbar_button"
+        onClick={handleTogglePopover}
+        role="button"
+        type="button"
     >
     <Flex 
-      align="center"
-      className="toolbar_button_icon"
-      justify="center"
+        align="center"
+        className="toolbar_button_icon"
+        justify="center"
     >
-      <Icon icon="ellipsis" size="lg" />
+      <Icon icon="ellipsis"
+          size="lg"
+      />
     </Flex>
   </button>
 
@@ -46,21 +48,21 @@ const popoverReference = (
           show={showPopover}
       >
         <Nav 
-          paddingTop={extensions.length > 1 ? "xs" : "none"}
-          paddingBottom={extensions.length > 1 ? "xs" : "none"} 
-          variant="subtle"
+            paddingBottom={extensions.length > 1 ? "xs" : "none"}
+            paddingTop={extensions.length > 1 ? "xs" : "none"} 
+            variant="subtle"
         >
-          {extensions && extensions.map(({ icon, text, onclick, isActive}:any, index:number) => ( 
+          {extensions && extensions.map(({ icon, text, onclick, isActive}: any, index: number) => ( 
             <NavItem
-              cursor="pointer"
-              className={`pb_tiptap_toolbar_dropdown_list_item ${isActive ? "is-active" : ""}`}
-              iconLeft={icon}
-              key={`${text}_${index}`}
-              margin='none'
-              onClick={()=> {onclick(); setShowPopover(false)}}
-              text={text}
-              paddingTop='xxs'
-              paddingBottom='xxs'
+                className={`pb_tiptap_toolbar_dropdown_list_item ${isActive ? "is-active" : ""}`}
+                cursor="pointer"
+                iconLeft={icon}
+                key={`${text}_${index}`}
+                margin='none'
+                onClick={()=> {onclick(); setShowPopover(false)}}
+                paddingBottom='xxs'
+                paddingTop='xxs'
+                text={text}
             />
           ))}
         </Nav>

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/Toolbar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/Toolbar.tsx
@@ -11,7 +11,7 @@ import { ToolbarTypes } from "./EditorTypes";
 import ToolbarHistoryItems from "./ToolbarHistory";
 import MoreExtensionsDropdown from "./MoreExtensionsDropdown";
 
-const EditorToolbar = ({ editor, extensions }:any) => {
+const EditorToolbar = ({ editor, extensions }: any): React.ReactElement => {
   const toolbaritems = [
     {
         icon: "bold",
@@ -34,19 +34,27 @@ const EditorToolbar = ({ editor, extensions }:any) => {
   ]
 
   return (
-    <Background backgroundColor="white" className="toolbar">
-      <Flex flex="0" justify="between" paddingX="sm" paddingY="xxs">
-        <FlexItem className="toolbar_block" displayFlex>
+    <Background backgroundColor="white"
+        className="toolbar"
+    >
+      <Flex flex="0"
+          justify="between"
+          paddingX="sm"
+          paddingY="xxs"
+      >
+        <FlexItem className="toolbar_block"
+            displayFlex
+        >
           <ToolbarDropdown editor={editor}/>
           <SectionSeparator orientation="vertical" />
             {toolbaritems && toolbaritems.map(
-              ({ icon, text, classname, onclick}:ToolbarTypes, index:number) => (
+              ({ icon, text, classname, onclick}: ToolbarTypes, index: number) => (
                 <EditorButton
-                  classname={classname}
-                  icon={icon}
-                  key={index}
-                  text={text}
-                  onclick={onclick}
+                    classname={classname}
+                    icon={icon}
+                    key={index}
+                    onclick={onclick}
+                    text={text}
                 />
               )
             )}

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarDropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarDropdown.tsx
@@ -9,7 +9,7 @@ import NavItem from '../../pb_nav/_item'
 
 import { ToolbarTypes } from './EditorTypes'
 
-const ToolbarDropdown = ({editor}: any) => {
+const ToolbarDropdown = ({editor}: any): React.ReactElement => {
   const [showPopover, setShowPopover] = useState(false)
 
 const toolbarDropdownItems = [
@@ -81,11 +81,21 @@ for (const { text, isActive, icon } of toolbarDropdownItems) {
   if (isActive) {
     activeCount ++
     activeItems.push(
-      <Flex align="center" key={icon} gap="xs">
-        <Icon icon={icon} size="lg" />
+      <Flex align="center"
+          gap="xs"
+          key={icon}
+      >
+        <Icon icon={icon}
+            size="lg"
+        />
         <div>{text}</div>
-        <Flex className={showPopover ? "fa-flip-vertical" : ""} display="inline_flex">
-          <Icon fixedWidth icon="angle-down" margin-left="xs" />
+        <Flex className={showPopover ? "fa-flip-vertical" : ""}
+            display="inline_flex"
+        >
+          <Icon fixedWidth
+              icon="angle-down"
+              margin-left="xs"
+          />
         </Flex>
       </Flex>
     );
@@ -93,7 +103,10 @@ for (const { text, isActive, icon } of toolbarDropdownItems) {
 }
 
 const popoverReference = (
-  <Button className="editor-dropdown-button" onClick={handleTogglePopover} variant="secondary">
+  <Button className="editor-dropdown-button"
+      onClick={handleTogglePopover}
+      variant="secondary"
+  >
     {
        activeCount === 2 ? (
         activeItems[1]
@@ -101,11 +114,21 @@ const popoverReference = (
         activeCount === 1 ? (
         activeItems[0] || null
         ) : (
-          <Flex align="center" key="paragraph" gap="xs">
-            <Icon icon="paragraph" size="lg" />
+          <Flex align="center"
+              gap="xs"
+              key="paragraph"
+          >
+            <Icon icon="paragraph"
+                size="lg"
+            />
             <div>Paragraph</div>
-            <Flex className={showPopover ? "fa-flip-vertical" : ""} display="inline_flex">
-              <Icon fixedWidth icon="angle-down" margin-left="xs" />
+            <Flex className={showPopover ? "fa-flip-vertical" : ""}
+                display="inline_flex"
+            >
+              <Icon fixedWidth
+                  icon="angle-down"
+                  margin-left="xs"
+              />
             </Flex>
           </Flex>
         )
@@ -124,21 +147,21 @@ const popoverReference = (
           show={showPopover}
       >
         <Nav 
-          paddingTop="xs"
-          paddingBottom="xs" 
-          variant="subtle"
+            paddingBottom="xs"
+            paddingTop="xs" 
+            variant="subtle"
         >
-          {toolbarDropdownItems.map(({ icon, text, onclick, isActive}:ToolbarTypes, index:number) => (
+          {toolbarDropdownItems.map(({ icon, text, onclick, isActive}: ToolbarTypes, index: number) => (
             <NavItem
-              cursor="pointer"
-              className={`pb_tiptap_toolbar_dropdown_list_item ${isActive ? "is-active" : ""}`}
-              iconLeft={icon}
-              key={`${text}_${index}`}
-              margin='none'
-              onClick={()=> {onclick(); setShowPopover(false)}}
-              text={text}
-              paddingTop='xxs'
-              paddingBottom='xxs'
+                className={`pb_tiptap_toolbar_dropdown_list_item ${isActive ? "is-active" : ""}`}
+                cursor="pointer"
+                iconLeft={icon}
+                key={`${text}_${index}`}
+                margin='none'
+                onClick={()=> {onclick(); setShowPopover(false)}}
+                paddingBottom='xxs'
+                paddingTop='xxs'
+                text={text}
             />
           ))}
         </Nav>

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarHistory.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarHistory.tsx
@@ -3,7 +3,7 @@ import FlexItem from "../../pb_flex/_flex_item";
 import EditorButton from "./EditorButton";
 import { ToolbarTypes } from "./EditorTypes";
 
-const ToolbarHistoryItems = ({editor}:any) => {
+const ToolbarHistoryItems = ({editor}: any): React.ReactElement => {
 
 const toolbarHistoryItems = [
     {
@@ -26,14 +26,14 @@ const toolbarHistoryItems = [
     <>
     <FlexItem displayFlex>
           {toolbarHistoryItems.map(
-            ({ onclick, classname, disable, icon, text }:ToolbarTypes, index:number) => (
+            ({ onclick, classname, disable, icon, text }: ToolbarTypes, index: number) => (
               <EditorButton
-                classname={classname}
-                onclick={onclick}
-                disable={disable}
-                icon={icon}
-                key={index}
-                text={text}
+                  classname={classname}
+                  disable={disable}
+                  icon={icon}
+                  key={index}
+                  onclick={onclick}
+                  text={text}
               />
             )
           )}

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarNodes.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarNodes.tsx
@@ -2,7 +2,7 @@ import React, {useCallback} from "react";
 import EditorButton from "./EditorButton";
 import { ToolbarTypes } from "./EditorTypes";
 
-const ToolbarNodes = ({editor}:any) => {
+const ToolbarNodes = ({editor}: any): React.ReactElement => {
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 const setLink = useCallback(() => {
@@ -42,13 +42,13 @@ const toolbarNodesItems = [
 
 return (
     <>
-        {toolbarNodesItems.map(({ onclick, icon, text, isActive }:ToolbarTypes, index:number) => (
+        {toolbarNodesItems.map(({ onclick, icon, text, isActive }: ToolbarTypes, index: number) => (
             <EditorButton
-            classname={`toolbar_button ${isActive ? 'is-active' : ''}`}
-            onclick={onclick}
-            icon={icon}
-            key={index}
-            text={text}
+                classname={`toolbar_button ${isActive ? 'is-active' : ''}`}
+                icon={icon}
+                key={index}
+                onclick={onclick}
+                text={text}
             />
         ))}
    </>

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.tsx
@@ -17,27 +17,27 @@ import { TrixEditor } from "react-trix"
 import EditorToolbar from './TipTap/Toolbar'
 
 type Editor = {
-  attributeIsActive?: Function,
+  attributeIsActive?: ([any]: string) => boolean,
   element?: HTMLElement,
-  getSelectedDocument?: Function,
+  getSelectedDocument?: () => any,
   getSelectedRange?: () => Array<number>,
-  insertHTML?: Function,
-  loadHTML?: Function,
-  setSelectedRange?: (range: Array<number>) => void,  
+  insertHTML?: ([any]: string) => void,
+  loadHTML?: ([any]: string) => void,
+  setSelectedRange?: (range: Array<number>) => void,
 }
 
 type RichTextEditorProps = {
   aria?: { [key: string]: string },
   advancedEditor?: any,
   advancedEditorToolbar?: boolean,
-  toolbarBottom?: Boolean,
+  toolbarBottom?: boolean,
   children?: React.ReactNode | React.ReactNode[]
   className?: string,
   data?: { [key: string]: string },
   focus?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
-  inline?: boolean, 
+  inline?: boolean,
   extensions?: { [key: string]: string }[],
   name?: string,
   onChange: (html: string, text: string) => void,
@@ -49,7 +49,7 @@ type RichTextEditorProps = {
   maxWidth?: string
 } & GlobalProps
 
-const RichTextEditor = (props: RichTextEditorProps) => {
+const RichTextEditor = (props: RichTextEditorProps): React.ReactElement => {
   const {
     aria = {},
     advancedEditor,
@@ -80,7 +80,6 @@ const RichTextEditor = (props: RichTextEditorProps) => {
   
   const handleOnEditorReady = (editorInstance: Editor) => setEditor(editorInstance),
     element = editor?.element
-
 
   // DOM manipulation must wait for editor to be ready
   if (editor) {
@@ -117,6 +116,7 @@ const RichTextEditor = (props: RichTextEditorProps) => {
     focus
       ? (document.addEventListener('trix-focus', useFocus),
         document.addEventListener('trix-blur', useFocus),
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         useFocus())
       : null
 
@@ -164,10 +164,10 @@ const RichTextEditor = (props: RichTextEditorProps) => {
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={css}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={css}
     >
       {
         advancedEditor ? (
@@ -175,9 +175,11 @@ const RichTextEditor = (props: RichTextEditorProps) => {
               className={classnames("pb_rich_text_editor_advanced_container", { 
               ["toolbar-active"]: advancedEditorToolbar,
               })}
-            >
+          >
             {advancedEditorToolbar && (
-              <EditorToolbar extensions={extensions} editor={advancedEditor}/>
+              <EditorToolbar editor={advancedEditor}
+                  extensions={extensions}
+              />
             )}
           { children }
           </div>

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
@@ -20,7 +20,7 @@ type SectionSeparatorProps = {
   variant?: "card" | "background",
 }
 
-const SectionSeparator = (props: SectionSeparatorProps) => {
+const SectionSeparator = (props: SectionSeparatorProps): React.ReactElement => {
   const {
     aria = {},
     children,
@@ -42,17 +42,19 @@ const SectionSeparator = (props: SectionSeparatorProps) => {
   return (
 
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classes}
-      id={id}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classes}
+        id={id}
     >
       {
         children && children ||
         text && (
           <span>
-            <Caption text={text} dark={dark} />
+            <Caption dark={dark}
+                text={text}
+            />
           </span>
         )
       }

--- a/playbook/app/pb_kits/playbook/pb_select/_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.tsx
@@ -63,7 +63,7 @@ const Select = ({
   inline = false,
   multiple = false,
   name,
-  onChange = () => {},
+  onChange = () => undefined,
   options = [],
   required = false,
   value,

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/_selectable_card_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/_selectable_card_icon.tsx
@@ -33,7 +33,7 @@ type SelectableCardIconProps = {
   onChange?: (event: React.FormEvent<HTMLInputElement>) => void,
 }
 
-const SelectableCardIcon = (props: SelectableCardIconProps) => {
+const SelectableCardIcon = (props: SelectableCardIconProps): React.ReactElement => {
   const {
     aria = {},
     checkmark = false,
@@ -70,36 +70,37 @@ const SelectableCardIcon = (props: SelectableCardIconProps) => {
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classes}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classes}
     >
       <SelectableCard
-        checked={checked}
-        customIcon={customIcon}
-        dark={dark}
-        disabled={disabled}
-        icon={checkmark}
-        inputId={inputId}
-        multi={multi}
-        name={name}
-        onChange={onChange}
-        value={value}
+          checked={checked}
+          customIcon={customIcon}
+          dark={dark}
+          disabled={disabled}
+          icon={checkmark}
+          inputId={inputId}
+          multi={multi}
+          name={name}
+          onChange={onChange}
+          value={value}
       >
         {
           <>
             <SelectableIcon
-              customIcon={customIcon}
-              icon={icon}
-              inputId={''}
-              inputs="disabled"
-              name={''}
-              text={titleText} />
+                customIcon={customIcon}
+                icon={icon}
+                inputId={''}
+                inputs="disabled"
+                name={''}
+                text={titleText}
+            />
             <Body
-              color="light"
-              dark={dark}
-              text={bodyText}
+                color="light"
+                dark={dark}
+                text={bodyText}
             />
           </>
         }

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/_selectable_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/_selectable_icon.tsx
@@ -6,10 +6,11 @@ import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-  buildHtmlProps 
+  buildHtmlProps
 } from '../utilities/props'
 import Icon from '../pb_icon/_icon'
 import Title from '../pb_title/_title'
+import { GenericObject } from '../types'
 
 type SelectableIconProps = {
   aria?: {[key: string]: string},
@@ -17,7 +18,7 @@ type SelectableIconProps = {
   className?: string,
   customIcon?: {[key: string] :SVGElement},
   disabled?: boolean,
-  data?: Object,
+  data?: GenericObject,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   icon: string,
   inputId: string,
@@ -44,7 +45,7 @@ const SelectableIcon = ({
   text,
   value,
   ...props
-}: SelectableIconProps) => {
+}: SelectableIconProps): React.ReactElement => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
@@ -64,22 +65,22 @@ const SelectableIcon = ({
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classes}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classes}
     >
       {inputs === 'disabled' && (
         <>
           <Icon
-            customIcon={customIcon}
-            icon={icon}
-            size="2x"
+              customIcon={customIcon}
+              icon={icon}
+              size="2x"
           />
           <Title
-            size={4}
-            tag="h4"
-            text={text}
+              size={4}
+              tag="h4"
+              text={text}
           />
         </>
       )}
@@ -87,24 +88,24 @@ const SelectableIcon = ({
       {inputs === 'enabled' && (
         <>
           <input
-            {...props}
-            checked={checked}
-            disabled={disabled}
-            id={inputIdPresent}
-            name={name}
-            type={inputType}
-            value={value}
+              {...props}
+              checked={checked}
+              disabled={disabled}
+              id={inputIdPresent}
+              name={name}
+              type={inputType}
+              value={value}
           />
           <label htmlFor={inputIdPresent}>
             <Icon
-              customIcon={customIcon}
-              icon={icon}
-              size="2x"
+                customIcon={customIcon}
+                icon={icon}
+                size="2x"
             />
             <Title
-              size={4}
-              tag="h4"
-              text={text}
+                size={4}
+                tag="h4"
+                text={text}
             />
           </label>
         </>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
@@ -7,12 +7,13 @@ import { SelectableListItemProps } from './_item.js'
 
 import List from  '../pb_list/_list'
 import SelectableListItem from './_item'
+import { GenericObject } from '../types'
 
 type SelectableListProps = {
   aria?: {[key: string]: string },
   children?: React.ReactElement[],
   className?: string,
-  data?: object,
+  data?: GenericObject,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   variant?: 'checkbox' | 'radio',

--- a/playbook/app/pb_kits/playbook/pb_source/_source.tsx
+++ b/playbook/app/pb_kits/playbook/pb_source/_source.tsx
@@ -32,7 +32,7 @@ const Source = ({
   source,
   type = 'inbound',
   user = {},
-}: SourceProps) => {
+}: SourceProps): React.ReactElement => {
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
   const ariaProps = buildAriaProps(aria)
@@ -72,11 +72,11 @@ const Source = ({
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={css}
-      id={id}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={css}
+        id={id}
     >
 
       <div className="pb__source_layout">
@@ -84,13 +84,13 @@ const Source = ({
           <>
             {showIcon() &&
               <IconCircle
-                icon={typeIconNames[type]}
-                size="sm"
+                  icon={typeIconNames[type]}
+                  size="sm"
               />
             }
             {!showIcon() &&
               <Avatar
-                {...avatar()}
+                  {...avatar()}
               />
             }
           </>
@@ -98,20 +98,20 @@ const Source = ({
 
         <div className="pb__source_content">
           <Title
-            size={4}
-            tag="h4"
-            text={source}
+              size={4}
+              tag="h4"
+              text={source}
           />
 
           <div className="pb__source_value">
             <Body
-              color="light"
-              text={typeText()}
+                color="light"
+                text={typeText()}
             />
 
             {user.userId &&
               <Caption
-                text={user.userId}
+                  text={user.userId}
               />
             }
           </div>

--- a/playbook/app/pb_kits/playbook/types/base.ts
+++ b/playbook/app/pb_kits/playbook/types/base.ts
@@ -4,6 +4,7 @@ import { SyntheticEvent } from "react"
 export const BitValues = [0, 1] as const
 export type Binary = typeof BitValues[number]
 export type Callback<T, K> = (arg: T) => K
+export type VoidCallback = () => void
 export type EmptyObject = Record<string, unknown>
 export type InputCallback<T> = Callback<SyntheticEvent<T>, void>
 export type Noop = () => void

--- a/playbook/app/pb_kits/playbook/types/data.ts
+++ b/playbook/app/pb_kits/playbook/types/data.ts
@@ -1,0 +1,1 @@
+export type GenericObject = Record<string, unknown>

--- a/playbook/app/pb_kits/playbook/types/index.ts
+++ b/playbook/app/pb_kits/playbook/types/index.ts
@@ -1,5 +1,6 @@
 export * from './base'
 export * from './colors'
+export * from './data'
 export * from './display'
 export * from './sizes'
 export * from './spacing'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

**Task**
Run our new linter on kits that start with P - T.

**Because**
We've implemented a linter config, but most/all of our library files are still failing its ruleset. We need to update all kits in groups to eventually clean up the entire library to confirm with the new linter configs.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
