### PR TITLE
[PBNTR-294] Fix for Nitro Style bleed with Pagination kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
+++ b/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
@@ -11,7 +11,7 @@ $top_bottom_radius: 0px;
   border-radius: $border_rad_light;
   border: $border_rad_lightest solid $border_light;
   background-color: $white;
-  padding: $space_xxs 0px;
+  padding: $space_xxs 0px !important;
   li {
     display: inline;
     > a, li > span {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[RUNWAY STORY](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-294)

- old-styles SCSS in Nitro was overriding the padding within pagination kit. 
- adding this important tag should fix the issue


**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2024-05-14 at 9 21 01 AM](https://github.com/powerhome/playbook/assets/73710701/20569882-3f33-4035-8bc7-d15ae4be4876)



**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.