### PR TITLE
[PBNTR-252] Investigate Bar Chart: Displaying Numbers on the Right Side of the Graph

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -125,8 +125,6 @@ const BarGraph = ({
     credits: false,
   };
 
-
-// Conditionally add second yAxis if axisTitle[1].name exists
 if (Array.isArray(axisTitle) && axisTitle.length > 1 && axisTitle[1].name) {
   staticOptions.yAxis.push({
     min: yAxisMin,

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx
@@ -13,12 +13,12 @@ import classnames from "classnames";
 
 type BarGraphProps = {
   align?: "left" | "right" | "center";
-  axisTitle: string;
+  axisTitle: { name: string; }[] | string;
   dark?: boolean;
   xAxisCategories: [];
   yAxisMin: number;
   yAxisMax: number;
-  chartData: { name: string; data: number[] }[];
+  chartData: { name: string; data: number[], yAxis: number }[];
   className?: string;
   customOptions?: Partial<Highcharts.Options>;
   id: string;
@@ -89,13 +89,14 @@ const BarGraph = ({
     subtitle: {
       text: subTitle,
     },
-    yAxis: {
+    yAxis: [{
       min: yAxisMin,
       max: yAxisMax,
+      opposite: false,
       title: {
-        text: axisTitle,
-      },
-    },
+        text: typeof axisTitle === 'string' ? axisTitle : axisTitle[0].name,
+      }
+    }],
     xAxis: {
       categories: xAxisCategories,
     },
@@ -123,6 +124,19 @@ const BarGraph = ({
     series: chartData,
     credits: false,
   };
+
+
+// Conditionally add second yAxis if axisTitle[1].name exists
+if (Array.isArray(axisTitle) && axisTitle.length > 1 && axisTitle[1].name) {
+  staticOptions.yAxis.push({
+    min: yAxisMin,
+    max: yAxisMax,
+    opposite: true,
+    title: {
+      text: axisTitle[1].name,
+    }
+  });
+}
 
   if (!toggleLegendClick) {
     staticOptions.plotOptions.series.events = { legendItemClick: () => false };

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_default.jsx
@@ -19,10 +19,12 @@ const chartData = [{
   data: [1111, 677, 3245, 500, 200],
 }]
 
+const Titles = [ {name: "title 1"}]
+
 const BarGraphDefault = (props) => (
   <div>
     <BarGraph
-        axisTitle="Number of Employees"
+        axisTitle = {Titles}
         chartData={chartData}
         id="bar-default"
         subTitle="Source: thesolarfoundation.com"

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_default.jsx
@@ -19,12 +19,10 @@ const chartData = [{
   data: [1111, 677, 3245, 500, 200],
 }]
 
-const Titles = [ {name: "title 1"}]
-
 const BarGraphDefault = (props) => (
   <div>
     <BarGraph
-        axisTitle = {Titles}
+        axisTitle="Number of Employees"
         chartData={chartData}
         id="bar-default"
         subTitle="Source: thesolarfoundation.com"

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_spline.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_spline.jsx
@@ -8,11 +8,12 @@ const chartData = [{
 }, {
   type: 'spline',
   name: 'Trend Line',
-  data: [1975, 600, 2500, 924, 500],
+  data: [8975, 600, 2500, 924, 500],
   color: '#F9BB00',
+  yAxis: 1
 }]
 
-const Titles = [ {name: "title 1"}, {name: "title 2"}]
+const Titles = [ {name: "Number of Installations"}, {name: " "}]
 
 const BarGraphSpline = (props) => (
   <div>

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_spline.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_spline.jsx
@@ -12,10 +12,12 @@ const chartData = [{
   color: '#F9BB00',
 }]
 
+const Titles = [ {name: "title 1"}, {name: "title 2"}]
+
 const BarGraphSpline = (props) => (
   <div>
     <BarGraph
-        axisTitle="Number of Employees"
+        axisTitle={Titles}
         chartData={chartData}
         id="bar-spline"
         legend


### PR DESCRIPTION
[PBNTR-252](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-252)



![Screenshot 2024-04-01 at 2 23 44 PM](https://github.com/powerhome/playbook/assets/92755007/f0a5ba9e-36e3-47c9-8977-f4862b232cf6)
your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.