### PR TITLE
[PLAY-998] Background kit remove empty inline styles/attributes

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_background/_background.tsx
+++ b/playbook/app/pb_kits/playbook/pb_background/_background.tsx
@@ -65,7 +65,7 @@ const getResponsiveValue = <T extends string | undefined>(prop: ResponsiveProp<T
 
 const Background = (props: BackgroundProps): React.ReactElement => {
   const {
-    alt = '',
+    alt = undefined,
     aria = {},
     backgroundColor = 'light',
     backgroundPosition = '',

--- a/playbook/app/pb_kits/playbook/pb_background/_background.tsx
+++ b/playbook/app/pb_kits/playbook/pb_background/_background.tsx
@@ -125,25 +125,19 @@ const Background = (props: BackgroundProps): React.ReactElement => {
     {
       [`pb_background_color_${resBackgroundColor}`]: resBackgroundColor && !customColor,
       [`pb_background_custom_color`]: !!customColor,
-      // [`pb_background_position_${resBackgroundPosition}`]: !resBackgroundPosition,
     },
     className
   );
 
-  const backgroundStyle =
-    (resImageUrl !== '') ? {
+  const backgroundStyle = {
+    backgroundColor: customColor || undefined,
+    ...(resImageUrl !== '' ? {
       backgroundImage: resImageUrl ? `url(${resImageUrl})` : undefined,
       backgroundRepeat: resBackgroundRepeat || undefined,
       backgroundPosition: resBackgroundPosition || undefined,
       backgroundSize: resBackgroundSize || undefined,
-      backgroundColor: customColor || undefined,
-    } : {
-      backgroundColor: customColor || undefined,
-      // backgroundPosition: resBackgroundPosition == "" ? null : (resBackgroundPosition || undefined),
-    }
-  ;
-  // console.log(backgroundPosition, resBackgroundPosition);
-  // debugger
+    } : {})
+  };
 
   const Tag: React.ReactElement | any = `${tag}`;
   const ariaProps = buildAriaProps(aria);
@@ -159,7 +153,6 @@ const Background = (props: BackgroundProps): React.ReactElement => {
         className={classes}
         id={id}
         style={backgroundStyle}
-        // style={{backgroundColor: customColor || undefined,}}
     >
       {children}
     </Tag>

--- a/playbook/app/pb_kits/playbook/pb_background/_background.tsx
+++ b/playbook/app/pb_kits/playbook/pb_background/_background.tsx
@@ -125,17 +125,25 @@ const Background = (props: BackgroundProps): React.ReactElement => {
     {
       [`pb_background_color_${resBackgroundColor}`]: resBackgroundColor && !customColor,
       [`pb_background_custom_color`]: !!customColor,
+      // [`pb_background_position_${resBackgroundPosition}`]: !resBackgroundPosition,
     },
     className
   );
 
-  const backgroundStyle = {
-    backgroundImage: resImageUrl ? `url(${resImageUrl})` : undefined,
-    backgroundRepeat: resBackgroundRepeat || undefined,
-    backgroundSize: resBackgroundSize || undefined,
-    backgroundPosition: resBackgroundPosition || undefined,
-    backgroundColor: customColor || undefined,
-  };
+  const backgroundStyle =
+    (resImageUrl !== '') ? {
+      backgroundImage: resImageUrl ? `url(${resImageUrl})` : undefined,
+      backgroundRepeat: resBackgroundRepeat || undefined,
+      backgroundPosition: resBackgroundPosition || undefined,
+      backgroundSize: resBackgroundSize || undefined,
+      backgroundColor: customColor || undefined,
+    } : {
+      backgroundColor: customColor || undefined,
+      // backgroundPosition: resBackgroundPosition == "" ? null : (resBackgroundPosition || undefined),
+    }
+  ;
+  // console.log(backgroundPosition, resBackgroundPosition);
+  // debugger
 
   const Tag: React.ReactElement | any = `${tag}`;
   const ariaProps = buildAriaProps(aria);
@@ -151,6 +159,7 @@ const Background = (props: BackgroundProps): React.ReactElement => {
         className={classes}
         id={id}
         style={backgroundStyle}
+        // style={{backgroundColor: customColor || undefined,}}
     >
       {children}
     </Tag>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-998](https://nitro.powerhrg.com/runway/backlog_items/PLAY-998) removes the null alt tag and empty style tag that appeared on the React Background kit (see example screenshot in ticket). The alt tag was a straightforward change, and now only appears when there is purposeful alt text to display for the background. For the style tag, it took some time to fully capture the behavior because this only happens when a page is first loaded: upon page reload, the style tag fills in with relevant style attribute information. The empty tag behavior occurs when the background does not have an image/image URL to display, and the the added conditional to the image-related props in backgroundStyle solve the issue.

**Screenshots:** Screenshots to visualize your addition/change
Light Background Kit Example (example from Runway) - no alt nor style tag when not necessary
<img width="1000" alt="no alt nor style tag on light background kit example" src="https://github.com/powerhome/playbook/assets/83474365/30374a85-f3bd-4fbd-914b-4b23e2bcbf3a">
Image Background Kit Example - alt and style tags contain relevant info 
<img width="1000" alt="correct alt and style tag on image background kit example" src="https://github.com/powerhome/playbook/assets/83474365/69f2ca52-60d1-4487-bfb7-d72b2f4b0524">


**How to test?** Steps to confirm the desired behavior:
1. Go to https://playbook.powerapp.cloud/kits/background/react or [code sandbox with examples](https://codesandbox.io/p/sandbox/play-998-background-kit-sdmdj5?file=%2Fsrc%2FApp.js%3A25%2C14)
2. Choose an example kit, click on the background and inspect element with dev tools
3. See only necessary/expected alt and/or style tag information
4. Even on page reload information does not change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~