### PR TITLE
[PLAY-1241] rebuild Playbook-Icons-react for use in Nitro

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/layouts/Footer.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Footer.tsx
@@ -72,10 +72,6 @@ const Footer = () => {
             flexDirection={{ xs: "row" }}
           >
             <Flex maxWidth='sm' paddingTop='xl' display={{ xs: "none" }}>
-              {/* <img
-                src='media/images/power-subtract-logo.svg'
-                alt='Power Subtract Logo'
-              /> */}
               <FlexItem alignSelf='center'>
                 <Body
                   dark

--- a/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
@@ -3,7 +3,22 @@ import React from "react"
 import { linkFormat } from "../../../../../utilities/website_sidebar_helper"
 
 import { Hero } from "../../components/Hero"
-import { Roofing, Powergon, Nitro, ChevronDown, Times, Bars, Calendar, Filter, Edit, Trash, Check, Plus, Search} from '@powerhome/playbook-icons-react'
+import {
+  Roofing,
+  Powergon,
+  Nitro,
+  ChevronDown,
+  Times,
+  Bars,
+  Calendar,
+  Filter,
+  Edit,
+  Trash,
+  Check,
+  Plus,
+  Search
+} from '@powerhome/playbook-icons-react'
+
 import { Body, Icon, Title, Flex, FlexItem, Card } from "playbook-ui"
 
 const pbIcons = {

--- a/playbook-website/app/javascript/packs/app.js
+++ b/playbook-website/app/javascript/packs/app.js
@@ -44,7 +44,7 @@ const router = createBrowserRouter(
       />
       <Route
           element={<IconList />}
-          path=":name"
+          path="icons"
       />
 
     </Route>

--- a/playbook-website/config/routes.rb
+++ b/playbook-website/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   ## Beta View
   get "beta/kits", to: "pages#application_beta"
   get "beta/kits/:name", to: "pages#application_beta"
+  get "beta/icons", to: "pages#application_beta"
 
   # Legacy View
   get "kits", to: "pages#kits"

--- a/playbook-website/config/webpack/environment.js
+++ b/playbook-website/config/webpack/environment.js
@@ -2,15 +2,25 @@ const path = require('path')
 
 const { environment } = require('@rails/webpacker')
 
-environment.loaders.insert('javascript', {
-  test: /\.(js|jsx)$/,
+const babelLoader = environment.loaders.get('babel')
+babelLoader.test = /\.(js|jsx|ts|tsx)?(\.erb)?$/
+
+const nodeLoader = environment.loaders.get('nodeModules')
+nodeLoader.exclude = [
+  nodeLoader.exclude,
+  /node_modules\/@powerhome\/playbook-icons-react/
+]
+
+environment.loaders.prepend('ESM', {
+  test: /\.mjs$/,
   use: {
     loader: 'babel-loader',
     options: {
       cacheDirectory: true,
     },
   },
-  include: path.resolve(__dirname, '../../app'),
+  // include: /node_modules/,
+  type: 'javascript/auto',
 })
 
 environment.loaders.prepend('svgr', {
@@ -42,19 +52,6 @@ environment.loaders.append('image', {
   include: [
     path.resolve(__dirname, '../../app')
   ],
-})
-
-// Allow ESM modules
-environment.config.merge({
-  module: {
-    rules: [
-      {
-        test: /\.mjs$/,
-        include: /node_modules/,
-        type: 'javascript/auto',
-      },
-    ],
-  },
 })
 
 environment.config.merge({

--- a/playbook-website/config/webpacker.yml
+++ b/playbook-website/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: []
+  additional_paths: ['app']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "^6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "0.0.1-alpha.2",
-    "@powerhome/playbook-icons-react": "0.0.1-alpha.2",
+    "@powerhome/playbook-icons": "0.0.1-alpha.8",
+    "@powerhome/playbook-icons-react": "0.0.1-alpha.8",
     "@rails/webpacker": "5.4.3",
     "@svgr/webpack": "5.5.0",
     "@tiptap/extension-document": "^2.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,6 +138,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.4.5":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.0.tgz#56cbda6b185ae9d9bed369816a8f4423c5f2ff1b"
+  integrity sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.23.5"
+    "@babel/generator" "^7.23.6"
+    "@babel/helper-compilation-targets" "^7.23.6"
+    "@babel/helper-module-transforms" "^7.23.3"
+    "@babel/helpers" "^7.24.0"
+    "@babel/parser" "^7.24.0"
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.20.7":
   version "7.20.7"
   resolved "https://npm.powerapp.cloud/@babel/generator/-/generator-7.20.7.tgz#f8ef57c8242665c5929fe2e8d82ba75460187b4a"
@@ -2066,6 +2087,15 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.12.6", "@babel/types@^7.23.4", "@babel/types@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
+  integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==
+  dependencies:
+    "@babel/helper-string-parser" "^7.23.4"
+    "@babel/helper-validator-identifier" "^7.22.20"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.22.15":
   version "7.23.6"
   resolved "https://npm.powerapp.cloud/@babel/types/-/types-7.23.6.tgz#be33fdb151e1f5a56877d704492c240fc71c7ccd"
@@ -2079,15 +2109,6 @@
   version "7.23.9"
   resolved "https://npm.powerapp.cloud/@babel/types/-/types-7.23.9.tgz#1dd7b59a9a2b5c87f8b41e52770b5ecbf492e002"
   integrity sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==
-  dependencies:
-    "@babel/helper-string-parser" "^7.23.4"
-    "@babel/helper-validator-identifier" "^7.22.20"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.24.0":
-  version "7.24.0"
-  resolved "https://npm.powerapp.cloud/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
-  integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==
   dependencies:
     "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"
@@ -3020,15 +3041,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@0.0.1-alpha.2":
-  version "0.0.1-alpha.2"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/c42ced1d7f9be19630cc013075e63238b7d25570#c42ced1d7f9be19630cc013075e63238b7d25570"
-  integrity sha512-Z6SoCndm6HTQav5Up3LxTj+0xW3BOy3pj2WnsdQzCBrPdf9oGR+k7zxvVX3YL8Jgtb6TCK0yr8FVYhnvbp/64A==
+"@powerhome/playbook-icons-react@0.0.1-alpha.8":
+  version "0.0.1-alpha.8"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/d71ffd31679c57b3a7358718ce84b2f9e5f0c577#d71ffd31679c57b3a7358718ce84b2f9e5f0c577"
+  integrity sha512-SUM1/MsJb4nnNEz2A9PMXa8hgBeCdGCNQWEdrozy1l2/1GZOkiw28aGIUZZN3LAR2+0hRRNhVhcetfpuGCZcFg==
 
-"@powerhome/playbook-icons@0.0.1-alpha.2":
-  version "0.0.1-alpha.2"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/5dce20f3dab62a07cb50a9414f08688a8c3cab24#5dce20f3dab62a07cb50a9414f08688a8c3cab24"
-  integrity sha512-DwbvpTfyiK6DHglGwyJ8yt/RRaMHOI51X5zN2cvFyancuwkdhXZy69v9Ii4yrnCfFgiZUbHG6iq4W7S9rrqvfg==
+"@powerhome/playbook-icons@0.0.1-alpha.8":
+  version "0.0.1-alpha.8"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/ab390d12f3621b45d7238f51995545c1d52f33e0#ab390d12f3621b45d7238f51995545c1d52f33e0"
+  integrity sha512-TX4GWwhU909LEzhJo8Eb/e3IBLFJu+2K5DeRffvDI5XaNxhFXZKfsgcgDtxsDPOmx/7Owk+Qs+IFJjwhZ6sbxw==
 
 "@rails/actioncable@^7.0":
   version "7.1.3"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This PR contains all changes from https://github.com/powerhome/playbook/pull/3182 and intends to:

- Use the latest version of `@powerhome/playbook-icons` and `@powerhome/playbook-icons-react`
- Handle ES modules from the above correctly

## Compare Branches

https://github.com/powerhome/playbook/compare/play/1141_icon_kit_using_library...PLAY-1241-2

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.