### PR TITLE
[PBNTR-184] Add Status Flag to Menu.yml

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -192,10 +192,12 @@ private
 
   def all_kits
     group_components = []
-    aggregate_kits.each do |category|
-      group_components.push(category["components"])
+    aggregate_kits.each do |kit|
+      group_components.push(kit["components"].map do |component|
+        { name: component["name"], status: component["status"] }
+      end)
     end
-    group_components.flatten.map { |item| item["name"] }
+    group_components.flatten
   end
 
   def set_js
@@ -218,8 +220,11 @@ private
   end
 
   def set_kit
-    if all_kits.include?(params[:name])
-      @kit = params[:name]
+    matching_kit = all_kits.find { |kit| kit[:name] == params[:name] }
+
+    if matching_kit
+      @kit = matching_kit[:name]
+      @kit_status = matching_kit[:status]
     else
       redirect_to root_path, flash: { error: "That kit does not exist" }
     end

--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -163,21 +163,47 @@ module ApplicationHelper
     all_kits
   end
 
+  def aggregate_kits_with_status
+    all_kits = []
+
+    MENU["kits"].each do |kit|
+      kit_name = kit["name"]
+      # Modify this line to include both name and status in the components array
+      components = kit["components"].map { |c| { name: c["name"], status: c["status"] } }
+
+      all_kits << if components.size == 1
+                    # For a single-component kit, return the component with its status
+                    components.first
+                  else
+                    # For multi-component kits, return the kit name with the components including their statuses
+                    { kit_name => components }
+                  end
+    end
+
+    all_kits
+  end
+
   def search_list
     all_kits = []
     formatted_kits = []
-    aggregate_kits.each do |kit|
+
+    aggregate_kits_with_status.each do |kit|
       if kit.is_a? Hash
-        kit.values[0].each do |sub_kit|
-          all_kits.push(sub_kit)
+        _kit_name, components = kit.first
+        components.each do |component|
+          all_kits.push(component[:name]) if component[:status] != "beta"
         end
       else
         all_kits.push(kit)
       end
     end
-    all_kits.sort!.each do |sorted_kit|
+
+    all_kits.sort!
+
+    all_kits.each do |sorted_kit|
       formatted_kits.push(format_search_hash(sorted_kit))
     end
+
     formatted_kits
   end
 

--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -146,23 +146,6 @@ module ApplicationHelper
     }
   end
 
-  def aggregate_kits
-    all_kits = []
-
-    MENU["kits"].each do |kit|
-      kit_name = kit["name"]
-      components = kit["components"].map { |c| c["name"] }
-
-      all_kits << if components.size == 1
-                    components.first
-                  else
-                    { kit_name => components }
-                  end
-    end
-
-    all_kits
-  end
-
   def aggregate_kits_with_status
     all_kits = []
 

--- a/playbook-website/app/javascript/components/MainSidebar/NavComponents/KitsNavComponent.tsx
+++ b/playbook-website/app/javascript/components/MainSidebar/NavComponents/KitsNavComponent.tsx
@@ -160,24 +160,18 @@ export const KitsNavItem = ({
         text={linkFormat(categoryKey)}
       >
         {sublinks.map((sublink, j) => (
-          <>
-            {
-              sublink !== "advanced_table" && (
-                <NavItem
-                  active={calculateIsActiveCategory(j, null, sublink)}
-                  cursor="pointer"
-                  dark={dark}
-                  fontSize="small"
-                  key={`${sublink}-${j}`}
-                  link={generateLink(categoryKey, sublink, type)}
-                  marginY="none"
-                  onClick={() => handleSubItemClick(j, sublink, kitIndex)}
-                  paddingY="xxs"
-                  text={linkFormat(sublink)}
-                />
-              )
-            }
-          </>
+          <NavItem
+            active={calculateIsActiveCategory(j, null, sublink)}
+            cursor="pointer"
+            dark={dark}
+            fontSize="small"
+            key={`${sublink}-${j}`}
+            link={generateLink(categoryKey, sublink, type)}
+            marginY="none"
+            onClick={() => handleSubItemClick(j, sublink, kitIndex)}
+            paddingY="xxs"
+            text={linkFormat(sublink)}
+          />
         ))}
       </NavItem>
     );

--- a/playbook-website/app/javascript/components/MainSidebar/index.tsx
+++ b/playbook-website/app/javascript/components/MainSidebar/index.tsx
@@ -10,7 +10,7 @@ const MainSidebar = ({
   type,
   category,
   kit,
-  kits,
+  kits_with_status,
   PBversion,
   search_list,
   samples,
@@ -18,10 +18,25 @@ const MainSidebar = ({
   //active state for navItems(will be redundant once routing moved to react router)
   const [isActive, setIsActive] = useState({});
 
+  const transformKitsData = (kitsArray) => {
+    return kitsArray.map(kit => {
+      // There's only one key per object, so we get the kit name and its components
+      const kitName = Object.keys(kit)[0];
+      const components = kit[kitName];
+  
+      // Filter out any components with status 'beta', then map to get their names
+      const componentNames = components
+        .filter(component => component.status !== 'beta')
+        .map(component => component.name);
+  
+      return { [kitName]: componentNames };
+    });
+  };
+  
+  const kits = transformKitsData(kits_with_status);
+  
   //hook into collapsible logic for all components nested nav items
   const collapsibles = kits.map(() => useCollapsible());
-
-  const filteredSearchList = search_list.filter(obj => obj.label !== "Advanced Table");
 
   //kits in alphabetical order
   kits.map((obj: {[key: string]: string[]}) => {
@@ -55,7 +70,7 @@ const MainSidebar = ({
         <KitSearch
           classname="desktop-kit-search"
           id="desktop-kit-search"
-          kits={filteredSearchList}
+          kits={search_list}
         />
       </Flex>
       <Nav dark={dark} variant="bold" paddingTop="xxs">

--- a/playbook-website/app/views/layouts/_sidebar.html.erb
+++ b/playbook-website/app/views/layouts/_sidebar.html.erb
@@ -1,1 +1,1 @@
-<%= react_component("MainSidebar", dark: dark_mode?, type: @type, category: @category, kit: @kit, kits: aggregate_kits, PBversion: Playbook::VERSION, search_list: search_list, samples: SAMPLES) %>
+<%= react_component("MainSidebar", dark: dark_mode?, type: @type, category: @category, kit: @kit, kits_with_status: aggregate_kits_with_status, PBversion: Playbook::VERSION, search_list: search_list, samples: SAMPLES) %>

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -6,7 +6,7 @@
   <% end %>
   <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin_top: "xl" }) %>
 
-  <% if @kit === "advanced_table" %> 
+  <% if @kit_status === "beta" %> 
     <%= pb_rails("card", props: {highlight: {position: "side", color:"primary", shadow:"deep"}, margin_y: "md", padding: "sm"}) do %>
       <%= pb_rails("flex", props:{ align: "center" }) do %>
         <%= pb_rails("body", props:{color: "light"}) do %>

--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -13,348 +13,447 @@ kits:
       - name: "dialog"
         platforms: *web
         description: 
+        status: "stable"
       - name: "fixed_confirmation_toast"
         platforms: *web
         description: Fixed Confirmation Toast is used as an alert. Success is used when a user successfully completes an action. Error is used when there is an error and the user cannot proceed. Neutral is used to display information to a user to complete a task.
+        status: "stable"
       - name: "popover"
         platforms: *web
         description: A popover is a way to toggle content on top of other content. It can be used for small texts, small forms, or even dropdowns. By default, popover will toggle open/closed by simply clicking the trigger element.
+        status: "stable"
       - name: "tooltip"
         platforms: *web
         description:
+        status: "stable"
   - name: buttons
     description: Buttons are used primarily for actions, such as “Save” and “Cancel”. Link Buttons are used for less important or less commonly used actions, such as “view shipping settings”.
     components:
       - name: "button"
         platforms: *web
         description: 
+        status: "stable"
       - name: "button_toolbar"
         platforms: *web
         description: This kit should primarily hold the most commonly used buttons.
+        status: "stable"
       - name: "circle_icon_button"
         platforms: *web
         description: When using Icon Circle Button, the icon must be clear a clear indication of what the button does because there is no text. 
+        status: "stable"
   - name: data_visualization
     description: 
     components:
       - name: "map"
         platforms: *react_only
         description: This kit provides a wrapping class to place around the MapLibre library.
+        status: "stable"
       - name: "table"
         platforms: *web
         description: Tables display a collection of structured data and typically have the ability to sort, filter, and paginate data. 
+        status: "stable"
       - name: "advanced_table"
         platforms: *react_only
-        description: The Advanced Table can be used to display complex, nested data in a way that allows for expansion and/or sorting. 
+        description: The Advanced Table can be used to display complex, nested data in a way that allows for expansion and/or sorting.
+        status: "beta" 
       - name: "list"
         platforms: *web
         description: Lists display a vertical set of related content.
+        status: "stable"
       - name: "filter"
         platforms: *web
         description: This kit can be implemented in a variety of ways. To see examples of how to implement this kit in production visit the /dev_docs/search page in production.
+        status: "stable"
       - name: "distribution_bar"
         platforms: *web
         description: Can be used in the same way a pie chart can be used. By default, Distribution Bar comparatively represents data without numbers. 
+        status: "stable"
       - name: "legend"
         platforms: *web
         description: A key used to compare the variables and their value in any given graph.
+        status: "stable"
       - name: "gauge"
         platforms: *web
         description: 
+        status: "stable"
       - name: "bar_graph"
         platforms: *web
         description: Bar graphs are used to compare data. Bar graphs are not typically used to show percentages.
+        status: "stable"
       - name: "circle_chart"
         platforms: *web
         description: 
+        status: "stable"
       - name: "line_graph"
         platforms: *web
         description: Line graphs are used to show changes in data over time.
+        status: "stable"
       - name: "treemap_chart"
         platforms: *web
         description: Treemap charts are used to compare the relative size of groups of data. They can also use a nested data structure, allowing a user to drill down into a group to see its constituent data points.
+        status: "stable"
   - name: date_and_time_text_patterns
     description: ""
     components:
       - name: "date"
         platforms: *web
         description: Use to display the date. Year will not display if it is the current year.
+        status: "stable"
       - name: "date_range_inline"
         platforms: *web
         description: Use to display a date range. Year will not show if it is the current year.
+        status: "stable"
       - name: "date_range_stacked"
         platforms: *web
-        description: 
+        description:
+        status: "stable" 
       - name: "date_stacked"
         platforms: *web
         description: Use to display the date, stacking month and day. Year will not show if it is the current year.
+        status: "stable"
       - name: "date_time"
         platforms: *web
         description: Date Time is a composite kit that leverages the Date and Time kits. The Date Time kit is affected by time zones and defaults to "America/New_York".
       - name: "date_time_stacked"
         platforms: *web
         description: 
+        status: "stable"
       - name: "date_year_stacked"
         platforms: *web
         description: This kit is a simple option for displaying dates in a month, day and the year format.
+        status: "stable"
       - name: "time"
         platforms: *web
         description: This kit consist of large display and table display format. It includes and icon, and a time zone.
+        status: "stable"
       - name: "time_range_inline"
         platforms: *web
         description: 
+        status: "stable"
       - name: "time_stacked"
         platforms: *web
         description: 
+        status: "stable"
       - name: "timestamp"
         platforms: *all
         description: This low profile kit displays time. Elapsed, current, future, or otherwise.
+        status: "stable"
       - name: "weekday_stacked"
         platforms: *web
         description: 
+        status: "stable"
   - name: form_and_dashboard_text_patterns
     description: ""
     components:
       - name: "contact"
         platforms: *web
         description: Use to display customer's or user's contact information.
+        status: "stable"
       - name: "currency"
         platforms: *web
         description: Use to display monetary amounts, typically on dashboards or other layouts to show an overview or summary. User understanding increase when paired with labels.
+        status: "stable"
       - name: "home_address_street"
         platforms: *web
         description: This kit can be used to display the address for a homeowner/project. It contains street address, APT format, City, state and zip. A Project hashtag can be used as a prop to link back to a project.
+        status: "stable"
       - name: "label_pill"
         platforms: *web
         description: This kit combines the caption and pill kit with all its variants.
+        status: "stable"
       - name: "label_value"
         platforms: *web
         description: This kit can be very versatile when used to display text data.
+        status: "stable"
       - name: "person"
         platforms: *web
         description: This kit is broken down into a first name last name format with normal and bold weighted text.
+        status: "stable"
       - name: "person_contact"
         platforms: *web
         description: This kit can be used to display a person contact information. 
+        status: "stable"
       - name: "source"
         platforms: *web
         description: General use is to describe the discovery of businesses, customers, etc. This kit can also be used for other purposes as well.
+        status: "stable"
       - name: "dashboard_value"
         platforms: *web
         description: Use in dashboards to give the viewer a quick overview of important metrics. If want to show currency, use Currency Kit.
+        status: "stable"
       - name: "stat_change"
         platforms: *web
         description: Displays the increase, decrease, or neutral change in data.
+        status: "stable"
       - name: "stat_value"
         platforms: *web
         description: This kit was cerated for the main use as a dashboard display for numbers. A large label is an optional part if it needs more clarity.
+        status: "stable"
       - name: "title_count"
         platforms: *web
         description: This kits consists of title kit and body text. It is used to display a title and a count (numbers). It has a base size and a large formation for dashboard use.
+        status: "stable"
       - name: "title_detail"
         platforms: *web
         description: This kit can be used in many versatile ways. It consist of a title 4 and light body text kit.
+        status: "stable"
   - name: form_elements
     description: 
     components:
       - name: "file_upload"
         platforms: *web
         description: 
+        status: "stable"
       - name: "toggle"
         platforms: *web
         description: Physical switch that allows users to turn things on or off. Used for applying system states, presenting binary options and activating a state.
+        status: "stable"
       - name: "form_pill"
         platforms: *web
         description: 
+        status: "stable"
       - name: "form"
         platforms: *rails_only
         description: The form kit provides consumers with a convenient, consistently styled <form> wrapper.
+        status: "stable"
       - name: "form_group"
         platforms: *web
         description: 
+        status: "stable"
   - name: form_input
     description: ""
     components:
       - name: "passphrase"
         platforms: *web
         description: 
+        status: "stable"
       - name: "phone_number_input"
         platforms: *web
         description: 
+        status: "stable"
       - name: "text_input"
         platforms: *web
         description: Area where user can enter small amount of text. Commonly used in forms.
+        status: "stable"
       - name: "rich_text_editor"
         platforms: *web
-        description: 
+        description:
+        status: "stable" 
       - name: "textarea"
         platforms: *web
         description: Area where user can enter larger amounts of text. Commonly used in forms.
+        status: "stable"
       - name: "typeahead"
         platforms: *web
         description: Typeahead is auto suggestion or completion based on what the user is starting to type, gets refined as the user types more.
+        status: "stable"
   - name: form_selection
     description: 
     components:
       - name: "date_picker"
         platforms: *web
         description: Playbook's date picker is built using flatpickr, a vanilla js library. Common date picker use cases and features have been adapted into simple prop based configuration detailed in the docs below.
+        status: "stable"
       - name: "multi_level_select"
         platforms: *web
         description: The MultiLevelSelect kit renders a multi leveled select dropdown based on data from the user. 
+        status: "stable"
       - name: "select"
         platforms: *web
         description: Select displays multiple options for a user to pick from in a dropdown menu. User selects one option.
+        status: "stable"
       - name: "selectable_card"
         platforms: *web
         description: Cards for information/content that can be selected. There is design for unselected and selected states. Typically used as a form element.
+        status: "stable"
       - name: "selectable_card_icon"
         platforms: *web
         description: 
+        status: "stable"
       - name: "selectable_icon"
         platforms: *web
         description: 
+        status: "stable"
       - name: "radio"
         platforms: *all
         description: Radio is a control that allows the user to only choose one predefined option.
+        status: "stable"
       - name: "checkbox"
         platforms: *web
         description: Checkbox is used for a list of selections that are meant to have one or more options checked.
+        status: "stable"
       - name: "selectable_list"
         platforms: *web
         description: 
+        status: "stable"
   - name: icons_and_images
     description: ""
     components:
       - name: "icon"
         platforms: *web
         description: An icon is a graphic symbol that represents an object (ie a file) or a function. They can be used to give the user feedback.
+        status: "stable"
       - name: "icon_circle"
         platforms: *web
         description: Similar to Icon, Icon Circle is a graphical symbol within a circle used to visually indicate an object or function.
+        status: "stable"
       - name: "icon_stat_value"
         platforms: *web
         description: 
+        status: "stable"
       - name: "icon_value"
         platforms: *web
         description: Icon Value leverages our icon kit, to display a value of some sort in the interface. Typically, this includes a numerical value.
+        status: "stable"
       - name: "user_badge"
         platforms: *web
         description: This kit was created to display employee icons related to a Nitro user. Currently there is the PVI logo and the Million Dollar Rep Icon.
+        status: "stable"
       - name: "image"
         platforms: *web
         description: A responsive image component.
+        status: "stable"
       - name: "lightbox"
         platforms: *react_only
         description: The Lightbox kit is a popup window overlay that will appear on top of your webpage and cover the entirety of the screen. 
+        status: "stable"
       - name: "star_rating"
         platforms: *web
         description: A component to view other people’s opinions and experiences. Use when you want to show evaluation or a quick quantitative rating. Most effective when paired with reviews.
+        status: "stable"
   - name: layout_and_structure
     description: 
     components:
       - name: "flex"
         platforms: *web
         description: This kit is used to build most of the complex interfaces. The Flex Kit is used the same way flex box is used.
+        status: "stable"
       - name: "layout"
         platforms: *web
         description: Layouts used for positioning content inside of pages, cards, or containers.
+        status: "stable"
       - name: "card"
         platforms: *all
         description: 
+        status: "stable"
       - name: "section_separator"
         platforms: *web
         description: Section separator is a divider line that compartmentalizes content, typically used on cards or white backgrounds.
+        status: "stable"
       - name: "background"
         platforms: *web
         description: The background kit is used for adding a background to a page or to any container.
+        status: "stable"
       - name: "collapsible"
         platforms: *web
         description: 
+        status: "stable"
   - name: message_text_patterns
     description: 
     components:
       - name: "highlight"
         platforms: *web
         description: Highlight is used to pick out or emphasize content.
+        status: "stable"
       - name: "message"
         platforms: *web
         description: This multi kit consist of a an avatar, a status, a caption, a body text, and a time stamp. All which can be optional.
+        status: "stable"
   - name: navigation
     description: 
     components:
       - name: "bread_crumbs"
         platforms: *web
         description: BreadCrumbs can be used for keeping a user aware of their route location.
+        status: "stable"
       - name: "nav"
         platforms: *web
         description: The nav is a grouped set of links that take the user to another page, or tab through parts of a page. It comes in horizontal or vertical with several different variants.
+        status: "stable"
       - name: "pagination"
         platforms: *rails_only
         description:
+        status: "stable"
   - name: state_and_progress_indicators
     description: 
     components:
       - name: "loading_inline"
         platforms: *web
         description: The loading kit is used to indicate to users that a page is still loading, or an action is still being processed.
+        status: "stable"
       - name: "progress_pills"
         platforms: *web
         description: Progress pills indicate a specific point in time of a series of sequential steps. They are used to track progress of something over time.
+        status: "stable"
       - name: "progress_simple"
         platforms: *web
         description: Displays the current progress of an operation flow. User understanding increases when paired with labels or numbers.
       - name: "progress_step"
         platforms: *web
         description: "Progress step kit is used to show the progress of a process. There are three types of steps in this kit: completed, active, and inactive."
+        status: "stable"
       - name: "walkthrough"
         platforms: *web
         description:
+        status: "stable"
       - name: "timeline"
         platforms: *web
         description: The timeline kit can use two different line styles in the same timeline - solid and dotted line styles.
+        status: "stable"
   - name: tags
     description: 
     components:
       - name: "badge"
         platforms: *web
         description: Badges can be used for notification, tags, and status. They are used for count and numbers.
+        status: "stable"
       - name: "pill"
         platforms: *all
         description: A pill uses both a keyword and a specific color to categorize an item. 
+        status: "stable"
       - name: "hashtag"
         platforms: *web
         description: Hashtag is used to display home, project and other forms of IDs. They can be used as a link.
+        status: "stable"
   - name: typography
     description: ""
     components:
       - name: "body"
         platforms: *web
         description: Default text style for paragraphs. Follow hiearchy when using "light" or "lighter" variants to deemphasize text — default style should be followed by "light" followed by "lighter".
+        status: "stable"
       - name: "caption"
         platforms: *web
         description: Use to provide supplementary context. Default size is best when providing supplementary context to a small section (i.e. label for a text input, label for a paragraph). Use large caption when supplementary text covers more content.
+        status: "stable"
       - name: "detail"
         platforms: *web
         description: Used for tables or designs with large amounts of data or text.
+        status: "stable"
       - name: "title"
         platforms: *web
         description: Typically used as headers. Follow semantic hierarchy — Title 1s should be followed by Title 2s followed by Title 3s and so on, without skipping any levels.
+        status: "stable"
   - name: user
     description: 
     components:
       - name: "avatar"
         platforms: *all
         description: Avatar displays a user's picture. This helps aid easy recognition of the user. This kit is normally not used by itself, but rather used within other kits. The only time Avatar should be used instead of the User kit is when you are not going to display the user's name.
+        status: "stable"
       - name: "avatar_action_button"
         platforms: *web
         description: 
+        status: "stable"
       - name: "multiple_users"
         platforms: *web
         description: The multiple users kit is used to show that more than one user is associated to an action or item.
+        status: "stable"
       - name: "multiple_users_stacked"
         platforms: *web
         description: Multiple users stacked is used in tight spaces, where we need to indicate that multiple users are associated to a specific action or item.
+        status: "stable"
       - name: "user"
         platforms: *web
         description: This kit was created for having a systematic way of displaying users with avatar, titles, name and territory. This is a versatile kit with features than can be added to display more info.
+        status: "stable"

--- a/playbook-website/lib/pb_doc_helper.rb
+++ b/playbook-website/lib/pb_doc_helper.rb
@@ -33,7 +33,7 @@ module PlaybookWebsite
       kits.each do |kit|
         if kit.is_a?(Hash)
           nav_hash_array(kit).each do |sub_kit|
-            display_kits << render_pb_doc_kit(sub_kit, type, limit_examples, false, dark_mode) if pb_doc_has_kit_type?(sub_kit, type)
+            display_kits << render_pb_doc_kit(sub_kit[:name], type, limit_examples, false, dark_mode) if sub_kit[:status] != "beta" && pb_doc_has_kit_type?(sub_kit[:name], type)
           end
         elsif pb_doc_has_kit_type?(kit, type)
           display_kits << render_pb_doc_kit(kit, type, limit_examples, false, dark_mode)
@@ -45,8 +45,7 @@ module PlaybookWebsite
 
     # rubocop:disable Naming/AccessorMethodName
     def get_kits(_type = "rails")
-      aggregate_kits || []
-      # Filter kits that have at least one component compatible with the type
+      aggregate_kits_with_status || []
     end
 
     def get_kits_pb_website
@@ -57,12 +56,10 @@ module PlaybookWebsite
 
     # rubocop:disable Style/OptionalBooleanParameter
     def render_pb_doc_kit(kit, type, limit_examples, code = true, dark_mode = false)
-      if kit != "advanced_table"
-        title = pb_doc_render_clickable_title(kit, type)
-        ui = raw("<div class='pb--docItem-ui'>
-            #{pb_kit(kit: kit, type: type, show_code: code, limit_examples: limit_examples, dark_mode: dark_mode)}</div>")
-        title + ui
-      end
+      title = pb_doc_render_clickable_title(kit, type)
+      ui = raw("<div class='pb--docItem-ui'>
+          #{pb_kit(kit: kit, type: type, show_code: code, limit_examples: limit_examples, dark_mode: dark_mode)}</div>")
+      title + ui
     end
   # rubocop:enable Style/OptionalBooleanParameter
 


### PR DESCRIPTION
**What does this PR do?**

[RUNWAY STORY](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-184)

This PR will:

- ✅ Add a 'status' flag to menu.yml file to track kit status ('stable' or 'beta')
- ✅ Create new aggregate_kits method to include kit status
- ✅ Use new method to render sidebar so if 'beta' kit, does not show up in sidebar
- ✅ Edit search_list method to exclude 'beta' kits from typeahead search
- ✅ kit_show page to use new method (call out on top if kit beta)
- ✅ category page to use new method (do not show if kit beta)
- ✅ all kits page to use new method (do not show if kit beta)



**Screenshots:** 


**How to test?** Steps to confirm the desired behavior:
1. Test search typeahead
2. Test all kits page
3. Test category page
4. Test kit show pages
5. Check sidebar
