### PR TITLE
Enable Remote Shell 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+SHELL=/bin/bash -o pipefail
+namespace ?= playbook-${environment}
+
+cluster=${shell playbook-website/bin/deployer bin/cluster_for_review_stack $(environment)}
+cluster_short_name=${shell playbook-website/bin/deployer bin/cluster_for_review_stack $(environment) short}
+review_cluster = ${shell playbook-website/bin/deployer bin/cluster_for_review_stack pr$(pr)}
+
 start:
 	docker compose up
 
@@ -21,6 +28,10 @@ test:
 
 shell:
 	docker compose run web /bin/bash --login
+
+time-to-live ?= 3h
+reviewShell: ## Opens a shell in the given environment (i.e.: make reviewShell pr=14166)
+	./playbook-website/bin/deployer bash -lc "playbook-website/bin/remote_exec --time-to-live $(time-to-live) --cluster $(review_cluster) --namespace playbook-pr$(pr) bash --login"
 
 console:
 	docker compose run web bin/rails console

--- a/playbook-website/bin/cluster_for_review_stack
+++ b/playbook-website/bin/cluster_for_review_stack
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+pr_number=$1
+mode=${2:-"long"}
+clusters=("hq" "gm" "px")
+
+function find_cluster_for_review_stack() {
+    found=$(kubectl --ignore-not-found=true --context app-beta-${1} get namespace playbook-${pr_number})
+
+    if [[ -n $found ]];
+    then
+        if [ "$mode" == "short" ];
+        then
+            echo $1
+        else
+            echo "app-beta-${1}"
+        fi
+        exit 0
+    fi
+}
+
+for cluster in ${clusters[@]}
+do
+  find_cluster_for_review_stack $cluster
+done
+

--- a/playbook-website/bin/remote_exec
+++ b/playbook-website/bin/remote_exec
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+#
+# Purpose:
+#
+#  Creates an application pod from the a pod template and connects the
+#  local terminal to the remote pod. This script is intended to
+#  be run from with the APP Platform's 'deployer' container which contains
+#  appropriate version of kubectl to apply the "pod".
+#
+# Usage:
+#   app bin/container/remote_exec --namespace=playbook-pr12345 --cluster=app-beta-gm bash -l
+#
+
+set -Eeuo pipefail
+trap "cleanup" SIGINT SIGTERM ERR EXIT
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+function usage() {
+    cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") -c cluster-name -n namespace [OPTIONS] command
+
+  Creates an application pod from the a pod template and connects the
+  local terminal to the remote pod. This script is intended to
+  be run from with the APP Platform's 'deployer' container which contains
+  appropriate version of kubectl to apply the "pod".
+
+Available options:
+
+Required:
+
+-c, --cluster          Required -The Kubernetes cluster in which a pod is
+                       desired.
+                       Examples:
+                         -c app-beta-qa
+                         --cluster app-beta-qa
+
+-n, --namespace        Required - The Kubernetes namespace in which a pod is
+                       desired.
+                       Examples:
+                         -n playbook-pr12345
+                         --namespace playbook-pr12345
+
+Optional:
+
+-f, --force            Always create a new , do not attempt to reconnect
+                       to existing pods.
+
+-h, --help             Print this help and exit
+
+-l, --component-name   The component name of the podtemplate which describes the
+                       desired pod.
+                       Default: 'shell'
+                       Examples:
+                         -l assets-utility
+                         --component-name assets-utility
+
+-t, --time-to-live     Automatically shut down the pod after the pod has run
+                       for this much time. The value format is "NUMm", where "NUM"
+                       is an amount of time and the "m" modifier is either s, m,
+                       or h for seconds, minutes and hours. To automatically
+                       terminate the pod after a day, one could select any
+                       one of the following forms: -t=86400s, -t=1440m, -t=24h,
+                       -t=1d. The modifier is not case sensitive, but it does
+                       require no space between the number and itself.
+                       Default: 3h
+                       Examples:
+                         -t 15m
+                         --time-to-live 1h
+
+-v, --verbose          Print script debug info
+
+Example:
+
+  app bin/container/remote_exec --namespace=playbook-pr12345 --cluster=app-beta-gm bash -l
+
+EOF
+    exit
+}
+
+function running_pod() {
+    msg "Looking for $component_name pods..."
+    kubectl get pod --context="$cluster" --namespace="$namespace" \
+            --field-selector="status.phase==Running" \
+            --selector="$component_label" \
+            -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || :
+}
+
+function create_pod() {
+    local pod_template=
+
+    pod_template="$(kubectl get podtemplate --context="$cluster" --namespace="$namespace" --selector="$component_label" --output=yaml | ruby -ryaml -e "
+      template = YAML.parse(STDIN.read).root.to_ruby.dig('items')[0]['template']
+      template = template.merge('kind' => 'Pod', 'apiVersion' => 'v1')
+      template['spec']['containers'][0]['args'] = ['--', 'sleep', '$ttl_in_seconds']
+      puts YAML.dump(template)
+    ")"
+
+    msg "${GREEN}Creating new $component_name pod which will automatically shut down after $ttl ($ttl_in_seconds seconds)${NOFORMAT}..."
+    echo "$pod_template" | kubectl create --context="$cluster" --namespace="$namespace" --output jsonpath='{.metadata.name}' --filename -
+}
+
+function pod_status() {
+    local pod_name=
+    pod_name="$1"
+
+    kubectl get pod --context="$cluster" --namespace="$namespace" "$pod_name" --output jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+}
+
+function find_or_create_pod() {
+    local pod_name=
+    pod_name="$(running_pod)"
+
+    if [[ $force -eq 1 ]]
+    then
+        msg "Forcing creation of new $component_name pod"
+
+        pod_name="$(create_pod)"
+
+        [[ -n "$pod_name" ]] || die "${RED}Failed to create '$component_name' pod in '$cluster / $namespace'${NOFORMAT}"
+    elif [[ "z${pod_name-}" != "z" ]]
+    then
+         msg "${ORANGE}Found an existing $component_name pod ($pod_name). Would you like to reconnect to it?${NOFORMAT} [y/n]:"
+         local reconnect=
+         read -re reconnect
+
+         if [[ "${reconnect-}" != "y" ]] && [[ "${reconnect-}" != "Y" ]]
+         then
+             pod_name="$(create_pod)"
+             [[ -n "$pod_name" ]] || die "${RED}Failed to create '$component_name' pod in '$cluster / $namespace'${NOFORMAT}"
+         fi
+    else
+        msg "No existing $component_name pods found. Creating a new one"
+        pod_name="$(create_pod)"
+        [[ -n "$pod_name" ]] || die "${RED}Failed to create '$component_name' pod in '$cluster / $namespace'${NOFORMAT}"
+
+        msg "Created $pod_name"
+    fi
+
+    echo "$pod_name"
+}
+
+function connect() {
+    local pod_name=
+    pod_name="$1"
+
+    local max_retries=
+    max_retries=${2:-120}
+
+    local current_retry=
+    current_retry=0
+
+    msg "Connecting to $pod_name"
+    until [ $current_retry -ge $max_retries ]
+    do
+        ((current_retry+=1))
+        printf "."
+        if [ "$(pod_status "$pod_name")" == "True" ]
+        then
+            msg "\n$pod_name is in a ready state. Running \"${cmd[*]-}\""
+            kubectl exec --stdin --tty --context="$cluster" --namespace="$namespace" "$pod_name" -- setuser app ${cmd[*]-}
+            break
+        fi
+        sleep 1
+    done
+
+    [ $current_retry -ge $max_retries ] &&  die "\n${RED}Failed to connect to $pod_name within a reasonable amount of retries. Aborting.${NOFORMAT}"
+
+    return 0
+}
+
+function delete() {
+    local pod_name=
+    pod_name="$1"
+
+    msg "${CYAN}Deleting $component_name pod ($pod_name)${NOFORMAT}"
+    kubectl delete pod --context="$cluster" --namespace="$namespace" --grace-period=0 --force "$pod_name"
+}
+
+function main() {
+    main_ran=1
+    pod_name="$(find_or_create_pod)"
+
+    connect "$pod_name"
+}
+
+function cleanup() {
+    trap - SIGINT SIGTERM ERR EXIT
+    if [[ $main_ran != 0 ]]
+    then
+        msg "Cleaning up completed $component_name pods..."
+        pod_statuses=$(kubectl get pod --selector="$component_label" --context="$cluster" --namespace="$namespace" --output jsonpath='{range .items[*]}{@.metadata.name}={@.status.phase};{end}' 2>/dev/null)
+
+        local completed_pods=
+        completed_pods=$(echo "$pod_statuses" | tr ';' '\n' | grep -vE "(=Running|=Pending)" | cut -f1 -d'=' | xargs)
+
+        local completed_pod_names=
+        completed_pod_names=$(echo "$pod_name $completed_pods" | awk '{$1=$1;print}')
+        for completed_pod_name in ${completed_pod_names}
+        do
+            delete "$completed_pod_name"
+        done
+    fi
+}
+
+function setup_colors() {
+    if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+        NOFORMAT='\033[0m'
+        RED='\033[0;31m'
+        GREEN='\033[0;32m'
+        ORANGE='\033[0;33m'
+        BLUE='\033[0;34m'
+        PURPLE='\033[0;35m'
+        CYAN='\033[0;36m'
+        YELLOW='\033[1;33m'
+    else
+        NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+    fi
+}
+
+function debug() {
+    echo >&2 -e "\n\n${ORANGE}${1-}${NOFORMAT}\n\n"
+}
+
+function msg() {
+    echo >&2 -e "${1-}"
+}
+
+function die() {
+    local msg=$1
+    local code=${2-1} # default exit status 1
+    msg "$msg"
+    exit "$code"
+}
+
+function validate_namespace_exists() {
+    kubectl get pod --context="$cluster" --namespace="$namespace" &>/dev/null || die "${RED}Failed to connect to $cluster / $namespace${NOFORMAT}."
+}
+
+function validate_params() {
+    [[ -z "${cluster-}" ]] && die "Missing required parameter: cluster"
+    [[ -z "${namespace-}" ]] && die "Missing required parameter: namespace"
+    validate_namespace_exists
+    parse_and_validate_time_to_live
+
+    return 0
+}
+
+function validate_cmd() {
+    [[ ${#cmd[@]} -eq 0 ]] && die "Missing script command"
+
+    return 0
+}
+
+function parse_and_validate_time_to_live() {
+    local days_in_seconds=
+    days_in_seconds="$(echo $ttl | awk 'match(tolower($0), /[0-9]+d/) {print 60 * 60 * 24 * substr($0, RSTART, RLENGTH)}')"
+
+    local hours_in_seconds=
+    hours_in_seconds="$(echo $ttl | awk 'match(tolower($0), /[0-9]+h/) {print 60 * 60 * substr($0, RSTART, RLENGTH)}')"
+
+    local minutes_in_seconds=
+    minutes_in_seconds="$(echo $ttl | awk 'match(tolower($0), /[0-9]+m/) {print 60 * substr($0, RSTART, RLENGTH)}')"
+
+    local seconds_in_seconds=
+    seconds_in_seconds="$(echo $ttl | awk 'match(tolower($0), /[0-9]+s/) {print 1 * substr($0, RSTART, RLENGTH)}')"
+
+    ttl_in_seconds=0
+    ttl_in_seconds="$((days_in_seconds + hours_in_seconds + minutes_in_seconds + seconds_in_seconds))"
+
+    [ $ttl_in_seconds -gt 0 ] || die "${RED}Couldn't parse time-to-live from '$ttl' perhaps you forgot to specify valid unit modifier - (s,m,h,d)?${NOFORMAT}"
+}
+
+function parse_params() {
+    # default values of variables set from params
+    main_ran=0
+    force=0
+    cluster=
+    namespace=
+    component_name="shell"
+    component_label="app.kubernetes.io/component=$component_name"
+    ttl=3h
+
+    while :; do
+        case "${1-}" in
+            -h | --help) usage ;;
+            -v | --verbose) set -x ;;
+            --no-color) NO_COLOR=1 ;;
+            -f | --force) force=1 ;;
+            -c | --cluster)
+                cluster="${2-}"
+                shift
+                ;;
+            -n | --namespace)
+                namespace="${2-}"
+                shift
+                ;;
+            -t | --time-to-live)
+                ttl="${2-}"
+                shift
+                ;;
+            -l | --component-name)
+                component_name="${2-}"
+                component_label="app.kubernetes.io/component=$component_name"
+                shift
+                ;;
+            -?*) die "Unknown option: $1" ;;
+            *) break ;;
+        esac
+        shift
+    done
+
+    cmd=("$@")
+
+    # check required params and command
+    validate_params
+    validate_cmd
+    return 0
+}
+
+setup_colors
+parse_params "$@"
+main


### PR DESCRIPTION
**What does this PR do?** 

✅ **This PR does not affect any development or production code!** ⭐️

As a bonus for devs, it would be great to be able to log into PR review environments from our local machines in order to inspect the running file system and debug any issues. 

Usage: `make reviewShell pr=XXXX`

The supporting bin stubs were lifted directly from `nitro-web` and only minor naming `nitro-web -> playbook` was updated within them.

## PR Needs to Merge First

```zsh
make reviewShell pr=3202
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "bin/cluster_for_review_stack": stat bin/cluster_for_review_stack: no such file or directory: unknown.
image-registry.powerapp.cloud/app/deployer:master-467d8015ffc91fc62c347367db792bb6de0eeea8-1439
./playbook-website/bin/deployer bash -lc "playbook-website/bin/remote_exec --time-to-live 3h --cluster  --namespace playbook-pr3202 bash --login"
image-registry.powerapp.cloud/app/deployer:master-467d8015ffc91fc62c347367db792bb6de0eeea8-1439
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
bash: playbook-website/bin/remote_exec: /usr/bin/env: bad interpreter: Permission denied
make: *** [reviewShell] Error 126
```

The above output just states that the specified bin stubs do no exist yet in master, so it is not possible to run them.

## How to Test

1. Merge this PR to master
2. run the command above
3. verify that you are logged into the remote shell

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.