### PR TITLE
Document reset css for Ruby on Rails setup guide

### DIFF
--- a/playbook-website/app/views/guides/getting_started/ruby_on_rails_setup.md
+++ b/playbook-website/app/views/guides/getting_started/ruby_on_rails_setup.md
@@ -29,6 +29,7 @@ gem "sassc-rails"
 ```scss
 # app/assets/stylesheets/application.scss
 
+ @import "reset";
  @import "playbook";
 ```
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Playbook was usable without the rest, but things were not quite right. I found small things like spacing didn't match what I thought it should. Also, link buttons had the underscore text decoration.


**Screenshots:** Screenshots to visualize your addition/change
Without reset imported
![without-reset-imported](https://github.com/powerhome/playbook/assets/584017/ea90edbd-d8a2-4cc9-a9ac-6dd94d238f02)

With reset imported
![with-reset-imported](https://github.com/powerhome/playbook/assets/584017/dc607bc8-af02-4fc1-ae05-a756c38b6549)



**How to test?** Steps to confirm the desired behavior:
1. Setup a blank Rails app with playbook imported but without importing the reset first.
2. Make a test page using some rails kits, like the link button.
3. See the kits render wrong, when compared to playbook examples.
4. Import the reset before playbook, and see See the kits render correctly, when compared to playbook examples.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.