### PR TITLE
[PLAY-1361] Fix kit props in Docs Circle Chart

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
@@ -26,6 +26,7 @@ type CircleChartProps = {
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
   innerSize?: "sm" | "md" | "lg" | "none";
+  itemToMove?: HTMLElement;
   legend?: boolean;
   maxPointSize?: number;
   minPointSize?: number;
@@ -44,16 +45,18 @@ type CircleChartProps = {
   borderWidth?: number;
 };
 
-// Adjust Circle Chart Block Kit Dimensions to Match the Chart for Centering
 const alignBlockElement = (event: any) => {
-  const itemToMove = document.querySelector(
+  const itemToMove = document.querySelector<HTMLElement>(
     `#wrapper-circle-chart-${event.target.renderTo.id} .pb-circle-chart-block`
-  ) as HTMLElement;
+  );
   const chartContainer = document.querySelector(`#${event.target.renderTo.id}`);
-  if (itemToMove !== null) {
+
+  if (itemToMove !== null && chartContainer !== null) {
     itemToMove.style.height = `${event.target.chartHeight}px`;
     itemToMove.style.width = `${event.target.chartWidth}px`;
-    chartContainer.firstChild.before(itemToMove);
+    if (chartContainer.firstChild !== null) {
+      chartContainer.firstChild.before(itemToMove);
+    }
   }
 };
 
@@ -75,6 +78,7 @@ const CircleChart = ({
   htmlOptions = {},
   id,
   innerSize = "md",
+  itemToMove,
   legend = false,
   maxPointSize = null,
   minPointSize = null,

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
@@ -26,7 +26,6 @@ type CircleChartProps = {
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
   innerSize?: "sm" | "md" | "lg" | "none";
-  itemToMove?: HTMLElement;
   legend?: boolean;
   maxPointSize?: number;
   minPointSize?: number;
@@ -44,6 +43,8 @@ type CircleChartProps = {
   borderColor?: string;
   borderWidth?: number;
 };
+
+
 
 const alignBlockElement = (event: any) => {
   const itemToMove = document.querySelector<HTMLElement>(

--- a/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/_circle_chart.tsx
@@ -79,7 +79,6 @@ const CircleChart = ({
   htmlOptions = {},
   id,
   innerSize = "md",
-  itemToMove,
   legend = false,
   maxPointSize = null,
   minPointSize = null,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Runway https://nitro.powerhrg.com/runway/backlog_items/PLAY-1361

Change assertion of `itemToMove` to just be an `HTMLElement`

![screenshot-127 0 0 1_3000-2024 06 03-14_15_36](https://github.com/powerhome/playbook/assets/38965626/95a92a27-4f90-48a7-9f14-8aef2ae614ef)

**How to test?** Steps to confirm the desired behavior:
1. Go to https://pr3448.playbook.beta.hq.powerapp.cloud/kits/circle_chart/react
2. Look at props
3. Pary


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [😈] **TESTS** I have added test coverage to my code.