### PR TITLE
[PLAY-1126] add px to Max Width global prop values left aligned

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
@@ -4,12 +4,21 @@ import React from 'react'
 
 import {
   Background,
+  Detail,
+  Flex,
   Title,
 } from 'playbook-ui'
 
 import Example from '../Templates/Example'
 
-const SIZES = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'] //TODO: investigate using types
+const SIZES: { [size: string]: string } = {
+  'xs': '360px max',
+  'sm': '540px max',
+  'md': '720px max',
+  'lg': '960px max',
+  'xl': '1140px max',
+  'xxl': '1320px max',
+}
 
 const MaxWidthDescription = () => (
   <>
@@ -23,11 +32,11 @@ const MaxWidth = ({ example }: {example: string}) => (
       description={<MaxWidthDescription />}
       example={example}
       globalProps={{
-        maxWidth: SIZES,
+        maxWidth: Object.keys(SIZES),
       }}
       title="Max Width"
   >
-    {SIZES.map((size: string) => (
+    {Object.keys(SIZES).map((size: string) => (
       <Background
           backgroundColor="gradient"
           key={size}
@@ -35,13 +44,18 @@ const MaxWidth = ({ example }: {example: string}) => (
           maxWidth={size}
           padding="xs"
       >
-        <Title
-          dark
-          size={4}
-        >
-          {size.toUpperCase()}
-        </Title>
-
+        <Flex gap="sm">
+          <Title
+            dark
+            size={4}
+            htmlOptions={{style: {minWidth:"30px"}}}
+          >
+            {size.toUpperCase()}
+          </Title>
+          <Detail color="lighter">
+            {SIZES[size]}
+          </Detail>
+        </Flex>
       </Background>
     ))}
   </Example>

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/MaxWidth.tsx
@@ -44,15 +44,19 @@ const MaxWidth = ({ example }: {example: string}) => (
           maxWidth={size}
           padding="xs"
       >
-        <Flex gap="sm">
+        <Flex>
           <Title
             dark
             size={4}
+            flex={1}
             htmlOptions={{style: {minWidth:"30px"}}}
           >
             {size.toUpperCase()}
           </Title>
-          <Detail color="lighter">
+          <Detail 
+            flex={0}
+            color="lighter"
+          >
             {SIZES[size]}
           </Detail>
         </Flex>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1126](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1126) adds the pixel values for each MaxWidth prop value to the visual guide on the guideline page (see runway ticket for specific designer feedback and context). Pixel values sourced from [here](https://github.com/powerhome/playbook/blob/6508e8593d0ac5b8c85a0e29fdd11c2a488b97fb/playbook/app/pb_kits/playbook/utilities/_max_width.scss).

**Screenshots:** Screenshots to visualize your addition/change
<img width="1000" alt="maxwidth lighter start" src="https://github.com/powerhome/playbook/assets/83474365/973992a7-6ee0-45ad-8af7-205072ec7dfd">

**How to test?** Steps to confirm the desired behavior:
1. Go to [MaxWidth guidelines page](https://playbook.powerapp.cloud/visual_guidelines/max_width)
2. Scroll down to the visual guide
3. See addition of pixel values in each example XS-XXL.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~