### PR TITLE
[PBNTR-242] Hotfix: Remove advanced_table_example_mock_data.rb

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_example_mock_data.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_example_mock_data.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-advanced_table_mock_data = File.read("../playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_mock_data.json")
-TABLE_DATA = JSON.parse(advanced_table_mock_data, object_class: OpenStruct)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

`advanced_table_example_mock_data.rb` is causing the site to crash repeatedly. The file isn't being used and is not a module, so Zeitwerk fails to autoload it. 


<img width="1680" alt="Screenshot 2024-04-01 at 11 50 21 AM" src="https://github.com/powerhome/playbook/assets/2293844/dd9f7955-dcf6-4e17-8c28-1868e6cccd1f">



#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.