### PR TITLE
[PLAY-1329] allow any icon to be used in Fixed Confirmation Toast

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
@@ -23,6 +23,7 @@ type FixedConfirmationToastProps = {
   data?: string;
   horizontal?: "right" | "left" | "center";
   htmlOptions?: { [key: string]: string | number | boolean | (VoidCallback) };
+  icon?: string,
   id?: string;
   multiLine?: boolean;
   onClose?: VoidCallback;
@@ -41,6 +42,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps): React.React
     closeable = false,
     horizontal,
     htmlOptions = {},
+    icon,
     multiLine = false,
     onClose = () => undefined,
     open = true,
@@ -48,14 +50,18 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps): React.React
     text,
     vertical,
   } = props;
+
+  const returnedIcon = icon || iconMap[status]
+  const iconClass = icon ? "custom_icon" : ""
+
   const css = classnames(
     `pb_fixed_confirmation_toast_kit_${status}`,
     { _multi_line: multiLine },
     { [`positioned_toast ${vertical} ${horizontal}`]: vertical && horizontal },
+    `${iconClass}`,
     globalProps(props),
     className
   );
-  const icon = iconMap[status];
 
   const htmlProps = buildHtmlProps(htmlOptions);
 
@@ -86,11 +92,11 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps): React.React
             onClick={handleClick}
             {...htmlProps}
         >
-          {icon && (
+          {returnedIcon && (
             <Icon
                 className="pb_icon"
                 fixedWidth
-                icon={icon}
+                icon={returnedIcon}
             />
           )}
 

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.html.erb
@@ -1,25 +1,29 @@
 <div>
   <%= pb_rails("fixed_confirmation_toast", props: {
-    text: "Error Message",
+    icon: "wrench",
+    text: "Fix before proceeding",
     status: "error",
     closeable: true
   })%>
 </div>
 <div>
   <%= pb_rails("fixed_confirmation_toast", props: {
-    text: "Items Successfully Moved",
+    icon: "star",
+    text: "Thank you for completing the form!",
     status: "success"
   })%>
 </div>
 <div>
   <%= pb_rails("fixed_confirmation_toast", props: {
-    text: "Scan to Assign Selected Items",
+    icon: "file-pdf",
+    text: "Saved as PDF",
     status: "neutral"
   })%>
 </div>
 <div>
   <%= pb_rails("fixed_confirmation_toast", props: {
-    text: "Primary Blue example",
+    icon: "arrow-down",
+    text: "New Messages",
     status: "tip"
   })%>
 </div>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.html.erb
@@ -3,21 +3,24 @@
     icon: "wrench",
     text: "Fix before proceeding",
     status: "error",
-    closeable: true
+    closeable: true,
+    margin_bottom: "md"
   })%>
 </div>
 <div>
   <%= pb_rails("fixed_confirmation_toast", props: {
     icon: "star",
     text: "Thank you for completing the form!",
-    status: "success"
+    status: "success",
+    margin_bottom: "md"
   })%>
 </div>
 <div>
   <%= pb_rails("fixed_confirmation_toast", props: {
     icon: "file-pdf",
     text: "Saved as PDF",
-    status: "neutral"
+    status: "neutral",
+    margin_bottom: "md"
   })%>
 </div>
 <div>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.html.erb
@@ -1,0 +1,25 @@
+<div>
+  <%= pb_rails("fixed_confirmation_toast", props: {
+    text: "Error Message",
+    status: "error",
+    closeable: true
+  })%>
+</div>
+<div>
+  <%= pb_rails("fixed_confirmation_toast", props: {
+    text: "Items Successfully Moved",
+    status: "success"
+  })%>
+</div>
+<div>
+  <%= pb_rails("fixed_confirmation_toast", props: {
+    text: "Scan to Assign Selected Items",
+    status: "neutral"
+  })%>
+</div>
+<div>
+  <%= pb_rails("fixed_confirmation_toast", props: {
+    text: "Primary Blue example",
+    status: "tip"
+  })%>
+</div>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
@@ -9,6 +9,7 @@ const FixedConfirmationToastCustomIcon = (props) => {
         <FixedConfirmationToast
             closeable
             icon="wrench"
+            marginBottom="md"
             status="error"
             text="Fix before proceeding"
             {...props}
@@ -17,6 +18,7 @@ const FixedConfirmationToastCustomIcon = (props) => {
       <div>
         <FixedConfirmationToast
             icon="star"
+            marginBottom="md"
             status="success"
             text="Thank you for completing the form!"
             {...props}
@@ -25,6 +27,7 @@ const FixedConfirmationToastCustomIcon = (props) => {
       <div>
         <FixedConfirmationToast
             icon="file-pdf"
+            marginBottom="md"
             status="neutral"
             text="Saved as PDF"
             {...props}

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import FixedConfirmationToast from '../_fixed_confirmation_toast'
 
-const FixedConfirmationToastDefault = (props) => {
+const FixedConfirmationToastCustomIcon = (props) => {
   return (
     <div>
       <div>
@@ -42,4 +42,4 @@ const FixedConfirmationToastDefault = (props) => {
   )
 }
 
-export default FixedConfirmationToastDefault
+export default FixedConfirmationToastCustomIcon

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
@@ -8,29 +8,33 @@ const FixedConfirmationToastDefault = (props) => {
       <div>
         <FixedConfirmationToast
             closeable
+            icon="wrench"
             status="error"
-            text="Error Message"
+            text="Fix before proceeding"
             {...props}
         />
       </div>
       <div>
         <FixedConfirmationToast
+            icon="star"
             status="success"
-            text="Items Successfully Moved"
+            text="Thank you for completing the form!"
             {...props}
         />
       </div>
       <div>
         <FixedConfirmationToast
+            icon="file-pdf"
             status="neutral"
-            text="Scan to Assign Selected Items"
+            text="Saved as PDF"
             {...props}
         />
       </div>
       <div>
         <FixedConfirmationToast
+            icon="arrow-down"
             status="tip"
-            text="Primary Blue example"
+            text="New Messages"
             {...props}
         />
       </div>

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/_fixed_confirmation_toast_custom_icon.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import FixedConfirmationToast from '../_fixed_confirmation_toast'
+
+const FixedConfirmationToastDefault = (props) => {
+  return (
+    <div>
+      <div>
+        <FixedConfirmationToast
+            closeable
+            status="error"
+            text="Error Message"
+            {...props}
+        />
+      </div>
+      <div>
+        <FixedConfirmationToast
+            status="success"
+            text="Items Successfully Moved"
+            {...props}
+        />
+      </div>
+      <div>
+        <FixedConfirmationToast
+            status="neutral"
+            text="Scan to Assign Selected Items"
+            {...props}
+        />
+      </div>
+      <div>
+        <FixedConfirmationToast
+            status="tip"
+            text="Primary Blue example"
+            {...props}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default FixedConfirmationToastDefault

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/example.yml
@@ -6,6 +6,7 @@ examples:
   - fixed_confirmation_toast_close: Click to Close
   - fixed_confirmation_toast_positions: Click to Show Positions
   - fixed_confirmation_toast_children: Children
+  - fixed_confirmation_toast_custom_icon: Custom Icon
   
   react:
   - fixed_confirmation_toast_default: Default
@@ -14,6 +15,7 @@ examples:
   - fixed_confirmation_toast_positions: Click to Show Positions
   - fixed_confirmation_toast_auto_close: Click to Show Auto Close
   - fixed_confirmation_toast_children: Children
+  - fixed_confirmation_toast_custom_icon: Custom Icon
 
   swift:
   - fixed_confirmation_toast_default_swift: Default

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/docs/index.js
@@ -4,3 +4,4 @@ export { default as FixedConfirmationToastClose } from './_fixed_confirmation_to
 export { default as FixedConfirmationToastPositions } from './_fixed_confirmation_toast_positions.jsx'
 export { default as FixedConfirmationToastAutoClose } from './_fixed_confirmation_toast_auto_close.jsx'
 export { default as FixedConfirmationToastChildren } from './_fixed_confirmation_toast_children.jsx'
+export { default as FixedConfirmationToastCustomIcon } from './_fixed_confirmation_toast_custom_icon.jsx'

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.rb
@@ -20,6 +20,7 @@ module Playbook
                       values: [nil, "top", "bottom"],
                       default: nil
       prop :auto_close, type: Playbook::Props::Number
+      prop :icon, type: Playbook::Props::String
 
       def show_text?
         text.present?
@@ -42,20 +43,24 @@ module Playbook
       end
 
       def icon_value
-        case status
-        when "success"
-          "check"
-        when "error"
-          "exclamation-triangle"
-        when "neutral"
-          "info-circle"
-        when "tip"
-          "info-circle"
-        end
+        icon || case status
+                when "success"
+                  "check"
+                when "error"
+                  "exclamation-triangle"
+                when "neutral"
+                  "info-circle"
+                when "tip"
+                  "info-circle"
+                end
+      end
+
+      def icon_class
+        icon.present? ? " custom_icon" : ""
       end
 
       def classname
-        generate_classname("pb_fixed_confirmation_toast_kit", status, multi_line_class) + close_class + position_class + auto_close_class
+        generate_classname("pb_fixed_confirmation_toast_kit", status, multi_line_class) + close_class + position_class + auto_close_class + icon_class
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.test.js
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.test.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { render, waitFor } from '../utilities/test-utils'
+
+import { FixedConfirmationToast } from '../'
+
+beforeEach(() => {
+    // Silences error logs within the test suite.
+    jest.spyOn(console, 'error')
+    // eslint-disable-next-line
+    console.error.mockImplementation(() => {})
+})
+  
+afterEach(() => {
+    // eslint-disable-next-line
+    console.error.mockRestore()
+})
+
+test('renders with default props', () => {
+    const { container } = render(<FixedConfirmationToast />);
+    expect(container.firstChild).toBeInTheDocument();
+});
+
+test('renders with text', () => {
+    const { getByText } = render(<FixedConfirmationToast text="Message Text" />);
+    expect(getByText('Message Text')).toBeInTheDocument();
+});
+
+test('does not render if open prop is false', () => {
+    const { container } = render(<FixedConfirmationToast open={false} />);
+    expect(container.firstChild).toBeNull();
+});
+
+test('closes after autoClose duration', async () => {
+    jest.useFakeTimers();
+    const onCloseMock = jest.fn();
+    render(
+        <FixedConfirmationToast 
+            autoClose={1000} 
+            onClose={onCloseMock}
+            open
+        />
+    );
+    
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => expect(onCloseMock).toHaveBeenCalled());
+});
+
+test('renders success status with icon', () => {
+    const { container } = render(<FixedConfirmationToast status="success" />);
+    expect(container.querySelector('.pb_fixed_confirmation_toast_kit_success')).toBeInTheDocument();
+    expect(container.querySelector('.pb_icon')).toBeInTheDocument();
+});
+  
+test('renders custom icon when provided', () => {
+    const { container } = render(<FixedConfirmationToast icon="wrench" />);
+    expect(container.querySelector('.custom_icon')).toBeInTheDocument();
+});
+
+test('renders correctly with multiLine prop', () => {
+    const { container } = render(<FixedConfirmationToast multiLine />);
+    expect(container.querySelector('._multi_line')).toBeInTheDocument();
+});
+
+test('renders position when provided', () => {
+    const { container } = render(
+        <FixedConfirmationToast 
+            horizontal="right"
+            vertical="bottom" 
+        />
+    );
+    expect(container.querySelector('.positioned_toast')).toBeInTheDocument();
+});

--- a/playbook/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/fixed_confirmation_toast_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Playbook::PbFixedConfirmationToast::FixedConfirmationToast do
       expect(subject.new(status: "error").icon_value).to eq "exclamation-triangle"
       expect(subject.new(status: "neutral").icon_value).to eq "info-circle"
       expect(subject.new(status: "tip").icon_value).to eq "info-circle"
+      expect(subject.new(status: "tip", icon: "arrow-down").icon_value).to eq "arrow-down"
     end
   end
 
@@ -68,6 +69,7 @@ RSpec.describe Playbook::PbFixedConfirmationToast::FixedConfirmationToast do
       expect(subject.new(text: text, status: "error", multi_line: true).classname).to eq "pb_fixed_confirmation_toast_kit_error_multi_line"
       expect(subject.new(text: text, status: "neutral", vertical: "top").classname).to eq "pb_fixed_confirmation_toast_kit_neutral"
       expect(subject.new(text: text, status: "neutral", vertical: "top", horizontal: "center").classname).to eq "pb_fixed_confirmation_toast_kit_neutral positioned_toast top center"
+      expect(subject.new(text: text, status: "tip", icon: "arrow-down").classname).to eq "pb_fixed_confirmation_toast_kit_tip custom_icon"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1329](https://nitro.powerhrg.com/runway/backlog_items/PLAY-1329) requests the ability to use custom icons in the Fixed Confirmation Toast kit. This PR allows for passing an icon prop to the component along with a status in order to add a new icon while utilizing one of the four style patterns for the confirmation toasts (error, success, neutral, and tip) in Rails and React. Other things of note: 

- Using a custom icon adds `custom_icon` to the classname construction. 
- Custom Icon Rails and React doc examples have been added to playbook (one of which is modeled after the mock provided by the requesting designer in runway). 
- Additionally, this PR adds a jest test file to the fixed confirmation toast kit for the first time - I have added some baseline tests for the kit as a whole, not just this new feature, but this test suite could be refined in a future story (notably, to include a test that confirms that onClose is called when the times icon that is present when the toast is "closeable" is clicked).

**Screenshots:** Screenshots to visualize your addition/change
Rails Custom Icon Doc Example
<img width="649" alt="for PR rails review env w spacing" src="https://github.com/powerhome/playbook/assets/83474365/c299d75f-021c-4714-9508-2ec2c677334b">
React Custom Icon Doc Example
<img width="656" alt="for PR react review env w spacing" src="https://github.com/powerhome/playbook/assets/83474365/0a6c5190-bef9-4715-bcec-0897d75d47d1">


**How to test?** Steps to confirm the desired behavior:
1. Go to the Custom Icon doc example in [Rails](https://playbook.powerapp.cloud/kits/fixed_confirmation_toast#custom-icon) [Rails review env](https://pr3478.playbook.beta.hq.powerapp.cloud/kits/fixed_confirmation_toast#custom-icon) or [React](https://playbook.powerapp.cloud/kits/fixed_confirmation_toast/react#custom-icon) [React review env](https://pr3478.playbook.beta.hq.powerapp.cloud/kits/fixed_confirmation_toast/react#custom-icon)
2. See set of doc examples with the default styling based on status (i.e. status="error" is red, etc.) but custom icons in place of the default ones (see default doc example for the default icon for each status type, statuses "neutral" and "tip" both have "info-circle" as their default icon).
3. Inspect the example Toasts to see the addition of `custom_icon` classname.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.