### PR TITLE
[PLAY-1274] Website: Allow Type-Specific Kit Doc Description Markdown

### DIFF
--- a/playbook-website/app/components/playbook/pb_docs/kit_example.rb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.rb
@@ -67,9 +67,32 @@ module Playbook
         stringified_code.gsub(" {...props}", "")
       end
 
-      def read_kit_file(folder, *args)
-        path = ::Playbook.kit_path(kit, folder, *args)
-        path.exist? ? path.read : ""
+      def read_kit_file(folder, file_name)
+        # puts *args.inspect
+        # byebug
+        # path = ::Playbook.kit_path(kit, folder, *args)
+        # path.exist? ? path.read : ""
+        name_array = file_name.split(".")
+        if name_array[1] != "md"
+          path = ::Playbook.kit_path(kit, folder, file_name)
+          path.exist? ? path.read : ""
+        else
+          puts file_name
+          path = ::Playbook.kit_path(kit, folder, file_name)
+          if path.exist?
+            path.read
+          elsif type == "rails"
+            name_array[0] += "_rails"
+            file_name = name_array.join(".")
+            path = ::Playbook.kit_path(kit, folder, file_name)
+            path.exist? ? path.read : ""
+          elsif type == "react"
+            name_array[0] += "_react"
+            file_name = name_array.join(".")
+            path = ::Playbook.kit_path(kit, folder, file_name)
+            path.exist? ? path.read : ""
+          end
+        end
       end
     end
   end

--- a/playbook-website/app/components/playbook/pb_docs/kit_example.rb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.rb
@@ -68,30 +68,23 @@ module Playbook
       end
 
       def read_kit_file(folder, file_name)
-        # puts *args.inspect
-        # byebug
-        # path = ::Playbook.kit_path(kit, folder, *args)
-        # path.exist? ? path.read : ""
         name_array = file_name.split(".")
+        path = ::Playbook.kit_path(kit, folder, file_name)
         if name_array[1] != "md"
-          path = ::Playbook.kit_path(kit, folder, file_name)
-          path.exist? ? path.read : ""
+          (path.exist? ? path.read : "")
         else
-          puts file_name
-          path = ::Playbook.kit_path(kit, folder, file_name)
           if path.exist?
             path.read
           elsif type == "rails"
             name_array[0] += "_rails"
             file_name = name_array.join(".")
             path = ::Playbook.kit_path(kit, folder, file_name)
-            path.exist? ? path.read : ""
           elsif type == "react"
             name_array[0] += "_react"
             file_name = name_array.join(".")
             path = ::Playbook.kit_path(kit, folder, file_name)
-            path.exist? ? path.read : ""
           end
+          (path.exist? ? path.read : "")
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1274](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1274) looks to update the way playbook parses the markdown files and example files of kit examples in order to streamline naming conventions in order to account for differences between Rails and React versions. This PR adds logic to the `read_kit_file` that displays the markdown description files based on file type. I have tested it against our current file naming conventions and with a trial of our idealized future naming conventions as outlined in the runway ticket - I will go into the specifics of the naming conventions as well below in the screenshot section. 

 _**NOTE:**_
This PR makes changes in `playbook-website/app/components/playbook/pb_docs/kit_example.rb`, which is "in control" of setting kit descriptions locally. This module is duplicated in a few places in the codebase and this behavior may change after [this PR](https://github.com/powerhome/playbook/pull/3465) gets merged. I expect the same code used here but in the remaining `kit_example.rb` file will function the same there, but will definitely retest all my findings outlined below once it is changed.

**Screenshots:** Screenshots to visualize your addition/change
The screenshots below demonstrate a side-by-side test using Tooltip to demonstrate how these changes preserve current markdown differentiation (see Tooltip Show Tooltip) and permit changes to the file naming conventions that match the idealized path outlined in the runway ticket. (see Tooltip Default). 

Locally, I tested several kits with different markdown conventions but did not take screenshots/write out the testing plans for each of those. Notably, I used date_picker_quick_pick to test a page with _rails.md and _react.md files already in place and table with sub components which has _rails suffixes indicating specificity and the unsuffixed versions default to react.

Tooltip Show Tooltip file naming setup:
Rails markdown: `_tooltip_show_tooltip.md`
Rails example: `_tooltip_show_tooltip.html.erb`
React markdown: `_tooltip_show_tooltip_react.md`
React example: `_tooltip_show_tooltip_react.jsx`
example.yml: rails: tooltip_show_tooltip; react: tooltip_show_tooltip_react
index.js (react only): `export { default as TooltipShowTooltipReact } from './_tooltip_show_tooltip_react'`

Tooltip Default file naming setup:
Rails markdown: `_tooltip_default_rails.md` (for screenshot 2; in screenshot 1 this file is not present)
Rails example: `_tooltip_default.html.erb`
React markdown: `_tooltip_default_react.md`
React example: `_tooltip_default.jsx`
example.yml: rails: tooltip_default; react: tooltip_default
index.js (react only): `export { default as TooltipDefault } from './_tooltip_default'`

Screenshot 1: Rails kit examples. There is no markdown file for default example present (and the kit loads fine without it) and the correct markdown description for show tooltip appears.
<img width="1635" alt="FOR PR rails tooltip old and new and no md file" src="https://github.com/powerhome/playbook/assets/83474365/79cf9174-cda3-4d93-9d28-8b2aa4a7da32">
Screenshot 2: Rails kit examples. There is a markdown file for default example present and appears, and again the correct markdown description for show tooltip appears.
<img width="1635" alt="FOR PR rails tooltip old and new rails md on both" src="https://github.com/powerhome/playbook/assets/83474365/a55ef491-417a-4934-adff-49f2a237c65d">
Screenshot 3: React kit examples. There are markdown files for both tooltip default and show tooltip, and the correct markdown description for each appears (different text than in rails screenshots above).
<img width="1638" alt="FOR PR react tooltip old and new" src="https://github.com/powerhome/playbook/assets/83474365/d3883031-4d4a-484c-a4cc-e7319bc8d3da">


**How to test?** Steps to confirm the desired behavior:
1. To test correct description behavior for kits that have divergent markdown under our current naming conventions, go to any of those kits in the milano review environment.
2. Click on the rails kit page and go to the specific kit example/description; read and acknowledge rails-specific content.
3. Click on the react kit page and go to the specific kit example/description; read and acknowledge react-specific content.

1. To trial new naming convention option as I did with Tooltip Default in the examples above, pull down this branch locally.
2. Identify your test file and alter the doc examples to match the idealized file naming (rails: my_kit.html.erb and my_kit_rails.md; react: my_kit.jsx and my_kit_react.md). Adjust example.yml to match the kit names (no _rails or _react suffixes) and correct the name of the import in the kit's index.js file if changed (from my_kit_react.jsx to my_kit).
3. Spin up local environment and visualize different markdown content for each kit type. Also works if you delete one of the markdown files entirely (ex. my_kit_rails.md exists and appears, but my_kit_react.md does not exist and the react kit example just has no description text).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~