### PR TITLE
[PBNTR-241] add xxs Icon Circle size variant

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
@@ -5,6 +5,7 @@
 @import "../pb_icon/icon";
 
 $pb_icon_circle_sizes: (
+  "xxs":  16px,
   "xs":   28px,
   "sm":   38px,
   "md":   60px,
@@ -62,5 +63,11 @@ $pb_icon_circle_sizes: (
         background: rgba(mix($bg_dark, $color_value, 10%), $opacity_2);
       }
     }
+  }
+}
+
+[class^=pb_icon_circle_kit_xxs] {
+  svg {
+    width: 10px !important;
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
@@ -15,7 +15,7 @@ type IconCircleProps = {
   icon: string,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
-  size?: "base" | "xs" | "sm" | "md" | "lg" | "xl",
+  size?: "base" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl",
   variant?: | "default"
     | "royal"
     | "blue"

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes.html.erb
@@ -1,5 +1,10 @@
 <%= pb_rails("icon_circle", props: {
   icon: "rocket",
+  size: "xxs"
+}) %>
+<br />
+<%= pb_rails("icon_circle", props: {
+  icon: "rocket",
   size: "xs"
 }) %>
 <br />

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes.jsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/docs/_icon_circle_sizes.jsx
@@ -6,6 +6,12 @@ const IconCircleSizes = (props) => {
     <div>
       <IconCircle
           icon="rocket"
+          size="xxs"
+          {...props}
+      />
+      <br />
+      <IconCircle
+          icon="rocket"
           size="xs"
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.rb
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.rb
@@ -7,7 +7,7 @@ module Playbook
       prop :emoji, type: Playbook::Props::String,
                    default: ""
       prop :size, type: Playbook::Props::Enum,
-                  values: %w[xs sm md base lg xl],
+                  values: %w[xxs xs sm md base lg xl],
                   default: "md"
       prop :variant, type: Playbook::Props::Enum,
                      values: %w[default royal blue orange purple teal red yellow green orange],

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.test.js
@@ -74,6 +74,7 @@ describe("IconCircle Kit", () => {
 
       test('displays size as expected', () => {
         [
+          "xxs",
           "xs",
           "sm",
           "md",


### PR DESCRIPTION
[PBNTR-241](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-241)


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.