### PR TITLE
[PLAY-1187] Fix Broken Doc Page Layouts

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Colors/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Colors/index.tsx
@@ -25,8 +25,8 @@ import {
 const Colors = (): React.ReactElement => (
   <React.Fragment>
     <Background
-        margin="xl"
-        paddingX="xl"
+        className="token-wrapper"
+        padding="xl"
     >
       <Title
           marginBottom="lg"

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
@@ -21,56 +21,56 @@ const TOKENS = {
 }
 
 const DATASET = [
-  {name: 'Rounded', class: 'border_radius_rounded'},
-  {name: 'Extra Large', class: 'border_radius_xl'},
-  {name: 'Large', class: 'border_radius_lg'},
-  {name: 'Medium', class: 'border_radius_md'},
-  {name: 'Small', class: 'border_radius_sm'},
-  {name: 'Extra Small', class: 'border_radius_xs'},
-  {name: 'None', class: 'border_radius_none'},
+  { name: 'Rounded', class: 'border_radius_rounded' },
+  { name: 'Extra Large', class: 'border_radius_xl' },
+  { name: 'Large', class: 'border_radius_lg' },
+  { name: 'Medium', class: 'border_radius_md' },
+  { name: 'Small', class: 'border_radius_sm' },
+  { name: 'Extra Small', class: 'border_radius_xs' },
+  { name: 'None', class: 'border_radius_none' },
 ]
 
-const BorderRadius = ({tokensExample}: { tokensExample: string }) => (
+const BorderRadius = ({ tokensExample }: { tokensExample: string }) => (
   <React.Fragment>
     <Background
-      className={`pb_background_kit token-wrapper`}
+      className="token-wrapper"
       paddingRight="xl"
       paddingLeft="xl"
       paddingTop="xl"
     >
       <Title
-          size={1}
-          text='Border Radius'
-          />
+        size={1}
+        text='Border Radius'
+      />
       <Body
-          marginBottom='lg'
-          marginTop='xs'
-          text='We have very specific settings for border radius to keep the interface looking consistent and clean. If you ever need to access these to build new things here are examples for how to do that.'
-          />
+        marginBottom='lg'
+        marginTop='xs'
+        text='We have very specific settings for border radius to keep the interface looking consistent and clean. If you ever need to access these to build new things here are examples for how to do that.'
+      />
     </Background>
     <Example
-        example={tokensExample}
-        tokens={TOKENS}
-        >
+      example={tokensExample}
+      tokens={TOKENS}
+    >
       <Flex
-          align='center'
-          flexWrap='wrap'
-          justifyContent='center'
-          orientation='row'
-          >
-        {DATASET.map((data: {[key: string]: string}) => (
+        align='center'
+        flexWrap='wrap'
+        justifyContent='center'
+        orientation='row'
+      >
+        {DATASET.map((data: { [key: string]: string }) => (
           <div className='border_radius_container'>
-            <div className={data.class}/>
+            <div className={data.class} />
             <Title
-                marginTop="xs"
-                size={4}
-                tag="h4"
-                text={data.name}
-                />
+              marginTop="xs"
+              size={4}
+              tag="h4"
+              text={data.name}
+            />
             <Caption
-                size="xs"
-                text={`$${data.class}`}
-                />
+              size="xs"
+              text={`$${data.class}`}
+            />
           </div>
         ))}
       </Flex>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import {
+  Background,
   Body,
   Caption,
   Flex,
@@ -31,25 +32,29 @@ const DATASET = [
 
 const BorderRadius = ({tokensExample}: { tokensExample: string }) => (
   <React.Fragment>
-    <Title
-        size={1}
-        text='Border Radius'
-    />
-    <Body
-        marginBottom='lg'
-        marginTop='xs'
-        text='We have very specific settings for border radius to keep the interface looking consistent and clean. If you ever need to access these to build new things here are examples for how to do that.'
-    />
+    <Background
+      margin="xl"
+    >
+      <Title
+          size={1}
+          text='Border Radius'
+          />
+      <Body
+          marginBottom='lg'
+          marginTop='xs'
+          text='We have very specific settings for border radius to keep the interface looking consistent and clean. If you ever need to access these to build new things here are examples for how to do that.'
+          />
+    </Background>
     <Example
         example={tokensExample}
         tokens={TOKENS}
-    >
+        >
       <Flex
           align='center'
           flexWrap='wrap'
           justifyContent='center'
           orientation='row'
-      >
+          >
         {DATASET.map((data: {[key: string]: string}) => (
           <div className='border_radius_container'>
             <div className={data.class}/>
@@ -58,11 +63,11 @@ const BorderRadius = ({tokensExample}: { tokensExample: string }) => (
                 size={4}
                 tag="h4"
                 text={data.name}
-            />
+                />
             <Caption
                 size="xs"
                 text={`$${data.class}`}
-            />
+                />
           </div>
         ))}
       </Flex>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
@@ -33,7 +33,10 @@ const DATASET = [
 const BorderRadius = ({tokensExample}: { tokensExample: string }) => (
   <React.Fragment>
     <Background
-      margin="xl"
+      className={`pb_background_kit token-wrapper`}
+      paddingRight="xl"
+      paddingLeft="xl"
+      paddingTop="xl"
     >
       <Title
           size={1}

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Cursor.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Cursor.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Card, Caption, FlexItem, Flex, Body } from 'playbook-ui'
+import { Background, Card, Caption, FlexItem, Flex, Body } from 'playbook-ui'
 import Example from '../Templates/Example'
 
 const CURSOR = [
@@ -18,32 +18,36 @@ const Cursor = ({ example }: { example: string }) => (
       }}
       title="Cursor"
     />
-    <Card
-      marginTop="md"
-      padding="none"
-      rounded
-      shadow="deeper"
+    <Background
+      margin="xl"
     >
-      <FlexItem>
-        <Card.Body>
-          <Caption
-            marginBottom="xs"
-            text="Visual Guide"
-          />
+      <Card
+        marginTop="md"
+        padding="none"
+        rounded
+        shadow="deeper"
+      >
+        <FlexItem>
+          <Card.Body>
+            <Caption
+              marginBottom="xs"
+              text="Visual Guide"
+            />
 
-          <Body text="Hover over any card below to display its cursor." marginBottom="sm" />
+            <Body text="Hover over any card below to display its cursor." marginBottom="sm" />
 
-          <Flex gap="xxs" wrap>
-            {CURSOR.map(function (cursor, i) {
-              return <Card borderRadius="none" padding="xs" cursor={cursor} key={i}>
-                {cursor}
-              </Card>
-            })}
-          </Flex>
+            <Flex gap="xxs" wrap>
+              {CURSOR.map(function (cursor, i) {
+                return <Card borderRadius="none" padding="xs" cursor={cursor} key={i}>
+                  {cursor}
+                </Card>
+              })}
+            </Flex>
           </Card.Body>
-      </FlexItem>
-    </Card>
+        </FlexItem>
+      </Card>
+    </Background>
   </>
-  )
+)
 
-  export default Cursor
+export default Cursor

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Cursor.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Cursor.tsx
@@ -19,7 +19,8 @@ const Cursor = ({ example }: { example: string }) => (
       title="Cursor"
     />
     <Background
-      margin="xl"
+      className="token-wrapper"
+      padding="xl"
     >
       <Card
         marginTop="md"
@@ -27,24 +28,29 @@ const Cursor = ({ example }: { example: string }) => (
         rounded
         shadow="deeper"
       >
-        <FlexItem>
-          <Card.Body>
-            <Caption
-              marginBottom="xs"
-              text="Visual Guide"
-            />
+        <Flex
+          maxWidth="xl"
+          orientation="column"
+        >
+          <FlexItem>
+            <Card.Body>
+              <Caption
+                marginBottom="xs"
+                text="Visual Guide"
+              />
 
-            <Body text="Hover over any card below to display its cursor." marginBottom="sm" />
+              <Body text="Hover over any card below to display its cursor." marginBottom="sm" />
 
-            <Flex gap="xxs" wrap>
-              {CURSOR.map(function (cursor, i) {
-                return <Card borderRadius="none" padding="xs" cursor={cursor} key={i}>
-                  {cursor}
-                </Card>
-              })}
-            </Flex>
-          </Card.Body>
-        </FlexItem>
+              <Flex gap="xxs" wrap>
+                {CURSOR.map(function (cursor, i) {
+                  return <Card borderRadius="none" padding="xs" cursor={cursor} key={i}>
+                    {cursor}
+                  </Card>
+                })}
+              </Flex>
+            </Card.Body>
+          </FlexItem>
+        </Flex>
       </Card>
     </Background>
   </>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Display.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Display.tsx
@@ -34,7 +34,8 @@ const Display = ({ example }: { example: string }) => (
       title='Display'
     />
     <Background
-      margin="xl"
+      className="token-wrapper"
+      padding="xl"
     >
       <Title
         size={4}

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Display.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Display.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  Background,
   Body,
   Caption,
   Table,
@@ -13,68 +14,72 @@ const screenSizeProps = {
 }
 
 const UTILITY_CLASSES = [
-  {size: 'xs', media: '@media screen and (max-width: 575px)', class: '.display_xs_hidden', properties: 'display: hidden !important'},
-  {size: 'sm', media: '@media screen and (max-width: 576px)', class: '.display_sm_block', properties: 'display: block !important'},
-  {size: 'md', media: '@media screen and (max-width: 768px)', class: '.display_md_inline_block', properties: 'display: inline-block !important'},
-  {size: 'lg', media: '@media screen and (max-width: 992px)', class: '.display_lg_inline', properties: 'display: inline !important'},
-  {size: 'xl', media: '@media screen and (max-width: 1200px)', class: '.display_xl_flex', properties: 'display: flex !important'},
+  { size: 'xs', media: '@media screen and (max-width: 575px)', class: '.display_xs_hidden', properties: 'display: hidden !important' },
+  { size: 'sm', media: '@media screen and (max-width: 576px)', class: '.display_sm_block', properties: 'display: block !important' },
+  { size: 'md', media: '@media screen and (max-width: 768px)', class: '.display_md_inline_block', properties: 'display: inline-block !important' },
+  { size: 'lg', media: '@media screen and (max-width: 992px)', class: '.display_lg_inline', properties: 'display: inline !important' },
+  { size: 'xl', media: '@media screen and (max-width: 1200px)', class: '.display_xl_flex', properties: 'display: flex !important' },
 ]
 
 const DISPLAY_VALUES = ['inline', 'flex', 'inline_flex', 'inline_block', 'block', 'none']
 
-const Display = ({example}: {example: string}) => (
+const Display = ({ example }: { example: string }) => (
   <React.Fragment>
     <Example
-        example={example}
-        globalProps={{
-          display: DISPLAY_VALUES
-        }}
-        screenSizes={screenSizeProps}
-        title='Display'
+      example={example}
+      globalProps={{
+        display: DISPLAY_VALUES
+      }}
+      screenSizes={screenSizeProps}
+      title='Display'
     />
-    <Title
+    <Background
+      margin="xl"
+    >
+      <Title
         size={4}
         text='Utility Classes'
-    />
-    <Body
+      />
+      <Body
         text='Just want the raw classes? We got you. All of our global props are simple CSS utilities available through classes.'
         marginBottom='sm'
-    />
-    <Caption
+      />
+      <Caption
         text='Visual Guide'
         marginBottom='sm'
-    />
-    <Table
+      />
+      <Table
         shadow='deep'
         size='sm'
-    >
-      <thead>
-        <tr>
-          <th>{'Screen Size'}</th>
-          <th>{'@Media Screen'}</th>
-          <th>{'Class'}</th>
-          <th>{'Properties'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {UTILITY_CLASSES.map((utilityClass: {[key: string]: string}) => (
+      >
+        <thead>
           <tr>
-            <td>
-              {utilityClass.size}
-            </td>
-            <td>
-              {utilityClass.media}
-            </td>
-            <td>
-              {utilityClass.class}
-            </td>
-            <td>
-              {utilityClass.properties}
-            </td>
+            <th>{'Screen Size'}</th>
+            <th>{'@Media Screen'}</th>
+            <th>{'Class'}</th>
+            <th>{'Properties'}</th>
           </tr>
-        ))}
-      </tbody>
-    </Table>
+        </thead>
+        <tbody>
+          {UTILITY_CLASSES.map((utilityClass: { [key: string]: string }) => (
+            <tr>
+              <td>
+                {utilityClass.size}
+              </td>
+              <td>
+                {utilityClass.media}
+              </td>
+              <td>
+                {utilityClass.class}
+              </td>
+              <td>
+                {utilityClass.properties}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </Background>
   </React.Fragment>
 )
 

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -22,9 +22,11 @@ const scaleObj = { 'sm': '@1.05', 'md': '@1.10', 'lg': '@1.15' }
 const Hover = ({ example }: { example: string }) => (
   <React.Fragment>
     <Background
-      margin="xl"
+      className={`pb_background_kit token-wrapper`}
+      paddingRight="xl"
+      paddingLeft="xl"
+      paddingTop="xl"
     >
-
       <Title
         marginBottom="sm"
         size={1}
@@ -172,7 +174,6 @@ const Hover = ({ example }: { example: string }) => (
     <Background
       margin="xl"
     >
-
       <Card
         marginTop="md"
         shadow="deep"

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -22,7 +22,7 @@ const scaleObj = { 'sm': '@1.05', 'md': '@1.10', 'lg': '@1.15' }
 const Hover = ({ example }: { example: string }) => (
   <React.Fragment>
     <Background
-      className={`pb_background_kit token-wrapper`}
+      className="token-wrapper"
       paddingRight="xl"
       paddingLeft="xl"
       paddingTop="xl"
@@ -172,7 +172,8 @@ const Hover = ({ example }: { example: string }) => (
       </Flex>
     </Example>
     <Background
-      margin="xl"
+      className="token-wrapper"
+      padding="xl"
     >
       <Card
         marginTop="md"
@@ -181,6 +182,7 @@ const Hover = ({ example }: { example: string }) => (
         <Flex
           orientation="column"
           wrap
+          maxWidth="xl"
         >
           <FlexItem paddingBottom="xs">
             <Caption

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  Background,
   Body,
   Button,
   Caption,
@@ -20,79 +21,84 @@ const scaleObj = { 'sm': '@1.05', 'md': '@1.10', 'lg': '@1.15' }
 
 const Hover = ({ example }: { example: string }) => (
   <React.Fragment>
-    <Title
+    <Background
+      margin="xl"
+    >
+
+      <Title
         marginBottom="sm"
         size={1}
         tag="h1"
         text="Hover"
-    />
-    <Body
+      />
+      <Body
         paddingBottom="xxs"
         text="Adding our hover prop is useful for easily customizing UI for kit interactions."
-    />
-    <Button
+      />
+      <Button
         link="https://codesandbox.io/s/playbook-global-hover-prop-example-forked-mhssmm?file=/src/App.js"
         newWindow
         padding="none"
         tabIndex={0}
         variant="link"
-    >
-      <Body
-          variant="link"
       >
-        {'See this prop in action in our sample UI'}
-        <Icon
+        <Body
+          variant="link"
+        >
+          {'See this prop in action in our sample UI'}
+          <Icon
             fixedWidth
             icon="angle-right"
-        />
-      </Body>
-    </Button>
-    <Title
+          />
+        </Body>
+      </Button>
+      <Title
         marginBottom="xs"
         marginTop="md"
         size={4}
         tag="h4"
         text="Global Props"
-    />
-    <Body
+      />
+      <Body
         marginBottom="md"
         text="Available in every kit. These are added globally as they are most flexible when developing."
-    />
+      />
+    </Background>
     <Example
-        customChildren
-        example={example}
+      customChildren
+      example={example}
     >
       <Flex
-          paddingBottom="sm"
-          vertical="stretch"
+        paddingBottom="sm"
+        vertical="stretch"
       >
         <Card.Body
-            marginRight="xl"
-            paddingRight="xl"
+          marginRight="xl"
+          paddingRight="xl"
         >
           <Caption
-              marginBottom="sm"
-              text="Props"
+            marginBottom="sm"
+            text="Props"
           />
           <Pill
-              text="hover"
-              textTransform="none"
+            text="hover"
+            textTransform="none"
           />
         </Card.Body>
         <SectionSeparator
-            marginBottom="xs"
-            marginLeft="xl"
-            marginTop="md"
-            orientation="vertical"
-            paddingLeft="xl"
-            variant="card"
+          marginBottom="xs"
+          marginLeft="xl"
+          marginTop="md"
+          orientation="vertical"
+          paddingLeft="xl"
+          variant="card"
         />
         <Table
-            container={false}
-            dataTable
-            marginTop="sm"
-            marginX="sm"
-            size="sm"
+          container={false}
+          dataTable
+          marginTop="sm"
+          marginX="sm"
+          size="sm"
         >
           <thead>
             <tr>
@@ -104,35 +110,35 @@ const Hover = ({ example }: { example: string }) => (
             <tr>
               <td>
                 <Pill
-                    text="background"
-                    textTransform="none"
-                    variant="warning"
+                  text="background"
+                  textTransform="none"
+                  variant="warning"
                 />
               </td>
               <td>
                 <Pill
-                    text="${color}"
-                    textTransform="none"
-                    variant="warning"
+                  text="${color}"
+                  textTransform="none"
+                  variant="warning"
                 />
               </td>
             </tr>
             <tr>
               <td>
                 <Pill
-                    text="shadow"
-                    textTransform="none"
-                    variant="warning"
+                  text="shadow"
+                  textTransform="none"
+                  variant="warning"
                 />
               </td>
               <td>
                 {shadowArr.map((value) => {
                   return (
                     <Pill
-                        key={value}
-                        text={value}
-                        textTransform="none"
-                        variant="warning"
+                      key={value}
+                      text={value}
+                      textTransform="none"
+                      variant="warning"
                     />
                   )
                 })}
@@ -141,19 +147,19 @@ const Hover = ({ example }: { example: string }) => (
             <tr>
               <td>
                 <Pill
-                    text="scale"
-                    textTransform="none"
-                    variant="warning"
+                  text="scale"
+                  textTransform="none"
+                  variant="warning"
                 />
               </td>
               <td>
                 {Object.entries(scaleObj).map(([key]) => {
                   return (
                     <Pill
-                        key={key}
-                        text={key}
-                        textTransform="none"
-                        variant="warning"
+                      key={key}
+                      text={key}
+                      textTransform="none"
+                      variant="warning"
                     />
                   )
                 })}
@@ -163,81 +169,85 @@ const Hover = ({ example }: { example: string }) => (
         </Table>
       </Flex>
     </Example>
+    <Background
+      margin="xl"
+    >
 
-    <Card
+      <Card
         marginTop="md"
         shadow="deep"
-    >
-      <Flex
+      >
+        <Flex
           orientation="column"
           wrap
-      >
-        <FlexItem paddingBottom="xs">
-          <Caption
+        >
+          <FlexItem paddingBottom="xs">
+            <Caption
               text="Visual Guide"
-          />
-        </FlexItem>
-        <FlexItem>
-          <Body
+            />
+          </FlexItem>
+          <FlexItem>
+            <Body
               text="Hover over any card below to view hover property."
-          />
-        </FlexItem>
-        <FlexItem paddingY="sm">
-          <Flex
+            />
+          </FlexItem>
+          <FlexItem paddingY="sm">
+            <Flex
               gap="sm"
               wrap
-          >
-            <Card
+            >
+              <Card
                 hover={{ background: 'success_subtle' }}
                 padding="xs"
-            >
-              <Body
+              >
+                <Body
                   text="background color*"
-              />
-            </Card>
-            {shadowArr.map((value) => {
-              return (
-                <Card
+                />
+              </Card>
+              {shadowArr.map((value) => {
+                return (
+                  <Card
                     hover={{ shadow: value }}
                     key={value}
                     padding="xs"
-                >
-                  <Body
+                  >
+                    <Body
                       text={`shadow ${value}`}
-                  />
-                </Card>
-              )
-            })}
-            {Object.entries(scaleObj).map(([key, value]) => {
-              return (
-                <Card
+                    />
+                  </Card>
+                )
+              })}
+              {Object.entries(scaleObj).map(([key, value]) => {
+                return (
+                  <Card
                     hover={{ scale: key }}
                     key={key}
                     padding="xs"
-                >
-                  <Flex align="center">
-                    <Body
+                  >
+                    <Flex align="center">
+                      <Body
                         paddingRight="xxs"
                         text={`scale ${key}`}
-                    />
-                    <Caption
+                      />
+                      <Caption
                         size="xs"
                         text={value}
-                    />
-                  </Flex>
-                </Card>
-              )
-            })}
-          </Flex>
-        </FlexItem>
-        <FlexItem>
-          <Caption
+                      />
+                    </Flex>
+                  </Card>
+                )
+              })}
+            </Flex>
+          </FlexItem>
+          <FlexItem>
+            <Caption
               size="xs"
               text="*background accepts any color token"
-          />
-        </FlexItem>
-      </Flex>
-    </Card>
+            />
+          </FlexItem>
+        </Flex>
+      </Card>
+    </Background>
   </React.Fragment>
 )
 

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/ZIndex.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/ZIndex.tsx
@@ -5,6 +5,7 @@ import {
   Body,
   Caption,
   Card,
+  Flex,
   Title,
   Table,
 } from 'playbook-ui'
@@ -53,6 +54,10 @@ const tokensDescription = (
 
 const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: string }) => (
   <React.Fragment>
+    {/* <Background
+      margin="xl"
+      padding="xl"
+    > */}
     <Example
       description="If you're using Position, you might also find it useful to specify a z-index. We have multiple ways to use z-index, take a look at the examples below:"
       example={example}
@@ -63,18 +68,28 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
       screenSizes={screenSizeProps}
       title="Z-Index"
     />
-    <Background
-      margin="xl"
-    >
+    {/* <Background
+      // margin="xl"
+      padding="xl"
+    > */}
+    {/* <Flex orientation='column'> */}
+
+    
+
+    
+    {/* <Example
+      description="Just want the raw classes? We got you. All of our global props are simple CSS utilities available through classes."
+      title="Utility Classes"
+      > */}
       <Title
         marginTop='sm'
         size={4}
         text='Utility Classes'
-      />
+        />
       <Body
         text='Just want the raw classes? We got you. All of our global props are simple CSS utilities available through classes.'
         marginBottom='sm'
-      />
+        />
       <Caption
         text='Visual Guide'
         marginBottom='sm'
@@ -110,7 +125,9 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
           ))}
         </tbody>
       </Table>
-    </Background>
+      {/* </Flex> */}
+      {/* </Example> */}
+    {/* </Background> */}
     <Example
       example={tokensExample}
       tokens={TOKENS}
@@ -130,6 +147,8 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
         ))}
       </div>
     </Example>
+
+    {/* </Background> */}
   </React.Fragment>
 )
 

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/ZIndex.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/ZIndex.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import {
+  Background,
   Body,
   Caption,
   Card,
@@ -29,11 +30,11 @@ const screenSizeProps = {
 }
 
 const UTILITY_CLASSES = [
-  {size: 'xs', media: '@media screen and (max-width: $screen-xs-min)', class: '.z_index_xs_{1-10}', properties: 'z_index: {100-1000} !important'},
-  {size: 'sm', media: '@media screen and (max-width: $screen-sm-min)', class: '.z_index_sm_{1-10}', properties: 'z_index: {100-1000} !important'},
-  {size: 'md', media: '@media screen and (max-width: $screen-md-min)', class: '.z_index_md_{1-10}', properties: 'z_index: {100-1000} !important'},
-  {size: 'lg', media: '@media screen and (max-width: $screen-lg-min)', class: '.z_index_lg_{1-10}', properties: 'z_index: {100-1000} !important'},
-  {size: 'xl', media: '@media screen and (max-width: $screen-xl-min)', class: '.z_index_xl_{1-10}', properties: 'z_index: {100-1000} !important'},
+  { size: 'xs', media: '@media screen and (max-width: $screen-xs-min)', class: '.z_index_xs_{1-10}', properties: 'z_index: {100-1000} !important' },
+  { size: 'sm', media: '@media screen and (max-width: $screen-sm-min)', class: '.z_index_sm_{1-10}', properties: 'z_index: {100-1000} !important' },
+  { size: 'md', media: '@media screen and (max-width: $screen-md-min)', class: '.z_index_md_{1-10}', properties: 'z_index: {100-1000} !important' },
+  { size: 'lg', media: '@media screen and (max-width: $screen-lg-min)', class: '.z_index_lg_{1-10}', properties: 'z_index: {100-1000} !important' },
+  { size: 'xl', media: '@media screen and (max-width: $screen-xl-min)', class: '.z_index_xl_{1-10}', properties: 'z_index: {100-1000} !important' },
 ]
 
 const globalPropsDescription = (
@@ -62,52 +63,54 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
       screenSizes={screenSizeProps}
       title="Z-Index"
     />
-
-    <Title
-      marginTop='sm'
-      size={4}
-      text='Utility Classes'
-    />
-    <Body
-      text='Just want the raw classes? We got you. All of our global props are simple CSS utilities available through classes.'
-      marginBottom='sm'
-    />
-    <Caption
-      text='Visual Guide'
-      marginBottom='sm'
-    />
-    <Table
-      shadow='deep'
-      size='sm'
+    <Background
+      margin="xl"
     >
-      <thead>
-        <tr>
-          <th>{'Screen Size'}</th>
-          <th>{'@Media Screen'}</th>
-          <th>{'Class'}</th>
-          <th>{'Properties'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {UTILITY_CLASSES.map((utilityClass: { [key: string]: string }) => (
+      <Title
+        marginTop='sm'
+        size={4}
+        text='Utility Classes'
+      />
+      <Body
+        text='Just want the raw classes? We got you. All of our global props are simple CSS utilities available through classes.'
+        marginBottom='sm'
+      />
+      <Caption
+        text='Visual Guide'
+        marginBottom='sm'
+      />
+      <Table
+        shadow='deep'
+        size='sm'
+      >
+        <thead>
           <tr>
-            <td>
-              {utilityClass.size}
-            </td>
-            <td>
-              {utilityClass.media}
-            </td>
-            <td>
-              {utilityClass.class}
-            </td>
-            <td>
-              {utilityClass.properties}
-            </td>
+            <th>{'Screen Size'}</th>
+            <th>{'@Media Screen'}</th>
+            <th>{'Class'}</th>
+            <th>{'Properties'}</th>
           </tr>
-        ))}
-      </tbody>
-    </Table>
-
+        </thead>
+        <tbody>
+          {UTILITY_CLASSES.map((utilityClass: { [key: string]: string }) => (
+            <tr>
+              <td>
+                {utilityClass.size}
+              </td>
+              <td>
+                {utilityClass.media}
+              </td>
+              <td>
+                {utilityClass.class}
+              </td>
+              <td>
+                {utilityClass.properties}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </Background>
     <Example
       example={tokensExample}
       tokens={TOKENS}
@@ -119,7 +122,7 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
             className="zIndex"
             key={`token-example-${token}`}
             shadow="deeper"
-            zIndex={TOKENS[token]/100}
+            zIndex={TOKENS[token] / 100}
           >
             <Body>{token}</Body>
             <Caption size="md">{`value: ${TOKENS[token]}`}</Caption>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/ZIndex.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/ZIndex.tsx
@@ -54,10 +54,6 @@ const tokensDescription = (
 
 const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: string }) => (
   <React.Fragment>
-    {/* <Background
-      margin="xl"
-      padding="xl"
-    > */}
     <Example
       description="If you're using Position, you might also find it useful to specify a z-index. We have multiple ways to use z-index, take a look at the examples below:"
       example={example}
@@ -68,28 +64,19 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
       screenSizes={screenSizeProps}
       title="Z-Index"
     />
-    {/* <Background
-      // margin="xl"
+    <Background
+      className="token-wrapper"
       padding="xl"
-    > */}
-    {/* <Flex orientation='column'> */}
-
-    
-
-    
-    {/* <Example
-      description="Just want the raw classes? We got you. All of our global props are simple CSS utilities available through classes."
-      title="Utility Classes"
-      > */}
+    >
       <Title
         marginTop='sm'
         size={4}
         text='Utility Classes'
-        />
+      />
       <Body
         text='Just want the raw classes? We got you. All of our global props are simple CSS utilities available through classes.'
         marginBottom='sm'
-        />
+      />
       <Caption
         text='Visual Guide'
         marginBottom='sm'
@@ -125,9 +112,7 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
           ))}
         </tbody>
       </Table>
-      {/* </Flex> */}
-      {/* </Example> */}
-    {/* </Background> */}
+    </Background>
     <Example
       example={tokensExample}
       tokens={TOKENS}
@@ -147,8 +132,6 @@ const ZIndex = ({ example, tokensExample }: { example: string, tokensExample?: s
         ))}
       </div>
     </Example>
-
-    {/* </Background> */}
   </React.Fragment>
 )
 

--- a/playbook/app/pb_kits/playbook/pb_flex/docs/_flex_spacing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_flex/docs/_flex_spacing.html.erb
@@ -46,7 +46,3 @@
     <%= pb_rails("flex/flex_item") do %>4<% end %>
   <% end %>
 </div>
-
-
-
-</div>


### PR DESCRIPTION
**What does this PR do?** [PLAY-1187](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1187) fixes some layout and page formatting issues on some pages of the Playbook website. See below for before/after screenshots of each affected page.

**Screenshots:** 
Colors Page: 
<img src='https://github.com/powerhome/playbook/assets/83474365/c4722d87-b9b3-4f3a-8c79-1e02145816c1'  width='250' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/f4e201ce-d305-48a1-bb4a-ee5d7e87d023'  width='250' height='250'>
Z-Index Page:
<img src='https://github.com/powerhome/playbook/assets/83474365/bac200e8-90f7-49f6-b613-1d99cb252f59'  width='250' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/851374d3-1a8a-4375-aaae-6702be14b7a2'  width='250' height='250'>
Border Radius Page: 
<img src='https://github.com/powerhome/playbook/assets/83474365/b029b53e-6049-45c7-bdb5-5c6823775e53' width='250' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/2e7ef6b1-b8ed-439e-91c3-05951c6e0a16'  width='250' height='250'>
Display Page:
<img src='https://github.com/powerhome/playbook/assets/83474365/47204174-7068-4fce-97cd-bb9c4bfcd5f5'  width='250' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/bd9c337a-661e-43e6-81cd-1d63b04cfe63'  width='250' height='250'>
Cursor Page:
<img src='https://github.com/powerhome/playbook/assets/83474365/6fb3a5af-b864-40f3-8777-13bc1dea4088'  width='300' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/fb5f3d98-af78-42c3-99ee-a9ce530ea1ef'  width='300' height='250'>
Hover Page (two sets as two spots affected):
<img src='https://github.com/powerhome/playbook/assets/83474365/2f6cd0c3-21e1-47ac-8fb8-6e765f18bfcc'  width='250' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/4db32fc3-ef19-4d83-88a5-226b53088ba2'  width='250' height='250'>
<img src='https://github.com/powerhome/playbook/assets/83474365/526befc6-8d50-42b0-a6d5-a2aea6ba2820'  width='300' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/1231f022-be8d-43d8-8090-0761f0fc9346'  width='300' height='250'>
Flex Page:
<img src='https://github.com/powerhome/playbook/assets/83474365/b3c8badd-975d-4581-82b1-ea396fe1472a'  width='250' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/0a80def9-e22e-457a-9eac-1222c767a69e'  width='250' height='250'>
Layout Page (the props floating outside the card in Flex is also fixed futher up on this page)
<img src='https://github.com/powerhome/playbook/assets/83474365/19515578-da1b-40c0-9172-d32a9a9b72b1'  width='250' height='250'><img src='https://github.com/powerhome/playbook/assets/83474365/57f952db-7786-492f-8d32-955fee0888d7'  width='250' height='250'>




**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~