### PR TITLE
[PBNTR-246] fix UI Samples code view

### DIFF
--- a/playbook-website/app/javascript/site_styles/_samples_show.scss
+++ b/playbook-website/app/javascript/site_styles/_samples_show.scss
@@ -24,7 +24,6 @@
   .pb--codeCopy {
     display: block;
     border: 0px;
-    position: fixed;
     width: 100%;
     height: calc(50vh - 45px);
     bottom: 0;

--- a/playbook-website/app/views/samples/show.html.erb
+++ b/playbook-website/app/views/samples/show.html.erb
@@ -67,7 +67,7 @@
               id: "toggle-button-js",
               icon: "code",
               margin_left: "md",
-              text: "Code"
+              text: "Show Code"
             }) %>
             <%= pb_rails("icon_value", props: {
               classname: "font-size-override",

--- a/playbook-website/app/views/samples/show.html.erb
+++ b/playbook-website/app/views/samples/show.html.erb
@@ -89,14 +89,15 @@
 
 <% end %>
 
-</div>
 
-<div class="pb--kit-show">
-    <div class="pb--doc light_ui">
-        <div class="pb--codeCopy close" >
-            <a class="pb--close-toggle copy-clipboard" href="#">Copy to Clipboard</a>
-            <div class="hiddenCodeforCopy"><%= get_raw_code(@sample, current_sample_type) %></div>
-            <pre class="highlight"><%= get_sample_code_content(@sample, current_sample_type) %></pre>
-        </div>
-    </div>
+
+  <div class="pb--kit-show">
+      <div class="pb--doc light_ui">
+          <div class="pb--codeCopy close" >
+              <a class="pb--close-toggle copy-clipboard" href="#">Copy to Clipboard</a>
+              <div class="hiddenCodeforCopy"><%= get_raw_code(@sample, current_sample_type) %></div>
+              <pre class="highlight"><%= get_sample_code_content(@sample, current_sample_type) %></pre>
+          </div>
+      </div>
+  </div>
 </div>


### PR DESCRIPTION
[PBNTR-246](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-246)

Fixes the "Code" icon to show sample code.
Updated copy to say "Show Code"

![Screen Recording 2024-03-28 at 03 20 36 PM](https://github.com/powerhome/playbook/assets/92755007/be83df34-1b2b-4120-b7a7-25d32af6a456)


**How to test?** Steps to confirm the desired behavior:
1.Go to any sample (/samples/crm_client_list)
2. Click "Code" to toggle code 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.