### PR TITLE
Fix typos: Phone Number Input kit error message

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_validation.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_validation.html.erb
@@ -1,5 +1,5 @@
 <form id="example-form-validation" action="" method="get">
-    <%= pb_rails("phone_number_input", props: { error: "Missing phone number.", id: "validation", initial_country: "af", value: "", required: true }) %>
+    <%= pb_rails("phone_number_input", props: { error: "Missing phone number", id: "validation", initial_country: "af", value: "", required: true }) %>
     <%= pb_rails("button", props: {html_type: "submit", text: "Save Phone Number"}) %>
 </form>
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Pb error message has a period; library default message does not. Removing Pb's punctuation to match the library default error.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.