### PR TITLE
[THOR-93] BarGraph customOptions prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -7,6 +7,7 @@ import Highcharts from "highcharts";
 import { highchartsTheme } from "../pb_dashboard/pbChartsLightTheme";
 import { highchartsDarkTheme } from "../pb_dashboard/pbChartsDarkTheme";
 import mapColors from "../pb_dashboard/pbChartsColorsHelper";
+import { merge } from 'lodash'
 
 import classnames from "classnames";
 
@@ -130,8 +131,10 @@ const BarGraph = ({
   const [options, setOptions] = useState({});
 
   useEffect(() => {
-    setOptions({ ...staticOptions, ...customOptions });
+    setOptions(merge(staticOptions, customOptions));
   }, [chartData]);
+
+  console.log(options, "options inside playbook")
 
   return (
     <HighchartsReact

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -134,8 +134,6 @@ const BarGraph = ({
     setOptions(merge(staticOptions, customOptions));
   }, [chartData]);
 
-  console.log(options, "options inside playbook")
-
   return (
     <HighchartsReact
         containerProps={{

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -19,6 +19,7 @@ type BarGraphProps = {
   yAxisMax: number;
   chartData: { name: string; data: number[] }[];
   className?: string;
+  customOptions?: Partial<Highcharts.Options>;
   id: string;
   pointStart: number;
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
@@ -48,6 +49,7 @@ const BarGraph = ({
   className = "pb_bar_graph",
   colors,
   htmlOptions = {},
+  customOptions = {},
   id,
   pointStart,
   subTitle,
@@ -128,7 +130,7 @@ const BarGraph = ({
   const [options, setOptions] = useState({});
 
   useEffect(() => {
-    setOptions({ ...staticOptions });
+    setOptions({ ...staticOptions, ...customOptions });
   }, [chartData]);
 
   return (

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/bar_graph.rb
@@ -9,6 +9,7 @@ module Playbook
       prop :axis_title
       prop :chart_data, type: Playbook::Props::Array,
                         default: []
+      prop :custom_options, default: {}
       prop :orientation, type: Playbook::Props::Enum,
                          values: %w[vertical horizontal],
                          default: "vertical"
@@ -39,7 +40,7 @@ module Playbook
         orientation == "horizontal" ? "bar" : "column"
       end
 
-      def chart_options
+      def standard_options
         {
           align: align,
           id: id,
@@ -63,6 +64,10 @@ module Playbook
           x: x,
           y: y,
         }
+      end
+
+      def chart_options
+        standard_options.deep_merge(custom_options)
       end
 
       def classname

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.html.erb
@@ -1,0 +1,39 @@
+<% data = [{
+    name: 'Installation',
+    data: [1475,200,3000,654,656]
+}, {
+    name: 'Manufacturing',
+    data: [4434,524,2320,440,500]
+}, {
+    name: 'Sales & Distribution',
+    data: [3387,743,1344,434,440,]
+}, {
+    name: 'Project Development',
+    data: [3227,878,999,780,1000]
+}, {
+    name: 'Other',
+    data: [1111,677,3245,500,200]
+}] %>
+
+<% custom_options = {
+    customOptions: {
+          subtitle: {
+            text: "Overwritten subtitle",
+            style: {
+                color: "red",
+                fontSize: 20
+            }
+        }
+    }
+} %>
+
+<%= pb_rails("bar_graph", props: {
+    axis_title: 'Number of Employees',
+    chart_data: data,
+    id: "bar-default",
+    y_axis_min: 0,
+    x_axis_categories:['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
+    subtitle: 'Subtitle to replace',
+    title: 'Solar Employment Growth by Sector, 2010-2016',
+    custom_options: custom_options
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.html.erb
@@ -17,11 +17,22 @@
 
 <% custom_options = {
     customOptions: {
-          subtitle: {
+        subtitle: {
             text: "Overwritten subtitle",
             style: {
-                color: "red",
-                fontSize: 20
+                color: "red"
+            }
+        },
+        xAxis: {
+            categories: [
+                '<i class="far fa-apple-whole"></i> Jan',
+                '<i class="far fa-strawberry"></i> Feb',
+                '<i class="far fa-lemon"></i> Mar',
+                '<i class="far fa-pear"></i> Apr',
+                '<i class="far fa-peach"></i> May'
+            ],
+            labels: {
+                useHTML: true,
             }
         }
     }
@@ -32,7 +43,6 @@
     chart_data: data,
     id: "bar-default",
     y_axis_min: 0,
-    x_axis_categories:['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
     subtitle: 'Subtitle to replace',
     title: 'Bar Graph with Custom Overrides',
     custom_options: custom_options

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.html.erb
@@ -34,6 +34,6 @@
     y_axis_min: 0,
     x_axis_categories:['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'],
     subtitle: 'Subtitle to replace',
-    title: 'Solar Employment Growth by Sector, 2010-2016',
+    title: 'Bar Graph with Custom Overrides',
     custom_options: custom_options
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import BarGraph from '../_bar_graph'
+
+const chartData = [{
+  name: 'Installation',
+  data: [1475, 200, 3000, 654, 656],
+}, {
+  name: 'Manufacturing',
+  data: [4434, 524, 2320, 440, 500],
+}, {
+  name: 'Sales & Distribution',
+  data: [3387, 743, 1344, 434, 440],
+}, {
+  name: 'Project Development',
+  data: [3227, 878, 999, 780, 1000],
+}, {
+  name: 'Other',
+  data: [1111, 677, 3245, 500, 200],
+}]
+
+const barGraphOptions = {
+  subtitle: {
+    text: "Overwritten subtitle"
+  },
+  xAxis: {
+      labels: {
+          useHTML: true,
+          formatter: function() {
+              switch (this.value) {
+                  case 'Jan':
+                      return `<i class="fa-regular fa-apple-whole"></i> ${this.value}`
+                  case 'Feb':
+                      return `<i class="far fa-strawberry"></i> ${this.value}`
+                  case 'Mar':
+                      return `<i class="far fa-lemon"></i> ${this.value}`
+                  case 'Apr':
+                      return `<i class="far fa-pear"></i> ${this.value}`
+                  case 'May':
+                      return `<i class="far fa-peach"></i> ${this.value}`
+                  default:
+                      return ''
+              }
+          }
+      }
+  }
+}
+
+const BarGraphCustom = (props) => (
+  <div>
+    <BarGraph
+        axisTitle="Number of Employees"
+        chartData={chartData}
+        customOptions={barGraphOptions}
+        id="bar-custom"
+        subTitle="Subtitle to replace"
+        title="Bar Graph with Custom Overrides"
+        xAxisCategories={['Jan', 'Feb', 'Mar', 'Apr', 'May']}
+        yAxisMin={0}
+        {...props}
+    />
+  </div>
+)
+
+export default BarGraphCustom

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.jsx
@@ -21,7 +21,10 @@ const chartData = [{
 
 const barGraphOptions = {
   subtitle: {
-    text: "Overwritten subtitle"
+    text: "Overwritten subtitle",
+    style: {
+      color: "red"
+    }
   },
   xAxis: {
       labels: {
@@ -29,7 +32,7 @@ const barGraphOptions = {
           formatter: function() {
               switch (this.value) {
                   case 'Jan':
-                      return `<i class="fa-regular fa-apple-whole"></i> ${this.value}`
+                      return `<i class="far fa-apple-whole"></i> ${this.value}`
                   case 'Feb':
                       return `<i class="far fa-strawberry"></i> ${this.value}`
                   case 'Mar':

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.md
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.md
@@ -1,0 +1,1 @@
+See https://api.highcharts.com/highcharts/ for a comprehensive list of available options.

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/example.yml
@@ -8,6 +8,7 @@ examples:
   - bar_graph_height: Height
   - bar_graph_spline: Spline
   - bar_graph_colors: Color Overrides
+  - bar_graph_custom: Custom Overrides
 
 
   react:
@@ -18,3 +19,4 @@ examples:
   - bar_graph_height: Height
   - bar_graph_spline: Spline
   - bar_graph_colors: Color Overrides
+  - bar_graph_custom: Custom Overrides

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/index.js
@@ -5,3 +5,4 @@ export { default as BarGraphLegendNonClickable } from './_bar_graph_legend_non_c
 export { default as BarGraphHeight } from './_bar_graph_height.jsx'
 export { default as BarGraphSpline } from './_bar_graph_spline.jsx'
 export { default as BarGraphColors } from './_bar_graph_colors.jsx'
+export { default as BarGraphCustom } from './_bar_graph_custom.jsx'

--- a/playbook/spec/pb_kits/playbook/kits/bar_graph_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/bar_graph_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Playbook::PbBarGraph::BarGraph do
   it { is_expected.to define_prop(:legend).of_type(Playbook::Props::Boolean).with_default(false) }
   it { is_expected.to define_prop(:toggle_legend_click).of_type(Playbook::Props::Boolean).with_default(true) }
   it { is_expected.to define_prop(:title) }
+  it { is_expected.to define_prop(:custom_options).with_default({}) }
   it {
     is_expected.to define_enum_prop(:orientation)
       .with_default("vertical")


### PR DESCRIPTION
**What does this PR do?**

Adds a customOptions prop that merges with the current options, allowing for more flexibility in the Highcharts BarGraph when needing to use more flexible/complex use cases. 

**Screenshots:** 
<img width="2224" alt="Screen Shot 2024-02-23 at 11 17 03 AM" src="https://github.com/powerhome/playbook/assets/10185546/a8a013a4-9b28-45ba-88b9-faec89d89757">


Nitro PR to test: https://github.com/powerhome/nitro-web/pull/38055

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.