### PR TITLE
[PLAY-1269] DRY up the content_tag portion of Rails kits: Avatar

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data.merge(initials: object.initials),
-    class: object.classname,
-    aria: object.aria,
-    **combined_html_options) do %>
+<%= object.pb_content_tag(:div, data: object.data.merge(initials: object.initials)) do %>
   <%= content_tag(:div, data: { initials: object.initials }, class: "avatar_wrapper") do %>
     <%= pb_rails("image", props: { alt: object.alt_text, url: object.image_url, on_error: object.handle_img_error }) if object.image_url.present? %>
   <% end %>

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -81,15 +81,11 @@ module Playbook
     end
 
     # rubocop:disable Style/OptionalBooleanParameter
-    def pb_content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
-      options ||= {}
-      combined_options = options.merge(combined_html_options)
-
-      if block_given?
-        content_tag(name, default_options.merge(content_or_options_with_block), combined_options, escape, &block)
-      else
-        content_tag(name, nil, default_options.merge(combined_options), escape)
-      end
+    def pb_content_tag(name, content_or_options_with_block = nil, options = {}, escape = true, &block)
+      combined_options = options
+                         .merge(combined_html_options)
+                         .merge(default_options.merge(content_or_options_with_block))
+      content_tag(name, combined_options, options, escape, &block)
     end
     # rubocop:enable Style/OptionalBooleanParameter
 
@@ -112,7 +108,7 @@ module Playbook
       {
         data: data,
         aria: aria,
-      }.transform_keys { |key| key.to_s.tr("_", "-") }
+      }.transform_keys { |key| key.to_s.tr("_", "-").to_sym }
     end
   end
 end

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -31,6 +31,8 @@ require "playbook/right"
 require "playbook/bottom"
 
 module Playbook
+  include ActionView::Helpers
+
   class KitBase < ViewComponent::Base
     include Playbook::PbKitHelper
     include Playbook::Props
@@ -78,7 +80,29 @@ module Playbook
       default_html_options.merge(html_options.deep_merge(data_attributes))
     end
 
+    # rubocop:disable Style/OptionalBooleanParameter
+    def pb_content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+      options ||= {}
+      combined_options = options.merge(combined_html_options)
+
+      if block_given?
+        content_tag(name, default_options.merge(content_or_options_with_block), combined_options, escape, &block)
+      else
+        content_tag(name, nil, default_options.merge(combined_options), escape)
+      end
+    end
+    # rubocop:enable Style/OptionalBooleanParameter
+
   private
+
+    def default_options
+      {
+        id: id,
+        data: data,
+        class: classname,
+        aria: aria,
+      }
+    end
 
     def default_html_options
       {}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

As a Playbook dev,
I want to provide a content tag helper (playbook_tag),
so that I can dry up kit template code where content_tag is currently being used.

**How to test?** Steps to confirm the desired behavior:
1. Go to kits/avatar
2. See kit renders with expected output
3. Spec test is green

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.