### PR TITLE
[PLAY-1203] Default cancel and close button type to prevent submission

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
@@ -9,7 +9,7 @@
             <%= pb_rails("button", props: { type: "submit", id: object.confirm_button_id }) do %>
                 <%= object.confirm_button %>
             <% end %>
-            <%= pb_rails("button", props: { data: {"close-dialog": "#{object.id}" }, id: object.cancel_button_id, variant: "link"}) do %>
+            <%= pb_rails("button", props: { type: "button", data: {"close-dialog": "#{object.id}" }, id: object.cancel_button_id, variant: "link"}) do %>
                 <%= object.cancel_button %>
             <% end %>
         <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
@@ -6,8 +6,8 @@
     **combined_html_options) do %>
         <%= pb_rails("flex", props: {classname:object.classname, spacing:"between", padding:"sm", align:"center"}) do %>
             <%= content.presence || object.title %>
-            
-            <button class="dialog-button-class" data-close-dialog= <%= object.id %> >
+
+            <button class="dialog-button-class" type="button" data-close-dialog= <%= object.id %> >
                 <%= pb_rails("icon", props:{icon: "times"}) %>
             </button>
         <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_compound_components.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_compound_components.html.erb
@@ -1,6 +1,7 @@
 <%= pb_rails("button", props: { text: "Open Complex Dialog", data:{"open-dialog": "dialog-complex"} }) %>
 
 <%= pb_rails("dialog", props: { id:"dialog-complex", size: "lg", full_height: true }) do %>
+  <form>
     <%= pb_rails("dialog/dialog_header", props: { id: "dialog-complex" } ) do %>
         <%= pb_rails("body", props: { text: "What do you need us to take care of?" }) %>
     <% end %>
@@ -12,4 +13,5 @@
 
     <% end %>
     <%= pb_rails("dialog/dialog_footer", props: {cancel_button: "Back", confirm_button: "Send my Issue", confirm_button_id:"confirm-complex", id: "dialog-complex"}) %>
+  </form>
 <% end %>


### PR DESCRIPTION
**What does this PR do?** 

When a form is used to wrap the Rails dialog kit block area content, any unspecified `button` element will submit the form. Only buttons specified with the `type="submit"` attribute should perform this function. 

By defaulting the cancel and close (X) buttons in the Rails version of the kit, we can avoid this unintended side effect. 

**Screenshots:** Screenshots to visualize your addition/change

- Please see the kits/dialog/rails#complex example

**How to test?** Steps to confirm the desired behavior:
1. Go to the aforementioned path on the review env
2. Activate the modal
3. Click either X or "Cancel"
4. The form should not submit (page should not reload and there should be no `?` at the end of the URL in the browser's address bar)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.