### PR TITLE
[PLAY-1265] Add 'svg-inline--fa' class to our icons

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon/_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon/_icon.tsx
@@ -103,6 +103,7 @@ const Icon = (props: IconProps) => {
     flipMap[flip],
     (!iconElement && !customIcon) ? 'pb_icon_kit' : '',
     (iconElement || customIcon) ? 'pb_custom_icon' : fontStyle,
+    iconElement ? 'svg-inline--fa' : '',
     faClasses,
     globalProps(props),
     className

--- a/playbook/app/pb_kits/playbook/pb_icon/icon.rb
+++ b/playbook/app/pb_kits/playbook/pb_icon/icon.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/StringConcatenation, Style/HashLikeCase
+# rubocop:disable Style/HashLikeCase
 
 require "open-uri"
 
@@ -89,7 +89,7 @@ module Playbook
       def render_svg
         doc = Nokogiri::XML(URI.open(asset_path || icon || custom_icon)) # rubocop:disable Security/Open
         svg = doc.at_css "svg"
-        svg["class"] = "pb_custom_icon " + object.custom_icon_classname
+        svg["class"] = %w[pb_custom_icon svg-inline--fa].concat([object.custom_icon_classname]).join(" ")
         svg["id"] = object.id
         svg["data"] = object.data
         svg["aria"] = object.aria
@@ -167,4 +167,4 @@ module Playbook
   end
 end
 
-# rubocop:enable Style/StringConcatenation, Style/HashLikeCase
+# rubocop:enable Style/HashLikeCase


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Fixes an issue where our own icons appear as vertically mis-aligned. 

**Screenshots:** Screenshots to visualize your addition/change

### Before

![play-1265 circle icon button icon alignment](https://github.com/powerhome/playbook/assets/2293844/749ddb9c-83ac-4830-ab10-429b4f81ec27)

### After

<img width="239" alt="Screenshot 2024-03-20 at 9 41 09 AM" src="https://github.com/powerhome/playbook/assets/2293844/04e22b5e-0f75-488f-be97-86794f998ebe">


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.