### PR TITLE
Play 1209 fix form group date picker border radius react

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -107,21 +107,6 @@
   }
 
   & > [class^=pb_date_picker_kit]:not(:last-child) {
-    .text_input_wrapper input, [class^=pb_text_input_kit] .text_input_wrapper .flatpickr-wrapper {
-      border-bottom-right-radius: 0;
-      border-top-right-radius: 0;
-      border-right-width: 0;
-    }
-  }
-
-  & > [class^=pb_date_picker_kit]:not(:first-child) {
-    .text_input_wrapper input, [class^=pb_text_input_kit] .text_input_wrapper .flatpickr-wrapper {
-      border-bottom-left-radius: 0;
-      border-top-left-radius: 0;
-    }
-  }
-
-  & > [class^=pb_date_picker_kit]:not(:last-child) {
     .input_wrapper input, [class^=pb_text_input_kit] .date_picker_input_wrapper .flatpickr-wrapper {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -121,6 +121,21 @@
     }
   }
 
+  & > [class^=pb_date_picker_kit]:not(:last-child) {
+    .input_wrapper input, [class^=pb_text_input_kit] .date_picker_input_wrapper .flatpickr-wrapper {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+      border-right-width: 0;
+    }
+  }
+
+  & > [class^=pb_date_picker_kit]:not(:first-child) {
+    .input_wrapper input, [class^=pb_text_input_kit] .date_picker_input_wrapper .flatpickr-wrapper {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+  }
+
   & > [class^=pb_select]:not(:last-child) {
     margin-bottom: 0px;
     .pb_select_kit_wrapper select {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1209](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1209) fixes the border radii of the Date Picker kit in React within a form group so they are flush and visually unified like it is for Rails and for Text Inputs with a form group. When looking at [_form_group.scss](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss) closely there was code in place to address this but the input wrapper classes had not been changed from those of a default text input to those found in date pickers.

[CSB reproducing issue](https://codesandbox.io/p/sandbox/play-1209-reproduce-issue-n2vrkm)
[CSB with alpha](https://codesandbox.io/p/sandbox/play-1209-alpha-vys2md)

**Screenshots:** Screenshots to visualize your addition/change
In the example screenshot below and in the CSB examples above, there are some constructions of form groups with several date picker inputs that do not match a real life date picker usecase, I was just making sure the border radii would line up no matter the position/order.
Current look: Border radii not flush at any borders of a date picker input
<img width="828" alt="react example group pre fix" src="https://github.com/powerhome/playbook/assets/83474365/07beeb2e-b75b-4631-9227-e8572e69c5f8">
Post fix: Border radii flush between all items within a form group
<img width="1013" alt="react example group post fix" src="https://github.com/powerhome/playbook/assets/83474365/c5e3ed0e-6a93-493b-a2e4-69208c3d99fb">



**How to test?** Steps to confirm the desired behavior:
1. Go to CSB with alpha or Date Picker kit example ([live link](https://playbook.powerapp.cloud/kits/form_group/react#date-picker), [milano env link](https://pr3431.playbook.beta.hq.powerapp.cloud/kits/form_group/react#date-picker))
2. See border radii connected between inputs in a form group.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~