### PR TITLE
[PBNTR-335] add border width prop to circle chart

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_circle_chart/circle_chart.rb
+++ b/playbook/app/pb_kits/playbook/pb_circle_chart/circle_chart.rb
@@ -6,6 +6,7 @@ module Playbook
       prop :align, type: Playbook::Props::Enum,
                    values: %w[left right center],
                    default: "center"
+      prop :border_width, type: Playbook::Props::Numeric
       prop :chart_data, type: Playbook::Props::Array,
                         default: []
       prop :custom_options, default: {}
@@ -44,6 +45,7 @@ module Playbook
       def standard_options
         {
           align: align,
+          borderWidth: border_width,
           id: id,
           colors: colors,
           chartData: chart_data,


### PR DESCRIPTION
This PR adds `border_width` prop the the rails circle chart so it matches the React side.

[PBNTR-335](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-335)


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.