### PR TITLE
[PLAY-888] Card kit highlight overflow w/ tooltip error

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.scss
@@ -63,15 +63,13 @@
   }
 
   &[class*=_highlight] {
-    // overflow: hidden;
+    overflow: hidden;
   }
 
   &[class*=_highlight_top] {
     @each $color_name, $color_value in $pb_card_highlight_colors {
       &[class*=_highlight_#{$color_name}]::before {
         @include pb_card_highlight(100%, $pb_card_highlight_size, $color_value);
-        border-top-left-radius: $pb_card_border_radius;
-        border-top-right-radius: $pb_card_border_radius;
       }
     }
   }
@@ -80,8 +78,6 @@
     @each $color_name, $color_value in $pb_card_highlight_colors {
       &[class*=_highlight_#{$color_name}]::before {
         @include pb_card_highlight($pb_card_highlight_size, 100%, $color_value);
-        border-top-left-radius: $pb_card_border_radius;
-        border-bottom-left-radius: $pb_card_border_radius;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_card/_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.scss
@@ -63,13 +63,15 @@
   }
 
   &[class*=_highlight] {
-    overflow: hidden;
+    // overflow: hidden;
   }
 
   &[class*=_highlight_top] {
     @each $color_name, $color_value in $pb_card_highlight_colors {
       &[class*=_highlight_#{$color_name}]::before {
         @include pb_card_highlight(100%, $pb_card_highlight_size, $color_value);
+        border-top-left-radius: $pb_card_border_radius;
+        border-top-right-radius: $pb_card_border_radius;
       }
     }
   }
@@ -78,6 +80,8 @@
     @each $color_name, $color_value in $pb_card_highlight_colors {
       &[class*=_highlight_#{$color_name}]::before {
         @include pb_card_highlight($pb_card_highlight_size, 100%, $color_value);
+        border-top-left-radius: $pb_card_border_radius;
+        border-bottom-left-radius: $pb_card_border_radius;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_tooltip/index.js
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/index.js
@@ -58,6 +58,7 @@ export default class PbTooltip extends PbEnhancedElement {
 
     this.popper = createPopper(trigger, this.tooltip, {
       placement: this.position,
+      strategy: 'fixed',
       modifiers: [
         {
           name: 'offset',


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-888](https://nitro.powerhrg.com/runway/backlog_items/PLAY-888) identifies an issue where CSS specific to the highlight card variant (an [overflow:hidden style](https://github.com/powerhome/playbook/blob/534b82c7285687edea605586545623ba284699c1/playbook/app/pb_kits/playbook/pb_card/_card.scss#L66) that keeps the highlight color constrained within the card's borders) caused Tooltips on text within the card to be hidden.

Due to the nature of how the highlight card variant functions, a solution was found by modifying the Tooltip kit using a Popper/FloatingUI property that has been utilized in the Popover kit. Adding `strategy: fixed` allows for Rails Tooltips to behave as expected/desired. The React Tooltip kit does have the [position kit prop](https://playbook.powerapp.cloud/kits/tooltip/react) exposed, and requires setting position to fixed for the same behavior to occur in React (see CSB example - will link when one with alpha ready).

**Screenshots:** Screenshots to visualize your addition/change
Rails: see style="position: fixed..." for Tooltip due to added line
<img width="1282" alt="Rails tooltip position fixed inspect" src="https://github.com/powerhome/playbook/assets/83474365/78df00c6-49dc-4ed0-a470-507ab24b5f0a">
React: see style="position: fixed..." due to `position="fixed"` as prop on Tooltip in example code
<img width="1304" alt="React tooltip position fixed inspect" src="https://github.com/powerhome/playbook/assets/83474365/5484e3c8-7e62-4958-854b-c6ff8ffda8da">


**How to test?** Steps to confirm the desired behavior:
[WILL FILL OUT - making alpha now]
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.