### PR TITLE
GH Release Workflow Fixes

### DIFF
--- a/.github/workflows/github-actions-alpha-version.yml
+++ b/.github/workflows/github-actions-alpha-version.yml
@@ -68,7 +68,7 @@ jobs:
           gem build playbook_ui.gemspec
           gem build lib/playbook_ui_docs.gemspec
           npm publish --registry https://registry.npmjs.org playbook-ui-${{ env.new_npm_alpha_version }}.tgz --tag alpha
-          rm -rf dist/playbook-doc.js dist/playbook-rails.js dist/app  dist/pb_doc_helper.rb dist/menu.yml
+
           echo "${{ env.new_ruby_alpha_version }}"
           gem push playbook_ui-${{ env.new_ruby_alpha_version }}.gem --host https://rubygems.org/ --key ${{ env.GEM_HOST_API_KEY }}
           gem push playbook_ui_docs-${{ env.new_ruby_alpha_version }}.gem --host https://rubygems.org/ --key ${{ env.GEM_HOST_API_KEY }}

--- a/.github/workflows/github-actions-alpha-version.yml
+++ b/.github/workflows/github-actions-alpha-version.yml
@@ -58,17 +58,19 @@ jobs:
           gem install bundler
           bundle
           bin/rails pb_release:action[${{env.new_ruby_alpha_version}}]
-      - name: Version Up, Distribute and Publish
+      - name: Version Up, Distribute and Publish (NPM)
         run: |
           yarn install
           yarn version --new-version ${{ env.new_npm_alpha_version }}
           bundle
           yarn release
           npm pack
+          npm publish --registry https://registry.npmjs.org playbook-ui-${{ env.new_npm_alpha_version }}.tgz --tag alpha
+      - name: Version Up, Distribute and Publish (RubyGems)
+        run: |
           gem build playbook_ui.gemspec
           gem build lib/playbook_ui_docs.gemspec
-          npm publish --registry https://registry.npmjs.org playbook-ui-${{ env.new_npm_alpha_version }}.tgz --tag alpha
-
+          rm -rf dist/playbook-doc.js dist/playbook-rails.js dist/app  dist/pb_doc_helper.rb dist/menu.yml
           echo "${{ env.new_ruby_alpha_version }}"
           gem push playbook_ui-${{ env.new_ruby_alpha_version }}.gem --host https://rubygems.org/ --key ${{ env.GEM_HOST_API_KEY }}
           gem push playbook_ui_docs-${{ env.new_ruby_alpha_version }}.gem --host https://rubygems.org/ --key ${{ env.GEM_HOST_API_KEY }}

--- a/.github/workflows/github-actions-alpha-version.yml
+++ b/.github/workflows/github-actions-alpha-version.yml
@@ -67,8 +67,8 @@ jobs:
           npm pack
           gem build playbook_ui.gemspec
           gem build lib/playbook_ui_docs.gemspec
-          rm -rf dist/playbook-doc.js dist/playbook-rails.js dist/app  dist/pb_doc_helper.rb dist/menu.yml
           npm publish --registry https://registry.npmjs.org playbook-ui-${{ env.new_npm_alpha_version }}.tgz --tag alpha
+          rm -rf dist/playbook-doc.js dist/playbook-rails.js dist/app  dist/pb_doc_helper.rb dist/menu.yml
           echo "${{ env.new_ruby_alpha_version }}"
           gem push playbook_ui-${{ env.new_ruby_alpha_version }}.gem --host https://rubygems.org/ --key ${{ env.GEM_HOST_API_KEY }}
           gem push playbook_ui_docs-${{ env.new_ruby_alpha_version }}.gem --host https://rubygems.org/ --key ${{ env.GEM_HOST_API_KEY }}

--- a/.github/workflows/github-actions-alpha-version.yml
+++ b/.github/workflows/github-actions-alpha-version.yml
@@ -25,7 +25,7 @@ jobs:
           echo "//npm.powerapp.cloud/:always-auth = true" >> .npmrc
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.11.0
       - name: Ruby Setup
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
- Use the exact version `20.11.0` as specified in `.tool-versions` for GH actions workflow.
- Separate NPM build/package/dist task from Ruby Gems.

<img width="1023" alt="Screenshot 2024-02-19 at 5 18 19 PM" src="https://github.com/powerhome/playbook/assets/2293844/e4ec37e7-ba6e-4a71-8d19-283ffbab07a1">
