### PR TITLE
[PLAY-1271][PLAY-1270] Enable Online Status & New Colors + Hide Date Range Picker Docs

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -407,6 +407,10 @@ kits:
         platforms: *web
         description: Badges can be used for notification, tags, and status. They are used for count and numbers.
         status: "stable"
+      - name: "online_status"
+        platforms: *web
+        description: Online Status is a small indicator that lets the user know the status of a person or item. 
+        status: "stable"
       - name: "pill"
         platforms: *all
         description: A pill uses both a keyword and a specific color to categorize an item. 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_default_date.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_default_date.html.erb
@@ -11,13 +11,6 @@
 }) %>
 
 <%= pb_rails("date_picker", props: {
-  default_date: [DateTime.current.utc.iso8601, (DateTime.current + 7.day).utc.iso8601],
-  label: "Default Date Range",
-  mode: "range",
-  picker_id: "date-picker-default-date3"
-}) %>
-
-<%= pb_rails("date_picker", props: {
   label: "Default Behavior",
   picker_id: "date-picker-default-date4"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_default_date.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_default_date.jsx
@@ -17,13 +17,6 @@ const DatePickerDefaultDate = (props) => (
         {...props}
     />
     <DatePicker
-        defaultDate={[new Date(), new Date().fp_incr(7)]}
-        label="Default Date Range"
-        mode="range"
-        pickerId="date-picker-default-date3"
-        {...props}
-    />
-    <DatePicker
         label="Default Behavior"
         pickerId="date-picker-default-date4"
         {...props}

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_range.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_range.html.erb
@@ -3,3 +3,10 @@
   mode: "range",
   picker_id: "date-picker-range"
 }) %>
+
+<%= pb_rails("date_picker", props: {
+  default_date: [DateTime.current.utc.iso8601, (DateTime.current + 7.day).utc.iso8601],
+  label: "Default Date Range",
+  mode: "range",
+  picker_id: "date-picker-default-date3"
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_range.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_range.jsx
@@ -10,6 +10,13 @@ const DatePickerRange = (props) => (
         pickerId="date-picker-range"
         {...props}
     />
+    <DatePicker
+        defaultDate={[new Date(), new Date().fp_incr(7)]}
+        label="Default Date Range"
+        mode="range"
+        pickerId="date-picker-default-date3"
+        {...props}
+    />
   </div>
 )
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
@@ -7,7 +7,7 @@ examples:
   - date_picker_allow_input: Allow Input
   - date_picker_input: Input Field
   - date_picker_label: Label
-  - date_picker_range: Range
+  # - date_picker_range: Range
   - date_picker_quick_pick_rails: Range (Quick Pick)
   - date_picker_quick_pick_range_limit: Range (Quick Pick w/ “This” Range limit)
   - date_picker_quick_pick_custom: Custom Quick Pick Dates
@@ -36,7 +36,7 @@ examples:
   - date_picker_label: Label
   - date_picker_on_change: onChange
   - date_picker_on_close: onClose
-  - date_picker_range: Range
+  # - date_picker_range: Range
   - date_picker_quick_pick_react: Range (Quick Pick)
   - date_picker_quick_pick_range_limit: Range (Quick Pick w/ “This” Range limit)
   - date_picker_quick_pick_custom: Custom Quick Pick Dates

--- a/playbook/app/pb_kits/playbook/pb_online_status/_online_status.scss
+++ b/playbook/app/pb_kits/playbook/pb_online_status/_online_status.scss
@@ -5,16 +5,7 @@
 
   @each $status_name, $status_value in $pb_online_status_statuses {
     &[class*=_#{$status_name}]  {
-      background: $status_value;
+      @include pb_online_status($status_value);
     }
-  }
-  &[class*=_online]  {
-    @include pb_online_status_online;
-  }
-  &[class*=_away]  {
-    @include pb_online_status_away;
-  }
-  &[class*=_offline]  {
-    @include pb_online_status_offline;
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_online_status/_online_status.tsx
+++ b/playbook/app/pb_kits/playbook/pb_online_status/_online_status.tsx
@@ -10,7 +10,7 @@ type OnlineStatusProps = {
   data?: {[key: string]: string | number},
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
-  status?: "online" | "offline" | "away",
+  status?: "away" | "error" | "info" | "neutral" | "offline" |"online" | "primary"| "success" | "warning",
 } & GlobalProps
 
 const OnlineStatus = (props: OnlineStatusProps) => {

--- a/playbook/app/pb_kits/playbook/pb_online_status/_online_status_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_online_status/_online_status_mixins.scss
@@ -7,6 +7,12 @@ $pb_online_status_statuses: (
   online: $success,
   away: $warning,
   offline: $neutral,
+  success: $success,
+  warning: $warning,
+  error: $error,
+  info: $info,
+  neutral: $neutral,
+  primary: $primary,
 );
 
 @mixin pb_online_status($background: $neutral) {
@@ -23,16 +29,4 @@ $pb_online_status_statuses: (
   border-style: solid;
   border-radius: 50%;
   background: $background;
-}
-
-@mixin pb_online_status_away {
-  @include pb_online_status($warning);
-}
-
-@mixin pb_online_status_online {
-  @include pb_online_status($success);
-}
-
-@mixin pb_online_status_offline {
-  @include pb_online_status($neutral);
 }

--- a/playbook/app/pb_kits/playbook/pb_online_status/docs/_online_status_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_online_status/docs/_online_status_default.html.erb
@@ -1,9 +1,6 @@
-<%= pb_rails("online_status", props: { status: "offline" }) %>
-
-<br>
-
-<%= pb_rails("online_status", props: { status: "online" }) %>
-
-<br>
-
-<%= pb_rails("online_status", props: { status: "away" }) %>
+<%= pb_rails("online_status", props: { status: "offline", margin_y: "xs" }) %>
+<%= pb_rails("online_status", props: { status: "online", margin_y: "xs" }) %>
+<%= pb_rails("online_status", props: { status: "away", margin_y: "xs" }) %>
+<%= pb_rails("online_status", props: { status: "error", margin_y: "xs" }) %>
+<%= pb_rails("online_status", props: { status: "info", margin_y: "xs" }) %>
+<%= pb_rails("online_status", props: { status: "primary", margin_y: "xs" }) %>

--- a/playbook/app/pb_kits/playbook/pb_online_status/docs/_online_status_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_online_status/docs/_online_status_default.jsx
@@ -5,24 +5,35 @@ import OnlineStatus from '../_online_status'
 const OnlineStatusDefault = (props) => (
   <>
     <OnlineStatus
+        marginY="xs"
         status="offline"
         {...props}
     />
-
-    <br />
-
     <OnlineStatus
+        marginY="xs"
         status="online"
         {...props}
     />
-
-    <br />
-
     <OnlineStatus
+        marginY="xs"
         status="away"
         {...props}
     />
-
+    <OnlineStatus
+        marginY="xs"
+        status="error"
+        {...props}
+    />
+    <OnlineStatus
+        marginY="xs"
+        status="info"
+        {...props}
+    />
+    <OnlineStatus
+        marginY="xs"
+        status="primary"
+        {...props}
+    />
   </>
 )
 

--- a/playbook/app/pb_kits/playbook/pb_online_status/online_status.rb
+++ b/playbook/app/pb_kits/playbook/pb_online_status/online_status.rb
@@ -4,7 +4,7 @@ module Playbook
   module PbOnlineStatus
     class OnlineStatus < Playbook::KitBase
       prop :status, type: Playbook::Props::Enum,
-                    values: %w[online offline away],
+                    values: %w[online offline away success warning error info neutral primary],
                     default: "offline"
 
       def classname

--- a/playbook/spec/pb_kits/playbook/kits/online_status_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/online_status_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Playbook::PbOnlineStatus::OnlineStatus do
   it {
     is_expected.to define_enum_prop(:status)
       .with_default("offline")
-      .with_values("online", "offline", "away")
+      .with_values("online", "offline", "away", "error", "neutral", "success", "warning", "info", "primary")
   }
 
   describe "#classname" do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
- [x] Show Hidden Online Status Kit
- [x] Adds Additional Colors to Online Status
- [x] Hides Date Picker Range docs to avoid user confusion.

https://nitro.powerhrg.com/runway/backlog_items/PLAY-1270
https://nitro.powerhrg.com/runway/backlog_items/PLAY-1271

**Screenshots:** Screenshots to visualize your addition/change
<img width="1274" alt="Screenshot 2024-03-20 at 6 30 55 PM" src="https://github.com/powerhome/playbook/assets/863031/03ed4b46-9c23-45ab-9160-13b8769c54d4">

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.