### PR TITLE
Add run.sh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,10 @@ Playbook is the first design system built for both Rails & React interfaces. Ins
 1. From the top-level playbook folder run `yarn start-dev` This may take a little while.
 1. Once you see the "compiled successfully" message in your terminal, navigate to [http://localhost:3000](http://localhost:3000) and you should see the playbook website.
 
+### Post Installation Startup
+
+Use `./run.sh` to run the application in one step. This will handle dependency updates then start the server. Helpful for fast start-up without bootstrapping especially when switching branches. 🚀
+
 ### Running Library Tests
 
 1. `cd playbook && ./test.sh`

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Installing library dependencies..."
+time (cd playbook; bundle; yarn)
+
+echo "Installing Website dependencies..."
+time (cd playbook-website; bundle; yarn)
+
+echo "Done. Now starting the app.."
+yarn start-dev


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Adds run script from playgrounds and huddle repo. This script allows quicker startup without the bootstrapping.

Example Usage:

* Working on PLAY-1234 branch, I made changes, committed and pushed. Now I need to checkout another branch to test locally. This requires installation bc dependencies are different. 

+ Simply executing `./run.sh` will install any dependencies (skip if unnecessary) and start the app. 

**References:**

1. https://github.com/powerhome/playgrounds/blob/master/run.sh
2. https://github.com/powerhome/huddle/blob/master/run.sh

**Pre-requisites** 

- You should have run `./setup.sh` at least once since downloading the repo. 

**How to test?** Steps to confirm the desired behavior:
1. checkout this branch
2. `./run.sh`
3. profit


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.