### PR TITLE
[PBNTR-345] Draggable v4 (Beta)

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/_card.tsx
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.tsx
@@ -20,6 +20,7 @@ type CardPropTypes = {
   children: React.ReactChild[] | React.ReactChild | number,
   className?: string,
   data?: {[key: string]: string},
+  dragId?: string,
   draggableItem?: boolean,
   dragHandle?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
@@ -85,11 +86,11 @@ const Card = (props: CardPropTypes): React.ReactElement => {
     children,
     className,
     data = {},
+    dragId,
     dragHandle = true,
     draggableItem = false,
     highlight = {},
     htmlOptions = {},
-    id,
     selected = false,
     tag = 'div',
   } = props
@@ -126,8 +127,8 @@ const Card = (props: CardPropTypes): React.ReactElement => {
     <>
     {
       draggableItem ? (
-        <Draggable.Item id={id} 
-            key={id}
+        <Draggable.Item dragId={dragId} 
+            key={dragId}
         >
         <Tag
             {...ariaProps}

--- a/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
+++ b/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
@@ -4,9 +4,6 @@
   .is_dragging {
     opacity: 40%;
   }
-  .active {
-    opacity: 60%;
-  }
   .pb_draggable_item:hover {
     cursor: grab;
   }

--- a/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
+++ b/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
@@ -1,10 +1,9 @@
 @import "../tokens/colors";
 
-.pb_draggable_container {
-  .is_dragging {
-    opacity: 40%;
-  }
-  .pb_draggable_item:hover {
-    cursor: grab;
-  }
+.pb_draggable_item.is_dragging {
+  opacity: 40% !important;
+}
+
+.pb_draggable_item:hover {
+  cursor: grab;
 }

--- a/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
+++ b/playbook/app/pb_kits/playbook/pb_draggable/_draggable.scss
@@ -1,9 +1,11 @@
 @import "../tokens/colors";
+@import "../tokens/opacity";
 
-.pb_draggable_item.is_dragging {
-  opacity: 40% !important;
-}
-
-.pb_draggable_item:hover {
-  cursor: grab;
+.pb_draggable_container {
+  .is_dragging {
+    opacity: $opacity_4;
+  }
+  .pb_draggable_item:hover {
+    cursor: grab;
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_draggable/context/types.ts
+++ b/playbook/app/pb_kits/playbook/pb_draggable/context/types.ts
@@ -1,0 +1,26 @@
+export interface ItemType {
+    id: string;
+    container: string;
+    [key: string]: any;
+  }
+  
+  export interface InitialStateType {
+    items: ItemType[];
+    dragData: { id: string; initialGroup: string };
+    isDragging: string;
+    activeContainer: string;
+  }
+  
+  export type ActionType =
+    | { type: 'SET_ITEMS'; payload: ItemType[] }
+    | { type: 'SET_DRAG_DATA'; payload: { id: string; initialGroup: string } }
+    | { type: 'SET_IS_DRAGGING'; payload: string }
+    | { type: 'SET_ACTIVE_CONTAINER'; payload: string }
+    | { type: 'CHANGE_CATEGORY'; payload: { itemId: string; container: string } }
+    | { type: 'REORDER_ITEMS'; payload: { dragId: string; targetId: string } };
+
+    export interface DraggableProviderType {
+      children: React.ReactNode;
+      initialItems: ItemType[];
+      onReorder: (items: ItemType[]) => void;
+    }

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
@@ -39,6 +39,7 @@ const DraggableDefault = (props) => {
                     label={text} 
                     name={id} 
                     value={id} 
+                    {...props}
                 />
               </Draggable.Item>
             ))}

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.jsx
@@ -32,7 +32,7 @@ const DraggableDefault = (props) => {
         <Draggable.Container {...props}>
           <SelectableList variant="checkbox">
             {initialState.map(({ id, text }) => (
-              <Draggable.Item id={id} 
+              <Draggable.Item dragId={id} 
                   key={id}
               >
                 <SelectableList.Item

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_default.md
@@ -1,4 +1,4 @@
 To use the Draggable kit, you must use the DraggableProvider and pass in `initialItems`. The `onReorder` is a function that returns the data as it changes as items are reordered. Use this to manage state as shown.
 
 The `Draggable.Container` specifies the container within which items can be dropped.
-The `Draggable.Item` specifies the items that can be dragged and dropped. `Draggable.Item` requires `id` to be passed in as shown.
+The `Draggable.Item` specifies the items that can be dragged and dropped. `dragId` is a REQUIRED prop for Draggable.Item.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers.jsx
@@ -119,6 +119,7 @@ const DraggableMultipleContainer = (props) => {
                           <Card
                               marginBottom="sm"
                               padding="sm"
+                              {...props}
                           >
                             <Flex justify="between">
                               <FlexItem>
@@ -131,6 +132,7 @@ const DraggableMultipleContainer = (props) => {
                                   <Title paddingLeft="xs" 
                                       size={4}
                                       text={title}
+                                      {...props}
                                   />
                                 </Flex>
                               </FlexItem>
@@ -139,10 +141,12 @@ const DraggableMultipleContainer = (props) => {
                                   rounded
                                   text={badgeProperties(container).text}
                                   variant={badgeProperties(container).color}
+                                  {...props}
                               />
                             </Flex>
                             <Body paddingTop="xs"
                                 text={description} 
+                                {...props}
                             />
                           </Card>
                         </Draggable.Item>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers.jsx
@@ -113,7 +113,7 @@ const DraggableMultipleContainer = (props) => {
                       }) => (
                         <Draggable.Item 
                             container={container}
-                            id={id} 
+                            dragId={id} 
                             key={id}
                         >
                           <Card

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.jsx
@@ -43,22 +43,26 @@ const DraggableWithCards = (props) => {
                   key={id}
                   marginBottom="xs"
                   padding="xs"
+                  {...props}
               >
                 <Flex alignItems="stretch" 
                     flexDirection="column"
                 >
                   <Flex gap="xs">
                     <Title size={4} 
-                        text={text} 
+                        text={text}
+                        {...props} 
                     />
                     <Badge 
                         text="35-12345" 
                         variant="primary" 
+                        {...props}
                     />
                   </Flex>
                       <Caption 
                           size="xs" 
                           text="8:00A • Township Name • 90210" 
+                          {...props}
                       />
                   <Flex gap="xxs" 
                       spacing="between"
@@ -66,6 +70,7 @@ const DraggableWithCards = (props) => {
                     <Flex gap="xxs">
                       <Caption color="error" 
                           size="xs"
+                          {...props}
                       >
                         <Icon icon="house-circle-exclamation" />
                       </Caption>
@@ -78,14 +83,17 @@ const DraggableWithCards = (props) => {
                       <Badge rounded 
                           text="Schedule QA" 
                           variant="warning" 
+                          {...props}
                        />
                       <Badge rounded 
                           text="Flex" 
-                          variant="primary" 
+                          variant="primary"
+                          {...props} 
                       />
                       <Badge rounded 
                           text="R99" 
                           variant="primary" 
+                          {...props}
                       />
                     </Flex>
                   </Flex>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.jsx
@@ -36,10 +36,9 @@ const DraggableWithCards = (props) => {
     >
         <Draggable.Container  {...props}>
           {initialState.map(({ id, text }) => (
-              <Card
+              <Card dragId={id}
                   draggableItem
                   highlight={{ color: "primary", position: "side" }}
-                  id={id}
                   key={id}
                   marginBottom="xs"
                   padding="xs"

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards.md
@@ -1,3 +1,5 @@
-For a simplified version of the Draggable API for the Card kit, You can use the the Card kit as the Draggable Item by using the `draggableItem` prop on Card. The dragHandle is added by default but this can be opted out off by setting `dragHandle` to false on the Card kit. 
+For a simplified version of the Draggable API for the Card kit, You can use the the Card kit as the Draggable Item by using the `draggableItem` prop. The dragHandle is added by default but this can be opted out of by setting `dragHandle` to false on the Card kit. 
 
-The dev must manage state as shown and pass in id to the Card for dragging to work.
+In addition to the above `dragId` is a REQUIRED prop to be passedd to the Card kit when implementing dragging.
+
+The dev must manage state as shown.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.jsx
@@ -30,7 +30,7 @@ const DraggableWithList = (props) => {
     <DraggableProvider initialItems={data}
         onReorder={(items) => setInitialState(items)}
     >
-        <List draggable
+        <List enableDrag
             {...props}
         >
             {initialState.map(({ id, text }) => (

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.jsx
@@ -34,7 +34,7 @@ const DraggableWithList = (props) => {
             {...props}
         >
             {initialState.map(({ id, text }) => (
-                <ListItem id={id}
+                <ListItem dragId={id}
                     key={id}
                 >
                     {text}

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.md
@@ -1,1 +1,1 @@
-For a simplified version of the Draggable API for the List kit, use the DraggableProvider to wrap the List kit and use the `draggable` prop on List. The dev must manage state as shown and pass in id to the ListItem for dragging to work.
+For a simplified version of the Draggable API for the List kit, use the DraggableProvider to wrap the List kit and use the `enableDrag` prop on List. The dev must manage state as shown and pass in id to the ListItem for dragging to work.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_list.md
@@ -1,1 +1,7 @@
-For a simplified version of the Draggable API for the List kit, use the DraggableProvider to wrap the List kit and use the `enableDrag` prop on List. The dev must manage state as shown and pass in id to the ListItem for dragging to work.
+For a simplified version of the Draggable API for the List kit, use the DraggableProvider to wrap the List kit and use the `enableDrag` prop. 
+
+In addition to the above `dragId` is a REQUIRED prop to be passed to the List kit when implementing dragging.
+
+The dev must manage state as shown.
+
+The dragHandle is added by default but this can be opted out of by setting `dragHandle` to false on the List kit.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
@@ -30,15 +30,15 @@ const DraggableWithSelectableList = (props) => {
         onReorder={(items) => setInitialState(items)}
     >
           <SelectableList enableDrag
-              variant="checkbox"
+              variant="radio"
               {...props}
               >
             {initialState.map(({ id, text }) => (
                 <SelectableList.Item 
-                    id={id}
+                    dragId={id}
                     key={id}
                     label={text} 
-                    name="radio" 
+                    name="radio-test" 
                     value={id}
                     {...props}
                 />

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
@@ -39,6 +39,7 @@ const DraggableWithSelectableList = (props) => {
                     label={text} 
                     name={id} 
                     value={id}
+                    {...props}
                 />
             ))}
           </SelectableList>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.jsx
@@ -29,15 +29,16 @@ const DraggableWithSelectableList = (props) => {
     <DraggableProvider initialItems={data}
         onReorder={(items) => setInitialState(items)}
     >
-          <SelectableList draggable 
+          <SelectableList enableDrag
               variant="checkbox"
               {...props}
               >
             {initialState.map(({ id, text }) => (
-                <SelectableList.Item id={id}
+                <SelectableList.Item 
+                    id={id}
                     key={id}
                     label={text} 
-                    name={id} 
+                    name="radio" 
                     value={id}
                     {...props}
                 />

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list.md
@@ -1,0 +1,7 @@
+For a simplified version of the Draggable API for the SelectableList kit, use the DraggableProvider to wrap the SelectableList kit and use the `enableDrag` prop. 
+
+In addition to the above `dragId` is a REQUIRED prop to be passed to the SelectableList kit when implementing dragging.
+
+The dev must manage state as shown.
+
+The dragHandle is added by default but this can be opted out of by setting `dragHandle` to false on the SelectableList kit.

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
@@ -43,7 +43,7 @@ const DefaultDraggableKit = () => {
         <Draggable.Container>
           <SelectableList variant="checkbox">
             {initialState.map(({ id, text }) => (
-              <Draggable.Item id={id} 
+              <Draggable.Item dragId={id} 
                   key={id}
               >
                 <SelectableList.Item label={text} 
@@ -69,7 +69,7 @@ const DraggableKitWithList = () => {
       >
         <List enableDrag>
           {initialState.map(({ id, text }) => (
-            <ListItem id={id} 
+            <ListItem dragId={id} 
                 key={id}
             >
               {text}
@@ -92,7 +92,7 @@ const DraggableKitWithSelectableList = () => {
         <SelectableList enableDrag>
           {initialState.map(({ id, text }) => (
             <SelectableList.Item
-                id={id}
+                dragId={id}
                 key={id}
                 label={text}
                 name={id}
@@ -115,8 +115,8 @@ const DraggableKitWithCard = () => {
       >
         <Draggable.Container>
           {initialState.map(({ id, text }) => (
-            <Card draggableItem 
-                id={id} 
+            <Card dragId={id} 
+                draggableItem 
                 key={id}
             >
               {text}

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
@@ -5,8 +5,8 @@ import {
   Draggable,
   DraggableProvider,
   SelectableList,
-  // List,
-  // ListItem,
+  List,
+  ListItem,
   Card,
 } from "../";
 
@@ -59,51 +59,51 @@ const DefaultDraggableKit = () => {
   );
 };
 
-// const DraggableKitWithList = () => {
-//   const [initialState, setInitialState] = useState(data);
-//   return (
-//     <div data-testid="draggable">
-//       <DraggableProvider
-//           initialItems={data}
-//           onReorder={(items) => setInitialState(items)}
-//       >
-//         <List draggable>
-//           {initialState.map(({ id, text }) => (
-//             <ListItem id={id} 
-//                 key={id}
-//             >
-//               {text}
-//             </ListItem>
-//           ))}
-//         </List>
-//       </DraggableProvider>
-//     </div>
-//   );
-// };
+const DraggableKitWithList = () => {
+  const [initialState, setInitialState] = useState(data);
+  return (
+    <div data-testid="draggable">
+      <DraggableProvider
+          initialItems={data}
+          onReorder={(items) => setInitialState(items)}
+      >
+        <List enableDrag>
+          {initialState.map(({ id, text }) => (
+            <ListItem id={id} 
+                key={id}
+            >
+              {text}
+            </ListItem>
+          ))}
+        </List>
+      </DraggableProvider>
+    </div>
+  );
+};
 
-// const DraggableKitWithSelectableList = () => {
-//   const [initialState, setInitialState] = useState(data);
-//   return (
-//     <div data-testid="draggable">
-//       <DraggableProvider
-//           initialItems={data}
-//           onReorder={(items) => setInitialState(items)}
-//       >
-//         <SelectableList draggable>
-//           {initialState.map(({ id, text }) => (
-//             <SelectableList.Item
-//                 id={id}
-//                 key={id}
-//                 label={text}
-//                 name={id}
-//                 value={id}
-//             />
-//           ))}
-//         </SelectableList>
-//       </DraggableProvider>
-//     </div>
-//   );
-// };
+const DraggableKitWithSelectableList = () => {
+  const [initialState, setInitialState] = useState(data);
+  return (
+    <div data-testid="draggable">
+      <DraggableProvider
+          initialItems={data}
+          onReorder={(items) => setInitialState(items)}
+      >
+        <SelectableList enableDrag>
+          {initialState.map(({ id, text }) => (
+            <SelectableList.Item
+                id={id}
+                key={id}
+                label={text}
+                name={id}
+                value={id}
+            />
+          ))}
+        </SelectableList>
+      </DraggableProvider>
+    </div>
+  );
+};
 
 const DraggableKitWithCard = () => {
   const [initialState, setInitialState] = useState(data);
@@ -159,25 +159,25 @@ test("Attached draggable HTML attributes", () => {
   expect(item).toHaveAttribute("draggable");
 });
 
-// test("generated dragHandle with List", () => {
-//   render(<DraggableKitWithList />);
-//   const kit = screen.getByTestId(testId);
+test("generated dragHandle with List", () => {
+  render(<DraggableKitWithList />);
+  const kit = screen.getByTestId(testId);
 
-//   const list = kit.querySelector(".pb_list_kit");
-//   expect(list).toBeInTheDocument();
-//   const dragHandle = list.querySelector(".fa-grip-dots-vertical");
-//   expect(dragHandle).toBeInTheDocument();
-// });
+  const list = kit.querySelector(".pb_list_kit");
+  expect(list).toBeInTheDocument();
+  const dragHandle = list.querySelector(".fa-grip-dots-vertical");
+  expect(dragHandle).toBeInTheDocument();
+});
 
-// test("generated dragHandle with SelectableList", () => {
-//   render(<DraggableKitWithSelectableList />);
-//   const kit = screen.getByTestId(testId);
+test("generated dragHandle with SelectableList", () => {
+  render(<DraggableKitWithSelectableList />);
+  const kit = screen.getByTestId(testId);
 
-//   const selectabellist = kit.querySelector(".pb_selectable_list_kit");
-//   expect(selectabellist).toBeInTheDocument();
-//   const dragHandle = selectabellist.querySelector(".fa-grip-dots-vertical");
-//   expect(dragHandle).toBeInTheDocument();
-// });
+  const selectabellist = kit.querySelector(".pb_selectable_list_kit");
+  expect(selectabellist).toBeInTheDocument();
+  const dragHandle = selectabellist.querySelector(".fa-grip-dots-vertical");
+  expect(dragHandle).toBeInTheDocument();
+});
 
 test("generated dragHandle with Card", () => {
   render(<DraggableKitWithCard />);

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
@@ -5,8 +5,8 @@ import {
   Draggable,
   DraggableProvider,
   SelectableList,
-  List,
-  ListItem,
+  // List,
+  // ListItem,
   Card,
 } from "../";
 
@@ -59,51 +59,51 @@ const DefaultDraggableKit = () => {
   );
 };
 
-const DraggableKitWithList = () => {
-  const [initialState, setInitialState] = useState(data);
-  return (
-    <div data-testid="draggable">
-      <DraggableProvider
-          initialItems={data}
-          onReorder={(items) => setInitialState(items)}
-      >
-        <List draggable>
-          {initialState.map(({ id, text }) => (
-            <ListItem id={id} 
-                key={id}
-            >
-              {text}
-            </ListItem>
-          ))}
-        </List>
-      </DraggableProvider>
-    </div>
-  );
-};
+// const DraggableKitWithList = () => {
+//   const [initialState, setInitialState] = useState(data);
+//   return (
+//     <div data-testid="draggable">
+//       <DraggableProvider
+//           initialItems={data}
+//           onReorder={(items) => setInitialState(items)}
+//       >
+//         <List draggable>
+//           {initialState.map(({ id, text }) => (
+//             <ListItem id={id} 
+//                 key={id}
+//             >
+//               {text}
+//             </ListItem>
+//           ))}
+//         </List>
+//       </DraggableProvider>
+//     </div>
+//   );
+// };
 
-const DraggableKitWithSelectableList = () => {
-  const [initialState, setInitialState] = useState(data);
-  return (
-    <div data-testid="draggable">
-      <DraggableProvider
-          initialItems={data}
-          onReorder={(items) => setInitialState(items)}
-      >
-        <SelectableList draggable>
-          {initialState.map(({ id, text }) => (
-            <SelectableList.Item
-                id={id}
-                key={id}
-                label={text}
-                name={id}
-                value={id}
-            />
-          ))}
-        </SelectableList>
-      </DraggableProvider>
-    </div>
-  );
-};
+// const DraggableKitWithSelectableList = () => {
+//   const [initialState, setInitialState] = useState(data);
+//   return (
+//     <div data-testid="draggable">
+//       <DraggableProvider
+//           initialItems={data}
+//           onReorder={(items) => setInitialState(items)}
+//       >
+//         <SelectableList draggable>
+//           {initialState.map(({ id, text }) => (
+//             <SelectableList.Item
+//                 id={id}
+//                 key={id}
+//                 label={text}
+//                 name={id}
+//                 value={id}
+//             />
+//           ))}
+//         </SelectableList>
+//       </DraggableProvider>
+//     </div>
+//   );
+// };
 
 const DraggableKitWithCard = () => {
   const [initialState, setInitialState] = useState(data);
@@ -159,25 +159,25 @@ test("Attached draggable HTML attributes", () => {
   expect(item).toHaveAttribute("draggable");
 });
 
-test("generated dragHandle with List", () => {
-  render(<DraggableKitWithList />);
-  const kit = screen.getByTestId(testId);
+// test("generated dragHandle with List", () => {
+//   render(<DraggableKitWithList />);
+//   const kit = screen.getByTestId(testId);
 
-  const list = kit.querySelector(".pb_list_kit");
-  expect(list).toBeInTheDocument();
-  const dragHandle = list.querySelector(".fa-grip-dots-vertical");
-  expect(dragHandle).toBeInTheDocument();
-});
+//   const list = kit.querySelector(".pb_list_kit");
+//   expect(list).toBeInTheDocument();
+//   const dragHandle = list.querySelector(".fa-grip-dots-vertical");
+//   expect(dragHandle).toBeInTheDocument();
+// });
 
-test("generated dragHandle with SelectableList", () => {
-  render(<DraggableKitWithSelectableList />);
-  const kit = screen.getByTestId(testId);
+// test("generated dragHandle with SelectableList", () => {
+//   render(<DraggableKitWithSelectableList />);
+//   const kit = screen.getByTestId(testId);
 
-  const selectabellist = kit.querySelector(".pb_selectable_list_kit");
-  expect(selectabellist).toBeInTheDocument();
-  const dragHandle = selectabellist.querySelector(".fa-grip-dots-vertical");
-  expect(dragHandle).toBeInTheDocument();
-});
+//   const selectabellist = kit.querySelector(".pb_selectable_list_kit");
+//   expect(selectabellist).toBeInTheDocument();
+//   const dragHandle = selectabellist.querySelector(".fa-grip-dots-vertical");
+//   expect(dragHandle).toBeInTheDocument();
+// });
 
 test("generated dragHandle with Card", () => {
   render(<DraggableKitWithCard />);

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
@@ -1,9 +1,16 @@
-import React, {useState} from "react"
-import { render, screen } from "../utilities/test-utils"
+import React, { useState } from "react";
+import { render, screen } from "../utilities/test-utils";
 
-import { Draggable, DraggableProvider, SelectableList } from '../'
+import {
+  Draggable,
+  DraggableProvider,
+  SelectableList,
+  List,
+  ListItem,
+  Card,
+} from "../";
 
-const testId = 'draggable'
+const testId = "draggable";
 
 const data = [
   {
@@ -24,7 +31,6 @@ const data = [
   },
 ];
 
-
 const DefaultDraggableKit = () => {
   const [initialState, setInitialState] = useState(data);
 
@@ -33,9 +39,7 @@ const DefaultDraggableKit = () => {
         initialItems={data}
         onReorder={(items) => setInitialState(items)}
     >
-      <Draggable
-          data={{ testid: testId }}
-      >
+      <Draggable data={{ testid: testId }}>
         <Draggable.Container>
           <SelectableList variant="checkbox">
             {initialState.map(({ id, text }) => (
@@ -55,9 +59,132 @@ const DefaultDraggableKit = () => {
   );
 };
 
-test('generated default kit and classname', () => {
-render(<DefaultDraggableKit/>)
-const kit = screen.getByTestId(testId)
-expect(kit).toBeInTheDocument()
-expect(kit).toHaveClass('pb_draggable')
-})
+const DraggableKitWithList = () => {
+  const [initialState, setInitialState] = useState(data);
+  return (
+    <div data-testid="draggable">
+      <DraggableProvider
+          initialItems={data}
+          onReorder={(items) => setInitialState(items)}
+      >
+        <List draggable>
+          {initialState.map(({ id, text }) => (
+            <ListItem id={id} 
+                key={id}
+            >
+              {text}
+            </ListItem>
+          ))}
+        </List>
+      </DraggableProvider>
+    </div>
+  );
+};
+
+const DraggableKitWithSelectableList = () => {
+  const [initialState, setInitialState] = useState(data);
+  return (
+    <div data-testid="draggable">
+      <DraggableProvider
+          initialItems={data}
+          onReorder={(items) => setInitialState(items)}
+      >
+        <SelectableList draggable>
+          {initialState.map(({ id, text }) => (
+            <SelectableList.Item
+                id={id}
+                key={id}
+                label={text}
+                name={id}
+                value={id}
+            />
+          ))}
+        </SelectableList>
+      </DraggableProvider>
+    </div>
+  );
+};
+
+const DraggableKitWithCard = () => {
+  const [initialState, setInitialState] = useState(data);
+  return (
+    <div data-testid="draggable">
+      <DraggableProvider
+          initialItems={data}
+          onReorder={(items) => setInitialState(items)}
+      >
+        <Draggable.Container>
+          {initialState.map(({ id, text }) => (
+            <Card draggableItem 
+                id={id} 
+                key={id}
+            >
+              {text}
+            </Card>
+          ))}
+        </Draggable.Container>
+      </DraggableProvider>
+    </div>
+  );
+};
+
+test("generated default kit and classname", () => {
+  render(<DefaultDraggableKit />);
+  const kit = screen.getByTestId(testId);
+  expect(kit).toBeInTheDocument();
+  expect(kit).toHaveClass("pb_draggable");
+});
+
+test("generated Draggable Container", () => {
+  render(<DefaultDraggableKit />);
+  const kit = screen.getByTestId(testId);
+
+  const container = kit.querySelector(".pb_draggable_container");
+  expect(container).toBeInTheDocument();
+});
+
+test("generated Draggable Item", () => {
+  render(<DefaultDraggableKit />);
+  const kit = screen.getByTestId(testId);
+
+  const item = kit.querySelector(".pb_draggable_item");
+  expect(item).toBeInTheDocument();
+});
+
+test("Attached draggable HTML attributes", () => {
+  render(<DefaultDraggableKit />);
+  const kit = screen.getByTestId(testId);
+
+  const item = kit.querySelector(".pb_draggable_item");
+  expect(item).toHaveAttribute("draggable");
+});
+
+test("generated dragHandle with List", () => {
+  render(<DraggableKitWithList />);
+  const kit = screen.getByTestId(testId);
+
+  const list = kit.querySelector(".pb_list_kit");
+  expect(list).toBeInTheDocument();
+  const dragHandle = list.querySelector(".fa-grip-dots-vertical");
+  expect(dragHandle).toBeInTheDocument();
+});
+
+test("generated dragHandle with SelectableList", () => {
+  render(<DraggableKitWithSelectableList />);
+  const kit = screen.getByTestId(testId);
+
+  const selectabellist = kit.querySelector(".pb_selectable_list_kit");
+  expect(selectabellist).toBeInTheDocument();
+  const dragHandle = selectabellist.querySelector(".fa-grip-dots-vertical");
+  expect(dragHandle).toBeInTheDocument();
+});
+
+test("generated dragHandle with Card", () => {
+  render(<DraggableKitWithCard />);
+  const kit = screen.getByTestId(testId);
+
+  const card = kit.querySelector(".pb_card_kit_deselected_border_radius_md");
+  expect(card).toBeInTheDocument();
+  const dragHandle = card.querySelector(".fa-grip-dots-vertical");
+  expect(dragHandle).toBeInTheDocument();
+});

--- a/playbook/app/pb_kits/playbook/pb_draggable/subcomponents/DraggableItem.tsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/subcomponents/DraggableItem.tsx
@@ -17,10 +17,11 @@ type DraggableItemProps = {
   data?: { [key: string]: string };
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string;
+  dragId?: string;
 };
 
 const DraggableItem = (props: DraggableItemProps) => {
-  const { aria = {}, children, className, container, data = {}, htmlOptions = {},  id } = props;
+  const { aria = {}, children, className, container, data = {}, htmlOptions = {},  id, dragId } = props;
 
   const { isDragging, handleDragStart, handleDragEnter, handleDragEnd } =
     DraggableContext();
@@ -31,7 +32,7 @@ const DraggableItem = (props: DraggableItemProps) => {
 
   const classes = classnames(
     buildCss("pb_draggable_item"),
-    `${isDragging === id ? "is_dragging" : ""}`,
+    `${isDragging === dragId ? "is_dragging" : ""}`,
     globalProps(props),
     className
   );
@@ -44,10 +45,10 @@ const DraggableItem = (props: DraggableItemProps) => {
         className={classes}
         draggable
         id={id}
-        key={id}
+        key={dragId}
         onDragEnd={() => handleDragEnd()}
-        onDragEnter={() => handleDragEnter(id, container)}
-        onDragStart={() => handleDragStart(id, container)}
+        onDragEnter={() => handleDragEnter(dragId, container)}
+        onDragStart={() => handleDragStart(dragId, container)}
     >
       {children}
     </div>

--- a/playbook/app/pb_kits/playbook/pb_list/_list.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list.tsx
@@ -10,7 +10,7 @@ type ListProps = {
   className?: string;
   children: React.ReactNode[] | React.ReactNode;
   dark?: boolean;
-  draggable?: boolean;
+  enableDrag?: boolean;
   data?: Record<string, unknown>;
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string;
@@ -32,7 +32,7 @@ const List = (props: ListProps) => {
     className,
     dark = false,
     data = {},
-    draggable = false,
+    enableDrag = false,
     htmlOptions = {},
     id,
     layout = "",
@@ -54,7 +54,7 @@ const List = (props: ListProps) => {
   const childrenWithProps = React.Children.map(
     children,
     (child: React.ReactElement) => {
-      return React.cloneElement(child, { text, variant, draggable });
+      return React.cloneElement(child, { text, variant, enableDrag });
     }
   );
   const ariaProps = buildAriaProps(aria);
@@ -74,7 +74,7 @@ const List = (props: ListProps) => {
   return (
     <>
     {
-      draggable ? (
+      enableDrag ? (
         <Draggable.Container>
      <div className={classes}>
       {ordered ? (

--- a/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
@@ -23,7 +23,7 @@ const ListItem = (props: ListItemProps) => {
     children,
     className,
     data = {},
-    draggable = false,
+    enableDrag,
     dragHandle = true,
     htmlOptions = {},
     id,
@@ -42,8 +42,10 @@ const ListItem = (props: ListItemProps) => {
   return (
     <>
     {
-      draggable ? (
-        <Draggable.Item id={id}>
+      enableDrag ? (
+        <Draggable.Item 
+            id={id}
+        >
         <li
             {...ariaProps}
             {...dataProps}

--- a/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_list/_list_item.tsx
@@ -11,6 +11,7 @@ type ListItemProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
   data?: Record<string, unknown>,
+  dragId?: string,
   dragHandle?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
@@ -24,6 +25,7 @@ const ListItem = (props: ListItemProps) => {
     className,
     data = {},
     enableDrag,
+    dragId, 
     dragHandle = true,
     htmlOptions = {},
     id,
@@ -44,7 +46,7 @@ const ListItem = (props: ListItemProps) => {
     {
       enableDrag ? (
         <Draggable.Item 
-            id={id}
+            dragId={dragId}
         >
         <li
             {...ariaProps}

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
@@ -106,6 +106,8 @@ const SelectableListItem = ({
                 text={label}
                 type="radio"
                 value={value}
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                //@ts-ignore
                 {...domSafeProps(props)}
             />
             {children}

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import classnames from "classnames";
 
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
-import { globalProps } from "../utilities/globalProps";
+import { globalProps, domSafeProps } from "../utilities/globalProps";
 
 import Checkbox from "../pb_checkbox/_checkbox";
 import ListItem from "../pb_list/_list_item";
@@ -67,7 +67,7 @@ const SelectableListItem = ({
         {...props}
         className={classnames(checkedState ? "checked_item" : "", className)}
         dragHandle={dragHandle}
-        id={id}
+        id={variant == "checkbox" ? id : null}
     >
       <div 
           {...ariaProps} 
@@ -106,7 +106,7 @@ const SelectableListItem = ({
                 text={label}
                 type="radio"
                 value={value}
-                {...props}
+                {...domSafeProps(props)}
             />
             {children}
           </>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_item.tsx
@@ -16,6 +16,7 @@ export type SelectableListItemProps = {
   className?: string;
   data?: GenericObject;
   defaultChecked?: boolean;
+  dragId?: string;
   dragHandle?: boolean;
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
@@ -33,6 +34,7 @@ const SelectableListItem = ({
   children,
   className,
   data = {},
+  dragId,
   dragHandle = true,
   defaultChecked,
   htmlOptions = {},
@@ -67,7 +69,7 @@ const SelectableListItem = ({
         {...props}
         className={classnames(checkedState ? "checked_item" : "", className)}
         dragHandle={dragHandle}
-        id={variant == "checkbox" ? id : null}
+        dragId={dragId}
     >
       <div 
           {...ariaProps} 

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/_selectable_list.tsx
@@ -14,7 +14,7 @@ type SelectableListProps = {
   children?: React.ReactElement[],
   className?: string,
   data?: GenericObject,
-  draggable?: boolean,
+  enableDrag?: boolean,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   variant?: 'checkbox' | 'radio',
@@ -26,7 +26,7 @@ const SelectableList = (props: SelectableListProps) => {
     children,
     className,
     data = {},
-    draggable = false,
+    enableDrag = false,
     htmlOptions = {},
     id,
   } = props
@@ -68,7 +68,7 @@ const SelectableList = (props: SelectableListProps) => {
         className={classes}
         id={id}
     >
-      <List draggable={draggable}
+      <List enableDrag={enableDrag}
           variant={props.variant}
       >
         {selectableListItems}

--- a/playbook/app/pb_kits/playbook/utilities/globalProps.ts
+++ b/playbook/app/pb_kits/playbook/utilities/globalProps.ts
@@ -520,6 +520,7 @@ export const domSafeProps = (props: {[key: string]: string}): {[key: string]: st
     'paddingY',
     'padding',
     'dark',
+    'enableDrag',
   ]
   return omit(props, notSafeProps)
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBNTR-345)

This PR:
- ✅ Refactors the context to use useReducer and memoization instead of just state for performance improvement
- ✅ Adds all Jest tests
- ✅ Changes prop names based on feedback to make them easier to understand
- ✅ Fixes a bug where it was not working with variant="radio" for SelectableList. 
    - TLDR: The DraggableItem requires id to function, but this was interfering with other kits (like the Radio kit) and how it handles id. Best solution was an additional prop called `dragId` in the same way we have pickerId for the datepicker: it is a required prop but will not interfere with how different kits handle id. In the long run, this will make sure we avoid any conflicts.

**Screenshots:** 

## List kit look and API
![Screenshot 2024-06-20 at 12 36 22 PM](https://github.com/powerhome/playbook/assets/73710701/6a483982-e88d-4ac1-854a-b3b8e873d6ff)

![Screenshot 2024-06-20 at 12 36 43 PM](https://github.com/powerhome/playbook/assets/73710701/c40d64d1-c4f8-409f-a946-d0dd87da839f)

## Card kit look and API

![Screenshot 2024-06-20 at 12 37 07 PM](https://github.com/powerhome/playbook/assets/73710701/4c0ff0d4-2dcd-4456-954c-cd81214c3808)

![Screenshot 2024-06-20 at 12 37 20 PM](https://github.com/powerhome/playbook/assets/73710701/49d16aac-58a7-4884-8894-ef20fe620a1e)