### PR TITLE
Dropdown to Use Content Tag instead of pb_content_tag

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
@@ -1,4 +1,9 @@
-<%= pb_content_tag do %>
+<%= content_tag(:div,
+    aria: object.aria,
+    class: object.classname,
+    data: object.data,
+    id: object.id,
+    **combined_html_options) do %>
     <% if object.label.present? %>
         <%= pb_rails("caption", props: {text: object.label, margin_bottom:"xs"}) %>
     <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.html.erb
@@ -1,4 +1,10 @@
-<%= pb_content_tag(:div, style: object.container_style) do %>
+<%= content_tag(:div,
+    aria: object.aria,
+    class: object.classname,
+    data: object.data,
+    id: object.id,
+    style: object.container_style,
+    **combined_html_options) do %>
     <%= pb_rails("list", props: {ordered: false, borderless: false}) do %>
             <% if content.present? %> 
                 <%= content.presence %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_option.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_option.html.erb
@@ -1,4 +1,9 @@
-<%= pb_content_tag do %>
+<%= content_tag(:div,
+    aria: object.aria,
+    class: object.classname,
+    data: object.data,
+    id: object.id,
+    **combined_html_options) do %>
     <%= pb_rails("list/item", props: {
         display: "flex", 
         justify_content: "center", 

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.html.erb
@@ -1,4 +1,9 @@
-<%= pb_content_tag do %>
+<%= content_tag(:div,
+    aria: object.aria,
+    class: object.classname,
+    data: object.data,
+    id: object.id,
+    **combined_html_options) do %>
     <% if content.present? %>
         <div style="display: inline-block" tabindex="0" data-dropdown-custom-trigger>
           <%= content.presence %>


### PR DESCRIPTION
Since we are reverting the PR that created the pb_content_tag [here](https://github.com/powerhome/playbook/pull/3391), we are reverting the dropdown kit to NOT use that pb_content_tag