### PR TITLE
[PLAY-1249] Fix Tooltips wrapping form elements causing misalignment

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -127,6 +127,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
             }
           }}
           role="tooltip_trigger"
+          style={{ display: "inline-block" }}
           {...ariaProps}
           {...dataProps}
           {...htmlProps}

--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -127,7 +127,6 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
             }
           }}
           role="tooltip_trigger"
-          style={{ display: "inline-flex" }}
           {...ariaProps}
           {...dataProps}
           {...htmlProps}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1249](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1249) addresses an issue on a Nitro page where a react Tooltip is shifting downward slightly when it is in a form. The react Tooltip was given an inline style of "display: inline-flex" when it was first created, but I'm not entirely sure as to it's purpose. Removing this line (or changing the display to inline or block) stops the misalignment from occurring. 

[CSB reproducing issue](https://codesandbox.io/p/sandbox/play-1249-reproduce-issue-v8xw4m)
[CSB with alpha](https://codesandbox.io/p/sandbox/little-fog-nd29j4)

**Screenshots:** Screenshots to visualize your addition/change
All three inputs are aligned when inline display styling is removed
<img width="793" alt="display inline-block with red line for PR" src="https://github.com/powerhome/playbook/assets/83474365/c6848520-b890-455a-bf31-806874e9fc43">
CSB example original misaligned vs. vertically aligned in alpha
<img width="620" alt="CSB original misaligned" src="https://github.com/powerhome/playbook/assets/83474365/7d5545d5-195b-4021-895d-10abaa9a5d78">
<img width="620" alt="CSB alpha vertically aligned and correct width 2nd alpha" src="https://github.com/powerhome/playbook/assets/83474365/20f58438-51d8-4d17-bdd3-eb61df2f7701">


**How to test?** Steps to confirm the desired behavior:
1. Go to a page with a tooltip in a form (CSB or NitroQA link with alpha to come)?
2. If CSB - see example form inputs on right and skip to step 5.
3. if NitroQA - toggle edit mode near top of page - scroll down to last row in the PROJECT PAYMENTS -> Credit Card Payment table with a future date (May 15th, 2024 in NitroQA) and selelct edit from action button on right side.
4. Scroll down to area of form with multiple inputs in a row, one of which has a tooltip.
5. See that they are all in exact alignment (not shifted downward or altered).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~