### PR TITLE
[PLAY-1115] fix Text input add-on dark mode border and message color

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -76,6 +76,25 @@
         .text_input {
           border-color: $error_dark;
         }
+        [class*=pb_body_kit_negative] {
+          color: $error_dark;
+        }
+      }
+      .text_input_wrapper_add_on {
+        .add-on {
+          &-right {
+            .add-on-card {
+              border: 1px solid $error_dark;
+              border-left: 0;
+            }
+          }
+          &-left {
+            .add-on-card {
+              border: 1px solid $error_dark;
+              border-right: 0;
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1115](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1115) corrects the error color for the border of text input addon cards and the error message in dark mode. These currently display as $error color in both light and dark modes but should change to $error_dark in dark (rails + react).

**Screenshots:** Screenshots to visualize your addition/change
<img width="281" alt="pre dark mode wrong color for addon and text" src="https://github.com/powerhome/playbook/assets/83474365/c665542a-9ed3-4348-baec-afc7bf20b163"> 
<img width="281" alt="post all errors now error_dark" src="https://github.com/powerhome/playbook/assets/83474365/813bc633-4ab0-4e41-8888-3a091c5633b8">


**How to test?** Steps to confirm the desired behavior:
1. Go to [text input](https://playbook.powerapp.cloud/kits/text_input) kit page (in either rails or react) and toggle to dark mode (top right corner).
2. Scroll down to the [with error](https://playbook.powerapp.cloud/kits/text_input#with-error) kit example.
3. See all error borders and text color by the Email Address input in the kit example are $error_dark (the "paler" red).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~