### PR TITLE
[PLAY-1367] Use new content tag

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_background/background.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_background/background.html.erb
@@ -1,23 +1,14 @@
 <% if object.image_url.present? %>
-  <%= content_tag(object.tag,
-      aria: object.aria,
-      data: object.data,
-      id: object.id,
-      class: object.classname,
+  <%= pb_content_tag(object.tag,
       style: "background-image: url('#{object.image_url}');
               background-repeat: #{object.background_repeat};
               background-size: #{object.background_size};
               background-position: #{object.background_position};",
-      **combined_html_options
   ) do %>
     <%= content.presence %>
   <% end %>
 <% else %>
-  <%= content_tag(object.tag,
-      aria: object.aria,
-      data: object.data,
-      id: object.id,
-      class: object.classname,
+  <%= pb_content_tag(object.tag,
       style: object.custom_background_color
   ) do %>
     <%= content.presence %>

--- a/playbook/app/pb_kits/playbook/pb_body/body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_body/body.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(object.tag,
-  aria: object.aria,
-  id: object.id,
-  data: object.data,
-  class: object.classname,
-  **combined_html_options) do %>
+<%= pb_content_tag(object.tag) do %>
   <%= object.content %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumb_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumb_item.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    aria: object.aria,
-    **combined_html_options) do%>
+<%= pb_content_tag do%>
 <%= content_tag(object.link ? 'a' : 'span', class: 'bread_crumb_item', href: object.link) do %>
     <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumbs.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/bread_crumbs.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(:nav,
-    aria: object.aria,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag(:nav) do %>
       <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_caption/caption.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_caption/caption.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(object.tag,
-  aria: object.aria,
-  id: object.id,
-  data: object.data,
-  class: object.classname,
-  **combined_html_options) do %>
+<%= pb_content_tag(object.tag) do %>
   <%= content.presence || object.text %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_card/card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.html.erb
@@ -1,10 +1,4 @@
-<%= content_tag(object.tag,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    aria: object.aria,
-    dark: object.dark,
-    **combined_html_options) do %>
+<%= pb_content_tag(object.tag) do %>
     <%= content.presence %>
 <% end %>
 

--- a/playbook/app/pb_kits/playbook/pb_detail/detail.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_detail/detail.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(object.tag,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag(object.tag) do %>
   <%= object.content %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -1,37 +1,37 @@
 <div class="pb_dialog_wrapper_rails <%= object.full_height_style %>" data-overlay-click= <%= object.overlay_close %> >
-  <%= pb_content_tag(:dialog) do %>
-    <% if object.status === "" && object.title %>
-      <%= pb_rails("dialog/dialog_header", props: { title: object.title, id: object.id }) %>
-    <% end %>
-    <% if object.status === "" && object.text %>
-      <%= pb_rails("dialog/dialog_body", props: { text: object.text }) %>
-    <% end %>
-    <% if object.status != "" %>
-      <%= pb_rails("dialog/dialog_body", props: { classname: "dialog_status_text_align" ,padding: "md" }) do %>
-        <%= pb_rails("flex", props: { align: "center", orientation: "column" }) do %>
-          <%= pb_rails("icon_circle", props: {
-            icon: object.status_alerts[0],
-            variant: object.status_alerts[1],
-            size: "lg"
-          }) %>
-        <%= pb_rails("title", props: { text: object.title, tag: "h1", size: 3, margin_top: "sm" }) %>
-        <%= pb_rails("body", props: { text: object.text, margin_top: "sm" }) %>
-      <% end %>
-    <% end %>
-  <% end %>
-  <% if object.cancel_button && object.confirm_button %>
-    <%= pb_rails("dialog/dialog_footer", props: {
-      cancel_button: object.cancel_button,
-      confirm_button: object.confirm_button,
-      id: object.id
-    }) %>
-<% end %>
+    <%= pb_content_tag(:dialog) do %>
+            <% if object.status === "" && object.title %>
+                <%= pb_rails("dialog/dialog_header", props: { title: object.title, id: object.id }) %>
+            <% end %>
+            <% if object.status === "" && object.text %>
+                <%= pb_rails("dialog/dialog_body", props: { text: object.text }) %>
+            <% end %>
+            <% if object.status != "" %>
+                <%= pb_rails("dialog/dialog_body", props: { classname: "dialog_status_text_align" ,padding: "md" }) do %>
+                    <%= pb_rails("flex", props: { align: "center", orientation: "column" }) do %>
+                        <%= pb_rails("icon_circle", props: {
+                                icon: object.status_alerts[0],
+                                variant: object.status_alerts[1],
+                                size: "lg"
+                            }) %>
+                        <%= pb_rails("title", props: { text: object.title, tag: "h1", size: 3, margin_top: "sm" }) %>
+                        <%= pb_rails("body", props: { text: object.text, margin_top: "sm" }) %>
+                    <% end %>
+                <% end %>
+            <% end %>
+            <% if object.cancel_button && object.confirm_button %>
+                        <%= pb_rails("dialog/dialog_footer", props: {
+                            cancel_button: object.cancel_button,
+                            confirm_button: object.confirm_button,
+                            id: object.id
+                        }) %>
+            <% end %>
 
-<%= content %>
+            <%= content %>
     <% end %>
 </div>
 
 <%= javascript_tag do %>
-  window.addEventListener("DOMContentLoaded", () => dialogHelper())
-  window.addEventListener("turbo:frame-load", () => dialogHelper())
+    window.addEventListener("DOMContentLoaded", () => dialogHelper())
+    window.addEventListener("turbo:frame-load", () => dialogHelper())
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -1,42 +1,37 @@
 <div class="pb_dialog_wrapper_rails <%= object.full_height_style %>" data-overlay-click= <%= object.overlay_close %> >
-    <%= content_tag(:dialog,
-        aria: object.aria,
-        data: object.data,
-        id: object.id,
-        class: object.classname,
-        **combined_html_options) do %>
-            <% if object.status === "" && object.title %>
-                <%= pb_rails("dialog/dialog_header", props: { title: object.title, id: object.id }) %>
-            <% end %>
-            <% if object.status === "" && object.text %>
-                <%= pb_rails("dialog/dialog_body", props: { text: object.text }) %>
-            <% end %>
-            <% if object.status != "" %>
-                <%= pb_rails("dialog/dialog_body", props: { classname: "dialog_status_text_align" ,padding: "md" }) do %>
-                    <%= pb_rails("flex", props: { align: "center", orientation: "column" }) do %>
-                        <%= pb_rails("icon_circle", props: {
-                                icon: object.status_alerts[0],
-                                variant: object.status_alerts[1],
-                                size: "lg"
-                            }) %>
-                        <%= pb_rails("title", props: { text: object.title, tag: "h1", size: 3, margin_top: "sm" }) %>
-                        <%= pb_rails("body", props: { text: object.text, margin_top: "sm" }) %>
-                    <% end %>
-                <% end %>
-            <% end %>
-            <% if object.cancel_button && object.confirm_button %>
-                        <%= pb_rails("dialog/dialog_footer", props: {
-                            cancel_button: object.cancel_button,
-                            confirm_button: object.confirm_button,
-                            id: object.id
-                        }) %>
-            <% end %>
+  <%= pb_content_tag(:dialog) do %>
+    <% if object.status === "" && object.title %>
+      <%= pb_rails("dialog/dialog_header", props: { title: object.title, id: object.id }) %>
+    <% end %>
+    <% if object.status === "" && object.text %>
+      <%= pb_rails("dialog/dialog_body", props: { text: object.text }) %>
+    <% end %>
+    <% if object.status != "" %>
+      <%= pb_rails("dialog/dialog_body", props: { classname: "dialog_status_text_align" ,padding: "md" }) do %>
+        <%= pb_rails("flex", props: { align: "center", orientation: "column" }) do %>
+          <%= pb_rails("icon_circle", props: {
+            icon: object.status_alerts[0],
+            variant: object.status_alerts[1],
+            size: "lg"
+          }) %>
+        <%= pb_rails("title", props: { text: object.title, tag: "h1", size: 3, margin_top: "sm" }) %>
+        <%= pb_rails("body", props: { text: object.text, margin_top: "sm" }) %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% if object.cancel_button && object.confirm_button %>
+    <%= pb_rails("dialog/dialog_footer", props: {
+      cancel_button: object.cancel_button,
+      confirm_button: object.confirm_button,
+      id: object.id
+    }) %>
+<% end %>
 
-            <%= content %>
+<%= content %>
     <% end %>
 </div>
 
 <%= javascript_tag do %>
-    window.addEventListener("DOMContentLoaded", () => dialogHelper())
-    window.addEventListener("turbo:frame-load", () => dialogHelper())
+  window.addEventListener("DOMContentLoaded", () => dialogHelper())
+  window.addEventListener("turbo:frame-load", () => dialogHelper())
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_body.html.erb
@@ -1,3 +1,3 @@
 <%= pb_content_tag do %>
-  <%= content.presence || object.text %>
+        <%= content.presence || object.text %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_body.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    aria: object.aria,
-    **combined_html_options) do %>
-        <%= content.presence || object.text %>
+<%= pb_content_tag do %>
+  <%= content.presence || object.text %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    aria: object.aria,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
     <% if object.confirm_button && object.cancel_button %>
         <div class="dialog-pseudo-footer"></div>
         <%= pb_rails("flex", props: { classname:object.classname, spacing:"between", padding_x:"sm", padding:"sm", padding_bottom:"sm" }) do %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
@@ -1,4 +1,5 @@
-<%= pb_content_tag do %>
+<%= pb_content_tag(:div, class: "") do %>
+  <%  'excluded classname?'  %>
     <% if object.confirm_button && object.cancel_button %>
         <div class="dialog-pseudo-footer"></div>
         <%= pb_rails("flex", props: { classname:object.classname, spacing:"between", padding_x:"sm", padding:"sm", padding_bottom:"sm" }) do %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.sticky_header,
-    aria: object.aria,
-    **combined_html_options) do %>
+<%= content_tag(:div, class: object.sticky_header) do %>
         <%= pb_rails("flex", props: {classname:object.classname, spacing:"between", padding:"sm", align:"center"}) do %>
             <%= content.presence || object.title %>
 

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_header.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag(:div, class: object.sticky_header) do %>
+<%= pb_content_tag(:div, class: object.sticky_header) do %>
         <%= pb_rails("flex", props: {classname:object.classname, spacing:"between", padding:"sm", align:"center"}) do %>
             <%= content.presence || object.title %>
 

--- a/playbook/app/pb_kits/playbook/pb_flex/flex.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_flex/flex.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_hashtag/hashtag.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_hashtag/hashtag.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:span,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag(:span) do %>
   <%= link_to object.url, target: object.link_option do %>
     <%= pb_rails("badge", props: { dark: object.dark, variant: "primary", text: object.hashtag_text }) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_highlight/highlight.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_highlight/highlight.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:span,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag(:span) do %>
     <mark>
       <%= content.presence || object.text %>
     </mark>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= pb_rails("home_address_street/#{emphasis}_emphasis", props: object.send("#{emphasis}_emphasis_props")) %>
 <% end %>
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Nitro Alpha https://pr40783.nitro-web.beta.hq.powerapp.cloud/user_requests/new?redirect_fallback=/sales/reps

Runway https://runway.powerhrg.com/backlog_items/PLAY-1367

replace's rails `content_tag' in some of our kits to our wrapper `pb_content_tag`

Only making these changes to a small number of kits because the scope is too large 
