### PR TITLE
[PLAY-1349] Checkbox z-index issue with Sticky

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.scss
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.scss
@@ -28,6 +28,7 @@ $transition: $transition_cubic;
       height: 16px;
       left: 1px;
       display: flex;
+      margin: auto;
       opacity: 0;
       width: 16px;
       &.hidden {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1349](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1349) removes the `position: relative` property from two places in _checkbox.scss to prevent style bleed from the checkbox box, checkmark, and indeterminate icon into a sticky header or element it scrolls through.

**Screenshots:** Screenshots to visualize your addition/change
[CSB with issue](https://codesandbox.io/p/sandbox/priceless-smoke-kymdl7?)
[CSB with alpha](https://codesandbox.io/p/sandbox/play-1349-alpha-vhgg7f)
Screen recording from playbook local (React): none of empty checkbox, highlighted unchecked checkbox, and checked checkbox styles bleed onto the Section Title.
https://github.com/powerhome/playbook/assets/83474365/8bbd4275-e705-46fe-880c-fbddf059eebf
Screen recording from playbook local (Rails): none of empty checkbox, highlighted unchecked checkbox, and checked checkbox styles bleed onto the Section Title.
https://github.com/powerhome/playbook/assets/83474365/9f15333a-7b0a-468c-b7b3-0f5041a92c68
Screen recording from alpha-in-nitro local environment of checkbox on a dialog.
Uploading Checkbox in dialog modal within alpha-in-nitro milano env.mov…



**How to test?** Steps to confirm the desired behavior:
1. Go to (CSB with alpha](https://codesandbox.io/p/sandbox/play-1349-alpha-vhgg7f).
2. Expand the Collapsible element (can select one or some of the checklist items to show how it works for checkboxes in all states)
3. Scroll down the page, the Section Title should remain sticky at the top of the page and no elements of a checkbox in any state should bleed through.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~