### PR TITLE
[PLAY-1302] Replace React logo on homepage

### DIFF
--- a/playbook-website/app/components/hp_solutions_component.html.erb
+++ b/playbook-website/app/components/hp_solutions_component.html.erb
@@ -130,7 +130,7 @@
 								}) do %>
 									<%= pb_rails("image", props: {
 										alt: "React logo",
-										url: asset_pack_path("power-subtract-logo.svg")
+										url: asset_pack_path("hp-react-solutions.svg")
 									}) %>
 								<% end %>
 							<% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1302](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1302) is a ticket to put back the React logo on the Playbook homepage. It was accidentally replaced with a different svg asset a few weeks ago in a [PR](https://github.com/powerhome/playbook/pull/3201/files) that updated the asset pathways for the logos in that homepage section.

**Screenshots:** Screenshots to visualize your addition/change
<img width="800" alt="fixed react hp solutions logo in place" src="https://github.com/powerhome/playbook/assets/83474365/8e2fde5d-da52-4bca-b10e-268f333f85f5">


**How to test?** Steps to confirm the desired behavior:
1. Go to the Playbook homepage (https://playbook.powerapp.cloud/)
2. Scroll down to the "Design, Develop, Deliver" section
3. See React logo in the first card


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~