### PR TITLE
[PLAY-867] Fixed Rails Kit Form Group DatePicker

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -57,6 +57,10 @@
     margin-bottom: 16px;
   }
 
+  &[class*=rails] > [class^=pb_date_picker_kit] {
+    margin-bottom: 0px;
+  }
+
   & > [class^=pb_date_picker_kit]:not(:last-child) {
     .text_input_wrapper input, [class^=pb_text_input_kit] .text_input_wrapper .flatpickr-wrapper {
       border-bottom-right-radius: 0;

--- a/playbook/app/pb_kits/playbook/pb_form_group/form_group.rb
+++ b/playbook/app/pb_kits/playbook/pb_form_group/form_group.rb
@@ -7,13 +7,17 @@ module Playbook
                         default: false
 
       def classname
-        generate_classname("pb_form_group_kit", full_width_class)
+        generate_classname("pb_form_group_kit", full_width_class) + form_group_rails
       end
 
     private
 
       def full_width_class
         full_width ? "full" : nil
+      end
+
+      def form_group_rails
+        " rails"
       end
     end
   end

--- a/playbook/spec/pb_kits/playbook/kits/form_group_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/form_group_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Playbook::PbFormGroup::FormGroup do
 
   describe "#classname" do
     it "returns namespaced class name" do
-      expect(subject.new({}).classname).to eq "pb_form_group_kit"
-      expect(subject.new(full_width: true).classname).to eq "pb_form_group_kit_full"
+      expect(subject.new({}).classname).to eq "pb_form_group_kit rails"
+      expect(subject.new(full_width: true).classname).to eq "pb_form_group_kit_full rails"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fixes the datepicker margin, when it is used within a form group. 

**Screenshots:** Screenshots to visualize your addition/change
<img width="522" alt="Screenshot 2024-02-20 at 9 58 56 AM" src="https://github.com/powerhome/playbook/assets/9158723/b652566d-407c-4fc0-ab1a-2fbebcfe2234">


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.