### PR TITLE
[PLAY-1330] Fix Kit Generator in Playbook

### DIFF
--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -120,19 +120,19 @@ module ApplicationHelper
   end
 
   def all_active(controller_name, action_name)
-    (controller_name == "pages" && action_name == "kits")
+    controller_name == "pages" && action_name == "kits"
   end
 
   def category_active(category, link)
-    (!category.nil? && category == nav_hash_category(link))
+    !category.nil? && category == nav_hash_category(link)
   end
 
   def kit_active(kit, link)
-    (!kit.nil? && kit == link)
+    !kit.nil? && kit == link
   end
 
   def sub_category_active(kit, link)
-    (!kit.nil? && @kit == link)
+    !kit.nil? && @kit == link
   end
 
   def format_search_hash(kit)
@@ -154,13 +154,7 @@ module ApplicationHelper
       # Modify this line to include both name and status in the components array
       components = kit["components"].map { |c| { name: c["name"], status: c["status"] } }
 
-      all_kits << if components.size == 1
-                    # For a single-component kit, return the component with its status
-                    components.first
-                  else
-                    # For multi-component kits, return the kit name with the components including their statuses
-                    { kit_name => components }
-                  end
+      all_kits << { kit_name => components }
     end
 
     all_kits

--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -468,4 +468,4 @@ kits:
       - name: "user"
         platforms: *web
         description: This kit was created for having a systematic way of displaying users with avatar, titles, name and territory. This is a versatile kit with features than can be added to display more info.
-        status: "stable"  
+        status: "stable"

--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -468,3 +468,4 @@ kits:
       - name: "user"
         platforms: *web
         description: This kit was created for having a systematic way of displaying users with avatar, titles, name and territory. This is a versatile kit with features than can be added to display more info.
+        status: "stable"  

--- a/playbook/lib/generators/kit/kit_generator.rb
+++ b/playbook/lib/generators/kit/kit_generator.rb
@@ -120,6 +120,7 @@ class KitGenerator < Rails::Generators::NamedBase
         f.puts "    components:"
         f.puts "      - name: #{@kit_name_underscore}"
         f.puts "        platforms: *#{platforms}"
+        f.puts "        status: \"beta\""
       end
 
       say_status  "complete",

--- a/playbook/lib/generators/kit/kit_generator.rb
+++ b/playbook/lib/generators/kit/kit_generator.rb
@@ -120,7 +120,6 @@ class KitGenerator < Rails::Generators::NamedBase
         f.puts "    components:"
         f.puts "      - name: #{@kit_name_underscore}"
         f.puts "        platforms: *#{platforms}"
-        f.puts "        status: \"beta\""
       end
 
       say_status  "complete",

--- a/playbook/lib/generators/kit/templates/kit_example_react.erb.tt
+++ b/playbook/lib/generators/kit/templates/kit_example_react.erb.tt
@@ -1,10 +1,10 @@
 import React from 'react'
-import <%= @kit_name_pascal %> from '../_<%= @kit_name_pascal %>'
+import { <%= @kit_name_pascal %> } from '../../'
 
 const <%= @kit_name_pascal %>Default = (props) => (
   <div>
     <<%= @kit_name_pascal %>
-      {...props}
+        {...props}
     />
   </div>
 )

--- a/playbook/lib/generators/kit/templates/kit_html.erb.tt
+++ b/playbook/lib/generators/kit/templates/kit_html.erb.tt
@@ -1,5 +1,5 @@
-# Go to pb_content_tag definition in kit_base.rb for usage information. Commented out options are default (showing the default shape), and each can be deleted if not customizing that param. 
-# If using nonstandard params please un-comment out and replace with your custom params.
+<%# Go to pb_content_tag definition in kit_base.rb for usage information. Commented out options are default (showing the default shape), and each can be deleted if not customizing that param. %>
+<%# If using nonstandard params please un-comment out and replace with your custom params. %>
 <%%= pb_content_tag(
     # :div,
     # aria: object.aria,

--- a/playbook/lib/generators/kit/templates/kit_html.erb.tt
+++ b/playbook/lib/generators/kit/templates/kit_html.erb.tt
@@ -1,5 +1,5 @@
-<%# Go to pb_content_tag definition in kit_base.rb for usage information. Commented out options are default (showing the default shape), and each can be deleted if not customizing that param. %>
-<%# If using nonstandard params please un-comment out and replace with your custom params. %>
+<!-- Go to pb_content_tag definition in kit_base.rb for usage information. Commented out options are default (showing the default shape), and each can be deleted if not customizing that param. -->
+<!-- If using nonstandard params please un-comment out and replace with your custom params. -->
 <%%= pb_content_tag(
     # :div,
     # aria: object.aria,

--- a/playbook/lib/generators/kit/templates/kit_html.erb.tt
+++ b/playbook/lib/generators/kit/templates/kit_html.erb.tt
@@ -1,8 +1,12 @@
-<%%= pb_content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+# Go to pb_content_tag definition in kit_base.rb for usage information. Commented out options are default (showing the default shape), and each can be deleted if not customizing that param. 
+# If using nonstandard params please un-comment out and replace with your custom params.
+<%%= pb_content_tag(
+    # :div,
+    # aria: object.aria,
+    # class: object.classname,
+    # data: object.data,
+    # id: object.id,
+    # **combined_html_options
+) do %>
   <span><%= @kit_name_uppercase %> CONTENT</span>
 <%% end %>

--- a/playbook/lib/generators/kit/templates/kit_html.erb.tt
+++ b/playbook/lib/generators/kit/templates/kit_html.erb.tt
@@ -1,4 +1,4 @@
-<%%= content_tag(:div,
+<%%= pb_content_tag(:div,
     aria: object.aria,
     class: object.classname,
     data: object.data,

--- a/playbook/lib/generators/kit/templates/kit_jsx_test.erb.tt
+++ b/playbook/lib/generators/kit/templates/kit_jsx_test.erb.tt
@@ -15,3 +15,7 @@ test('generated scaffold test - update me', () => {
   const kit = renderKit(<%= @kit_name_pascal %> , props)
   expect(kit).toBeInTheDocument()
 })
+
+it("should be accessible", async () => {
+  ensureAccessible(<%= @kit_name_pascal %>, props)
+})

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -82,6 +82,25 @@ module Playbook
       default_html_options.merge(html_options.deep_merge(data_attributes))
     end
 
+    # rubocop:disable Layout/CommentIndentation
+    # pb_content_tag information (potentially to be abstracted into its own dev doc in the future)
+    # The pb_content_tag generates HTML content tags for rails kits with flexible options.
+    # Modify a generated kit.html.erb file accordingly (the default_options listed below no longer need to be explictly outlined in that file, only modifications).
+    # name - the first argument is for HTML tag. The default is :div.
+    # content_or_options_with_block - additional content or options for the tag (i.e., the customizations a dev adds to kit.html.erb).
+    # options - Within combined_options, the empty options hash allows for customizations to
+        # merge with the default_options and combined_html_options.
+    # escape - set to true, this allows for HTML-escape.
+    # block - an optional block for content inside the tag.
+    # The return is a HTML tag that includes any provided customizations. If nothing is specified in kit.html.erb, the default shape is:
+        # :div,
+        # aria: object.aria,
+        # class: object.classname,
+        # data: object.data,
+        # id: object.id,
+        # **combined_html_options
+    # rubocop:enable Layout/CommentIndentation
+
     # rubocop:disable Style/OptionalBooleanParameter
     def pb_content_tag(name = :div, content_or_options_with_block = {}, options = {}, escape = true, &block)
       combined_options = options


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1330](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1330) and this [issue-documentation gist](https://gist.github.com/nidaqg/4519e2f383bf9d5700bd0af71e6f64ac) request a few fixes and a documentation update so the kit generator can function again. 

**Description + Screenshots:** 
- It is now possible to have a sidebar subcategory with only one component in it. The page will load without erroring out. This works whether or not the sole kit is of status beta or stable (there are follow up tickets in place to address beta adding beta status by default and the fact that beta kits show without warning in the kit_category page). 
<img width="731" alt="FOR PR one category one component and react default imports" src="https://github.com/powerhome/playbook/assets/83474365/e58db71a-0b87-49a9-9cfd-0dcb89cad86a">

- It is ideal to leave a blank line at the end of `menu.yml` so that the next generated kit appears on a new line. If there is no blank line, the first line related to the new kit may appear at the end of the last line regarding the old kit and just requires an adjustment to a new line (or cut+paste to it’s intended section in the `menu.yml` file as per current Generating a Kit wiki instructions).
<img width="300" alt="FOR PR menuyml" src="https://github.com/powerhome/playbook/assets/83474365/6a08ea44-b9ee-4108-bb1a-d989798c2a1b">

- Default react doc example `my_kit_default.tsx` has updated imports so the doc example loads from the base react file `my_kit.tsx` without error and spacing been updated to address linting error. (1st screenshot above demonstrates this, see "test default kit example imports working as expected").

- An example ‘ensureAccessible’ test is provided the `my_kit.jest.jsx` file to address the linting error from defining it but never using it (test can just be deleted from scaffold if not going to be used). 

- `pb_content_tag` has been added to rails kit generation and  a commented out note regarding pb_content_tag usage will now appear in the generated `my_kit.html.erb` file. A lengthier note has been added to `kit_base.rb` above where `pb_content_tag` is defined with more detailed instructions about it. 
<img width="1265" alt="FOR PR commented out pb content tag stuff does not show on website" src="https://github.com/powerhome/playbook/assets/83474365/73c8d74f-af41-4762-8793-b9045cd4e432">

- Updated Generating-a-Kit wiki - this wiki is very out of date and does not include recent updates to kit generator change to type flags and addition of swift kit. Right now my proposed changes are [here](https://gist.github.com/ElisaShapiro/922d47e7518971e49ff1014e5c1fcc36). I might also suggest including this info in the [Huddle Dev Docs](https://huddle.powerapp.cloud/v2/projects/419/artifacts) section.


**How to test?** Steps to confirm the desired behavior:
1. Download PR/ run branch locally
2. Make sure you are in `playbook/playbook` folder and follow updated wiki instructions on how to generate kits with type flags, and generate some test kits.
3. After kit generation, check that the edits to edited files and the newly generated files match what we expect as per the Wiki for each kit type.
4. Run `yarn start-dev` and ensure playbook and the new test kit pages (/kits page, /kit_category page, all kits page) load without error. Test different `menu.yml` page configurations as well (nesting a newly created kit under a pre-existing category, for example) - just remember to stop and restart the server every time that file is changed in order to see changes on localhost.

**Future Steps:**
- [Beta kit status](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1392) - add as default to any newly generated kit or add ability to make beta with a status flag.

- [Category kit flag](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1391) - assign category to newly generated kit validating against current categories in order to sort newly generated kits into an existing category. Not to be used as method to create new categories. 

- Prop generation via kit generator - currently, --props flag works for React kit only. This is despite outdated Wiki which states works for Rails kits only. I found [this PR](https://github.com/powerhome/playbook/pull/194) from 2019 adding props functionality to React kits; and I’m not positive but I think maybe [this PR]( https://github.com/powerhome/playbook/pull/1369) from 2021 broke the props functionality in Rails kits. Nida said using the props flag is not part of her typical kit generation flow so I propose abstracting this into a third follow up story so the more pertinent fixes can go through.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code~~