### PR TITLE
[PLAY-1328] fix Timeline kit (react) not accepting global props

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_timeline/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_item.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { buildCss, buildHtmlProps } from '../utilities/props'
+import { globalProps, GlobalProps } from "../utilities/globalProps";
 
 import DateStacked from '../pb_date_stacked/_date_stacked'
 import IconCircle from '../pb_icon_circle/_icon_circle'
@@ -14,7 +15,7 @@ type ItemProps = {
   icon?: string,
   iconColor?: 'default' | 'royal' | 'blue' | 'purple' | 'teal' | 'red' | 'yellow' | 'green',
   lineStyle?: 'solid' | 'dotted',
-}
+} & GlobalProps
 
 const TimelineItem = ({
   className,
@@ -24,7 +25,7 @@ const TimelineItem = ({
   icon = 'user',
   iconColor = 'default',
   lineStyle = 'solid',
-
+  ...props
 }: ItemProps) => {
   const timelineItemCss = buildCss('pb_timeline_item_kit', lineStyle)
 
@@ -32,23 +33,23 @@ const TimelineItem = ({
 
   return (
     <div 
-      {...htmlProps}
-      className={classnames(timelineItemCss, className)}
+        {...htmlProps}
+        className={classnames(timelineItemCss, globalProps(props), className)}
     >
       <div className="pb_timeline_item_left_block">
         {date &&
           <DateStacked
-            align="center"
-            date={date}
-            size="sm"
+              align="center"
+              date={date}
+              size="sm"
           />
         }
       </div>
       <div className="pb_timeline_item_step">
         <IconCircle
-          icon={icon}
-          size="xs"
-          variant={iconColor}
+            icon={icon}
+            size="xs"
+            variant={iconColor}
         />
         <div className="pb_timeline_item_connector" />
       </div>

--- a/playbook/app/pb_kits/playbook/pb_timeline/_timeline.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_timeline.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
+import { GlobalProps, globalProps } from '../utilities/globalProps'
 
 import TimelineItem from './_item'
 
@@ -14,7 +15,7 @@ type TimelineProps = {
   id?: string,
   orientation?: string,
   showDate?: boolean,
-}
+} & GlobalProps
 
 const Timeline = ({
   aria = {},
@@ -25,6 +26,7 @@ const Timeline = ({
   id,
   orientation = 'horizontal',
   showDate = false,
+  ...props
 }: TimelineProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
@@ -33,11 +35,11 @@ const Timeline = ({
   const timelineCss = buildCss('pb_timeline_kit', `_${orientation}`, dateStyle)
   return (
     <div
-      {...ariaProps}
-      {...dataProps}
-      {...htmlProps}
-      className={classnames(timelineCss, className)}
-      id={id}
+        {...ariaProps}
+        {...dataProps}
+        {...htmlProps}
+        className={classnames(timelineCss, globalProps(props), className)}
+        id={id}
     >
       {children}
     </div>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1328](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1328) addresses a bug where Global Props are not working with the Timeline kit in React. Upon closer inspection, it appears Global Props were never imported into this kit. I have added them to the main Timeline React file as well as the Timeline Item React file. Global props now work when applied to the <Timeline /> parent component as well as any <Timeline.Item /> child component.

[CSB with issue](https://codesandbox.io/p/sandbox/elated-panka-j3cpz5)
[CSB with alpha (once alpha ready)](https://codesandbox.io/p/sandbox/play-1328-alpha-vkmgll)

**Screenshots:** Screenshots to visualize your addition/change
In screenshot below, I'm modified the Default Timeline React example to have margin and padding applied to the parent Timeline and two child TimelineItems. You can see the misalignment caused by margin and padding as well as the added m_ and p_ to the classnames in the console.
<img width="1583" alt="timeline global props kit and item" src="https://github.com/powerhome/playbook/assets/83474365/3fed1261-50f4-482f-9201-8a8246d1a62a">


**How to test?** Steps to confirm the desired behavior:
1. Go to the [CSB with alpha](https://codesandbox.io/p/sandbox/play-1328-alpha-vkmgll).
2. See how global props apply to Timeline and TimelineItem portions. 
3. Can modify CSB by adding or changing Global Props - all changes should render.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~