### PR TITLE
[PLAY-1245] Make border of Breadcrumbs kit transparent

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.scss
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.scss
@@ -1,4 +1,3 @@
-@import "../tokens/border_radius";
 @import "../tokens/colors";
 @import "../tokens/opacity";
 @import "../tokens/spacing";
@@ -10,11 +9,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: $border_rad_light;
   padding: 0 $space_xs/2;
-  border-width: 1px;
-  border-style: solid;
-  border-color: $transparent;
 
   svg {
    margin-right: 8px;
@@ -44,8 +39,6 @@
   }
 
   &.dark {
-    border-width: 0;
-
     @each $color_name, $color_value in $status_colors {
       &[class*=_#{$color_name}]  {
         background: rgba(mix($bg_dark, $color_value, 10%), $opacity_2);

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.scss
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.scss
@@ -14,7 +14,7 @@
   padding: 0 $space_xs/2;
   border-width: 1px;
   border-style: solid;
-  border-color: $card_light;
+  border-color: $transparent;
 
   svg {
    margin-right: 8px;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1245 ](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1245) makes the border of the Breadcrumbs kit ticket transparent on non-white backgrounds - see Runway ticket for before screenshot and discussion regarding change of scope of ticket to removal of border entirely, and below for after screenshots on Rails/React pages.

TODO:
- [x] question about observed behavior in dark mode - (see runway ticket)

**Screenshots:** Screenshot with red background shows removed border on React example; screenshot with blue background shows removed border on Rails example; darkmode screenshot shows removed border in darkmode.
<img width="1656" alt="Remove border in react dev" src="https://github.com/powerhome/playbook/assets/83474365/8bd20dac-8bba-4c5d-ad1f-37c527fe8036">
<img width="1641" alt="Remove border in rails dev" src="https://github.com/powerhome/playbook/assets/83474365/eabedb63-721b-4c03-8670-7901af6fbed0">
<img width="1661" alt="Remove border in darkmode dev" src="https://github.com/powerhome/playbook/assets/83474365/213a4760-ac2d-4c4e-b27f-bddf5392ef19">




**How to test?** Steps to confirm the desired behavior: n/a



#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~