### PR TITLE
[PLAY-1266] Fix Nav Category Page

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -70,6 +70,7 @@ class PagesController < ApplicationController
   def kit_category_show_rails
     params[:type] ||= "rails"
     @type = params[:type]
+    @users = Array.new(9) { Faker::Name.name }.paginate(page: params[:page], per_page: 2)
     render template: "pages/kit_category_show"
   end
 

--- a/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default.html.erb
@@ -1,1 +1,2 @@
 <%= pb_rails("pagination", props: { model: @users, view: self}) %>
+


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Runway: https://nitro.powerhrg.com/runway/backlog_items/PLAY-1266

This page was broken in prod https://playbook.powerapp.cloud/kit_category/navigation?type=rails

I was broken because the pagination kit needs the `@users` vairable

review env https://pr3296.playbook.beta.hq.powerapp.cloud/kit_category/navigation?type=rails