### PR TITLE
[PLAY-1250] fix Text Input addon border radius within a form group

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -33,10 +33,25 @@
         outline-offset: -1px;
       }
     }
+    .text_input_wrapper_add_on .add-on-right [class^=pb_card_kit] {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+      border-right-width: 0;
+    }
+    .text_input_wrapper_add_on .add-on-right.border_left_on .card-right-aligned {
+      border-left: 1px $border_light solid;
+      &.dark {
+        border-left: 1px rgba($white, 0.15) solid;
+      }
+    }
   }
 
   & > [class^=pb_text_input_kit]:not(:first-child) {
     .text_input_wrapper input, [class^=pb_text_input_kit] .text_input_wrapper .text_input {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+    .text_input_wrapper_add_on .add-on-left [class^=pb_card_kit] {
       border-bottom-left-radius: 0;
       border-top-left-radius: 0;
     }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1250](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1250) addresses the issue of border radii not lining up flush for text input addons within a form group like they do for default text inputs in a form group. This PR corrects this issue. 
I also discovered and fixed a related bug present in production but not reported by devs/designers regarding this kit: for right-aligned Text Input addon cards with ```border: true```, the border was not appearing unless the card was the last item in the form group.

[CSB reproducing issue](https://codesandbox.io/p/sandbox/play-1250-reproduce-issue-hp7pf7)
[CSB alpha](https://codesandbox.io/p/sandbox/play-1250-alpha-p23m95)

**Screenshots:** Screenshots below, compare/contrast the CSBs linked above as well
Current look: Border radii not flush between items in form group and Card addon border missing
<img width="492" alt="pre ss for PR" src="https://github.com/powerhome/playbook/assets/83474365/8b744844-2f80-491b-81f0-972c800def93">
React, light mode, default form group at top then 6 permutations of 3 text input add on form groups showing correct border radius and functioning card border: true for right-aligned cards
<img width="774" alt="light mode react for PR" src="https://github.com/powerhome/playbook/assets/83474365/16f51cbe-1ed4-4516-b028-2bd638e504eb">
Rails, dark mode, 4 permutations of 2 text input add on form groups showing correct border radius and card border: true for right-aligned cards
<img width="530" alt="darkmode rails for PR" src="https://github.com/powerhome/playbook/assets/83474365/785617d5-5d14-425c-bdb5-571ea8925e35">


**How to test?** Steps to confirm the desired behavior:
1. Go to a codesandbox and create a [form group](https://playbook.powerapp.cloud/kits/form_group/react#default-1)with some [text input add ons](https://playbook.powerapp.cloud/kits/text_input/react#add-on) within it, including a right-aligned add on with border as any of the first or middle items within in the group.
2. See the form group appear with smooth internal border radii and the borders of each card add-on appear where expected.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~