### PR TITLE
[PLAY-1291] hide beta versions of kits within Beta Index (with menu.yml)

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
@@ -15,11 +15,16 @@ export type Kit = {
     name: string;
     description: string;
     platforms: string[];
+    status: "stable" | "beta";
   }[];
   description: string;
 };
 
 export type Kits = Kit[];
+
+export interface Component {
+  status: string;
+}
 
 const description =
   "Components are the reusable building blocks of our design system. Each component meets a specific interaction or UI need, and has been specifically created to work together to create patterns and intuitive user experiences."
@@ -49,7 +54,8 @@ export default function ComponentList() {
           </Flex>
 
           <PageContainer>
-            {!kitsToShow.length && (
+            {kitsToShow.filter(({ components }: {components: Component[] }) => 
+            components.some((component: Component) => component.status === "stable")).length === 0 ? (
               <Flex
                 justify="center"
                 orientation="row"
@@ -58,28 +64,31 @@ export default function ComponentList() {
                   text="No Results, Try Again"
                 />
               </Flex>
+            ) : (
+              kitsToShow.map(({ name, components }: Kit, index: number) => (
+                <section
+                  className="category mb_xl"
+                  key={`${name}-${index}`}
+                  id={name}
+                >
+                  <NavLink to={`/beta/kit_category/${name}`}>
+                    <CategoryTitle name={name} />
+                  </NavLink>
+                  <KitGrid>
+                    {components
+                    .filter(component => component.status === "stable")
+                    .map(({ name, description }, index) => (
+                      <KitCard
+                        description={description}
+                        name={name}
+                        key={`${name}-${index}`}
+                        platform={platform}
+                      />
+                    ))}
+                  </KitGrid>
+                </section>
+              ))
             )}
-            {kitsToShow.map(({ name, components }: Kit, index: number) => (
-              <section
-                className="category mb_xl"
-                key={`${name}-${index}`}
-                id={name}
-              >
-                <NavLink to={`/beta/kit_category/${name}`}>
-                  <CategoryTitle name={name} />
-                </NavLink>
-                <KitGrid>
-                  {components.map(({ name, description }, index) => (
-                    <KitCard
-                      description={description}
-                      name={name}
-                      key={`${name}-${index}`}
-                      platform={platform}
-                    />
-                  ))}
-                </KitGrid>
-              </section>
-            ))}
           </PageContainer>
         </>
       )}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1291](https://runway.powerhrg.com/backlog_items/PLAY-1291) requests a way to remove any beta kits from appearing on the beta version of the all kits page. 
Beta all kits page: https://playbook.powerapp.cloud/beta/kits
Current all kits page: https://playbook.powerapp.cloud/kits/

This PR achieves this by filtering through the components list and only displaying those with status "stable". Beta kits have status "beta". The review environment just has one beta kit, Draggable, (which matches current state of kits in production) but when testing locally I made many kits status "beta". 

Next Steps: there is a follow up ticket to address beta kits appearing on the current and beta versions of the kit_category page (https://playbook.powerapp.cloud/kit_category/layout_and_structure and https://playbook.powerapp.cloud/beta/kit_category/layout_and_structure), but should keep in mind that the direct link to the beta version does not work (must access via clicking the category title while on the /beta/kits page.

**Screenshots:** Screenshots to visualize your addition/change
Current behavior in production: the beta React kit "Draggable" appears on the all kits beta page and is searchable.
<img width="1545" alt="beta kit present production" src="https://github.com/powerhome/playbook/assets/83474365/caee6307-2dd9-4605-9830-ed692b534d58">
<img width="1168" alt="beta kit searchable production" src="https://github.com/powerhome/playbook/assets/83474365/6eeebc2c-b707-40c4-a083-6d979e07d84f">

Corrected behavior: the beta React kit "Draggable" does not appear on the all kits beta page and is not searchable.
<img width="1537" alt="beta kit absent in all kits beta" src="https://github.com/powerhome/playbook/assets/83474365/249b9bd4-4d6a-4f3e-a01d-1a6de09a926a">
<img width="1180" alt="beta kit absent search" src="https://github.com/powerhome/playbook/assets/83474365/80e99683-cc73-4849-89c3-df7e1dd7d5b9">


**How to test?** Steps to confirm the desired behavior:
1. Go to review environment beta all kits page https://pr3500.playbook.beta.px.powerapp.cloud/beta/kits.
2. In React, down to "Layouts & Structure" category section.
3. Draggable kit should not be visible.
4. Scroll up to the filter and search for "Draggable" kit.
5. No results should be found.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~