### PR TITLE
[PLAY-1159] Make rails disable prop for toggle kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
@@ -2,23 +2,17 @@
 
 $color_checkbox_success: $data_1;
 $color_checkbox_default: $border_light;
+$color_disabled: darken($border_light, 20%);
 $transition: .2s ease-in-out;
 
 [class^=pb_toggle_kit] {
   position: relative;
   $width: 44px;
-  $height: $width/2;
+  $height: $width / 2;
   $border_success: 3px solid $color_checkbox_success;
   $border_default: 3px solid $color_checkbox_default;
 
   .pb_toggle_wrapper {
-    input:disabled + .pb_toggle_control {
-      cursor: default;
-      &:hover {
-        border: $border_default; // Keep the default border on hover for disabled
-      }
-    }
-
     .pb_toggle_control {
       cursor: pointer;
       transition: $transition;
@@ -29,11 +23,11 @@ $transition: .2s ease-in-out;
       border: $border_default;
       position: relative;
       box-sizing: content-box;
-      
+
       &:after {
         transition: $transition;
         content: "";
-        width: $width/2 - 4px;
+        width: $width / 2 - 4px;
         height: $height - 4px;
         background-color: $color_checkbox_default;
         border-radius: 50%;
@@ -41,10 +35,10 @@ $transition: .2s ease-in-out;
         top: 2px;
         left: 2px;
       }
-      
-      // Apply hover styles for enabled state
+
       &:hover {
         border: $border_success;
+
         &:after {
           background-color: $color_checkbox_success;
         }
@@ -53,12 +47,25 @@ $transition: .2s ease-in-out;
 
     input {
       display: none;
+
       &:checked + .pb_toggle_control {
         border: $border_success;
         background-color: $color_checkbox_success;
+
         &:after {
-          left: $width/2 + 2px;
+          left: $width / 2 + 2px;
           background-color: $white;
+        }
+      }
+
+      &:disabled + .pb_toggle_control {
+        cursor: not-allowed;
+        opacity: 0.5; 
+        border: 3px solid $color_disabled;
+        background-color: $color_disabled;
+
+        &:after {
+          background-color: darken($color_disabled, 15%);
         }
       }
     }

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
@@ -11,8 +11,14 @@ $transition: .2s ease-in-out;
   $border_success: 3px solid $color_checkbox_success;
   $border_default: 3px solid $color_checkbox_default;
 
-
   .pb_toggle_wrapper {
+    input:disabled + .pb_toggle_control {
+      cursor: default;
+      &:hover {
+        border: $border_default; // Keep the default border on hover for disabled
+      }
+    }
+
     .pb_toggle_control {
       cursor: pointer;
       transition: $transition;
@@ -23,6 +29,7 @@ $transition: .2s ease-in-out;
       border: $border_default;
       position: relative;
       box-sizing: content-box;
+      
       &:after {
         transition: $transition;
         content: "";
@@ -34,19 +41,22 @@ $transition: .2s ease-in-out;
         top: 2px;
         left: 2px;
       }
+      
+      // Apply hover styles for enabled state
       &:hover {
         border: $border_success;
-        &:after{
+        &:after {
           background-color: $color_checkbox_success;
         }
       }
     }
+
     input {
       display: none;
       &:checked + .pb_toggle_control {
         border: $border_success;
         background-color: $color_checkbox_success;
-        &:after{
+        &:after {
           left: $width/2 + 2px;
           background-color: $white;
         }
@@ -54,3 +64,4 @@ $transition: .2s ease-in-out;
     }
   }
 }
+

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
@@ -48,6 +48,21 @@ $transition: .2s ease-in-out;
     input {
       display: none;
 
+      &:disabled + .pb_toggle_control {
+        cursor: not-allowed;
+        opacity: 0.5; 
+        border: 3px solid $border_light;
+        background-color: $border_light;
+
+        &:after {
+          background-color: darken($neutral, 15%);
+        }
+      }
+    }
+
+    input:checked {
+      display: none;
+
       &:checked + .pb_toggle_control {
         border: $border_success;
         background-color: $color_checkbox_success;
@@ -61,11 +76,11 @@ $transition: .2s ease-in-out;
       &:disabled + .pb_toggle_control {
         cursor: not-allowed;
         opacity: 0.5; 
-        border: 3px solid $color_disabled;
-        background-color: $color_disabled;
+        border: 3px solid $text_lt_light;
+        background-color: $text_lt_light;
 
         &:after {
-          background-color: darken($color_disabled, 15%);
+          background-color: $neutral;
         }
       }
     }

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
@@ -17,6 +17,7 @@ type Props = {
   children?: React.ReactNode | React.ReactNode[],
   className?: string,
   data?: { [key: string]: string },
+  disabled?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   name?: string,
@@ -31,10 +32,13 @@ const Toggle = ({
   children,
   className,
   data = {},
+  disabled = false,
   id,
   htmlOptions = {},
   name,
-  onChange = () => { },
+  onChange = (): void => {
+  // Function body here
+  },
   size = 'sm',
   value,
   ...props
@@ -53,23 +57,24 @@ const Toggle = ({
 
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classnames(css, globalProps(props), className)}
-      id={id}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classnames(css, globalProps(props), className)}
+        id={id}
     >
       <label className="pb_toggle_wrapper">
         {children && children}
 
         {!children &&
           <input
-            {...props}
-            defaultChecked={checked}
-            name={name}
-            onChange={onChange}
-            type="checkbox"
-            value={value}
+              {...props}
+              defaultChecked={checked}
+              disabled={disabled}
+              name={name}
+              onChange={onChange}
+              type="checkbox"
+              value={value}
           />
         }
         <div className="pb_toggle_control" />

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_disabled.html.erb
@@ -1,0 +1,11 @@
+<%= pb_rails("toggle", props: {
+  checked: true,
+  disabled: true
+}) %>
+
+<br>
+
+<%= pb_rails("toggle", props: {
+  checked: false,
+  disabled: true
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_disabled.jsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_disabled.jsx
@@ -1,0 +1,21 @@
+// @flow
+
+import React from 'react'
+import { Toggle } from '../..'
+
+const ToggleDisabled= () => {
+  return (
+    <>
+      <Toggle
+          checked
+          disabled 
+      />
+
+      <br />
+
+      <Toggle disabled />
+    </>
+  )
+}
+
+export default ToggleDisabled 

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/example.yml
@@ -2,7 +2,7 @@ examples:
 
   rails:
   - toggle_default: Default State
-  - toggle_disabled: Disabled Prop
+  - toggle_disabled: Disabled
   - toggle_name: Name and Value
   - toggle_custom: Custom checkbox input
   - toggle_custom_radio: Custom radio inputs
@@ -10,7 +10,7 @@ examples:
 
   react:
   - toggle_default: Default State
-  - toggle_disabled: Disabled Prop
+  - toggle_disabled: Disabled
   - toggle_name: Name and Value
   - toggle_custom: Custom checkbox input
   - toggle_custom_radio: Custom radio inputs

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/example.yml
@@ -10,6 +10,7 @@ examples:
 
   react:
   - toggle_default: Default State
+  - toggle_disabled: Disabled Prop
   - toggle_name: Name and Value
   - toggle_custom: Custom checkbox input
   - toggle_custom_radio: Custom radio inputs

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/example.yml
@@ -2,6 +2,7 @@ examples:
 
   rails:
   - toggle_default: Default State
+  - toggle_disabled: Disabled Prop
   - toggle_name: Name and Value
   - toggle_custom: Custom checkbox input
   - toggle_custom_radio: Custom radio inputs

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/index.js
@@ -1,4 +1,5 @@
 export { default as ToggleDefault } from './_toggle_default'
+export { default as ToggleDisabled } from './_toggle_disabled'
 export { default as ToggleCustom } from './_toggle_custom'
 export { default as ToggleName } from './_toggle_name'
 export { default as ToggleCustomRadio } from './_toggle_custom_radio'

--- a/playbook/app/pb_kits/playbook/pb_toggle/toggle.rb
+++ b/playbook/app/pb_kits/playbook/pb_toggle/toggle.rb
@@ -15,13 +15,14 @@ module Playbook
                   values: %w[sm md],
                   default: "sm"
       prop :value
+      prop :disabled, type: Playbook::Props::Boolean, default: false
 
       def classname
         generate_classname("pb_toggle_kit", size, checked_class)
       end
 
       def input
-        check_box_tag(name, value, checked, input_options)
+        check_box_tag(name, value, checked, input_options.merge(disabled: disabled))
       end
 
     private

--- a/playbook/app/pb_kits/playbook/pb_toggle/toggle.test.js
+++ b/playbook/app/pb_kits/playbook/pb_toggle/toggle.test.js
@@ -60,6 +60,13 @@ test('should have sm size by default', () => {
     expect(kit).toHaveClass('pb_toggle_kit_sm_off')
 })
 
+test('should pass disabled prop', () => {
+    render(<ToggleDefault disabled />)
+    const kit = screen.getByTestId(testId)
+    const input = kit.querySelector('input')
+    expect(input).toHaveAttribute('disabled')
+})  
+
 test('should pass size prop', () => {
     render(<ToggleDefault size='md' />)
     const kit = screen.getByTestId(testId)

--- a/playbook/spec/pb_kits/playbook/kits/toggle_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/toggle_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Playbook::PbToggle::Toggle do
   }
   it { is_expected.to define_boolean_prop(:checked).with_default(false) }
   it { is_expected.to define_prop(:name) }
+  it { is_expected.to define_prop(:disabled).with_default(false) }
   it { is_expected.to define_prop(:value) }
   it { is_expected.to define_hash_prop(:input_options).with_default({}) }
 
@@ -21,6 +22,7 @@ RSpec.describe Playbook::PbToggle::Toggle do
       expect(subject.new(classname: "additional_class").classname).to eq "pb_toggle_kit_sm_off additional_class"
       expect(subject.new(size: "md").classname).to eq "pb_toggle_kit_md_off"
       expect(subject.new(checked: true).classname).to eq "pb_toggle_kit_sm_on"
+      expect(subject.new(disabled: true).disabled).to eq true
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

RUNWAY https://nitro.powerhrg.com/runway/backlog_items/PLAY-1159

Add dedicated disabled prop to the toggle kit,

You can disable with our `input_options` prop, but we want to have disabled styles 

**Screenshots:** Screenshots to visualize your addition/change

![screenshot-pr3266 playbook beta gm powerapp cloud-2024 03 21-16_23_18](https://github.com/powerhome/playbook/assets/38965626/8e1c87e3-39f4-4f13-9a41-e8f5f3e60a84)


**How to test?** Steps to confirm the desired behavior:
1. Go to https://pr3266.playbook.beta.gm.powerapp.cloud/kits/toggle/react#disabled-prop
2. Whitness greatness 

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.