### PR TITLE
[PLAY-1343] fix Tooltip oversize and misalignment issue

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -127,7 +127,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
             }
           }}
           role="tooltip_trigger"
-          style={{ display: "inline-block" }}
+          style={{ display: "inline-flex" }}
           {...ariaProps}
           {...dataProps}
           {...htmlProps}

--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -127,7 +127,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
             }
           }}
           role="tooltip_trigger"
-          style={{ display: "inline-flex" }}
+          style={{ display: "inline-block" }}
           {...ariaProps}
           {...dataProps}
           {...htmlProps}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1343](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1343) -  as of right now this PR is for making an alpha that reverts change from [PLAY-1249](https://github.com/powerhome/playbook/pull/3380) in order to truly verify that this change isn't the cause of the runway tooltip misalignment issue.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.