### PR TITLE
[PLAY-1316] Package Product Icon Exports - Test Alpha on Playbook Website

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
@@ -409,6 +409,7 @@ export default function IconList() {
             <Icon icon="circle-product-accessories" />
             <Icon icon="circle-product-attic-insulation" />
             <Icon icon="circle-product-doors" />
+            <Icon icon="circle-product-gutters" />
             <Icon icon="circle-product-roofing" />
             <Icon icon="circle-product-siding" />
             <Icon icon="circle-product-solar" />
@@ -426,7 +427,6 @@ export default function IconList() {
             <Icon icon="product-accessories" />
             <Icon icon="product-attic-insulation" />
             <Icon icon="product-doors" />
-            <Icon icon="product-gutters-1" />
             <Icon icon="product-gutters" />
             <Icon icon="product-roofing" />
             <Icon icon="product-siding" />

--- a/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
@@ -43,7 +43,7 @@ export default function IconList() {
 
   return (
     <>
-      <Hero description={"Powerhome Icons"} title={linkFormat("Playbook Icons")} />
+      {/* <Hero description={"Powerhome Icons"} title={linkFormat("Playbook Icons")} /> */}
       {/* <Flex
         justify='center'
         marginX={{ lg: "sm", xl: "sm" }}
@@ -406,55 +406,13 @@ export default function IconList() {
       >
         <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
           <Flex>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-product-accessories" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-product-attic-insulation" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-product-doors" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-product-roofing" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-product-siding" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-product-solar" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-product-windows" />
-            </Card>
+            <Icon icon="circle-product-accessories" />
+            <Icon icon="circle-product-attic-insulation" />
+            <Icon icon="circle-product-doors" />
+            <Icon icon="circle-product-roofing" />
+            <Icon icon="circle-product-siding" />
+            <Icon icon="circle-product-solar" />
+            <Icon icon="circle-product-windows" />
           </Flex>
         </FlexItem>
       </Flex>
@@ -465,69 +423,15 @@ export default function IconList() {
       >
         <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
           <Flex>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-accessories" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-attic-insulation" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-doors" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-gutters-1" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-gutters" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-roofing" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-siding" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-solar" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="product-windows" />
-            </Card>
+            <Icon icon="product-accessories" />
+            <Icon icon="product-attic-insulation" />
+            <Icon icon="product-doors" />
+            <Icon icon="product-gutters-1" />
+            <Icon icon="product-gutters" />
+            <Icon icon="product-roofing" />
+            <Icon icon="product-siding" />
+            <Icon icon="product-solar" />
+            <Icon icon="product-windows" />
           </Flex>
         </FlexItem>
       </Flex>
@@ -538,20 +442,8 @@ export default function IconList() {
       >
         <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
           <Flex>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="circle-estimate-photos" />
-            </Card>
-            <Card
-              marginRight='sm'
-              hover={{ shadow: "deeper" }}
-              cursor='pointer'
-            >
-              <Icon icon="estimate-photos" />
-            </Card>
+            <Icon icon="circle-estimate-photos" />      
+            <Icon icon="estimate-photos" />
           </Flex>
         </FlexItem>
       </Flex>

--- a/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/IconList/index.tsx
@@ -4,52 +4,52 @@ import { linkFormat } from "../../../../../utilities/website_sidebar_helper"
 
 import { Hero } from "../../components/Hero"
 import {
-  Roofing,
-  Powergon,
-  Nitro,
-  ChevronDown,
-  Times,
-  Bars,
-  Calendar,
-  Filter,
-  Edit,
-  Trash,
-  Check,
-  Plus,
-  Search
+  // Roofing,
+  // Powergon,
+  // Nitro,
+  // ChevronDown,
+  // Times,
+  // Bars,
+  // Calendar,
+  // Filter,
+  // Edit,
+  // Trash,
+  // Check,
+  // Plus,
+  // Search
 } from '@powerhome/playbook-icons-react'
 
 import { Body, Icon, Title, Flex, FlexItem, Card } from "playbook-ui"
 
-const pbIcons = {
-  roofing: Roofing,
-  nitro: Nitro,
-  powergon: Powergon,
-  chevrondown: ChevronDown,
-  times: Times,
-  bars: Bars,
-  calendar: Calendar,
-  filter: Filter,
-  edit: Edit,
-  trash: Trash,
-  check: Check,
-  plus: Plus,
-  search: Search
-}
+// const pbIcons = {
+//   roofing: Roofing,
+//   nitro: Nitro,
+//   powergon: Powergon,
+//   chevrondown: ChevronDown,
+//   times: Times,
+//   bars: Bars,
+//   calendar: Calendar,
+//   filter: Filter,
+//   edit: Edit,
+//   trash: Trash,
+//   check: Check,
+//   plus: Plus,
+//   search: Search
+// }
 
-window.PB_ICONS = pbIcons
+// window.PB_ICONS = pbIcons
 
 export default function IconList() {
 
   return (
     <>
       <Hero description={"Powerhome Icons"} title={linkFormat("Playbook Icons")} />
-      <Flex
+      {/* <Flex
         justify='center'
         marginX={{ lg: "sm", xl: "sm" }}
         paddingLeft="xs"
-      >
-        <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
+      > */}
+        {/* <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
           <Title paddingBottom="sm" size={3} tag='h3' text='Power Icons' />
         </FlexItem>
       </Flex>
@@ -383,6 +383,174 @@ export default function IconList() {
               cursor='pointer'
             >
               <Icon icon="nitro" size="3x" rotation={270}  />
+            </Card>
+          </Flex>
+        </FlexItem>
+      </Flex> */}
+
+
+      <Flex
+        justify='center'
+        marginX={{ lg: "sm", xl: "sm" }}
+        paddingLeft="xs"
+      >
+        <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
+          <Title paddingBottom="sm" paddingTop="sm" size={3} tag='h3' text='PLAY-1316 Products Batch Testing' />
+        </FlexItem>
+      </Flex>
+
+      <Flex
+        justify='center'
+        marginX={{ lg: "sm", xl: "sm" }}
+        paddingLeft="xs"
+      >
+        <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
+          <Flex>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-product-accessories" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-product-attic-insulation" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-product-doors" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-product-roofing" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-product-siding" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-product-solar" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-product-windows" />
+            </Card>
+          </Flex>
+        </FlexItem>
+      </Flex>
+      <Flex
+        justify='center'
+        marginX={{ lg: "sm", xl: "sm" }}
+        paddingLeft="xs"
+      >
+        <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
+          <Flex>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-accessories" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-attic-insulation" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-doors" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-gutters-1" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-gutters" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-roofing" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-siding" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-solar" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="product-windows" />
+            </Card>
+          </Flex>
+        </FlexItem>
+      </Flex>
+      <Flex
+        justify='center'
+        marginX={{ lg: "sm", xl: "sm" }}
+        paddingLeft="xs"
+      >
+        <FlexItem alignSelf='stretch' maxWidth='xxl' flexGrow={1}>
+          <Flex>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="circle-estimate-photos" />
+            </Card>
+            <Card
+              marginRight='sm'
+              hover={{ shadow: "deeper" }}
+              cursor='pointer'
+            >
+              <Icon icon="estimate-photos" />
             </Card>
           </Flex>
         </FlexItem>

--- a/playbook-website/app/javascript/packs/application.js
+++ b/playbook-website/app/javascript/packs/application.js
@@ -32,6 +32,19 @@ import { Turbo } from "@hotwired/turbo-rails"
 // Disable Turbo Drive by default (Turbo Drive is equivalent to Turbolinks)
 Turbo.session.drive = false
 
+// Icons from playbook-icons-react for testing PLAY-1316
+import * as icons from "@powerhome/playbook-icons-react"
+
+window.PB_ICONS = {}
+
+function pascalToKebabCase(str) {
+  return str.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
+}
+
+Object.entries(icons).forEach(([key, value]) => {
+  const iconName = pascalToKebabCase(key)
+  window.PB_ICONS[iconName] = value
+})
 
 document.addEventListener('DOMContentLoaded', () => {
   const anchors = new AnchorJS()

--- a/playbook-website/app/views/samples/icons.html.erb
+++ b/playbook-website/app/views/samples/icons.html.erb
@@ -1,118 +1,34 @@
-<%= pb_rails("flex", props: {justify: 'center'}) do %>
-  <%= pb_rails("flex/flex_item") do %>
-    <%= pb_rails("title", props: {size: 1, text: "Playbook Icons", padding_top: "sm" })%>
-  <% end %>
-<% end %>
-<%= pb_rails("flex", props: {justify: 'center'}) do %>
-  <%= pb_rails("flex/flex_item") do %>
-    <%= pb_rails("title", props: {size: 3, text: "Rails", padding_bottom: "sm"})%>
-  <% end %>
-<% end %>
-
-<%= pb_rails("flex", props: { padding_left: "md"} ) do %>
+<%= pb_rails("flex", props: { padding_left: "xl", padding_top: "xl"} ) do %>
   <%= pb_rails("flex/flex_item") do %>
     <%= pb_rails("title", props: {size: 3, text: "PLAY-1316 Products Batch Testing", padding_bottom: "sm"})%>
   <% end %>
 <% end %>
 
-<%= pb_rails("flex", props: { padding_left: "md" }) do %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-product-accessories" } ) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-product-attic-insulation" } ) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-product-doors" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-product-roofing" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-product-siding" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-product-solar" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-product-windows" }) %>
-    <% end %>
-  <% end %>
+<%= pb_rails("flex", props: { padding_left: "xl" }) do %>
+  <%= pb_rails("icon", props: { icon: "circle-product-accessories" } ) %>
+  <%= pb_rails("icon", props: { icon: "circle-product-attic-insulation" } ) %>
+  <%= pb_rails("icon", props: { icon: "circle-product-doors" }) %>
+  <%= pb_rails("icon", props: { icon: "circle-product-roofing" }) %>
+  <%= pb_rails("icon", props: { icon: "circle-product-siding" }) %>
+  <%= pb_rails("icon", props: { icon: "circle-product-solar" }) %>
+  <%= pb_rails("icon", props: { icon: "circle-product-windows" }) %>
 <% end %>
 
-
-<%= pb_rails("flex", props: { padding_left: "md" }) do %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-accessories" } ) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-attic-insulation" } ) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-doors" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-gutters-1" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-gutters" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-roofing" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-siding" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-solar" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "product-windows" }) %>
-    <% end %>
-  <% end %>
+<%= pb_rails("flex", props: { padding_left: "xl" }) do %>
+  <%= pb_rails("icon", props: { icon: "product-accessories" } ) %>
+  <%= pb_rails("icon", props: { icon: "product-attic-insulation" } ) %>
+  <%= pb_rails("icon", props: { icon: "product-doors" }) %>
+  <%= pb_rails("icon", props: { icon: "product-gutters-1" }) %>
+  <%= pb_rails("icon", props: { icon: "product-gutters" }) %>
+  <%= pb_rails("icon", props: { icon: "product-roofing" }) %>
+  <%= pb_rails("icon", props: { icon: "product-siding" }) %>
+  <%= pb_rails("icon", props: { icon: "product-solar" }) %>
+  <%= pb_rails("icon", props: { icon: "product-windows" }) %>
 <% end %>
 
-<%= pb_rails("flex", props: { padding_left: "md" }) do %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "circle-estimate-photos" } ) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "estimate-photos" } ) %>
-    <% end %>
-  <% end %>
+<%= pb_rails("flex", props: { padding_left: "xl" }) do %>
+  <%= pb_rails("icon", props: { icon: "circle-estimate-photos" } ) %>
+  <%= pb_rails("icon", props: { icon: "estimate-photos" } ) %>
 <% end %>
 
 

--- a/playbook-website/app/views/samples/icons.html.erb
+++ b/playbook-website/app/views/samples/icons.html.erb
@@ -8,6 +8,7 @@
   <%= pb_rails("icon", props: { icon: "circle-product-accessories" } ) %>
   <%= pb_rails("icon", props: { icon: "circle-product-attic-insulation" } ) %>
   <%= pb_rails("icon", props: { icon: "circle-product-doors" }) %>
+  <%= pb_rails("icon", props: { icon: "circle-product-gutters" }) %>
   <%= pb_rails("icon", props: { icon: "circle-product-roofing" }) %>
   <%= pb_rails("icon", props: { icon: "circle-product-siding" }) %>
   <%= pb_rails("icon", props: { icon: "circle-product-solar" }) %>
@@ -18,7 +19,6 @@
   <%= pb_rails("icon", props: { icon: "product-accessories" } ) %>
   <%= pb_rails("icon", props: { icon: "product-attic-insulation" } ) %>
   <%= pb_rails("icon", props: { icon: "product-doors" }) %>
-  <%= pb_rails("icon", props: { icon: "product-gutters-1" }) %>
   <%= pb_rails("icon", props: { icon: "product-gutters" }) %>
   <%= pb_rails("icon", props: { icon: "product-roofing" }) %>
   <%= pb_rails("icon", props: { icon: "product-siding" }) %>

--- a/playbook-website/app/views/samples/icons.html.erb
+++ b/playbook-website/app/views/samples/icons.html.erb
@@ -11,153 +11,110 @@
 
 <%= pb_rails("flex", props: { padding_left: "md"} ) do %>
   <%= pb_rails("flex/flex_item") do %>
-    <%= pb_rails("title", props: {size: 3, text: "Power Icons", padding_bottom: "sm"})%>
+    <%= pb_rails("title", props: {size: 3, text: "PLAY-1316 Products Batch Testing", padding_bottom: "sm"})%>
   <% end %>
 <% end %>
 
 <%= pb_rails("flex", props: { padding_left: "md" }) do %>
   <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
     <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing" } ) %>
+      <%= pb_rails("icon", props: { icon: "circle-product-accessories" } ) %>
     <% end %>
   <% end %>
   <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
     <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "powergon" } ) %>
+      <%= pb_rails("icon", props: { icon: "circle-product-attic-insulation" } ) %>
     <% end %>
   <% end %>
   <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
     <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "nitro" }) %>
+      <%= pb_rails("icon", props: { icon: "circle-product-doors" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "circle-product-roofing" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "circle-product-siding" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "circle-product-solar" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "circle-product-windows" }) %>
     <% end %>
   <% end %>
 <% end %>
 
-<%= pb_rails("flex", props: { padding_left: "md"} ) do %>
-  <%= pb_rails("flex/flex_item") do %>
-    <%= pb_rails("title", props: {size: 3, text: "Sizes", padding_bottom: "sm"})%>
+
+<%= pb_rails("flex", props: { padding_left: "md" }) do %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-accessories" } ) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-attic-insulation" } ) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-doors" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-gutters-1" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-gutters" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-roofing" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-siding" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-solar" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
+    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
+      <%= pb_rails("icon", props: { icon: "product-windows" }) %>
+    <% end %>
   <% end %>
 <% end %>
 
 <%= pb_rails("flex", props: { padding_left: "md" }) do %>
   <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
     <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "xs" }) %>
+      <%= pb_rails("icon", props: { icon: "circle-estimate-photos" } ) %>
     <% end %>
   <% end %>
   <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
     <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "sm" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "lg" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "1x" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "2x" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "3x" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "4x" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "5x" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "6x" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md",  }) do %>
-      <%= pb_rails("icon", props: { icon: "roofing", size: "7x" }) %>
-    <% end %>
-  <% end %>
-<% end %>
-
-<%= pb_rails("flex", props: { padding_left: "md"} ) do %>
-  <%= pb_rails("flex/flex_item") do %>
-    <%= pb_rails("title", props: {size: 3, text: "Color", padding_bottom: "sm"})%>
-  <% end %>
-<% end %>
-
-<%= pb_rails("flex", props: { padding_left: "md" }) do %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("body", props: { color: "error" }) do %>
-        <%= pb_rails("icon", props: { icon: "powergon", size: "2x" }) %>
-      <% end %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("body", props: { color: "link" }) do %>
-        <%= pb_rails("icon", props: { icon: "powergon", size: "2x" }) %>
-      <% end %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("body", props: { color: "success" }) do %>
-        <%= pb_rails("icon", props: { icon: "powergon", size: "2x" }) %>
-      <% end %>
+      <%= pb_rails("icon", props: { icon: "estimate-photos" } ) %>
     <% end %>
   <% end %>
 <% end %>
 
 
-<%= pb_rails("flex", props: { padding_left: "md"} ) do %>
-  <%= pb_rails("flex/flex_item") do %>
-    <%= pb_rails("title", props: {size: 3, text: "Animation & Transformation", padding_bottom: "sm"})%>
-  <% end %>
-<% end %>
 
-<%= pb_rails("flex", props: { padding_left: "md" }) do %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("icon", props: { icon: "nitro", size: "2x", spin: true }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("icon", props: { icon: "nitro", size: "2x", pulse: true }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("icon", props: { icon: "nitro", size: "2x" }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("icon", props: { icon: "nitro", size: "2x", rotation: 90 }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("icon", props: { icon: "nitro", size: "2x", rotation: 180 }) %>
-    <% end %>
-  <% end %>
-  <%= pb_rails("card", props: { padding: "none", header: true, margin_bottom: "sm"}) do %>
-    <%= pb_rails("card/card_body", props: { padding: "md" }) do %>
-      <%= pb_rails("icon", props: { icon: "nitro", size: "2x", rotation: 270 }) %>
-    <% end %>
-  <% end %>
-<% end %>
+

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "^6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "0.0.1-alpha.16",
-    "@powerhome/playbook-icons-react": "0.0.1-alpha.8",
+    "@powerhome/playbook-icons": "0.0.1-alpha.24",
+    "@powerhome/playbook-icons-react": "0.0.1-alpha.24",
     "@powerhome/power-fonts": "0.0.1-alpha.4",
     "@rails/webpacker": "5.4.3",
     "@svgr/webpack": "5.5.0",

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "^6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "0.0.1-alpha.24",
-    "@powerhome/playbook-icons-react": "0.0.1-alpha.24",
+    "@powerhome/playbook-icons": "0.0.1-alpha.25",
+    "@powerhome/playbook-icons-react": "0.0.1-alpha.25",
     "@powerhome/power-fonts": "0.0.1-alpha.4",
     "@rails/webpacker": "5.4.3",
     "@svgr/webpack": "5.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,15 +2832,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@0.0.1-alpha.8":
-  version "0.0.1-alpha.8"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/d71ffd31679c57b3a7358718ce84b2f9e5f0c577#d71ffd31679c57b3a7358718ce84b2f9e5f0c577"
-  integrity sha512-SUM1/MsJb4nnNEz2A9PMXa8hgBeCdGCNQWEdrozy1l2/1GZOkiw28aGIUZZN3LAR2+0hRRNhVhcetfpuGCZcFg==
+"@powerhome/playbook-icons-react@0.0.1-alpha.24":
+  version "0.0.1-alpha.24"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/ad2bdb054f4e25986a39cdfc4fcd503870569d4c#ad2bdb054f4e25986a39cdfc4fcd503870569d4c"
+  integrity sha512-g1Q/29McKpAS7ZnYgwt5YU80y6K9hNF9JSE/95L46OCs1/oYFJgxeWa64GGTVOxwt8EBWMpHUPxaIoU575yMIQ==
 
-"@powerhome/playbook-icons@0.0.1-alpha.16":
-  version "0.0.1-alpha.16"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/273baad6202de2736f9e38287e5589e00f47dfb8#273baad6202de2736f9e38287e5589e00f47dfb8"
-  integrity sha512-Kim7OqGxotUuhcxHBQI8a1M184DvzSyHU3ZmN/B6JANcw2jIOVL9z0f+qa9Trgij1cmyY444WC51LDbYaGvEug==
+"@powerhome/playbook-icons@0.0.1-alpha.24":
+  version "0.0.1-alpha.24"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/59cae43af16127ab899dbe425c4901815b8c7bdb#59cae43af16127ab899dbe425c4901815b8c7bdb"
+  integrity sha512-ZxdSvfg+TkJSOcTaGBaP1BS+5rA8CP21mKcA7vEtGFCUwqnsrvyLBLbFAj5ykD/iiVnzARbdGqKhnFpBABnHIg==
 
 "@powerhome/power-fonts@0.0.1-alpha.4":
   version "0.0.1-alpha.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,15 +2832,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@0.0.1-alpha.24":
-  version "0.0.1-alpha.24"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/ad2bdb054f4e25986a39cdfc4fcd503870569d4c#ad2bdb054f4e25986a39cdfc4fcd503870569d4c"
-  integrity sha512-g1Q/29McKpAS7ZnYgwt5YU80y6K9hNF9JSE/95L46OCs1/oYFJgxeWa64GGTVOxwt8EBWMpHUPxaIoU575yMIQ==
+"@powerhome/playbook-icons-react@0.0.1-alpha.25":
+  version "0.0.1-alpha.25"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/3a700f9b6d6427aefe0fb94039e292cea462fe9e#3a700f9b6d6427aefe0fb94039e292cea462fe9e"
+  integrity sha512-0h53TdW/PrUrwYFxonE0dIN9vupqAVLwBv70hSrRkrKb8chuLc/+kBtL15MeSJ+9cWIXF0ocFOHBlNTc25hmyw==
 
-"@powerhome/playbook-icons@0.0.1-alpha.24":
-  version "0.0.1-alpha.24"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/59cae43af16127ab899dbe425c4901815b8c7bdb#59cae43af16127ab899dbe425c4901815b8c7bdb"
-  integrity sha512-ZxdSvfg+TkJSOcTaGBaP1BS+5rA8CP21mKcA7vEtGFCUwqnsrvyLBLbFAj5ykD/iiVnzARbdGqKhnFpBABnHIg==
+"@powerhome/playbook-icons@0.0.1-alpha.25":
+  version "0.0.1-alpha.25"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/261d2f40561f1d4d0505e4af18892916941ed1a0#261d2f40561f1d4d0505e4af18892916941ed1a0"
+  integrity sha512-LtnN8E/yHaXzjQG+sZfpUbGA9Xdqpwhx8aFSPvg0lGf7phOoNFHSmjXhK0a36bZnPn0tIGBct9LhSzp6zhyVBA==
 
 "@powerhome/power-fonts@0.0.1-alpha.4":
   version "0.0.1-alpha.4"


### PR DESCRIPTION
## **DO NOT MERGE**

**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1316](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1316) for Product Icons Batch.
[playbook-icons](https://github.com/powerhome/playbook-icons/pull/34) PR.
This version bump will let us test this batch of new icons that are not very common in Nitro. This PR is for a testing milano only.

Local and milano env testing: 
Rails: 18/18 icons appeared.
React: 18/18 icons appeared.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1225" alt="rails icons for PR screenshot play-1316" src="https://github.com/powerhome/playbook/assets/83474365/6b7aca22-2c20-4f64-9cba-84142adb64cb">
<img width="1224" alt="react icons for PR screenshot play-1316" src="https://github.com/powerhome/playbook/assets/83474365/9e270c96-00a4-4c67-b55f-7567ecda6541">



**How to test?** Steps to confirm the desired behavior:
1. Go to [review env samples/icons](https://pr3476.playbook.beta.hq.powerapp.cloud/samples/icons) to test Rails icons and [review env beta/icons](https://pr3476.playbook.beta.hq.powerapp.cloud/beta/icons) to test React icons.
2. Inspect each icon - should see `pb_custom_icon` as the start of each classname.
3. Note which icons (if any) do not appear on these pages.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~