### PR TITLE
[PBNTR-328] Draggable v2

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
+++ b/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
@@ -1,6 +1,6 @@
 @import "../tokens/colors";
 
-.pb_draggable {
+.pb_draggable_container {
   .is_dragging {
     opacity: 40%;
   }

--- a/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
+++ b/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
@@ -7,4 +7,7 @@
   .active {
     opacity: 60%;
   }
+  .pb_draggable_item:hover {
+    cursor: grab;
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
@@ -28,10 +28,7 @@ const DraggableDefault = (props) => {
     <DraggableProvider initialItems={data}
         onChange={(items) => setInitialState(items)}
     >
-      <Draggable
-          {...props}
-      >
-        <Draggable.Container>
+        <Draggable.Container {...props}>
           <SelectableList variant="checkbox">
             {initialState.map(({ id, text }) => (
               <Draggable.Item id={id} 
@@ -45,7 +42,6 @@ const DraggableDefault = (props) => {
             ))}
           </SelectableList>
         </Draggable.Container>
-      </Draggable>
     </DraggableProvider>
   );
 };

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
@@ -25,6 +25,7 @@ const DraggableDefault = (props) => {
   const [initialState, setInitialState] = useState(data);
 
   return (
+    <>
     <DraggableProvider initialItems={data}
         onChange={(items) => setInitialState(items)}
     >
@@ -34,7 +35,8 @@ const DraggableDefault = (props) => {
               <Draggable.Item id={id} 
                   key={id}
               >
-                <SelectableList.Item label={text} 
+                <SelectableList.Item dragHandle
+                    label={text} 
                     name={id} 
                     value={id} 
                 />
@@ -43,6 +45,8 @@ const DraggableDefault = (props) => {
           </SelectableList>
         </Draggable.Container>
     </DraggableProvider>
+    </>
+
   );
 };
 

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.md
@@ -1,0 +1,4 @@
+To use the Draggable kit, you must use the DraggableProvider and pass in `initialItems`. The `onChange` is a function that returns the data as it changes as items are reordered. Use this to manage state as shown.
+
+The `Draggable.Container` specifies the container within which items can be dropped.
+The `Draggable.Item` specifies the items that can be dragged and dropped. `Draggable.Item` requires `id` to be passed in as shown.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers.jsx
@@ -85,8 +85,7 @@ const DraggableMultipleContainer = (props) => {
     <DraggableProvider initialItems={data}
         onChange={(items) => setInitialState(items)}
     >
-      <Draggable
-          display="flex"
+      <Flex
           justifyContent="center"
           {...props}
       >
@@ -151,7 +150,7 @@ const DraggableMultipleContainer = (props) => {
                 </Flex>
             </Draggable.Container>
           ))}
-      </Draggable>
+      </Flex>
     </DraggableProvider>
   );
 };

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.jsx
@@ -34,8 +34,7 @@ const DraggableWithCards = (props) => {
         initialItems={data}
         onChange={(items) => setInitialState(items)}
     >
-      <Draggable {...props}>
-        <Draggable.Container>
+        <Draggable.Container  {...props}>
           {initialState.map(({ id, text }) => (
             <Draggable.Item id={id} 
                 key={id}
@@ -113,7 +112,6 @@ const DraggableWithCards = (props) => {
             </Draggable.Item>
           ))}
         </Draggable.Container>
-      </Draggable>
     </DraggableProvider>
   );
 };

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { DraggableProvider, List, ListItem } from "../../";
+
+// Initial items to be dragged
+const data = [
+  {
+    id: "1",
+    text: "Philadelphia",
+  },
+  {
+    id: "2",
+    text: "New Jersey",
+  },
+  {
+    id: "3",
+    text: "Maryland",
+  },
+  {
+    id: "4",
+    text: "Connecticut",
+  },
+];
+
+const DraggableWithList = (props) => {
+  const [initialState, setInitialState] = useState(data);
+
+
+  return (
+    <>
+    <DraggableProvider initialItems={data}
+        onChange={(items) => setInitialState(items)}
+    >
+        <List draggable
+            {...props}
+        >
+            {initialState.map(({ id, text }) => (
+                <ListItem id={id}
+                    key={id}
+                >
+                    {text}
+                </ListItem>
+            ))}
+        </List>
+    </DraggableProvider>
+    </>
+
+  );
+};
+
+export default DraggableWithList;

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.md
@@ -1,0 +1,1 @@
+For a simplified version of the Draggable API fro the List kit, use the DraggableProvider to wrap the List use the `draggable` prop on List. The dev must manage state as shown and pass in id to the ListItem.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { SelectableList, Draggable, DraggableProvider } from "../../";
+import { SelectableList, DraggableProvider } from "../../";
 
 // Initial items to be dragged
 const data = [
@@ -21,7 +21,7 @@ const data = [
   },
 ];
 
-const DraggableDefault = (props) => {
+const DraggableWithSelectableList = (props) => {
   const [initialState, setInitialState] = useState(data);
 
   return (
@@ -29,25 +29,23 @@ const DraggableDefault = (props) => {
     <DraggableProvider initialItems={data}
         onChange={(items) => setInitialState(items)}
     >
-        <Draggable.Container {...props}>
-          <SelectableList variant="checkbox">
-            {initialState.map(({ id, text }) => (
-              <Draggable.Item id={id} 
-                  key={id}
+          <SelectableList draggable 
+              variant="checkbox"
+              {...props}
               >
-                <SelectableList.Item
+            {initialState.map(({ id, text }) => (
+                <SelectableList.Item id={id}
+                    key={id}
                     label={text} 
                     name={id} 
-                    value={id} 
+                    value={id}
                 />
-              </Draggable.Item>
             ))}
           </SelectableList>
-        </Draggable.Container>
     </DraggableProvider>
     </>
 
   );
 };
 
-export default DraggableDefault;
+export default DraggableWithSelectableList

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
@@ -3,6 +3,7 @@ examples:
   
   react:
   - draggable_default: Default
+  - draggable_with_list: Draggable with List Kit
   - draggable_with_cards: Draggable with Cards
   - draggable_multiple_containers: Dragging Across Multiple Containers
   

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
@@ -4,6 +4,7 @@ examples:
   react:
   - draggable_default: Default
   - draggable_with_list: Draggable with List Kit
+  - draggable_with_selectable_list: Draggable with SelectableList Kit
   - draggable_with_cards: Draggable with Cards
   - draggable_multiple_containers: Dragging Across Multiple Containers
   

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/index.js
@@ -1,4 +1,5 @@
 export { default as DraggableDefault } from './_draggable_default.jsx'
 export { default as DraggableWithCards } from './_draggable_with_cards.jsx'
 export { default as DraggableWithList } from './_draggable_with_list.jsx'
+export { default as DraggableWithSelectableList } from './_draggable_with_selectable_list.jsx'
 export { default as DraggableMultipleContainers } from './_draggable_multiple_containers.jsx'

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/index.js
@@ -1,3 +1,4 @@
 export { default as DraggableDefault } from './_draggable_default.jsx'
 export { default as DraggableWithCards } from './_draggable_with_cards.jsx'
+export { default as DraggableWithList } from './_draggable_with_list.jsx'
 export { default as DraggableMultipleContainers } from './_draggable_multiple_containers.jsx'

--- a/playbook/app/pb_kits/playbook/pb_list/_list.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import classnames from "classnames";
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
+import Draggable from "../pb_draggable/_draggable";
 
 type ListProps = {
   aria?: { [key: string]: string };
@@ -9,6 +10,7 @@ type ListProps = {
   className?: string;
   children: React.ReactNode[] | React.ReactNode;
   dark?: boolean;
+  draggable?: boolean;
   data?: Record<string, unknown>;
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string;
@@ -30,6 +32,7 @@ const List = (props: ListProps) => {
     className,
     dark = false,
     data = {},
+    draggable = false,
     htmlOptions = {},
     id,
     layout = "",
@@ -51,7 +54,7 @@ const List = (props: ListProps) => {
   const childrenWithProps = React.Children.map(
     children,
     (child: React.ReactElement) => {
-      return React.cloneElement(child, { text, variant });
+      return React.cloneElement(child, { text, variant, draggable });
     }
   );
   const ariaProps = buildAriaProps(aria);
@@ -69,7 +72,11 @@ const List = (props: ListProps) => {
   );
 
   return (
-    <div className={classes}>
+    <>
+    {
+      draggable ? (
+        <Draggable.Container>
+     <div className={classes}>
       {ordered ? (
         <ol
             {...ariaProps}
@@ -96,6 +103,40 @@ const List = (props: ListProps) => {
         </ul>
       )}
     </div>
+        </Draggable.Container>
+      ) :
+      (
+<div className={classes}>
+      {ordered ? (
+        <ol
+            {...ariaProps}
+            {...dataProps}
+            {...htmlProps}
+            className={className}
+            id={id}
+            role={role}
+            tabIndex={tabIndex}
+        >
+          {childrenWithProps}
+        </ol>
+      ) : (
+        <ul
+            {...ariaProps}
+            {...dataProps}
+            {...htmlProps}
+            className={className}
+            id={id}
+            role={role}
+            tabIndex={tabIndex}
+        >
+          {childrenWithProps}
+        </ul>
+      )}
+    </div>
+      )
+    }
+    
+    </>
   );
 };
 

--- a/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
@@ -2,12 +2,16 @@ import React from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
+import Icon from '../pb_icon/_icon'
+import Body from '../pb_body/_body'
+import Draggable from '../pb_draggable/_draggable'
 
 type ListItemProps = {
   aria?: { [key: string]: string },
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
   data?: Record<string, unknown>,
+  dragHandle?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   tabIndex?: number,
@@ -19,6 +23,8 @@ const ListItem = (props: ListItemProps) => {
     children,
     className,
     data = {},
+    draggable = false,
+    dragHandle = true,
     htmlOptions = {},
     id,
     tabIndex,
@@ -35,16 +41,46 @@ const ListItem = (props: ListItemProps) => {
 
   return (
     <>
-      <li
-          {...ariaProps}
-          {...dataProps}
-          {...htmlProps}
-          className={classes}
-          id={id}
-          tabIndex={tabIndex}
-      >
-        {children}
-      </li>
+    {
+      draggable ? (
+        <Draggable.Item id={id}>
+        <li
+            {...ariaProps}
+            {...dataProps}
+            {...htmlProps}
+            className={classes}
+            id={id}
+            tabIndex={tabIndex}
+        >
+          {
+            dragHandle && (
+              <span style={{verticalAlign: 'middle'}}>
+                <Body color="lighter">
+                <Icon 
+                    icon="grip-dots-vertical"
+                    verticalAlign="middle" 
+                />
+                </Body>
+              </span>
+            )
+          }
+          {children}
+        </li>
+        </Draggable.Item>
+        ) : (
+        <li
+            {...ariaProps}
+            {...dataProps}
+            {...htmlProps}
+            className={classes}
+            id={id}
+            tabIndex={tabIndex}
+        >
+          {children}
+        </li>
+      )
+    }
+      
     </>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
@@ -55,7 +55,7 @@ const ListItem = (props: ListItemProps) => {
           {
             dragHandle && (
               <span style={{verticalAlign: 'middle'}}>
-                <Body color="lighter">
+                <Body color="light">
                 <Icon 
                     icon="grip-dots-vertical"
                     verticalAlign="middle" 

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
@@ -7,14 +7,16 @@ import { globalProps } from "../utilities/globalProps";
 import Checkbox from "../pb_checkbox/_checkbox";
 import ListItem from "../pb_list/_list_item";
 import Radio from "../pb_radio/_radio";
+import { GenericObject } from "../types";
 
 export type SelectableListItemProps = {
   aria?: { [key: string]: string };
   children: React.ReactNode[] | React.ReactNode;
   checked?: boolean;
   className?: string;
-  data?: object;
+  data?: GenericObject;
   defaultChecked?: boolean;
+  dragHandle?: boolean;
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
   label?: string;
@@ -31,6 +33,7 @@ const SelectableListItem = ({
   children,
   className,
   data = {},
+  dragHandle = true,
   defaultChecked,
   htmlOptions = {},
   id,
@@ -39,7 +42,7 @@ const SelectableListItem = ({
   name = "",
   value = "",
   variant = "checkbox",
-  onChange = () => {},
+  onChange = () => {void 0},
   ...props
 }: SelectableListItemProps) => {
   const ariaProps = buildAriaProps(aria);
@@ -61,28 +64,31 @@ const SelectableListItem = ({
 
   return (
     <ListItem
-      {...props}
-      className={classnames(checkedState ? "checked_item" : "", className)}
+        {...props}
+        className={classnames(checkedState ? "checked_item" : "", className)}
+        dragHandle={dragHandle}
+        id={id}
     >
       <div 
-        {...ariaProps} 
-        {...dataProps}
-        {...htmlProps} 
-        className={classes}
+          {...ariaProps} 
+          {...dataProps}
+          {...htmlProps} 
+          className={classes}
       >
         {variant == "checkbox" && (
           <>
             <Checkbox
-              checked={checkedState}
-              id={id}
-              name={name}
-              onChange={handleChecked}
-              // eslint suppressor, text is needed to display on screen
-              //@ts-ignore
-              text={label || (text && false)}
-              type="checkbox"
-              value={value}
-              {...props}
+                checked={checkedState}
+                id={id}
+                name={name}
+                onChange={handleChecked}
+                // eslint suppressor, text is needed to display on screen
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                //@ts-ignore
+                text={label || (text && false)}
+                type="checkbox"
+                value={value}
+                {...props}
             />
             {children}
           </>
@@ -90,16 +96,17 @@ const SelectableListItem = ({
         {variant == "radio" && (
           <>
             <Radio
-              defaultChecked={defaultChecked}
-              id={id}
-              label={label}
-              name={name}
-              onChange={onChange}
-              //@ts-ignore
-              text={label}
-              type="radio"
-              value={value}
-              {...props}
+                defaultChecked={defaultChecked}
+                id={id}
+                label={label}
+                name={name}
+                onChange={onChange}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                //@ts-ignore
+                text={label}
+                type="radio"
+                value={value}
+                {...props}
             />
             {children}
           </>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
@@ -14,6 +14,7 @@ type SelectableListProps = {
   children?: React.ReactElement[],
   className?: string,
   data?: GenericObject,
+  draggable?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   variant?: 'checkbox' | 'radio',
@@ -25,6 +26,7 @@ const SelectableList = (props: SelectableListProps) => {
     children,
     className,
     data = {},
+    draggable = false,
     htmlOptions = {},
     id,
   } = props
@@ -66,7 +68,9 @@ const SelectableList = (props: SelectableListProps) => {
         className={classes}
         id={id}
     >
-      <List variant={props.variant}>
+      <List draggable={draggable}
+          variant={props.variant}
+      >
         {selectableListItems}
       </List>
     </div>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Ticket](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-328)

✅ Make `<Draggable>` optional for kit to work for fewer nesting requirements
✅ Drag handle styling for Drag Item
✅ dragHandle should be able to be turned off if needed
✅ dragHandle inside specific kits
✅ Build our prop enabled dragging for following kits with Draggable under the hood:
    ✅ List
    ✅ SelectableList
✅ Separate code into proper folder structure and finalize all prop names after feedback from V1.

**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2024-06-06 at 9 15 53 AM](https://github.com/powerhome/playbook/assets/73710701/407e9c09-ad3b-4e17-80b1-4dfbd5159fcf)

![Screenshot 2024-06-06 at 9 15 58 AM](https://github.com/powerhome/playbook/assets/73710701/d21eb3a8-3504-43b7-a4da-1ec2fc71981c)
