### PR TITLE
[PLAY-1297] Update text styles to prevent inconsistent Tiptap output

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_body/_body.scss
+++ b/playbook/app/pb_kits/playbook/pb_body/_body.scss
@@ -19,7 +19,7 @@
     }
   }
   b, strong {
-    @include pb_title_4
+    font-weight: $bold;
   }
 
   a {
@@ -29,8 +29,8 @@
     }
   }
 
-  em {
-    font-weight: $bold;
+  em, i {
+    font-style: italic;
   }
 
   small {


### PR DESCRIPTION
**What does this PR do?**
[PLAY-1297](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1297) adjusts the italic and bold text style in the body kit so they exhibit predictable behavior when used in text editors. See technical details of runway ticket for explicit changes made as interim step before a more comprehensive PBHUB ticket improves upon this (runway ticket also links to the prior investigations that prompted this change).


**Screenshots:** Screenshots from code sandboxes (left = previous version; right = new alpha)
<img width="263" alt="before code sandbox" src="https://github.com/powerhome/playbook/assets/83474365/4fc2b919-91a1-4646-8ff0-f38e3128bc8e"><img width="160" alt="after code sandbox" src="https://github.com/powerhome/playbook/assets/83474365/de580613-90ac-4361-b7b5-63f2cefee552">



**How to test?** Steps to confirm the desired behavior:
1. Review code sandbox with new alpha provided in runway ticket.
2. Test italicization: italicized/emphasized text should become italicized (but not bold).
3. Test bold links: a link that is then made bold should show a bold, blue hyperlink; bold text that is turned into a link should show a bold, blue hyperlink as well.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~