### PR TITLE
[PLAY-1339] Add dependabot yml

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+    allow:
+      - dependency-name: "will_paginate"
+      - dependency-name: "view_component"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+    allow:
+      - dependency-name: "@babel/runtime"
+      - dependency-name: "@floating-ui/react"
+      - dependency-name: "@fortawesome/fontawesome-free"
+      - dependency-name: "@popperjs/core"
+      - dependency-name: "@tanstack/react-table"
+      - dependency-name: "classnames"
+      - dependency-name: "core-js"
+      - dependency-name: "file-loader"
+      - dependency-name: "flatpickr"
+      - dependency-name: "highcharts"
+      - dependency-name: "highcharts-react-official"
+      - dependency-name: "intl-tel-input"
+      - dependency-name: "lazysizes"
+      - dependency-name: "lodash"
+      - dependency-name: "react-animate-height"
+      - dependency-name: "react-dropzone"
+      - dependency-name: "react-highlight-words"
+      - dependency-name: "react-joyride"
+      - dependency-name: "react-modal"
+      - dependency-name: "react-popper"
+      - dependency-name: "react-select"
+      - dependency-name: "react-trix"
+      - dependency-name: "react-zoom-pan-pinch"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Runway https://nitro.powerhrg.com/runway/backlog_items/PLAY-1339

We get too many notifications and/or don't want to update a 3rd party library when the latest version comes out.But **some libraries we do want to stay up to date** on.

Using `dependabot.yml` we can white/black list certain libraries. I tried to make a list of 3rd Party Libraries by package name and associated kit.

Then we can just go to Insights > Dependancy Graph > Dependabot https://github.com/powerhome/playbook/network/updates