### PR TITLE
[PLAY-468] Change darkmode button and link color

### DIFF
--- a/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
@@ -23,11 +23,11 @@
         <ul>
           <% hide_button = type == "rails" ? 'flex' : 'none' %>
             <li>
-            <%= pb_rails("button", props: { id:"copy-html-#{example_key}", icon: "copy", text: "Copy HTML", variant: "link", size: "sm", display: hide_button }) %>
+            <%= pb_rails("button", props: { id:"copy-html-#{example_key}", icon: "copy", text: "Copy HTML", classname: dark ? "dark" : "", variant: "link", size: "sm", display: hide_button }) %>
             </li>
           <li>
-            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-opened", text: "Close Code", variant: "link", size: "sm", display: "none" }) %>
-            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-closed", text: "Show Code", variant: "link", size: "sm" }) %>
+            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-opened", classname: dark ? "dark" : "", text: "Close Code", variant: "link", size: "sm", display: "none" }) %>
+            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-closed", classname: dark ? "dark" : "", text: "Show Code", variant: "link", size: "sm" }) %>
           </li>
         </ul>
       </div>

--- a/playbook/app/pb_kits/playbook/pb_body/_body.scss
+++ b/playbook/app/pb_kits/playbook/pb_body/_body.scss
@@ -45,6 +45,9 @@
   }
 
   &[class*=dark] {
+    a {
+      color: $active_dark;
+    }
     @include pb_body_dark();
     @each $dark_color_name, $dark_color_value in $pb_dark_body_colors{
       &[class*=_#{$dark_color_name}][class*=dark]{

--- a/playbook/app/pb_kits/playbook/pb_body/_body_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_body/_body_mixins.scss
@@ -15,7 +15,7 @@ $pb_dark_body_colors: (
   default:        $text_dk_default,
   light:          $text_dk_light,
   lighter:        $text_dk_lighter,
-  link:           $primary_action_dark,
+  link:           $active_dark,
   error:          $error,
   success:        $text_dk_success_sm,
 );

--- a/playbook/app/pb_kits/playbook/pb_button/_button_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button_mixins.scss
@@ -167,15 +167,15 @@ $pb_button_border_width: 0px;
 
 // Dark Primary =================
 @mixin pb_button_primary_dark{
-  @include pb_button_variant($active_dark);
+  @include pb_button_variant($primary_action);
 
   @media (hover:hover) {
     &:hover {
-      @include pb_button_hover($bg: darken($active_dark, $pb_button_hover_darken));
+      @include pb_button_hover($bg: darken($primary_action, $pb_button_hover_darken));
     }
     &:active {
       transition: none;
-      @include pb_button_variant($active_dark);
+      @include pb_button_variant($primary_action);
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_button/_button_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button_mixins.scss
@@ -197,16 +197,16 @@ $pb_button_border_width: 0px;
 
 // Dark Link =============
 @mixin pb_button_link_dark {
-  @include pb_button_variant($transparent, $white);
+  @include pb_button_variant($transparent, $active_dark);
 
   @media (hover:hover) {
     &:hover {
       @include pb_button_hover($transparent);
-      color: rgba($white, $opacity_6)
+      color: rgba($active_dark, $opacity_6)
     }
     &:active {
       transition: none;
-      @include pb_button_variant($transparent, $white);
+      @include pb_button_variant($transparent, $active_dark);
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_button/_button_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button_mixins.scss
@@ -167,15 +167,15 @@ $pb_button_border_width: 0px;
 
 // Dark Primary =================
 @mixin pb_button_primary_dark{
-  @include pb_button_variant($primary_action);
+  @include pb_button_variant($active_dark);
 
   @media (hover:hover) {
     &:hover {
-      @include pb_button_hover($bg: darken($primary_action, $pb_button_hover_darken));
+      @include pb_button_hover($bg: darken($active_dark, $pb_button_hover_darken));
     }
     &:active {
       transition: none;
-      @include pb_button_variant($primary_action);
+      @include pb_button_variant($active_dark);
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_caption/_caption_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_caption/_caption_mixin.scss
@@ -13,7 +13,7 @@ $pb_caption_colors: (
 $pb_dark_caption_colors: (
   default:        $text_dk_default,
   light:          $text_dk_light,
-  link:           $primary,
+  link:           $active_dark,
   success:        $text_dk_success_sm,
   error:          $error,
 );

--- a/playbook/app/pb_kits/playbook/pb_detail/_detail_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_detail/_detail_mixins.scss
@@ -15,7 +15,7 @@ $pb_dark_detail_colors: (
   light:          $text_dk_light,
   default:        $text_dk_default,
   lighter:        $text_dk_lighter,
-  link:           $primary,
+  link:           $active_dark,
   error:          $error_dark,
   success:        $text_dk_success_sm,
 );

--- a/playbook/app/pb_kits/playbook/pb_docs/kit_example.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_docs/kit_example.html.erb
@@ -23,11 +23,11 @@
         <ul>
           <% hide_button = type == "rails" ? 'flex' : 'none' %>
             <li>
-            <%= pb_rails("button", props: { id:"copy-html-#{example_key}", icon: "copy", text: "Copy HTML", variant: "link", size: "sm", display: hide_button }) %>
+            <%= pb_rails("button", props: { id:"copy-html-#{example_key}", icon: "copy", text: "Copy HTML", classname: dark ? "dark" : "", variant: "link", size: "sm", display: hide_button }) %>
             </li>
           <li>
-            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-opened", text: "Close Code", variant: "link", size: "sm", display: "none" }) %>
-            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-closed", text: "Show Code", variant: "link", size: "sm" }) %>
+            <%= pb_rails("button", props: { icon: "code", classname: dark ? "dark" : "", id:"toggle-open-opened", text: "Close Code", variant: "link", size: "sm", display: "none" }) %>
+            <%= pb_rails("button", props: { icon: "code", classname: dark ? "dark" : "", id:"toggle-open-closed", text: "Show Code", variant: "link", size: "sm" }) %>
           </li>
         </ul>
       </div>

--- a/playbook/app/pb_kits/playbook/pb_title/_title.scss
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.scss
@@ -49,6 +49,10 @@
   }
 
   &.dark {
-    @include pb_title_dark;
+    @include pb_title_dark; 
+  }
+
+  &[class*=_link] { 
+    @include pb_title_dark('link'); 
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_title/_title.scss
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.scss
@@ -52,7 +52,7 @@
     @include pb_title_dark; 
   }
 
-  &[class*=_link] { 
-    @include pb_title_dark('link'); 
+  &.dark[class*=_link] { 
+    @include pb_title_dark_link; 
   }
 }

--- a/playbook/app/pb_kits/playbook/tokens/_titles.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_titles.scss
@@ -33,12 +33,12 @@
   letter-spacing: -0.03em;
 }
 
-@mixin pb_title_dark($name: "") {
-  @if $name == 'link' {
-    color: $active_dark !important;
-  } @else {
+@mixin pb_title_dark {
     color: $text_dk_default;
-  }
+} 
+
+@mixin pb_title_dark_link {
+    color: $active_dark;
 }
 
 @mixin pb_title_bold {

--- a/playbook/app/pb_kits/playbook/tokens/_titles.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_titles.scss
@@ -33,8 +33,12 @@
   letter-spacing: -0.03em;
 }
 
-@mixin pb_title_dark {
-  color: $text_dk_default;
+@mixin pb_title_dark($name: "") {
+  @if $name == 'link' {
+    color: $active_dark !important;
+  } @else {
+    color: $text_dk_default;
+  }
 }
 
 @mixin pb_title_bold {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

runway https://nitro.powerhrg.com/runway/backlog_items/PLAY-468
changes the color on all buttons and links to active dark when in dark mode 

**Screenshots:** Screenshots to visualize your addition/change
![screenshot-127 0 0 1_3000-2024 04 30-08_16_51](https://github.com/powerhome/playbook/assets/38965626/a0b0f88d-230e-4bb3-b366-f3463ab3ae6a)
