### PR TITLE
[PLAY-1307] add Loading Inline custom text option

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_loading_inline/_loading_inline.tsx
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/_loading_inline.tsx
@@ -14,6 +14,7 @@ type LoadingInlineProps = {
   data?: { [key: string]: string },
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
+  text?: string,
 }
 
 const LoadingInline = (props: LoadingInlineProps) => {
@@ -24,6 +25,7 @@ const LoadingInline = (props: LoadingInlineProps) => {
     data = {},
     htmlOptions = {},
     id,
+    text = ' Loading',
   } = props
 
   const ariaProps = buildAriaProps(aria)
@@ -50,7 +52,7 @@ const LoadingInline = (props: LoadingInlineProps) => {
             icon="spinner"
             pulse
         />
-        {' Loading'}
+        {text}
       </Body>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_custom.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_custom.html.erb
@@ -1,0 +1,13 @@
+<%= pb_rails("loading_inline", props: {
+	text: "Saving"
+}) %> 
+
+<%= pb_rails("loading_inline", props: {
+	align: "center",
+    text: "Saving"
+}) %> 
+
+<%= pb_rails("loading_inline", props: {
+	align: "right",
+    text: "Saving"
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_custom.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_custom.html.erb
@@ -1,13 +1,13 @@
 <%= pb_rails("loading_inline", props: {
-	text: "Saving"
-}) %> 
-
-<%= pb_rails("loading_inline", props: {
-	align: "center",
     text: "Saving"
 }) %> 
 
 <%= pb_rails("loading_inline", props: {
-	align: "right",
+    align: "center",
     text: "Saving"
+}) %> 
+
+<%= pb_rails("loading_inline", props: {
+    align: "right",
+    text: "Saving",
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_custom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_custom.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import LoadingInline from '../_loading_inline'
+
+const LoadingInlineCustom = (props) => {
+  return (
+    <div>
+      <LoadingInline
+          text=' Saving'
+          {...props}
+      />
+      <LoadingInline
+          align="center"
+          text=' Saving'      
+          {...props}
+      />
+      <LoadingInline
+          align="right"
+          text=' Saving'
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default LoadingInlineCustom

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_default.html.erb
@@ -1,9 +1,9 @@
 <%= pb_rails("loading_inline") %>
 
 <%= pb_rails("loading_inline", props: {
-	align: "center"
+    align: "center"
 }) %>
 
 <%= pb_rails("loading_inline", props: {
-	align: "right"
+    align: "right"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_loading_inline_default.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import LoadingInline from '../_loading_inline'
 
-const LoadingInlineLight = (props) => {
+const LoadingInlineDefault = (props) => {
   return (
     <div>
       <LoadingInline
@@ -20,4 +20,4 @@ const LoadingInlineLight = (props) => {
   )
 }
 
-export default LoadingInlineLight
+export default LoadingInlineDefault

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/example.yml
@@ -2,8 +2,10 @@ examples:
   
   rails:
   - loading_inline_light: Light
+  - loading_inline_custom: Custom Text
 
   
   
   react:
   - loading_inline_light: Default
+  - loading_inline_custom: Custom Text

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/example.yml
@@ -1,11 +1,11 @@
 examples:
   
   rails:
-  - loading_inline_light: Light
+  - loading_inline_default: Default
   - loading_inline_custom: Custom Text
 
   
   
   react:
-  - loading_inline_light: Default
+  - loading_inline_default: Default
   - loading_inline_custom: Custom Text

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/index.js
@@ -1,1 +1,2 @@
 export { default as LoadingInlineLight } from './_loading_inline_light.jsx'
+export { default as LoadingInlineCustom } from './_loading_inline_custom.jsx'

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/index.js
@@ -1,2 +1,2 @@
-export { default as LoadingInlineLight } from './_loading_inline_light.jsx'
+export { default as LoadingInlineDefault } from './_loading_inline_default.jsx'
 export { default as LoadingInlineCustom } from './_loading_inline_custom.jsx'

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.html.erb
@@ -1,5 +1,5 @@
 <%= pb_content_tag do %>
   <%= pb_rails("body", props: { color: "light", dark: object.dark }) do %>
-    <%= pb_rails("icon", props: { aria: { label: "loading icon" }, fixed_width: true, icon: "spinner", pulse: true }) %> Loading
+    <%= pb_rails("icon", props: { aria: { label: "loading icon" }, fixed_width: true, icon: "spinner", pulse: true }) %> <%= object.text %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.rb
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.rb
@@ -7,6 +7,7 @@ module Playbook
                    values: %w[left center right],
                    default: "left"
       prop :dark, type: Playbook::Props::Boolean, default: false
+      prop :text, type: Playbook::Props::String, default: "Loading"
 
       def classname
         generate_classname("pb_loading_inline_kit", align)

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.test.js
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.test.js
@@ -39,3 +39,17 @@ test('should render aria-label', () => {
     const kit = screen.getByTestId(testId)
     expect(kit).toHaveAttribute('aria-label', testId)
 })
+
+
+test('displays custom text content', () => {
+    render(
+        <LoadingInline
+            aria={{ label: testId }}
+            data={{ testid: testId }}
+            text=' Saving'
+        />
+    )
+  
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveTextContent('Saving')
+})

--- a/playbook/spec/pb_kits/playbook/kits/loading_inline_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/loading_inline_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Playbook::PbLoadingInline::LoadingInline do
       .with_default("left")
       .with_values("left", "center", "right")
   }
+  it { is_expected.to define_prop(:text).with_default("Loading") }
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_loading_inline_kit_left"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1307](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1307) adds a text prop with a default value of 'Loading' to the [Loading Inline kit](https://playbook.powerapp.cloud/kits/loading_inline/), and adds a Custom Text kit example showing developers how to customize their Loading Inline components with the new prop. Both the Rails and React versions of the kit have been updated, as have their tests.

In the course of this ticket I also standardized the primary Loading Inline example's name as "default" instead of "light" which was set ~5 years ago - the name is now "default" consistently across Rails and React files and kit example pages.

**Screenshots:** Screenshots of Custom Text kit example on Rails and React kit pages
<img width="1499" alt="Rails custom text example" src="https://github.com/powerhome/playbook/assets/83474365/112d5d14-30a6-4c59-b208-7ddafb350097">
<img width="1524" alt="React custom text example" src="https://github.com/powerhome/playbook/assets/83474365/06fddd7d-e870-42c3-a4f8-39703b648bcc">


**How to test?** Steps to confirm the desired behavior:
1. Go to Loading Inline kit page ([rails](https://playbook.powerapp.cloud/kits/loading_inline/rails) and [react](https://playbook.powerapp.cloud/kits/loading_inline/react)).
2. Scroll down to 'Custom Text' kit example.
4. See added kit example and select '</> Show Code' to see how custom text values are set.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.