### PR TITLE
[PLAY-1181] Circle Icon kit: fix sizing error when global spacing props are used

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
@@ -51,7 +51,7 @@ $pb_icon_circle_sizes: (
   }
 
   @each $name, $size in $pb_icon_circle_sizes {
-    &[class*=_#{$name}] {
+    &[class*=_size_#{$name}] {
       width: $size;
       height: $size;
       border-radius: $size/2;

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.tsx
@@ -43,7 +43,7 @@ const IconCircle = (props: IconCircleProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
-  const classes = classnames(buildCss('pb_icon_circle_kit', size, variant), globalProps(props), className)
+  const classes = classnames(buildCss('pb_icon_circle_kit', `size_${size}`, variant), globalProps(props), className)
 
 
   return (

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.rb
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.rb
@@ -14,7 +14,7 @@ module Playbook
                      default: "default"
 
       def classname
-        generate_classname("pb_icon_circle_kit", size, variant)
+        generate_classname("pb_icon_circle_kit", "size_#{size}", variant)
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.test.js
@@ -16,7 +16,7 @@ describe("IconCircle Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("pb_icon_circle_kit_md_default")
+        expect(kit).toHaveClass("pb_icon_circle_kit_size_md_default")
     })
 
     test("renders icon", () => {
@@ -66,7 +66,7 @@ describe("IconCircle Kit", () => {
             />
           )
           const kit = screen.getByTestId(testId)
-          expect(kit).toHaveClass(`pb_icon_circle_kit_sm_${colorVariant}`)
+          expect(kit).toHaveClass(`pb_icon_circle_kit_size_sm_${colorVariant}`)
       
           cleanup()
         })
@@ -89,7 +89,7 @@ describe("IconCircle Kit", () => {
             />
           )
           const kit = screen.getByTestId(testId)
-          expect(kit).toHaveClass(`pb_icon_circle_kit_${sizeVariant}_default`)
+          expect(kit).toHaveClass(`pb_icon_circle_kit_size_${sizeVariant}_default`)
       
           cleanup()
         })

--- a/playbook/spec/pb_kits/playbook/kits/icon_circle_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/icon_circle_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe Playbook::PbIconCircle::IconCircle do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       icon = "user"
-      expect(subject.new(icon: icon, variant: "royal").classname).to eq "pb_icon_circle_kit_md_royal"
-      expect(subject.new(icon: icon, size: "sm").classname).to eq "pb_icon_circle_kit_sm_default"
-      expect(subject.new(icon: icon, size: "sm", dark: true).classname).to eq "pb_icon_circle_kit_sm_default dark"
-      expect(subject.new(icon: icon, variant: "purple", size: "lg").classname).to eq "pb_icon_circle_kit_lg_purple"
-      expect(subject.new(icon: icon, classname: "additional_class").classname).to eq "pb_icon_circle_kit_md_default additional_class"
+      expect(subject.new(icon: icon, variant: "royal").classname).to eq "pb_icon_circle_kit_size_md_royal"
+      expect(subject.new(icon: icon, size: "sm").classname).to eq "pb_icon_circle_kit_size_sm_default"
+      expect(subject.new(icon: icon, size: "sm", dark: true).classname).to eq "pb_icon_circle_kit_size_sm_default dark"
+      expect(subject.new(icon: icon, variant: "purple", size: "lg").classname).to eq "pb_icon_circle_kit_size_lg_purple"
+      expect(subject.new(icon: icon, classname: "additional_class").classname).to eq "pb_icon_circle_kit_size_md_default additional_class"
     end
 
     it "raises an error when not given an icon" do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1181](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1181) prevents global spacing props (margin and padding) from altering the size of the circle icon kit by adding `size` to the classname. 

ToDo/Breaking Change consideration:
- [ ] This will add word size on iconcircle kits but the actual size will remain the same. The only thing we need to do is make sure iconcircle kits with size on are not being targeted anywhere in Nitro so we can safely update the classname.

**Screenshots:** Screenshots to visualize your addition/change
Before (from [example CSB](https://codesandbox.io/p/sandbox/navigator-forked-7ckgws?file=%2Fsrc%2FApp.js%3A38%2C1)): when present, a padding or margin larger than the Icon Circle's prescribed size causes the size to change to the largest prop value.
<img width="700" alt="codesandbox example before" src="https://github.com/powerhome/playbook/assets/83474365/38509665-5e39-4b39-8666-d3b8e43c8e5c">
After React:
<img width="700" alt="react examples inspect" src="https://github.com/powerhome/playbook/assets/83474365/a40daf5f-1328-49fe-94d8-665711643ae8">
After Rails:
<img width="700" alt="rails examples inspect" src="https://github.com/powerhome/playbook/assets/83474365/10d982e2-ad24-4109-af60-9a77e98689f4">


**How to test?** Steps to confirm the desired behavior:
1. Go to code sandbox (will update with link once created with alpha)
2. Create IconCircle example with any size, plus padding and/or margin of any size.
3. The resultant IconCircle displaying on the left should display an IconCircle of the indicated size, with a padding and/or margin if given of the correct value. The size of the IconCircle should NOT be altered to the largest size given to any of the size/padding/margin props.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.