### PR TITLE
[PBNTR-238] Fix for DatePicker Year Gug

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -1,4 +1,5 @@
 import flatpickr from 'flatpickr'
+import { Instance } from "flatpickr/dist/types/instance"
 import { BaseOptions } from 'flatpickr/dist/types/options'
 import monthSelectPlugin from 'flatpickr/dist/plugins/monthSelect'
 import weekSelect from "flatpickr/dist/plugins/weekSelect/weekSelect"
@@ -165,9 +166,9 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
   }
 
   // two way binding
-  const initialDropdown = document.querySelector<HTMLElement & { [x: string]: any }>(`#year-${pickerId}`)
-  const yearChangeHook = () => {
-    initialDropdown.value = initialPicker.currentYear
+  const yearChangeHook = (fp: Instance) => {
+      const yearInput = document.querySelector(`#year-${fp.input.id}`) as HTMLInputElement
+      yearInput.value = fp.currentYear?.toString()
   }
 
   // ===========================================================
@@ -199,11 +200,12 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
       if (!staticPosition && scrollContainer) detachFromScroll(scrollContainer as HTMLElement)
       onClose(selectedDates, dateStr)
     }],
-    onChange: [(selectedDates, dateStr) => {
+    onChange: [(selectedDates, dateStr, fp) => {
+      yearChangeHook(fp)
       onChange(dateStr, selectedDates)
     }],
-    onYearChange: [() => {
-      yearChangeHook()
+    onYearChange: [(_selectedDates, _dateStr, fp) => {
+      yearChangeHook(fp)
     }],
     plugins: setPlugins(thisRangesEndToday, customQuickPickDates),
     position,
@@ -248,7 +250,7 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
         /* Reset date picker to default value on form.reset() */
         if (defaultDate){
           picker.setDate(defaultDate)
-          yearChangeHook()
+          yearChangeHook(picker)
         }
       }, 0)
     })


### PR DESCRIPTION
**What does this PR do?**

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-238)

Date Picker `default date` variant's selected year did not match the days/contents of the visible month in the calendar
This PR implements this [solution](https://gist.github.com/mterezac/213b4fe3bb5356a8a589db8f7b3c2546) proposed by MT

**Screenshots:**

![Screenshot 2024-03-21 at 1 57 04 PM](https://github.com/powerhome/playbook/assets/73710701/cd3d358a-95d3-45b1-a58a-e5f72146f508)


**How to test?** Steps to confirm the desired behavior:
1. Open a date range picker with Default Date variant
2. Change the year to 2020
3. Select a date then click out of the picker
4. Open it again and select a date
5. You should see the correct year displayed
