### PR TITLE
[PBNTR-326] Adding Vertical Align global prop doc

### DIFF
--- a/playbook-website/app/javascript/components/MainSidebar/MenuData/GuidelinesNavItems.ts
+++ b/playbook-website/app/javascript/components/MainSidebar/MenuData/GuidelinesNavItems.ts
@@ -12,6 +12,10 @@ export const VisualGuidelinesItems = [
         link: "/visual_guidelines/position"
     },
     {
+        name: "Vertical Align",
+        link: "/visual_guidelines/vertical_align"
+    },
+    {
         name: "Z-Index",
         link: "/visual_guidelines/z_index"
     },

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/VerticalAlign.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/VerticalAlign.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Example from "../Templates/Example"
+import { Table } from "playbook-ui"
 
 const VALUES = ["baseline", "super", "top", "middle", "bottom", "sub", "text-top", "text-bottom"]
 
@@ -16,7 +17,38 @@ const VerticalAlign = ({
         verticalAlign: VALUES,
       }}
       title='Vertical Align'
-    />
+    >
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Column 1'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row verticalAlign="middle">
+            <Table.Cell>
+              {'Value 1a'}
+              <br />
+              {'Value 1a'}
+              <br />
+              {'Value 1a'}
+            </Table.Cell>
+            <Table.Cell>{'Value 2a'}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              {'Value 1b'}
+              <br />
+              {'Value 1b'}
+              <br />
+              {'Value 1b'}
+            </Table.Cell>
+            <Table.Cell verticalAlign="bottom">{'Value 2b'}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Example>
   </>
 )
 

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/VerticalAlign.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/VerticalAlign.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import Example from "../Templates/Example"
+
+const VALUES = ["baseline", "super", "top", "middle", "bottom", "sub", "text-top", "text-bottom"]
+
+const VerticalAlign = ({
+  example,
+}: {
+  example: string,
+}) => (
+  <>
+    <Example
+      description='Specifying position can be useful for customizing page elements and layouts. The examples below demonstrate how you can apply (or override) position:'
+      example={example}
+      globalProps={{
+        verticalAlign: VALUES,
+      }}
+      title='Vertical Align'
+    />
+  </>
+)
+
+export default VerticalAlign

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/VerticalAlign.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/VerticalAlign.tsx
@@ -10,7 +10,7 @@ const VerticalAlign = ({
 }) => (
   <>
     <Example
-      description='Specifying position can be useful for customizing page elements and layouts. The examples below demonstrate how you can apply (or override) position:'
+      description='Vertical alignment is an important aspect of layout, particularly for inline text and table cells, where Flex Box support can be limited. Our global prop allows you to quickly apply vertical alignment when and where you need it.'
       example={example}
       globalProps={{
         verticalAlign: VALUES,

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -20,6 +20,7 @@ import Hover from "../VisualGuidelines/Examples/Hover";
 import TextAlign from "../VisualGuidelines/Examples/TextAlign";
 import Overflow from "./Examples/Overflow";
 import Truncate from "./Examples/Truncate";
+import VerticalAlign from "./Examples/VerticalAlign";
 
 const VisualGuidelines = ({
   examples,
@@ -72,6 +73,8 @@ const VisualGuidelines = ({
                    tokensExample={examples.position_token}
                    secondExample={examples.global_positioning}
                />;
+      case "vertical_align":
+        return <VerticalAlign example={examples.vertical_align_jsx}/>;
       case "hover":
         return <Hover example={examples.hover_jsx}/>;
       case "text_align":

--- a/playbook-website/app/views/pages/code_snippets/vertical_align_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/vertical_align_jsx.txt
@@ -1,0 +1,1 @@
+<Pill text="example" position="absolute" />

--- a/playbook-website/app/views/pages/code_snippets/vertical_align_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/vertical_align_jsx.txt
@@ -6,7 +6,7 @@
     </Table.Row>
     </Table.Head>
     <Table.Body>
-    <Table.Row>
+    <Table.Row verticalAlign="middle">
         <Table.Cell>
         {'Value 1a'}
         <br />
@@ -16,7 +16,7 @@
         </Table.Cell>
         <Table.Cell>{'Value 2a'}</Table.Cell>
     </Table.Row>
-    <Table.Row verticalAlign="middle">
+    <Table.Row>
         <Table.Cell>
         {'Value 1b'}
         <br />
@@ -24,17 +24,7 @@
         <br />
         {'Value 1b'}
         </Table.Cell>
-        <Table.Cell>{'Value 2b'}</Table.Cell>
-    </Table.Row>
-    <Table.Row verticalAlign="bottom">
-        <Table.Cell>
-        {'Value 1c'}
-        <br />
-        {'Value 1c'}
-        <br />
-        {'Value 1c'}
-        </Table.Cell>
-        <Table.Cell>{'Value 2c'}</Table.Cell>
+        <Table.Cell verticalAlign="bottom">{'Value 2b'}</Table.Cell>
     </Table.Row>
     </Table.Body>
 </Table>

--- a/playbook-website/app/views/pages/code_snippets/vertical_align_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/vertical_align_jsx.txt
@@ -1,1 +1,40 @@
-<Pill text="example" position="absolute" />
+<Table>
+    <Table.Head>
+    <Table.Row>
+        <Table.Header>{'Column 1'}</Table.Header>
+        <Table.Header>{'Column 2'}</Table.Header>
+    </Table.Row>
+    </Table.Head>
+    <Table.Body>
+    <Table.Row>
+        <Table.Cell>
+        {'Value 1a'}
+        <br />
+        {'Value 1a'}
+        <br />
+        {'Value 1a'}
+        </Table.Cell>
+        <Table.Cell>{'Value 2a'}</Table.Cell>
+    </Table.Row>
+    <Table.Row verticalAlign="middle">
+        <Table.Cell>
+        {'Value 1b'}
+        <br />
+        {'Value 1b'}
+        <br />
+        {'Value 1b'}
+        </Table.Cell>
+        <Table.Cell>{'Value 2b'}</Table.Cell>
+    </Table.Row>
+    <Table.Row verticalAlign="bottom">
+        <Table.Cell>
+        {'Value 1c'}
+        <br />
+        {'Value 1c'}
+        <br />
+        {'Value 1c'}
+        </Table.Cell>
+        <Table.Cell>{'Value 2c'}</Table.Cell>
+    </Table.Row>
+    </Table.Body>
+</Table>


### PR DESCRIPTION
**What does this PR do?**
Adding Vertical Align global prop doc.

**Screenshots:**
<img width="1222" alt="image" src="https://github.com/powerhome/playbook/assets/2573205/32343650-7b2f-49f8-baa7-28dc190dc553">

**How to test?**
1. Go to /visual_guidelines/vertical_align page.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.