### PR TITLE
[PLAY-1178] Fixed Styling when Select Kit is used within a Flex Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -102,6 +102,9 @@
     pointer-events: none;
   }
   &.inline {
+    svg {
+      right: 6px;
+    }
     @mixin active_arrow_style {
       svg {
         color: $primary !important;
@@ -130,6 +133,7 @@
       box-shadow: none;
       border-color: transparent;
       padding: 4px 8px;
+      padding-right: $space_lg; 
       border-radius: 4px;
       option {
         background-color: $white;
@@ -213,6 +217,9 @@
     }
   }
   &.inline {
+    svg {
+      right: 6px;
+    }
     &:not(:hover) {
       svg {
         display: none;
@@ -233,6 +240,7 @@
       border-color: transparent;
       background: transparent;
       padding: 4px 8px;
+      padding-right: $space_lg; 
       border-radius: 4px;
       option {
         background-color: $white;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This allows the dev more fine-grained control over the elements inside of our Select kit, and enables them to move things around using our global spacing props-- which in turn, fixes a bug where the Select kit is broken when nested inside of a Flex kit. 

**Screenshots:** Screenshots to visualize your addition/change
<img width="205" alt="Screenshot 2024-05-17 at 9 25 11 AM" src="https://github.com/powerhome/playbook/assets/9158723/b7b4d6ac-8947-4c31-a4ba-72f709e4e0ed">

<img width="216" alt="Screenshot 2024-05-17 at 9 25 25 AM" src="https://github.com/powerhome/playbook/assets/9158723/7521df66-a8cf-408f-824e-7850ecc6e20e">


**How to test?** Steps to confirm the desired behavior:
https://codesandbox.io/p/sandbox/funny-booth-rqd9dq


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.