### PR TITLE
[PLAY-1205] Update Multilevel React Doc for clarity on selectedIds

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids.md
@@ -1,4 +1,4 @@
-`selected_ids` (Rails) / `selectedIds` (React) is an optional prop that accepts an array of ids that, if present, will mark the corresponding nodes on the treeData as checked on page load. 
+`selected_ids` is an optional prop that accepts an array of ids that, if present, will mark the corresponding nodes on the treeData as checked on page load. 
 
 Items that include `checked:true` on the treeData itself will also be selected on page load, even without being passed to `selectedIds`.
 

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.jsx
@@ -68,7 +68,7 @@ const treeData = [
   },
 ];
 
-const MultiLevelSelectSelectedIds = (props) => {
+const MultiLevelSelectSelectedIdsReact = (props) => {
   return (
     <div>
       <MultiLevelSelect
@@ -85,4 +85,4 @@ const MultiLevelSelectSelectedIds = (props) => {
   );
 };
 
-export default MultiLevelSelectSelectedIds;
+export default MultiLevelSelectSelectedIdsReact;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.md
@@ -1,0 +1,5 @@
+`selected_ids` is an optional prop that accepts an array of ids and controls the selected state of the tree nodes that match the values passed. When used within react-hook-form, this prop can be used to manage the selected state of any ids passed to it. 
+
+Items that include `checked:true` on the treeData itself will also be selected on page load, even without being passed to `selectedIds`.
+
+When an item is marked as checked on page load by any means, the dropdown will expand to show the checked items for easier accessibility. 

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
@@ -12,4 +12,4 @@ examples:
   - multi_level_select_single: Single Select
   - multi_level_select_single_children_only: Single Select w/ Hidden Radios
   - multi_level_select_return_all_selected: Return All Selected
-  - multi_level_select_selected_ids: Selected Ids
+  - multi_level_select_selected_ids_react: Selected Ids

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
@@ -2,4 +2,4 @@ export { default as MultiLevelSelectDefault } from './_multi_level_select_defaul
 export { default as MultiLevelSelectSingle } from './_multi_level_select_single.jsx'
 export { default as MultiLevelSelectSingleChildrenOnly } from './_multi_level_select_single_children_only.jsx'
 export { default as MultiLevelSelectReturnAllSelected } from './_multi_level_select_return_all_selected.jsx'
-export { default as MultiLevelSelectSelectedIds } from "./_multi_level_select_selected_ids.jsx"
+export { default as MultiLevelSelectSelectedIdsReact } from "./_multi_level_select_selected_ids_react.jsx"


### PR DESCRIPTION
**What does this PR do?** 
[PLAY-1205](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1205) requests doc changes for the Selected Ids example on the Multi Level Select Kit. Files were edited and created to support differences in markdown text between the Rails and React example that follow a pre-existing but not ideal pattern (that is, appending a `_react` suffix to the .md and .jsx files supporting React and leaving the Rails filenames unaltered) - this will be updated in a [future tech debt ticket](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1274).


**Screenshots:**
Before version of markdown (same for both Rails/React examples):
<img width="600" alt="Markdown before" src="https://github.com/powerhome/playbook/assets/83474365/1465d6c5-7378-4b0f-aa2b-18951f3a786a">
After version of Rails example markdown:
<img width="600" alt="Rails markdown changed" src="https://github.com/powerhome/playbook/assets/83474365/a419ee41-b423-45ae-8e5c-0b31426b9838">
After version of React example markdown:
<img width="600" alt="React markdown changed" src="https://github.com/powerhome/playbook/assets/83474365/bacd1c09-e160-470e-997f-29a36200f043">




**How to test?** Steps to confirm the desired behavior:
1. Go to 'https://playbook.powerapp.cloud/kits/multi_level_select/rails' and 'https://playbook.powerapp.cloud/kits/multi_level_select/react'
2. Scroll down to Selected Ids example
3. See changes to markdown text on each page.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~