### PR TITLE
[PBNTR-331] Adding column sort to Advanced Table kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.html.erb
@@ -1,0 +1,59 @@
+<%# Example sort method for demonstration purposes %>
+<% if params["sort"] %>
+  <% sort_param = params["sort"].gsub(/_(asc|desc)\z/, "") %>
+  <% sort_direction = params["sort"].end_with?("_asc") ? 1 : -1 %>
+  <% @table_data.sort! do |a, b|
+    value_a = a[sort_param]
+    value_b = b[sort_param]
+
+    value_a = value_a.to_i if value_a.is_a?(String) && value_a.match?(/^\d+$/)
+    value_b = value_b.to_i if value_b.is_a?(String) && value_b.match?(/^\d+$/)
+
+    sort_direction * (value_a <=> value_b)
+  end %>
+<% end %>
+
+<% 
+  column_definitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+      sort_menu: [
+        { item: "Year", link: "?sort=year_asc#table-sort", active: params["sort"] == "year_asc", direction: "asc" },
+        { item: "Year", link: "?sort=year_desc#table-sort", active: params["sort"] == "year_desc", direction: "desc" }
+      ],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance Rate",
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed Classes",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Class Completion Rate",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated Students",
+    }
+  ]
+
+  subrow_headers = ["Quarter", "Month", "Day"]
+%>
+
+<%= pb_rails("advanced_table", props: { table_data: @table_data, column_definitions: column_definitions }) do %>
+  <%= pb_rails("advanced_table/table_header", props: { column_definitions: column_definitions }) %>
+  <%= pb_rails("advanced_table/table_body", props: { id: "subrow_headers", table_data: @table_data, column_definitions: column_definitions, subrow_headers: subrow_headers, enable_toggle_expansion: "all" }) %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.md
@@ -1,0 +1,1 @@
+Description goes here.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.md
@@ -1,1 +1,5 @@
-Description goes here.
+Optionally enable sorting by passing `sort_menu` to any `column_definition`(s). Sort options are determined by an array of `item` objects passed to the `sort_menu` prop. 
+
+<div class="pb_pill_kit_warning"><div class="pb_title_kit_size_4 pb_pill_text">Disclaimer</div></div>
+
+This example uses a custom sort method that may need to be modified or replaced within your project.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_beta_sort.md
@@ -1,5 +1,6 @@
 Optionally enable sorting by passing `sort_menu` to any `column_definition`(s). Sort options are determined by an array of `item` objects passed to the `sort_menu` prop. 
 
+</br>
 <div class="pb_pill_kit_warning"><div class="pb_title_kit_size_4 pb_pill_text">Disclaimer</div></div>
 
 This example uses a custom sort method that may need to be modified or replaced within your project.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -2,15 +2,15 @@ examples:
   rails:
   - advanced_table_beta: Default (Required Props)
   - advanced_table_beta_subrow_headers: SubRow Headers
-  - advanced_table_beta_sort: Table Sort
+  - advanced_table_beta_sort: Enable Sorting
   react:
   - advanced_table_default: Default (Required Props)
   - advanced_table_loading: Loading State
-  - advanced_table_sort: enable Sorting
+  - advanced_table_sort: Enable Sorting
   - advanced_table_sort_control: Sort Control
   - advanced_table_expanded_control: Expanded Control
   - advanced_table_subrow_headers: SubRow Headers
   - advanced_table_collapsible_trail: Collapsible Trail
   - advanced_table_table_options: Table Options
   - advanced_table_table_props: Table Props
-  - advanced_table_inline_row_loading: inline Row Loading
+  - advanced_table_inline_row_loading: Inline Row Loading

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -2,6 +2,7 @@ examples:
   rails:
   - advanced_table_beta: Default (Required Props)
   - advanced_table_beta_subrow_headers: SubRow Headers
+  - advanced_table_beta_sort: Table Sort
   react:
   - advanced_table_default: Default (Required Props)
   - advanced_table_loading: Loading State

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.html.erb
@@ -1,11 +1,11 @@
 <%= pb_content_tag do %>
-        <%= pb_rails("table/table_row", props: {tag:"div"}) do %>
+        <%= pb_rails("table/table_row", props: { tag: "div" }) do %>
             <% object.column_definitions.each_with_index do |item, index| %>
-                <%= pb_rails("table/table_header", props: { tag:"div", id:item[:accessor], classname:object.th_classname}) do %>
-                    <%= pb_rails("flex", props:{ align: "center", justify: index.zero? ? "start" : "end", text_align:"end" }) do %>
+                <%= pb_rails("table/table_header", props: { tag: "div", id: item[:accessor], classname: object.th_classname, sort_menu: item[:sort_menu] }) do %>
+                    <%= pb_rails("flex", props:{ align: "center", justify: index.zero? ? "start" : "end", text_align: "end" }) do %>
                         <% if index.zero? && (object.enable_toggle_expansion == "header" || object.enable_toggle_expansion == "all") %>
                             <button class="gray-icon toggle-all-icon" onclick="expandAllRows(this)">
-                                <%= pb_rails("icon", props: { icon: "arrows-from-line", cursor: "pointer", fixed_width: true, padding_right:"xs" }) %>
+                                <%= pb_rails("icon", props: { icon: "arrows-from-line", cursor: "pointer", fixed_width: true, padding_right: "xs" }) %>
                             </button>
                         <% end %>
                         <%= item[:label] %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
@@ -52,6 +52,20 @@
     data: object.data,
     id: object.id,
     **combined_html_options) do %>
-      <%= content.presence || object.text %>
+      <% unless sorting_style? %>
+        <%= content.presence || object.text %>
+      <% else %>
+        <%= link_to next_link, style: link_style do %>
+          <%= pb_rails("flex", props:{ align: object.align_content, justify: object.justify_sort_icon, classname: "pb_th_link" }) do %>
+            <%= content.presence || object.text %>
+              <% if sorting_style? %>
+                <%= pb_rails("icon", props: { icon: object.sort_icon(active_item[:direction], active_item[:active]),
+                                              fixed_width: true,
+                                              classname: active_item.any? ? "pb_th_active" : "",
+                                              padding_left: "xs" }) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
   <% end %>
-<% end %>


### PR DESCRIPTION
**What does this PR do?**
Adding column sort to Advanced Table kit

**Screenshots:**
![image](https://github.com/powerhome/playbook/assets/2573205/4ab3456f-5387-4f97-8eb0-f7c2af9f4e67)

**How to test?** Steps to confirm the desired behavior:
1. Go to the Advanced Table kit
2. Scroll down to the Table Sort doc example


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.