### PR TITLE
Fix typos: Homepage + Number Spacing

### DIFF
--- a/playbook-website/app/javascript/components/HomepageHero/HeroComponents/LettuceCheckbox.tsx
+++ b/playbook-website/app/javascript/components/HomepageHero/HeroComponents/LettuceCheckbox.tsx
@@ -32,7 +32,7 @@ const LettuceCheckboxCard = () => {
             paddingY="xs"
             checked
             tabIndex={1}
-            text="Chopped Romain"
+            text="Chopped Romaine"
             hover={{ background: "active_light" }}
           />
           <SectionSeparator />

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/NumberSpacing.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/NumberSpacing.tsx
@@ -13,7 +13,7 @@ const NUMBERS = ['$1,231,123,123.00', '$7,444,112,512.00']
 
 const NumberSpacing = ({ example }: {example: string}) => (
   <Example
-      description="When dealing with numbers it can be helpful to controll the way the font handles number spacing. A font like proxima nova is an open type face that enables us to use tabular spacing for example. This alligns the numbers equally to make those numbers in a table easier to compare. This is avaliable in EVERY kit as a global prop. See example:"
+      description="When dealing with numbers it can be helpful to control the way the font handles number spacing. A font like Proxima Nova is an open type face that enables us to use tabular spacing for example. This aligns the numbers equally to make those numbers in a table easier to compare. This is available in EVERY kit as a global prop. See example:"
       example={example}
       globalProps={{
         numberSpacing: ['tabular'],


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fixes typos within the Homepage hero and on the Number Spacing doc page under Visual Guidelines.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.