### PR TITLE
[PBNTR-360] Adding Collapsed Prop to Collapsible Nav on Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_collapsible/index.js
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/index.js
@@ -14,7 +14,12 @@ export default class PbCollapsible extends PbEnhancedElement {
     this.element.addEventListener('click', () => {
       this.toggleElement(this.target)
     })
-    this.displayDownArrow()
+     // Check the initial state of the collapsible content and set the arrow accordingly
+     if (this.target.classList.contains('is-visible')) {
+      this.displayUpArrow()
+    } else {
+      this.displayDownArrow()
+    }
     // Listen for a custom event to toggle the collapsible
     document.addEventListener(`${this.target.id}`, () => {
       this.toggleElement(this.target)

--- a/playbook/app/pb_kits/playbook/pb_nav/docs/_collapsible_nav.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_nav/docs/_collapsible_nav.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("nav", props: { variant: "bold" }) do %>
-    <%= pb_rails("nav/item", props: { text: "Overview", link: "#", collapsible: true, icon_left:"city" }) do %>
+    <%= pb_rails("nav/item", props: { text: "Overview", link: "#", collapsible: true, icon_left:"city", collapsed: false }) do %>
         <%= pb_rails("nav", props: { variant: "bold" }) do %>
             <%= pb_rails("nav/item", props: { text: "City", link: "#" }) %>
             <%= pb_rails("nav/item", props: { text: "People", link: "#" }) %>

--- a/playbook/app/pb_kits/playbook/pb_nav/docs/_collapsible_nav.jsx
+++ b/playbook/app/pb_kits/playbook/pb_nav/docs/_collapsible_nav.jsx
@@ -9,6 +9,7 @@ const CollapsibleNav = (props) => {
     >
       <NavItem
           active
+          collapsed={false}
           collapsible 
           iconLeft="city" 
           link="#" 

--- a/playbook/app/pb_kits/playbook/pb_nav/docs/_collapsible_nav.md
+++ b/playbook/app/pb_kits/playbook/pb_nav/docs/_collapsible_nav.md
@@ -1,1 +1,3 @@
 The `collapsible` prop allows users to create a nested, collapsible nav. Pass `collapsible` to any NavItem and pass that navItem any number of NavItems as children to create a collapsible nav.
+
+The optional `collapsed` prop can also be used to set the default state for the collapsed nav on first render of the page. `collapsed` takes a boolean value that is set to true (meaning nav is collapsed) by default. Set it to false as shown here to have the nav open on first render.

--- a/playbook/app/pb_kits/playbook/pb_nav/item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_nav/item.html.erb
@@ -22,7 +22,7 @@
           </span>
         <% end %>    
        <% end %>
-      <%= pb_rails("collapsible/collapsible_content") do %>
+      <%= pb_rails("collapsible/collapsible_content", props: {collapsed: object.collapsed}) do %>
         <%= content.presence %>
       <% end %>
     <% end %>

--- a/playbook/app/pb_kits/playbook/pb_nav/item.rb
+++ b/playbook/app/pb_kits/playbook/pb_nav/item.rb
@@ -12,6 +12,7 @@ module Playbook
                          default: "regular"
       prop :highlighted_border, type: Playbook::Props::Boolean, default: true
       prop :collapsible, type: Playbook::Props::Boolean, default: false
+      prop :collapsed, type: Playbook::Props::Boolean, default: true
       prop :link
       prop :text
       prop :collapsible_trail, type: Playbook::Props::Boolean, default: false

--- a/playbook/spec/pb_kits/playbook/kits/nav_item_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/nav_item_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Playbook::PbNav::Item do
   it { is_expected.to define_prop(:icon_left) }
   it { is_expected.to define_prop(:icon_right) }
   it { is_expected.to define_prop(:image_url) }
+  it { is_expected.to define_prop(:collapsible) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
@@ -18,6 +19,7 @@ RSpec.describe Playbook::PbNav::Item do
       expect(subject.new(active: true).classname).to eq "pb_nav_list_kit_item_active font_size_normal font_regular pb_nav_list_item_link"
       expect(subject.new(active: true, highlighted_border: false).classname).to eq "pb_nav_list_kit_item_active_highlighted_border_none font_size_normal font_regular pb_nav_list_item_link"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_nav_list_kit_item additional_class font_size_normal font_regular pb_nav_list_item_link"
+      expect(subject.new(collapsible: true).classname).to eq "pb_nav_list_kit_item pb_collapsible_nav_item font_size_normal font_regular pb_nav_list_item_link_collapsible"
     end
   end
 end

--- a/playbook/spec/pb_kits/playbook/kits/nav_item_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/nav_item_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Playbook::PbNav::Item do
   it { is_expected.to define_prop(:icon_right) }
   it { is_expected.to define_prop(:image_url) }
   it { is_expected.to define_prop(:collapsible) }
+  it { is_expected.to define_prop(:collapsed) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Adds `collapsed` prop to rails side of collapsible nav so you can set initial state for collapsed nav
- Fixes bug where icon was not rendering according to it being open or closed


**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2024-06-25 at 1 26 06 PM](https://github.com/powerhome/playbook/assets/73710701/1d022fac-9a21-449c-88b1-0841ff8890c3)

