### PR TITLE
[PLAY-1247] Add html options global prop RAILS

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
@@ -2,7 +2,8 @@
     id: object.id,
     data: object.data.merge(initials: object.initials),
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
   <%= content_tag(:div, data: { initials: object.initials }, class: "avatar_wrapper") do %>
     <%= pb_rails("image", props: { alt: object.alt_text, url: object.image_url, on_error: object.handle_img_error }) if object.image_url.present? %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/avatar_action_button.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
     <% if object.tooltip_text.present? %>
         <%= pb_rails("tooltip", props: {
           trigger_element_id: object.tooltip_id,

--- a/playbook/app/pb_kits/playbook/pb_background/background.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_background/background.html.erb
@@ -7,7 +7,8 @@
       style: "background-image: url('#{object.image_url}');
               background-repeat: #{object.background_repeat};
               background-size: #{object.background_size};
-              background-position: #{object.background_position};"
+              background-position: #{object.background_position};",
+      **combined_html_options
   ) do %>
     <%= content.presence %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_badge/badge.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_badge/badge.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <span><%= object.text %></span>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_body/body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_body/body.html.erb
@@ -2,6 +2,7 @@
   aria: object.aria,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
   <%= object.content %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumb_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumb_item.html.erb
@@ -2,7 +2,8 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do%>
+    aria: object.aria,
+    **combined_html_options) do%>
 <%= content_tag(object.link ? 'a' : 'span', class: 'bread_crumb_item', href: object.link) do %>
     <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumbs.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumbs.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
       <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_button/button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/button.html.erb
@@ -1,5 +1,6 @@
 <%= content_tag(object.tag,
-    object.tag == "button" ? object.options : object.link_options) do %>
+                object.tag == "button" ? object.options : object.link_options,
+                **combined_html_options) do %>
     <% if object.variant === "reaction" %>
         <% if icon && object.valid_emoji(object.icon) %>
             <%= pb_rails("flex", props:{ align: "center" }) do %>

--- a/playbook/app/pb_kits/playbook/pb_button/button.rb
+++ b/playbook/app/pb_kits/playbook/pb_button/button.rb
@@ -34,10 +34,8 @@ module Playbook
                               default: "far"
 
       def options
-        {
-          aria: aria,
+        options = {
           class: classname,
-          data: data,
           disabled: disabled,
           id: id,
           role: "button",
@@ -46,6 +44,7 @@ module Playbook
           value: value,
           form: form,
         }.compact
+        combined_html_options.merge!(options) if combined_html_options.present?
       end
 
       def target_attribute

--- a/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button_toolbar/button_toolbar.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
       <%= content.presence || object.text %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_caption/caption.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_caption/caption.html.erb
@@ -2,6 +2,7 @@
   aria: object.aria,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
   <%= content.presence || object.text %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_card/card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.html.erb
@@ -3,7 +3,8 @@
     data: object.data,
     class: object.classname,
     aria: object.aria,
-    dark: object.dark) do %>
+    dark: object.dark,
+    **combined_html_options) do %>
     <%= content.presence %>
 <% end %>
 

--- a/playbook/app/pb_kits/playbook/pb_card/card_body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card_body.html.erb
@@ -2,6 +2,7 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_card/card_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card_header.html.erb
@@ -2,6 +2,7 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.html.erb
@@ -1,7 +1,9 @@
 <%= content_tag(:label, aria: object.aria,
                         id: object.id,
                         data: object.data,
-                        class: object.classname) do %>
+                        class: object.classname,
+                        **combined_html_options
+                ) do %>
   <%= content.presence || object.input %>
   <% if object.indeterminate %>
     <span class="pb_checkbox_indeterminate">

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
@@ -2,7 +2,8 @@
   aria: object.aria,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
   <%= pb_rails("button", props: {type: object.type, link: object.link, new_window:object.new_window, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
     <%= pb_rails("icon", props: {icon: object.icon, fixed_width: true, dark: object.dark}) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/collapsible.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/collapsible.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_content.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_content.html.erb
@@ -2,6 +2,7 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_main.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/collapsible_main.html.erb
@@ -2,7 +2,8 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
 
     <%= pb_rails("flex", props: {vertical: "center", spacing: "between", cursor: "pointer"}) do %>
       <%= pb_rails("flex/flex_item") do %>

--- a/playbook/app/pb_kits/playbook/pb_contact/contact.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_contact/contact.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= pb_rails("body", props: { 
         tag: "span", 
         classname: "pb_contact_kit", 

--- a/playbook/app/pb_kits/playbook/pb_currency/currency.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_currency/currency.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= pb_rails("caption", props: object.caption_props) %>
 
   <div class=<%= "pb_currency_wrapper#{object.variant_class || object.emphasized_class}" %>>

--- a/playbook/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dashboard_value/dashboard_value.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <% if object.stat_label.present? %>
     <%= pb_rails("body", props: { color: "light", text: object.stat_label } ) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_date/date.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date/date.html.erb
@@ -2,7 +2,8 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
 
   <% if object.unstyled %>
     <!-- icon -->

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname + object.error_class,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <div class="input_wrapper">
     <% if content.present? %>
       <%= content %>

--- a/playbook/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <div class="pb_date_range_inline_wrapper">
     <% if object.icon == true %>
       <%= pb_rails(object.text_kit, props: { tag: "span", dark: object.dark, color: object.icon_color, text: pb_rails("icon", props: { icon: "calendar-alt", fixed_width: true, size: object.size, classname: "pb_date_range_inline_icon" }) }) %>

--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/date_range_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/date_range_stacked.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
     <%= pb_rails("flex", props: {vertical: "center"}) do %>
       <%= pb_rails("flex/flex_item") do %>

--- a/playbook/app/pb_kits/playbook/pb_date_stacked/date_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_stacked/date_stacked.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
     <% if object.bold == false %>
 

--- a/playbook/app/pb_kits/playbook/pb_date_time/date_time.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_time/date_time.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
     <%= pb_rails("flex", props: {
       orientation: "row",

--- a/playbook/app/pb_kits/playbook/pb_date_time_stacked/date_time_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_time_stacked/date_time_stacked.html.erb
@@ -2,7 +2,8 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
 
   <%= pb_rails("flex", props: {classname: "flex-container", vertical: "stretch"}) do %>
       <%= pb_rails("body", props: {classname: "flex-item"}) do %>

--- a/playbook/app/pb_kits/playbook/pb_date_year_stacked/date_year_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_year_stacked/date_year_stacked.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= pb_rails("title", props: { text: object.day_month, size: 4, dark: object.dark }) %>
   <%= pb_rails("body", props: { text: object.year, size: 4, color: "light", dark: object.dark }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_detail/detail.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_detail/detail.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= object.content %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -3,7 +3,8 @@
         aria: object.aria,
         data: object.data,
         id: object.id,
-        class: object.classname) do %>
+        class: object.classname,
+        **combined_html_options) do %>
             <% if object.status === "" && object.title %>
                 <%= pb_rails("dialog/dialog_header", props: { title: object.title, id: object.id }) %>
             <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_body.html.erb
@@ -2,6 +2,7 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
         <%= content.presence || object.text %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
     <% if object.confirm_button && object.cancel_button %>
         <div class="dialog-pseudo-footer"></div>
         <%= pb_rails("flex", props: { classname:object.classname, spacing:"between", padding_x:"sm", padding:"sm", padding_bottom:"sm" }) do %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
@@ -2,7 +2,8 @@
     id: object.id,
     data: object.data,
     class: object.sticky_header,
-    aria: object.aria) do %>
+    aria: object.aria,
+    **combined_html_options) do %>
         <%= pb_rails("flex", props: {classname:object.classname, spacing:"between", padding:"sm", align:"center"}) do %>
             <%= content.presence || object.title %>
             

--- a/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
       <%= pb_rails("form_group", props: {cursor: "pointer", full_width: object.full_width}) do %>
         <label for="upload-<%= object.id %>" class="pb_button_kit_secondary_inline_enabled"><%= "#{object.label}" %></label>
         <%= pb_rails("text_input", props: {

--- a/playbook/app/pb_kits/playbook/pb_filter/filter.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/filter.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
     <%= object.wrapper do %>
       <%= pb_rails("flex", props: { orientation: "row", padding_right: "lg", vertical: "center" }) do %>
         <% if (object.template != "sort_only") %>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
     <%= pb_rails("icon", props: { icon: object.icon_value, classname: "pb_icon", fixed_width: true }) %>
 
     <% if content %>

--- a/playbook/app/pb_kits/playbook/pb_flex/flex.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_flex/flex.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_flex/flex_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_flex/flex_item.html.erb
@@ -2,6 +2,7 @@
     id: object.id,
     data: object.data,
     class: object.classname,
-    style: object.style_value) do %>
+    style: object.style_value,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_form_group/form_group.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_group/form_group.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag(:div, id: object.id, data: object.data, class: object.classname + object.size_class) do %>
+<%= content_tag(:div, id: object.id, data: object.data, class: object.classname + object.size_class, **combined_html_options) do %>
   <% if object.name.present? %>
     <%= pb_rails("avatar", props: { name: object.name, image_url: object.avatar_url, size: "xs" }) %>
       <%= pb_rails("title", props: { text: object.name, size: 4, classname: "pb_form_pill_text" }) %>

--- a/playbook/app/pb_kits/playbook/pb_hashtag/hashtag.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_hashtag/hashtag.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= link_to object.url, target: object.link_option do %>
     <%= pb_rails("badge", props: { dark: object.dark, variant: "primary", text: object.hashtag_text }) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_highlight/highlight.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_highlight/highlight.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:span,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
     <mark>
       <%= content.presence || object.text %>
     </mark>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= pb_rails("home_address_street/#{emphasis}_emphasis", props: object.send("#{emphasis}_emphasis_props")) %>
 <% end %>
 

--- a/playbook/app/pb_kits/playbook/pb_icon/icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon/icon.html.erb
@@ -8,7 +8,8 @@
   <%= content_tag(:i, nil,
       id: object.id,
       data: object.data,
-      class: object.classname
+      class: object.classname,
+      **combined_html_options
   ) %>
   <%= content_tag(:span, nil,
       aria: { label: "#{object.icon} icon" }.merge(object.aria),

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
     <%= pb_rails("icon", props: { dark: object.dark, icon: object.icon, fixed_width: true }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_icon_stat_value/icon_stat_value.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon_stat_value/icon_stat_value.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
     <%= pb_rails("icon_circle", props: {
         dark: object.dark,

--- a/playbook/app/pb_kits/playbook/pb_icon_value/icon_value.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon_value/icon_value.html.erb
@@ -2,7 +2,8 @@
   aria: object.aria,
   class: object.classname,
   data: object.data,
-  id: object.id) do %>
+  id: object.id,
+  **combined_html_options) do %>
   <%= pb_rails("body", props: { color: "light", dark: object.dark }) do %>
     <%= pb_rails("icon", props: { icon: object.icon, fixed_width: true }) %>
     <%= object.text %>

--- a/playbook/app/pb_kits/playbook/pb_image/image.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_image/image.html.erb
@@ -6,5 +6,6 @@
     src: object.url,
     alt: object.alt,
     onerror: object.on_error,
+    **combined_html_options
     )
 %>

--- a/playbook/app/pb_kits/playbook/pb_label_pill/label_pill.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_label_pill/label_pill.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
       <%= pb_rails("caption", props: { text: object.label, classname: "pb_label_pill_label"}) %>
       <%= pb_rails("pill", props: { text: object.pill_value, variant: object.variant, classname: "pb_label_pill_pill" }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_label_value/label_value.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_label_value/label_value.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
     <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>
     <% if object.variant == "details" %>
         <%= pb_rails("flex", props: {inline: true, vertical: "center"}) do %>

--- a/playbook/app/pb_kits/playbook/pb_layout/body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/body.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(object.tag,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/footer.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(object.tag,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/header.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(object.tag,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/item.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/layout.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/layout.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/sidebar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/sidebar.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_legend/legend.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_legend/legend.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= pb_rails("body", props: {color: object.body_color}) do %>
     <span style="<%= object.custom_color %>" class=<%= object.custom_color_class %>></span>
     <%= pb_rails("title", props: { dark: object.dark, text: object.prefix_text, tag: "span", size: 4 }) %>

--- a/playbook/app/pb_kits/playbook/pb_list/item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_list/item.html.erb
@@ -3,7 +3,8 @@
                 class: object.classname,
                 data: object.data,
                 id: object.id,
-                tabindex: object.tabindex
+                tabindex: object.tabindex,
+                **combined_html_options
   ) do %>
     <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_list/list.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_list/list.html.erb
@@ -5,7 +5,8 @@
                   data: object.data,
                   id: object.id,
                   role: object.role,
-                  tabindex: object.tabindex
+                  tabindex: object.tabindex,
+                  **combined_html_options
     ) do %>
       <%= content.presence %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
   <%= pb_rails("body", props: { color: "light", dark: object.dark }) do %>
     <%= pb_rails("icon", props: { aria: { label: "loading icon" }, fixed_width: true, icon: "spinner", pulse: true }) %> Loading

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
     <% if object.valid? %>
       <%= pb_rails("avatar", props: {
         name: object.avatar_name,

--- a/playbook/app/pb_kits/playbook/pb_message/message_mention.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message_mention.html.erb
@@ -2,6 +2,7 @@
   id: object.id,
   data: object.data,
   class: object.classname,
-  aria: object.aria) do %>
+  aria: object.aria,
+  **combined_html_options) do %>
     <%= content %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/multi_level_select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/multi_level_select.html.erb
@@ -2,6 +2,7 @@
       aria: object.aria,
       data: object.data,
       id: object.id,
-      class: object.classname) do %>
+      class: object.classname,
+      **combined_html_options) do %>
   <%= react_component("MultiLevelSelect", object.multi_level_select_options)  %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/multiple_users.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/multiple_users.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
     <% object.users.take(object.display_count).each do |user| %>
       <%= pb_rails("avatar", props: user.merge({size: object.size, classname: "pb_multiple_users_item", dark: object.dark}) ) %>
     <% end %>

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.html.erb
@@ -2,7 +2,8 @@
   aria: object.aria,
   class: object.classname,
   data: object.data,
-  id: object.id) do %>
+  id: object.id,
+  **combined_html_options) do %>
   <%= pb_rails("avatar", props: object.users[0].merge({size: "xs", classname: "pb_multiple_users_stacked_item", dark: object.dark}) ) %>
 
   <% unless object.only_one %>

--- a/playbook/app/pb_kits/playbook/pb_nav/item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_nav/item.html.erb
@@ -8,7 +8,8 @@
           dark: object.dark,
           id: object.id,
           href: object.link && object.link,
-          target: object.link && object.target    
+          target: object.link && object.target,
+          **combined_html_options
           ) do %>
           <% if object.image_url %>
             <%= pb_rails("image", props: { url: object.image_url, classname: "pb_nav_img_wrapper_collapsible" }) %>
@@ -29,6 +30,7 @@
     <%= content_tag(object.tag,
       aria: object.aria,
       class: object.classname,
+      **combined_html_options,
       data: object.data,
       dark: object.dark,
       id: object.id,

--- a/playbook/app/pb_kits/playbook/pb_nav/nav.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_nav/nav.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <% if object.title %>
     <%= content_tag(:div, class: "pb_nav_list_title") do %>
       <%= content_tag(:a, class: "pb_nav_list_item_link_text", href: object.link) do %>

--- a/playbook/app/pb_kits/playbook/pb_online_status/online_status.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_online_status/online_status.html.erb
@@ -2,5 +2,6 @@
     aria: object.aria.merge!(label: object.status),
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_pagination/pagination.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pagination/pagination.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
      <%= will_paginate object.model, renderer: Playbook::Pagination::Rails %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.html.erb
@@ -1,1 +1,1 @@
-  <%= react_component('Passphrase', object.passphrase_options, class: object.classname,) %>
+  <%= react_component('Passphrase', object.passphrase_options, class: object.classname, **combined_html_options) %>

--- a/playbook/app/pb_kits/playbook/pb_person/person.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_person/person.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
       <%= pb_rails("body", props: {
         tag: "span",
         classname: "pb_person_first" }) { object.first_name } %>

--- a/playbook/app/pb_kits/playbook/pb_person_contact/person_contact.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_person_contact/person_contact.html.erb
@@ -2,7 +2,8 @@
   aria: object.aria,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
   <%= pb_rails("person", props: {
       first_name: object.first_name,
       last_name: object.last_name,

--- a/playbook/app/pb_kits/playbook/pb_pill/pill.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pill/pill.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= pb_rails("title", props: { text: object.display_text, tag: "div", size: 4, classname: "pb_pill_text" }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_popover/popover.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_popover/popover.html.erb
@@ -2,7 +2,8 @@
   aria: object.aria,
   class: object.classname,
   data: object.data,
-  id: object.id) do %>
+  id: object.id,
+  **combined_html_options) do %>
   <div class="pb_popover_tooltip hide" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.z_index_helper %>">
     <div class="pb_popover_body <%= object.width_height_class_helper %> <%= object.popover_spacing_helper %>" style="<%= object.width_height_helper %>">
       <%= content.presence %>

--- a/playbook/app/pb_kits/playbook/pb_progress_pills/progress_pills.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/progress_pills.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria_attributes,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
     <div class="progress_pills_status">
       <% object.with_status do |status| %>

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/progress_simple.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/progress_simple.html.erb
@@ -3,7 +3,8 @@
   id: object.id,
   data: object.data_values,
   class: object.classname,
-  style: object.style) do %>
+  style: object.style,
+  **combined_html_options) do %>
     <%= content_tag(:div, "",
       class: "progress_simple_value",
       style: object.value_style) %>

--- a/playbook/app/pb_kits/playbook/pb_progress_step/progress_step.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/progress_step.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:ul,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:li,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
   <div class="box" style="max-width: min-content;" id="<%= object.tooltip_trigger_class %>">
     <div class="circle">
       <%= pb_rails("icon", props: { icon: object.icon, size: "xs" }) if object.icon.present? %>

--- a/playbook/app/pb_kits/playbook/pb_radio/radio.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_radio/radio.html.erb
@@ -4,7 +4,8 @@
     class: object.classname,
     data: object.data,
     id: object.id,
-    value: object.value) do %>
+    value: object.value,
+    **combined_html_options) do %>
 
     <% if content.present? %>
       <%= content %>

--- a/playbook/app/pb_kits/playbook/pb_section_separator/section_separator.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/section_separator.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
     <% if object.orientation === 'horizontal' %>
         <% if content %>
             <%= content %>

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
   aria: object.aria,
   data: object.data,
-  class: object.classnames) do %>
+  class: object.classnames,
+  **combined_html_options) do %>
   <% if object.label %>
     <label class="pb_select_kit_label" for="<%= object.name %>">
       <%= pb_rails("caption", props: { text: object.label }) %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
 
   <% if object.multi %>
     <%= check_box_tag(object.name, object.value, object.checked, object.additional_input_options) %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:div,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
   <%= pb_rails("selectable_card", props: {
     input_id: object.input_id,

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
     <% if object.inputs == "disabled" %>
 

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= pb_rails("list") do %>
     <% object.items.each do |item| %>
       <%= pb_rails("selectable_list/selectable_list_item", props: item.merge(variant: object.variant, id: object.get_id(item)) )%>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <% if object.variant == "radio"%>
     <%= pb_rails("radio", props: { text: object.text, checked: object.checked, input_options: object.input_options } ) %>
     <% if content.present? %>

--- a/playbook/app/pb_kits/playbook/pb_source/source.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_source/source.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <div class="pb__source_layout">
     <% if !object.hide_icon %>
       <% if object.show_icon? %>

--- a/playbook/app/pb_kits/playbook/pb_star_rating/star_rating.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_star_rating/star_rating.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
   <% if layout_option == "number" %>
     <% case object.size %>
       <% when "xs", "sm" %>

--- a/playbook/app/pb_kits/playbook/pb_stat_change/stat_change.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_stat_change/stat_change.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
       <%= pb_rails("body", props: { status: object.status }) do %>
         <%= pb_rails("icon", props: { fixed_width: true, icon: object.returned_icon }) if object.returned_icon %>
         <%= "#{object.value}%" if object.value %>

--- a/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_stat_value/stat_value.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <div class="pb_stat_value_wrapper">
     <%= pb_rails "title", props: {
       classname: "pb_stat_value_kit",

--- a/playbook/app/pb_kits/playbook/pb_table/table.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table.html.erb
@@ -4,7 +4,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
   <% else %>
@@ -12,7 +13,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_body.html.erb
@@ -3,7 +3,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
 <% else %>
@@ -11,7 +12,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_cell.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_cell.html.erb
@@ -3,7 +3,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence || object.text %>
     <% end %>
 <% else %>
@@ -11,7 +12,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence || object.text %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_head.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_head.html.erb
@@ -3,7 +3,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
 <% else %>
@@ -11,7 +12,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
@@ -4,7 +4,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: "pb-th#{object.id}" ) do %>
+      id: "pb-th#{object.id}",
+      **combined_html_options) do %>
     <% unless sorting_style? %>
       <%= pb_rails("flex", props:{ align: object.align_content, justify: object.justify_sort_icon, classname: "pb_th_nolink" }) do %>
         <%= content.presence || object.text %>
@@ -51,7 +52,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
       <%= content.presence || object.text %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_row.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_row.html.erb
@@ -3,7 +3,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
 <% else %>
@@ -11,7 +12,8 @@
       aria: object.aria,
       class: object.classname,
       data: object.data,
-      id: object.id) do %>
+      id: object.id,
+      **combined_html_options) do %>
       <%= content.presence %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     aria: object.aria,
     class: object.classname,
-    data: object.data) do %>
+    data: object.data,
+    **combined_html_options) do %>
   <% if object.label.present? %>
     <%= pb_rails("caption", props: { text: object.label, dark: object.dark, classname: "pb_text_input_kit_label" }) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_textarea/textarea.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_textarea/textarea.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <% if object.label.present? %>
     <%= pb_rails("caption", props: {text: object.label, dark: object.dark}) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_time/time.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_time/time.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%
     # convert deprecated prop values
     size = object.size

--- a/playbook/app/pb_kits/playbook/pb_time_range_inline/time_range_inline.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_time_range_inline/time_range_inline.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
       <div class="pb_time_range_inline_wrapper">
         <% if object.icon == true %>
           <%= pb_rails(object.text_kit, props: { tag: "span", dark: object.dark, color: object.icon_color, text: pb_rails("icon", props: { icon: "clock", dark: object.dark, classname:"pb_time_range_inline_icon", fixed_width: true, size: object.size }) }) %>

--- a/playbook/app/pb_kits/playbook/pb_time_stacked/time_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_time_stacked/time_stacked.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
 
     <%= pb_rails("body", props: { color: "light", dark: object.dark, classname: "pb_time_stacked time-spacing" }) do %>
       <time>

--- a/playbook/app/pb_kits/playbook/pb_timeline/item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timeline/item.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
 
   <div class="pb_timeline_item_left_block">
     <% if object.date.present? %>

--- a/playbook/app/pb_kits/playbook/pb_timeline/timeline.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timeline/timeline.html.erb
@@ -1,6 +1,7 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.html.erb
@@ -2,7 +2,8 @@
   aria: object.aria,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
 
   <% if object.unstyled %>
     <div><%= object.timestamp_text %></div>

--- a/playbook/app/pb_kits/playbook/pb_title/title.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_title/title.html.erb
@@ -2,5 +2,6 @@
     aria: object.aria,
     id: object.id,
     data: object.data,
-    class: object.classname) do %><%= content.presence || object.text %><% end %>
+    class: object.classname,
+    **combined_html_options) do %><%= content.presence || object.text %><% end %>
     

--- a/playbook/app/pb_kits/playbook/pb_title_count/title_count.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_title_count/title_count.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= pb_rails("title", props: {
     dark: object.dark,
     size: object.title_size,

--- a/playbook/app/pb_kits/playbook/pb_title_detail/title_detail.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_title_detail/title_detail.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
     id: object.id,
     data: object.data,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <%= pb_rails("title", props: { text: object.title, size: 4 }) %>
   <%= pb_rails("body", props: { text: object.detail, color: "light" }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_toggle/toggle.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_toggle/toggle.html.erb
@@ -2,7 +2,8 @@
     id: object.id,
     data: object.data,
     aria: object.aria,
-    class: object.classname) do %>
+    class: object.classname,
+    **combined_html_options) do %>
   <label class="pb_toggle_wrapper">
     <%= content.presence || object.input %>
     <div class="pb_toggle_control"></div>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
@@ -1,7 +1,8 @@
 <%= content_tag(:div,
   id: object.id,
   data: object.data,
-  class: object.classname) do %>
+  class: object.classname,
+  **combined_html_options) do %>
   <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip">
     <%= content.presence %>
     <div class="arrow" id="<%= object.tooltip_id %>-arrow"></div>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.html.erb
@@ -4,7 +4,8 @@
   <%= content_tag(:div,
                 id: object.id,
                 data: object.data,
-                class: object.classname + object.inline_class) do %>
+                class: object.classname + object.inline_class,
+                **combined_html_options) do %>
     <div class="pb_typeahead_wrapper">
       <div class="pb_typeahead_loading_indicator" data-pb-typeahead-kit-loading-indicator>
         <%= pb_rails("icon", props: {

--- a/playbook/app/pb_kits/playbook/pb_user/user.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_user/user.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <% if object.avatar_url.present? || object.avatar %>
     <%= pb_rails("avatar", props: {
       name: object.name,

--- a/playbook/app/pb_kits/playbook/pb_user_badge/user_badge.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_user_badge/user_badge.html.erb
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <%= content_tag(:div, object.display_badge, class: "pb_user_badge_wrapper") %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_weekday_stacked/weekday_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_weekday_stacked/weekday_stacked.html.erb
@@ -2,7 +2,8 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
     <%= pb_rails("caption", props: {dark: object.dark, text: object.day_of_week}) %>
     <%= pb_rails("title", props: {dark: object.dark, size: 4, tag: "span", text: object.formatted_month_and_day}) %>
 <% end %>

--- a/playbook/lib/generators/kit/templates/kit_html.erb.tt
+++ b/playbook/lib/generators/kit/templates/kit_html.erb.tt
@@ -2,6 +2,7 @@
     aria: object.aria,
     class: object.classname,
     data: object.data,
-    id: object.id) do %>
+    id: object.id,
+    **combined_html_options) do %>
   <span><%= @kit_name_uppercase %> CONTENT</span>
 <%% end %>

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -67,10 +67,28 @@ module Playbook
     prop :id
     prop :data, type: Playbook::Props::HashProp, default: {}
     prop :aria, type: Playbook::Props::HashProp, default: {}
+    prop :html_options, type: Playbook::Props::HashProp, default: {}
     prop :children, type: Playbook::Props::Proc
 
     def object
       self
+    end
+
+    def combined_html_options
+      default_html_options.merge(html_options.deep_merge(data_attributes))
+    end
+
+  private
+
+    def default_html_options
+      {}
+    end
+
+    def data_attributes
+      {
+        data: data,
+        aria: aria,
+      }.transform_keys { |key| key.to_s.gsub("_", "-") }
     end
   end
 end

--- a/playbook/spec/playbook/global_props/html_options_spec.rb
+++ b/playbook/spec/playbook/global_props/html_options_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../../../app/pb_kits/playbook/pb_body/body"
+
+RSpec.describe Playbook::Flex do
+  subject { Playbook::PbBody::Body }
+
+  describe "html_options" do
+    it "returns html options", :aggregate_failures do
+      body = subject.new(html_options: { foo: "bar" })
+      expect(body.html_options).to eq(foo: "bar")
+    end
+  end
+end

--- a/playbook/spec/playbook/kit_base_spec.rb
+++ b/playbook/spec/playbook/kit_base_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Playbook::KitBase do
 
   it { is_expected.to define_prop(:id) }
   it { is_expected.to define_hash_prop(:data).with_default({}) }
+  it { is_expected.to define_hash_prop(:html_options).with_default({}) }
   it { is_expected.to define_prop(:classname) }
   it { is_expected.to define_hash_prop(:aria).with_default({}) }
   it { is_expected.to define_prop(:margin) }
@@ -37,6 +38,7 @@ RSpec.describe Playbook::KitBase do
   it { is_expected.to define_prop(:flex_grow) }
   it { is_expected.to define_prop(:flex_shrink) }
   it { is_expected.to define_prop(:order) }
+  it { is_expected.to define_prop(:truncate) }
 
   describe "#children" do
     it "allows to be passed as prop" do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Runway: https://nitro.powerhrg.com/runway/backlog_items/PLAY-1247
Checkout the playground here https://pr807.playgrounds.beta.gm.powerapp.cloud/mark/index

A new global prop called `html_options` for the rails kits. It lets devs pass any html option to the outer most div of a kit

it looks like this 
`html_options: { OnClick: 'alert("Heyyyy")' }`

![screenshot-nimbusweb me-2024 03 19-21_56_23](https://github.com/powerhome/playbook/assets/38965626/c7acd5c0-e5f3-430a-8d2b-f14413c67b27)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.