### PR TITLE
Fix colors guidelines layout

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Colors/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Colors/index.tsx
@@ -3,7 +3,7 @@
 // React Pure component - do not use state!
 import React from 'react'
 
-import { Title } from 'playbook-ui'
+import { Background, Title } from 'playbook-ui'
 import Example from './Example'
 import StatusExample from './StatusExample'
 
@@ -24,58 +24,63 @@ import {
 
 const Colors = (): React.ReactElement => (
   <React.Fragment>
-    <Title
-        marginBottom="lg"
-        size={1}
-        tag="h1"
+    <Background
+        margin="xl"
+        paddingX="xl"
     >
-      {'Colors'}
-    </Title>
-    <Example
-        colors={TEXT_COLORS}
-        title="Text Colors"
-    />
-    <Example
-        colors={BACKGROUND}
-        title="Backgrounds"
-    />
-    <Example
-        colors={CARDS}
-        title="Cards"
-    />
-    <StatusExample
-        statusColors={STATUS}
-        subtleColors={STATUS_SUBTLE}
-        title="Status"
-    />
-    <Example
-        colors={DATA}
-        title="Data"
-    />
-    <Example
-        colors={ACTIONS}
-        title="Actions"
-    />
-    <Example
-        colors={ACTIVE}
-        title="Active"
-    />
-    <Example
-        colors={BORDER}
-        title="Border"
-    />
-    <Example
-        colors={SHADOW}
-        title="Shadow"
-    />
-    <Example
-        colors={PRODUCTS}
-        title="Product Colors"
-    />
-    <Example
-        colors={CATEGORY}
-        title="Category Colors"
-    />
+      <Title
+          marginBottom="lg"
+          size={1}
+          tag="h1"
+      >
+        {'Colors'}
+      </Title>
+      <Example
+          colors={TEXT_COLORS}
+          title="Text Colors"
+      />
+      <Example
+          colors={BACKGROUND}
+          title="Backgrounds"
+      />
+      <Example
+          colors={CARDS}
+          title="Cards"
+      />
+      <StatusExample
+          statusColors={STATUS}
+          subtleColors={STATUS_SUBTLE}
+          title="Status"
+      />
+      <Example
+          colors={DATA}
+          title="Data"
+      />
+      <Example
+          colors={ACTIONS}
+          title="Actions"
+      />
+      <Example
+          colors={ACTIVE}
+          title="Active"
+      />
+      <Example
+          colors={BORDER}
+          title="Border"
+      />
+      <Example
+          colors={SHADOW}
+          title="Shadow"
+      />
+      <Example
+          colors={PRODUCTS}
+          title="Product Colors"
+      />
+      <Example
+          colors={CATEGORY}
+          title="Category Colors"
+      />
+    </Background>
   </React.Fragment>
 )
 


### PR DESCRIPTION
Fixes layout issue with https://playbook.powerapp.cloud/visual_guidelines/colors

## Before
<img width="946" alt="Screenshot 2024-03-01 at 11 26 49 AM" src="https://github.com/powerhome/playbook/assets/2293844/0094aaa1-3736-4a65-be60-a713a84e6447">

## After
<img width="1427" alt="Screenshot 2024-03-01 at 11 27 31 AM" src="https://github.com/powerhome/playbook/assets/2293844/29f13c4b-7127-4ff9-a027-067480ad8a59">
