### PR TITLE
[PLAY-1122] fix Multiple Users padding overflow

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.scss
@@ -35,6 +35,10 @@ $pb_multiple_users_size_xxs: map-get($avatar-sizes, "xxs");
     margin-left: $pb_multiple_users_overlap;
     margin-right: 0;
 
+    &:first-child {
+      margin-left: 0;
+    }
+
     &.dark {
       .avatar_wrapper {
         border: $pb_multiple_users_border_size solid $bg_dark;
@@ -58,6 +62,10 @@ $pb_multiple_users_size_xxs: map-get($avatar-sizes, "xxs");
     .pb_multiple_users_item {
       margin-left: 0;
       margin-right: $pb_multiple_users_overlap;
+
+      &:first-child {
+        margin-right: 0;
+      }
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.scss
@@ -35,7 +35,7 @@ $pb_multiple_users_size_xxs: map-get($avatar-sizes, "xxs");
     margin-left: $pb_multiple_users_overlap;
     margin-right: 0;
 
-    &:first-child {
+    &:first-of-type {
       margin-left: 0;
     }
 
@@ -63,7 +63,7 @@ $pb_multiple_users_size_xxs: map-get($avatar-sizes, "xxs");
       margin-left: 0;
       margin-right: $pb_multiple_users_overlap;
 
-      &:first-child {
+      &:first-of-type {
         margin-right: 0;
       }
     }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1122](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1122) addresses a longstanding bug on the Multiple Users kit wherein the first user badge in the group (the leftmost one on the Default and Size examples, the rightmost one on the Reverse example) overflows out of the expected border. 

This occurred because the token ```pb_multiple_users_overlap``` a negative pixel value which was used to cause the visual overlapping of multiple user avatars, applied this negative to the first avatar which had no neighbor to overlap with. This PR removes this spacing token from the first ```pb_multiple_users_item``` and stops it from shifting "out of bounds" anymore. It does increase the width of ```pb_multiple_users_kit``` by 9px and will require regression testing (will add videos of expected concerns to runway ticket).


**Screenshots:** Screenshots to visualize your addition/change
Current behavior: overlapping negative value on all avatars, width 76px
<img width="304" alt="current pb_multiple_users_kit behavior and width" src="https://github.com/powerhome/playbook/assets/83474365/8d30bb1a-b00f-400e-abdb-94a80fa6e9e9">
New behavior: overlapping negative value on all but first avatar, width 85px now (+9 change)
<img width="280" alt="after pb_multiple_users_kit " src="https://github.com/powerhome/playbook/assets/83474365/4fb84cc8-5ffb-4524-9c91-6dd8d3860705">
Adding margin-left: 0 to outermost div of first avatar in multiple users group shifts entire group over while preserving overlapping of avatars with each other, compare to unmodified example below
<img width="705" alt="see before:after affect together - margin left 0 on correct div" src="https://github.com/powerhome/playbook/assets/83474365/edfcb144-6317-4c00-8bc5-0c15b377d18f">



**How to test?** Steps to confirm the desired behavior:
1. Go to Multiple Users kit page ([rails](https://playbook.powerapp.cloud/kits/multiple_users/rails) and [react](https://playbook.powerapp.cloud/kits/multiple_users/react))
2. Scroll down to [Default example](https://playbook.powerapp.cloud/kits/multiple_users/rails#default)
3. See Multiple Users group of avatars is left-aligned with the Default caption; inspect group and see that all four Avatars are contained within div without overflow to the left
4. Scroll down to [Reverse example](https://playbook.powerapp.cloud/kits/multiple_users/react#reverse)
5. Inspect group and see that all four Avatars are contained within div without overflow to the right


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~