### PR TITLE
[PLAY-692] Remove duplicate "block" button in RTE on start, not change

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.tsx
@@ -86,32 +86,17 @@ const RichTextEditor = (props: RichTextEditorProps): React.ReactElement => {
     const toolbarElement = element.parentElement.querySelector('trix-toolbar') as HTMLElement,
       blockCodeButton = toolbarElement.querySelector('[data-trix-attribute=code]') as HTMLElement
 
+    // replace default trix "block code" button with "inline code" button
     let inlineCodeButton = toolbarElement.querySelector('[data-trix-attribute=inlineCode]') as HTMLElement
-    if (!inlineCodeButton) inlineCodeButton = blockCodeButton.cloneNode(true) as HTMLElement
-
-    // set button attributes
-    inlineCodeButton.dataset.trixAttribute = 'inlineCode'
-    blockCodeButton.insertAdjacentElement('afterend', inlineCodeButton)
+    if (!inlineCodeButton) {
+      inlineCodeButton = blockCodeButton.cloneNode(true) as HTMLElement
+      blockCodeButton.hidden = true
+      // set button attributes
+      inlineCodeButton.dataset.trixAttribute = 'inlineCode'
+      blockCodeButton.insertAdjacentElement('afterend', inlineCodeButton)
+    } 
 
     if (toolbarBottom) editor.element.after(toolbarElement)
-
-    const getCodeFormattingType = (): string => {
-      if (editor.attributeIsActive('code')) return 'block'
-      if (editor.attributeIsActive('inlineCode')) return 'inline'
-
-      const range = editor.getSelectedRange()
-      if (range[0] == range[1]) return 'block'
-
-      const text = editor.getSelectedDocument().toString().trim()
-      return /\n/.test(text) ? 'block' : 'inline'
-    }
-
-    // DOM event listeners
-    element.addEventListener('trix-selection-change', () => {
-      const type = getCodeFormattingType()
-      blockCodeButton.hidden = type == 'inline'
-      inlineCodeButton.hidden = type == 'block'
-    })
 
     focus
       ? (document.addEventListener('trix-focus', useFocus),


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Remove duplicate "code block" button in Rich Text Editor.
The default Trix "code" button displays code text as a "block", but we want code to display "inline". 
Fix duplicate button as the logic for hiding the "block" button happened on `trix-selection-change`, not at the start. 

**Screenshots:** Screenshots to visualize your addition/change

Current prod behavior:
![Screenshot 2024-07-01 at 3 21 31 PM](https://github.com/powerhome/playbook/assets/42440452/ae910da1-6f7c-4089-a301-702a08af3e0d)

If you click the first "code" button, then there is broken "code block" styling:
![Screenshot 2024-07-01 at 4 48 51 PM](https://github.com/powerhome/playbook/assets/42440452/97fcf127-7de5-4c4c-a561-bbfb1d03e2ed)

New behavior:
![Screenshot 2024-07-01 at 3 20 18 PM](https://github.com/powerhome/playbook/assets/42440452/0a3d38a2-688c-404f-85ec-0240b3aed537)

![Screenshot 2024-07-01 at 4 50 02 PM](https://github.com/powerhome/playbook/assets/42440452/292c3e0b-1ad1-4f72-96e9-256099ebbaa5)

**How to test?** Steps to confirm the desired behavior:
1. Go to https://pr3501.playbook.beta.hq.powerapp.cloud/kits/rich_text_editor/react
3. The code button in the RTE should show only once
4. Highlight some text
5. Click the code button.
6. The text should be formatted as `code`. 
7. You should be able to toggle code formatting on and off. 

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.