### PR TITLE
Remove rails upper version limit in gemspec

### DIFF
--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: ../playbook
   specs:
     playbook_ui (13.22.0)
-      actionpack (>= 5.2.4.5, <= 7.0.8.1)
-      actionview (>= 5.2.4.5, <= 7.0.8.1)
-      activesupport (>= 5.2.4.5, <= 7.0.8.1)
+      actionpack (>= 5.2.4.5)
+      actionview (>= 5.2.4.5)
+      activesupport (>= 5.2.4.5)
       react-rails (= 2.6.1)
       view_component (= 2.55.0)
       webpacker-react (~> 0.3.2)

--- a/playbook/Gemfile.lock
+++ b/playbook/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     playbook_ui (13.22.0)
-      actionpack (>= 5.2.4.5, <= 7.0.8.1)
-      actionview (>= 5.2.4.5, <= 7.0.8.1)
-      activesupport (>= 5.2.4.5, <= 7.0.8.1)
+      actionpack (>= 5.2.4.5)
+      actionview (>= 5.2.4.5)
+      activesupport (>= 5.2.4.5)
       react-rails (= 2.6.1)
       view_component (= 2.55.0)
       webpacker-react (~> 0.3.2)
@@ -290,7 +290,7 @@ DEPENDENCIES
   byebug (>= 11.0.0)
   github_changelog_generator (= 1.15.2)
   playbook_ui!
-  rails (>= 5.2.4.5, <= 7.0.8.1)
+  rails (>= 5.2.4.5)
   rspec-html-matchers (= 0.9.1)
   rspec-rails (~> 3.8, >= 3.8.0)
   rubocop

--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -31,16 +31,16 @@ Gem::Specification.new do |s|
   #   (file == "docs") || (file.include? "docs")
   # end
 
-  s.add_dependency "actionpack", ">= 5.2.4.5", "<= 7.0.8.1"
-  s.add_dependency "actionview", ">= 5.2.4.5", "<= 7.0.8.1"
-  s.add_dependency "activesupport", ">= 5.2.4.5", "<= 7.0.8.1"
+  s.add_dependency "actionpack", ">= 5.2.4.5"
+  s.add_dependency "actionview", ">= 5.2.4.5"
+  s.add_dependency "activesupport", ">= 5.2.4.5"
   s.add_dependency "react-rails", "2.6.1"
   s.add_dependency "view_component", "2.55.0"
   s.add_dependency "webpacker-react", "~> 0.3.2"
 
   s.add_development_dependency "byebug", ">= 11.0.0"
   s.add_development_dependency "github_changelog_generator", "1.15.2"
-  s.add_development_dependency "rails", ">= 5.2.4.5", "<= 7.0.8.1"
+  s.add_development_dependency "rails", ">= 5.2.4.5"
   s.add_development_dependency "rspec-html-matchers", "0.9.1"
   s.add_development_dependency "rspec-rails", "~> 3.8", ">= 3.8.0"
   s.add_development_dependency "rubocop"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Remove the limit imposed for Rails and friends within the gemspec from [this PR](https://github.com/powerhome/playbook/commit/4d179c672c8fc554a235c34246f1a0dde40ea622#diff-14c9f8391ff13e0125d9abf5439cee7e259fc8da50d8a4ceba7e68ce66aeff03R34-R36)

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.