### PR TITLE
[PLAY-1132] Apply Datepicker global margin to sub input kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.scss
@@ -10,7 +10,6 @@
 
 [class^=pb_date_picker_kit] {
   .input_wrapper {
-    margin-bottom: $space_sm;
     position: relative;
 
     .flatpickr-wrapper {
@@ -47,7 +46,7 @@
   .text_input_wrapper_add_on .add-on-right .text_input{
     cursor: pointer;
   }
-  
+
 }
 
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react'
 import classnames from 'classnames'
 
+import { Spacing } from "../types"
+
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { deprecatedProps, globalProps, GlobalProps } from '../utilities/globalProps'
 
@@ -8,6 +10,7 @@ import datePickerHelper from './date_picker_helper'
 import Icon from '../pb_icon/_icon'
 import Caption from '../pb_caption/_caption'
 import Body from '../pb_body/_body'
+
 
 type DatePickerProps = {
   allowInput?: boolean,
@@ -34,6 +37,13 @@ type DatePickerProps = {
   inputOnChange?: (e: React.FormEvent<HTMLInputElement>) => void,
   inputValue?: string,
   label?: string,
+  margin?: Spacing;
+  marginBottom?: Spacing;
+  marginTop?: Spacing;
+  marginRight?: Spacing;
+  marginLeft?: Spacing;
+  marginX?: Spacing;
+  marginY?: Spacing;
   maxDate: string,
   minDate: string,
   name: string,
@@ -78,6 +88,13 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     inputOnChange,
     inputValue,
     label = 'Date Picker',
+    margin,
+    marginBottom,
+    marginTop,
+    marginRight,
+    marginLeft,
+    marginX,
+    marginY,
     maxDate,
     minDate,
     mode = 'single',
@@ -134,8 +151,36 @@ useEffect(() => {
     required: false,
   }, scrollContainer)
 })
+
+  const spacingMarginProps = {
+    margin,
+    marginBottom,
+    marginTop,
+    marginRight,
+    marginLeft,
+    marginX,
+    marginY,
+  }
+
   const filteredProps = {...props}
   delete filteredProps?.position
+  delete filteredProps?.margin;
+  delete filteredProps?.marginX;
+  delete filteredProps?.marginY;
+  delete filteredProps?.marginBottom;
+  delete filteredProps?.marginTop;
+  delete filteredProps?.marginRight;
+  delete filteredProps?.marginLeft;
+
+  const inputClasses = classnames(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    globalProps(spacingMarginProps),
+    className
+  )
+
+  console.log(inputClasses)
+  console.log('duckyyyyyy')
 
   const classes = classnames(
     buildCss('pb_date_picker_kit'),
@@ -179,7 +224,7 @@ useEffect(() => {
             text={hideLabel ? null : label}
         />
           <>
-            <div className="date_picker_input_wrapper">
+            <div className={`date_picker_input_wrapper ${inputClasses}`}>
               <input
                   autoComplete="off"
                   className="date_picker_input"

--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -88,13 +88,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     inputOnChange,
     inputValue,
     label = 'Date Picker',
-    margin,
     marginBottom = "sm",
-    marginTop,
-    marginRight,
-    marginLeft,
-    marginX,
-    marginY,
     maxDate,
     minDate,
     mode = 'single',
@@ -153,24 +147,12 @@ useEffect(() => {
 })
 
   const spacingMarginProps = {
-    margin,
     marginBottom,
-    marginTop,
-    marginRight,
-    marginLeft,
-    marginX,
-    marginY,
   }
 
   const filteredProps = {...props}
   delete filteredProps?.position
-  delete filteredProps?.margin;
-  delete filteredProps?.marginX;
-  delete filteredProps?.marginY;
   delete filteredProps?.marginBottom;
-  delete filteredProps?.marginTop;
-  delete filteredProps?.marginRight;
-  delete filteredProps?.marginLeft;
 
   const inputClasses = classnames(
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -89,7 +89,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     inputValue,
     label = 'Date Picker',
     margin,
-    marginBottom,
+    marginBottom = "sm",
     marginTop,
     marginRight,
     marginLeft,

--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -179,9 +179,6 @@ useEffect(() => {
     className
   )
 
-  console.log(inputClasses)
-  console.log('duckyyyyyy')
-
   const classes = classnames(
     buildCss('pb_date_picker_kit'),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -19,6 +19,7 @@
         name: object.name,
         placeholder: object.placeholder,
         required: object.required,
+        classname: margins_to_remove.join(" ")
       }) %>
     <% end %>
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
@@ -76,13 +76,7 @@ module Playbook
 
       def margins_to_remove
         margin_classes_to_remove = []
-        margin_classes_to_remove << "m_#{object.margin}" if object.margin
-        margin_classes_to_remove << "mx_#{object.margin_x}" if object.margin_x
-        margin_classes_to_remove << "my_#{object.margin_y}" if object.margin_y
         margin_classes_to_remove << "mb_#{object.margin_bottom}" if object.margin_bottom
-        margin_classes_to_remove << "mt_#{object.margin_top}" if object.margin_top
-        margin_classes_to_remove << "mr_#{object.margin_right}" if object.margin_right
-        margin_classes_to_remove << "ml_#{object.margin_left}" if object.margin_left
         margin_classes_to_remove
       end
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
@@ -74,8 +74,22 @@ module Playbook
       prop :year_range, type: Playbook::Props::Array,
                         default: [1900, 2100]
 
+      def margins_to_remove
+        margin_classes_to_remove = []
+        margin_classes_to_remove << "m_#{object.margin}" if object.margin
+        margin_classes_to_remove << "mx_#{object.margin_x}" if object.margin_x
+        margin_classes_to_remove << "my_#{object.margin_y}" if object.margin_y
+        margin_classes_to_remove << "mb_#{object.margin_bottom}" if object.margin_bottom
+        margin_classes_to_remove << "mt_#{object.margin_top}" if object.margin_top
+        margin_classes_to_remove << "mr_#{object.margin_right}" if object.margin_right
+        margin_classes_to_remove << "ml_#{object.margin_left}" if object.margin_left
+        margin_classes_to_remove
+      end
+
       def classname
-        generate_classname("pb_date_picker_kit")
+        regex = Regexp.union(margins_to_remove)
+        classnames = generate_classname("pb_date_picker_kit")
+        classnames.gsub(regex, "").strip.gsub(/\s+/, " ")
       end
 
       def date_picker_config

--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_input_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_input_styles.scss
@@ -1,7 +1,6 @@
 @import "../../pb_textarea/textarea_mixin";
 
 [class^=pb_date_picker_kit] {
-  margin-bottom: $space_sm;
 
   .pb_date_picker_kit_label {
     margin-bottom: $space_xs;

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -3,7 +3,6 @@
 @import "../tokens/colors";
 
 [class^="pb_text_input_kit"] {
-  margin-bottom: $space_sm;
   .pb_text_input_kit_label {
     margin-bottom: $space_xs;
     display: block;

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
@@ -70,12 +70,15 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
   const shouldShowAddOn = icon !== null
   const addOnCss = shouldShowAddOn ? 'text_input_wrapper_add_on' : ""
   const addOnDarkModeCardCss = (shouldShowAddOn && dark) ? 'add-on-card-dark' : ""
+  const defaultMarginBottom = props.marginBottom ?? "mb_sm"
+
   const css = classnames([
     'pb_text_input_kit',
     inline ? 'inline' : "",
     error ? 'error' : "",
     globalProps(props),
     className,
+    defaultMarginBottom
   ])
   const addOnIcon = (
     <Icon
@@ -144,7 +147,7 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
         {...htmlProps}
         className={css}
     >
-      {label && 
+      {label &&
         <Caption
             className="pb_text_input_kit_label"
             text={label}

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -25,8 +25,12 @@ module Playbook
       prop :add_on, type: Playbook::Props::NestedProps,
                     nested_kit: Playbook::PbTextInput::AddOn
 
+      def default_margin_bottom
+        object.margin_bottom.present? ? " #{object.margin}" : " mb_sm"
+      end
+
       def classname
-        generate_classname("pb_text_input_kit") + error_class + inline_class
+        generate_classname("pb_text_input_kit") + error_class + inline_class + default_margin_bottom
       end
 
       def input_tag

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -26,7 +26,7 @@ module Playbook
                     nested_kit: Playbook::PbTextInput::AddOn
 
       def default_margin_bottom
-        object.margin_bottom.present? ? " #{object.margin}" : " mb_sm"
+        object.margin_bottom.present? ? "" : " mb_sm"
       end
 
       def classname

--- a/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Playbook::PbTextInput::TextInput do
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
-      expect(subject.new({}).classname).to eq "pb_text_input_kit"
-      expect(subject.new(classname: "additional_class").classname).to eq "pb_text_input_kit additional_class"
-      expect(subject.new({ dark: true }).classname).to eq "pb_text_input_kit dark"
-      expect(subject.new({ inline: true }).classname).to eq "pb_text_input_kit inline"
-      expect(subject.new({ error: "Please enter a valid email" }).classname).to eq "pb_text_input_kit error"
-      expect(subject.new({ dark: true, error: "Please enter a valid email" }).classname).to eq "pb_text_input_kit dark error"
+      expect(subject.new({}).classname).to eq "pb_text_input_kit mb_sm"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_text_input_kit additional_class mb_sm"
+      expect(subject.new({ dark: true }).classname).to eq "pb_text_input_kit dark mb_sm"
+      expect(subject.new({ inline: true }).classname).to eq "pb_text_input_kit inline mb_sm"
+      expect(subject.new({ error: "Please enter a valid email" }).classname).to eq "pb_text_input_kit error mb_sm"
+      expect(subject.new({ dark: true, error: "Please enter a valid email" }).classname).to eq "pb_text_input_kit dark error mb_sm"
       expect(subject.new({ margin_bottom: "lg" }).classname).to eq "pb_text_input_kit mb_lg"
     end
   end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

https://nitro.powerhrg.com/runway/backlog_items/PLAY-1132

Applies the margin global prop to the input kit or input wrapper div on on the Date picker kit

Had to remove some css and change the text input kit in rails, as it is a sub of Date picker. So instead of css it has `margin_bottom: "sm"` prop by default

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2024-01-17 at 4 20 10 PM](https://github.com/powerhome/playbook/assets/38965626/80a0e927-d80f-46f3-afed-d9eedb90e0fa)

**How to test?** Steps to confirm the desired behavior:
1. Go to https://pr3047.playbook.beta.gm.powerapp.cloud/kits/date_picker/react
2. inspect the date picker 
3. See how the `mb_sm` is applying the margin now instead of raw css


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.