### PR TITLE
[PBNTR-181] Adding striped option to Table

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_table/_table.tsx
@@ -20,6 +20,7 @@ type TableProps = {
   singleLine?: boolean,
   size?: "sm" | "md" | "lg",
   sticky?: boolean,
+  striped?: boolean,
   verticalBorder?: boolean,
 } & GlobalProps
 
@@ -40,6 +41,7 @@ const Table = (props: TableProps) => {
     singleLine = false,
     size = 'sm',
     sticky = false,
+    striped = false,
     verticalBorder = false,
   } = props
 
@@ -70,6 +72,7 @@ const Table = (props: TableProps) => {
             'single-line': singleLine,
             'no-hover': disableHover,
             'sticky-header': sticky,
+            'striped': striped,
           },
           globalProps(props),
           tableCollapseCss,

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_striped.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_striped.html.erb
@@ -1,0 +1,48 @@
+<%= pb_rails("table", props: { striped: true }) do %>
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+      <th>Column 4</th>
+      <th>Column 5</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+  </tbody>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_striped.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_striped.jsx
@@ -1,0 +1,58 @@
+import React from "react"
+import Table from "../_table"
+
+const TableStriped = (props) => (
+  <Table
+      striped
+      {...props}
+  >
+    <thead>
+      <tr>
+        <th>{'Column 1'}</th>
+        <th>{'Column 2'}</th>
+        <th>{'Column 3'}</th>
+        <th>{'Column 4'}</th>
+        <th>{'Column 5'}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+      <tr>
+        <td>{'Value 1'}</td>
+        <td>{'Value 2'}</td>
+        <td>{'Value 3'}</td>
+        <td>{'Value 4'}</td>
+        <td>{'Value 5'}</td>
+      </tr>
+    </tbody>
+  </Table>
+)
+
+export default TableStriped

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_striped.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_striped.md
@@ -1,0 +1,1 @@
+Optionally pass the `striped` (boolean, defaults to false) prop to set odd rows to a contrasting background color. This helps with readability on larger tables with lots of data.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
@@ -23,6 +23,7 @@ examples:
     - table_icon_buttons: Table with Icon Buttons
     - table_with_background_kit: Table With Background Kit
     - table_vertical_border: Vertical Borders
+    - table_striped: Striped Table
 
   react:
     - table_sm: Small
@@ -47,3 +48,4 @@ examples:
     - table_icon_buttons: Table with Icon Buttons
     - table_with_background_kit: Table With Background Kit
     - table_vertical_border: Vertical Borders
+    - table_striped: Striped Table

--- a/playbook/app/pb_kits/playbook/pb_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/index.js
@@ -20,3 +20,4 @@ export { default as TableAlignmentShiftRow } from './_table_alignment_shift_row.
 export { default as TableAlignmentShiftData } from './_table_alignment_shift_data.jsx'
 export { default as TableWithBackgroundKit } from './_table_with_background_kit.jsx'
 export { default as TableVerticalBorder } from './_table_vertical_border.jsx'
+export { default as TableStriped } from './_table_striped.jsx'

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_all.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_all.scss
@@ -18,3 +18,4 @@
 @import "sticky_header";
 @import "vertical_border";
 @import "table_header";
+@import "striped";

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_striped.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_striped.scss
@@ -1,0 +1,19 @@
+[class^=pb_table] {
+  &.striped {
+    tbody {
+      tr:nth-child(odd) {
+        background-color: $bg_light;
+      }
+    }
+  }
+
+  &.dark {
+    &.striped {
+      tbody {
+        tr:nth-child(odd) {
+          background-color: $bg_dark;
+        }
+      }
+    }
+  }
+}

--- a/playbook/app/pb_kits/playbook/pb_table/table.rb
+++ b/playbook/app/pb_kits/playbook/pb_table/table.rb
@@ -25,12 +25,14 @@ module Playbook
                     default: false
       prop :vertical_border, type: Playbook::Props::Boolean,
                              default: false
+      prop :striped, type: Playbook::Props::Boolean,
+                     default: false
 
       def classname
         generate_classname(
           "pb_table", "table-#{size}", single_line_class, dark_class,
           disable_hover_class, container_class, data_table_class, sticky_class, collapse_class,
-          vertical_border_class, "table-responsive-#{responsive}", separator: " "
+          vertical_border_class, striped_class, "table-responsive-#{responsive}", separator: " "
         )
       end
 
@@ -62,6 +64,10 @@ module Playbook
 
       def sticky_class
         sticky ? "sticky-header" : nil
+      end
+
+      def striped_class
+        striped ? "striped" : nil
       end
 
       def vertical_border_class

--- a/playbook/app/pb_kits/playbook/pb_table/table.test.js
+++ b/playbook/app/pb_kits/playbook/pb_table/table.test.js
@@ -15,3 +15,8 @@ test("when sticky is true", () => {
   const kit = renderKit(Table, props, { sticky: true })
   expect(kit).toHaveClass("pb_table table-sm table-responsive-collapse table-card sticky-header table-collapse-sm")
 })
+
+test("when striped is true", () => {
+  const kit = renderKit(Table, props, { striped: true })
+  expect(kit).toHaveClass("pb_table table-sm table-responsive-collapse table-card striped table-collapse-sm")
+})


### PR DESCRIPTION
**What does this PR do?
Add a zebra strip option for the table kit to implement zebra stripes on larger tables (for readability).

**Screenshots:**
![image](https://github.com/powerhome/playbook/assets/2573205/1e48339d-08cb-4aab-ae23-862509a859ed)
![image](https://github.com/powerhome/playbook/assets/2573205/de6c4c3a-15cc-425a-b702-aafd25bdb258)


**How to test?** Steps to confirm the desired behavior:
1. Go to Table docs
2. Scroll down to the last one (Striped doc)


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.