### PR TITLE
[PBNTR-312] Table_header flex removal

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_alignment_column_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_alignment_column_rails.html.erb
@@ -1,34 +1,33 @@
-<%= pb_rails("table") do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th align="center">Rating</th>
-      <th align="right">Money</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td align="center">3</td>
-      <td align="right">$57.32</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td align="center">2</td>
-      <td align="right">$5,657.08</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td align="center">4</td>
-      <td align="right">$358.77</td>
-    </tr>
-  </tbody>
+<%= pb_rails("table") do %>  <%= pb_rails("table/table_head") do %>
+      <%= pb_rails("table/table_row") do %>
+          <%= pb_rails("table/table_header", props: { text: "Column 1"}) %>
+          <%= pb_rails("table/table_header", props: { text: "Column 2"}) %>
+          <%= pb_rails("table/table_header", props: { text: "Column 3"}) %>
+          <%= pb_rails("table/table_header", props: { text: "Rating", text_align: "center" }) %>
+          <%= pb_rails("table/table_header", props: { text: "Money", text_align: "right" }) %>
+       <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+      <%= pb_rails("table/table_row") do %>
+          <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+          <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+          <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+          <%= pb_rails("table/table_cell", props: { text: "3", text_align: "center" }) %>
+          <%= pb_rails("table/table_cell", props: { text: "$57.32", text_align: "right" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+        <%= pb_rails("table/table_cell", props: { text: "2", text_align: "center" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "$5,657.08", text_align: "right" }) %>
+    <% end %>
+      <%= pb_rails("table/table_row") do %>
+          <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+          <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+          <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+          <%= pb_rails("table/table_cell", props: { text: "4", text_align: "center" }) %>
+          <%= pb_rails("table/table_cell", props: { text: "$358.77", text_align: "right" }) %>
+      <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
@@ -7,9 +7,7 @@
       id: "pb-th#{object.id}",
       **combined_html_options) do %>
     <% unless sorting_style? %>
-      <%= pb_rails("flex", props:{ align: object.align_content, justify: object.justify_sort_icon, classname: "pb_th_nolink" }) do %>
         <%= content.presence || object.text %>
-      <% end %>
     <% else %>
       <%= link_to next_link, style: link_style do %>
         <%= pb_rails("flex", props:{ align: object.align_content, justify: object.justify_sort_icon, classname: "pb_th_link" }) do %>


### PR DESCRIPTION
[PBNTR-312](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-312)

This PR removed the Flex wrapper when there is no `sorting_style`. Since there is no `sorting_style`, there shouldn't be a need for a flex.

![Screenshot 2024-06-05 at 2 35 26 PM](https://github.com/powerhome/playbook/assets/92755007/59ccc067-a61f-4ec5-ba04-78b3d75a0296)


**How to test?** Steps to confirm the desired behavior:
1. Go to the rails Table kit and confirm styling is still correct.  Especially `/kits/table/rails#table-header-11`
2. Check the Table Sorts on the [Alpha](https://pr40246.nitro-web.beta.px.powerapp.cloud/sales/reps?redirect_fallback=/sales/reps)


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.