### PR TITLE
[PLAY-939] Section Separator Vertical Variant Fixes

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
@@ -47,8 +47,7 @@ $section_colors_dark: (
 
   &[class*=_dashed] {
     &::before, &::after {
-      border: 1px dashed $border_light;
-      background: none;
+      @include section_separator_dashed(false);
     }
   }
 
@@ -64,6 +63,11 @@ $section_colors_dark: (
     &[class*=_vertical] {
       &::after {
         @include section_separator_vertical(true);
+      }
+    }
+    &[class*=_dashed] {
+      &::before, &::after {
+        @include section_separator_dashed(true);
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
@@ -21,3 +21,13 @@
         background: $border_dark;
     }
 }
+
+@mixin section_separator_dashed($dark: false) {
+    @if $dark == false {
+        border: 1px dashed $border_light;
+        background: none;
+    } @else {
+        border: 1px dashed $border_dark;
+        background: none;
+    }
+}

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator_mixin.scss
@@ -9,7 +9,7 @@
     }
     content: "";
     height: 100%;
-    width: 1px;
+    width: 1.9px;
     position: initial;
     z-index: 0;
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
runway https://nitro.powerhrg.com/runway/backlog_items/PLAY-939

the vertical section separator doesn't show up on fire fox because fire fox is rounding down on a 1px width

using width of 1.9 forces the width to be greater than 1 but less than 2 which should result in 1px all the time 

**Screenshots:** Screenshots to visualize your addition/change

![screenshot-nimbusweb me-2024 04 25-13_30_32](https://github.com/powerhome/playbook/assets/38965626/fa63a4bc-8885-46f8-be50-682dbfaee841)

check it out here https://pr3370.playbook.beta.px.powerapp.cloud/kits/section_separator/react#vertical
