### PR TITLE
[PLAY-882] Form pills: match handoff (primary + default)

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
@@ -60,9 +60,11 @@ $form_pill_colors: (
         padding-right: $space-sm/4;
         display: flex;
         align-items: center;
-        height: 100%;
-        cursor: pointer;
+        // I had to temporarily change height to 27px so new hover state darker background forms a circle not an oval
+        // before size change (ticket 2 of 4) - change back to 100% when $pb_form_pill_height changed to 27px from 37px
+        height: 27px;
         border-radius: 70px;
+        cursor: pointer;
         &:hover {
           background-color: mix($color_value, $card_light, 40%);
           @if ($color_name == "neutral") {

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
@@ -5,9 +5,10 @@
 @import "../pb_avatar/avatar";
 
 $selector: ".pb_form_pill";
-$pb_form_pill_height: 37px;
+$pb_form_pill_height: 27px;
 $form_pill_colors: (
   primary: map-get($status_color_text, "primary"),
+  neutral: map-get($status_color_text, "neutral"),
 );
 
 
@@ -23,33 +24,69 @@ $form_pill_colors: (
   cursor: pointer;
   @each $color_name, $color_value in $form_pill_colors {
     &[class*=_#{$color_name}]  {
-      background-color: rgba($color_value, $opacity-1);
+      background-color: mix($color_value, $card_light, 10%);
+      @if ($color_name == "neutral") {
+        background-color: $white;
+        border: 1px solid $border_light;
+      }
       transition: background-color 0.2s ease;
       box-shadow: none;
       @media (hover:hover) {
         &:hover {
-          background-color: rgba($color_value, $opacity-2);
+          background-color: mix($color_value, $card_light, 20%);
+          @if ($color_name == "neutral") {
+            background-color: mix($neutral, $card_light, 20%);
+            border: 1px solid $border_light;
+          }
         }
+        &:active {
+          background-color: mix($color_value, $card_light, 30%);
+          @if ($color_name == "neutral") {
+            background-color: mix($neutral, $card_light, 30%);
+          }
+        }
+        // &:hover #{$selector}_close {
+        //   background-color: mix($color_value, $card_light, 40%);
+        //   // border-radius: 70px;
+        //   // border-radius: $border_radius_rounded;
+        //   @if ($color_name == "neutral") {
+        //     background-color: mix($neutral, $card_light, 90%);
+        //   }
+        // }
       }
       #{$selector}_text {
         color: $color_value;
+        @if ($color_name == "neutral") {
+          color: $text_lt_default;
+        }
         padding-left: $space-sm;
-        padding-right: $space-sm/4;
+        padding-right: $space-sm/2;
       }
       #{$selector}_close {
         color: $color_value;
-        padding-left: $space-sm/2;
+        padding-left: $space-sm/4;
         padding-right: $space-sm/4;
         display: flex;
         align-items: center;
         height: 100%;
         cursor: pointer;
-      }
+        border-radius: 70px;
+        // border-radius: $border_radius_rounded;
+        &:hover {
+          background-color: mix($color_value, $card_light, 40%);
+          // border-radius: 70px;
+          // border-radius: $border_radius_rounded;
+            @if ($color_name == "neutral") {
+              background-color: mix($neutral, $card_light, 60%);
+              // border: 1px solid $border_light;
+            }
+        }
       #{$selector}_tag {
         color: $color_value;
         padding-left: $space-sm;
       }
     }
+  }
   }
   &.small {
     height: fit-content;

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
@@ -5,7 +5,7 @@
 @import "../pb_avatar/avatar";
 
 $selector: ".pb_form_pill";
-$pb_form_pill_height: 27px;
+$pb_form_pill_height: 37px;
 $form_pill_colors: (
   primary: map-get($status_color_text, "primary"),
   neutral: map-get($status_color_text, "neutral"),
@@ -45,14 +45,6 @@ $form_pill_colors: (
             background-color: mix($neutral, $card_light, 30%);
           }
         }
-        // &:hover #{$selector}_close {
-        //   background-color: mix($color_value, $card_light, 40%);
-        //   // border-radius: 70px;
-        //   // border-radius: $border_radius_rounded;
-        //   @if ($color_name == "neutral") {
-        //     background-color: mix($neutral, $card_light, 90%);
-        //   }
-        // }
       }
       #{$selector}_text {
         color: $color_value;
@@ -71,22 +63,21 @@ $form_pill_colors: (
         height: 100%;
         cursor: pointer;
         border-radius: 70px;
-        // border-radius: $border_radius_rounded;
         &:hover {
           background-color: mix($color_value, $card_light, 40%);
-          // border-radius: 70px;
-          // border-radius: $border_radius_rounded;
-            @if ($color_name == "neutral") {
-              background-color: mix($neutral, $card_light, 60%);
-              // border: 1px solid $border_light;
-            }
+          @if ($color_name == "neutral") {
+            background-color: mix($neutral, $card_light, 60%);
+          }
         }
+      }
       #{$selector}_tag {
         color: $color_value;
         padding-left: $space-sm;
+        @if ($color_name == "neutral") {
+          color: $text_lt_default;
+        }
       }
     }
-  }
   }
   &.small {
     height: fit-content;
@@ -107,6 +98,71 @@ $form_pill_colors: (
       &::before { line-height: 21px; }
     }
   }
+  &.dark {
+    @each $color_name, $color_value in $form_pill_colors {
+      // In dark mode, the base patterns below are needed for the next tickets for success, warning, error, info. 
+      // Primary and Neutral are exceptions to the general rule in the handoff 
+      &[class*=_#{$color_name}]  {
+      //   background-color: mix($color_value, $card_dark, 10%);
+        // .pb_form_pill_tag {
+        //   color: $color_name;
+        // }
+        // .pb_form_pill_close {
+        //   color: $color_name;
+        //   &:hover {
+        //     background-color: mix($color_value, $card_dark, 40%);
+        //   }
+        // }
+        // &:hover {
+        //   background-color: mix($color_value, $card_dark, 20%);
+        // }
+        // &:active {
+        //   background-color: mix($color_value, $card_dark, 30%);
+        // }
+        @if ($color_name == "neutral") {
+          background-color: transparent;
+          border: 1px solid $border_dark;
+          .pb_form_pill_text, .pb_form_pill_tag {
+            color: $text_dk_default;
+          }
+          .pb_form_pill_close {
+            color: $text_dk_default;
+            &:hover {
+              background-color: mix($neutral, $card_dark, 40%);
+            }
+          }
+          &:hover {
+            background-color: mix($white, $card_dark, 10%);
+          }
+          &:active {
+            background-color: mix($white, $card_dark, 20%);
+          }
+          &:focus {
+            border: 1px solid $primary;
+          }
+        }
+        @if ($color_name == "primary") {
+          background-color: mix($active_dark, $card_dark, 10%);
+          .pb_form_pill_text, .pb_form_pill_tag {
+            color: $active_dark;
+          }
+          .pb_form_pill_close {
+            color: $active_dark;
+            &:hover {
+              background-color: mix($active_dark, $card_dark, 40%);
+            }
+          }
+          &:hover {
+            background-color: mix($active_dark, $card_dark, 20px);
+          }
+          &:active {
+            background-color: mix($active_dark, $card_dark, 30%);
+          }
+        }
+      }
+    }
+  }
+
   &[class*=lowercase] {
     text-transform: lowercase;
   }

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
@@ -79,6 +79,14 @@ $form_pill_colors: (
       }
     }
   }
+  &:focus {
+    outline: $primary solid 2px;
+    outline-offset: -1px;
+  }
+  &:focus-visible {
+    outline: $primary solid 2px;
+    outline-offset: -1px;
+  }
   &.small {
     height: fit-content;
     height: -moz-fit-content;

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '../utilities/test-utils';
+import FormPill from './_form_pill';
+
+const testId = 'formpill';
+
+test('should render classname', () => {
+    render(
+        <FormPill
+            data={{ testid: testId }}
+            text="test"
+        /> 
+    )
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass('pb_form_pill_kit_primary none')
+});
+
+test('displays text content', () => {
+    render(
+        <FormPill
+            data={{ testid: testId }}
+            text="test"
+        /> 
+    )
+  
+    const text = screen.getByText("test")
+    expect(text).toBeInTheDocument()
+});
+
+test('displays color variant', () => {
+    render(
+        <FormPill
+            color={"neutral"}
+            data={{ testid: testId }}
+            text={"test"}
+        />
+    )
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass(`pb_form_pill_kit_neutral none`)
+});
+
+test('displays size variant', () => {
+    render(
+        <FormPill            
+            data={{ testid: testId }}
+            size={"small"}
+            text={"test"}
+        />
+    )
+    const kit = screen.getByTestId('formpill')
+    expect(kit).toHaveClass(`pb_form_pill_kit_primary small none`)
+});

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
@@ -19,6 +19,7 @@ type FormPillProps = {
   size?: string,
   textTransform?: 'none' | 'lowercase',
   color?: "primary" | "neutral",
+  tabIndex?: number,
   closeProps?: {
     onClick?: React.MouseEventHandler<HTMLSpanElement>,
     onMouseDown?: React.MouseEventHandler<HTMLSpanElement>,
@@ -38,6 +39,7 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
     size = '',
     textTransform = 'none',
     color = "primary",
+    tabIndex,
   } = props
   const css = classnames(
     `pb_form_pill_kit_${color}`,
@@ -52,6 +54,7 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
   return (
     <div className={css}
         id={id}
+        tabIndex={tabIndex}
         {...htmlProps}
     >
         {name &&

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
@@ -18,6 +18,7 @@ type FormPillProps = {
   avatarUrl?: string,
   size?: string,
   textTransform?: 'none' | 'lowercase',
+  color?: "primary" | "neutral",
   closeProps?: {
     onClick?: React.MouseEventHandler<HTMLSpanElement>,
     onMouseDown?: React.MouseEventHandler<HTMLSpanElement>,
@@ -36,9 +37,10 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
     closeProps = {},
     size = '',
     textTransform = 'none',
+    color = "primary",
   } = props
   const css = classnames(
-    `pb_form_pill_kit_${'primary'}`,
+    `pb_form_pill_kit_${color}`,
     globalProps(props),
     className,
     size === 'small' ? 'small' : null,

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
@@ -5,7 +5,7 @@ import Title from '../pb_title/_title'
 import Icon from '../pb_icon/_icon'
 import Avatar from '../pb_avatar/_avatar'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
-import { buildHtmlProps } from '../utilities/props'
+import { buildDataProps, buildHtmlProps } from '../utilities/props'
 
 type FormPillProps = {
   className?: string,
@@ -19,6 +19,7 @@ type FormPillProps = {
   size?: string,
   textTransform?: 'none' | 'lowercase',
   color?: "primary" | "neutral",
+  data?: {[key: string]: string},
   tabIndex?: number,
   closeProps?: {
     onClick?: React.MouseEventHandler<HTMLSpanElement>,
@@ -39,6 +40,7 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
     size = '',
     textTransform = 'none',
     color = "primary",
+    data = {},
     tabIndex,
   } = props
   const css = classnames(
@@ -49,12 +51,14 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
     textTransform,
   )
 
+  const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
 
   return (
     <div className={css}
         id={id}
         tabIndex={tabIndex}
+        {...dataProps}
         {...htmlProps}
     >
         {name &&

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_example.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_example.html.erb
@@ -1,1 +1,5 @@
-<%= pb_rails("form_pill", props: { text_transform: "lowercase" , text: "THIS IS A TAG" }) %>
+<%= pb_rails("form_pill", props: {
+    text_transform: "lowercase" ,
+    text: "THIS IS A TAG",
+    tabindex: 0,
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_example.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_example.jsx
@@ -6,6 +6,7 @@ const FormPillExample = (props) => {
     <div>
       <FormPill
           onClick={() => alert('Click!')}
+          tabIndex={0}
           text="THIS IS A TAG"
           textTransform="lowercase"
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_size.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_size.html.erb
@@ -2,6 +2,7 @@
    name: "Anna Black",
    avatar_url: "https://randomuser.me/api/portraits/women/44.jpg",
    size: "small",
+   tabindex: 0,
 }) %>
 
 <br />
@@ -10,4 +11,5 @@
 <%= pb_rails("form_pill", props: {
    name: "Anna Black",
    size: "small",
+   tabindex: 0,
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_size.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_size.jsx
@@ -9,6 +9,7 @@ const FormPillSize = (props) => {
           avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
           name="Anna Black"
           size="small"
+          tabIndex={0}
           {...props}
       />
       <br />
@@ -16,6 +17,7 @@ const FormPillSize = (props) => {
       <FormPill
           name="Anna Black"
           size="small"
+          tabIndex={0}
           {...props}
       />
     </div>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.html.erb
@@ -1,1 +1,4 @@
-<%= pb_rails("form_pill", props: { text: "this is a tag" }) %>
+<%= pb_rails("form_pill", props: {
+    text: "this is a tag",
+    tabindex: 0,
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_tag.jsx
@@ -6,8 +6,9 @@ const FormPillDefault = (props) => {
     <div>
       <FormPill
           onClick={() => {
-alert('Click!')
-}}
+            alert('Click!')
+          }}
+          tabIndex={0}
           text="this is a tag"
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.html.erb
@@ -1,6 +1,7 @@
 <%= pb_rails("form_pill", props: {
    name: "Anna Black",
    avatar_url: "https://randomuser.me/api/portraits/women/44.jpg",
+   tabindex: 0,
 }) %>
 
 <br />
@@ -8,4 +9,5 @@
 
 <%= pb_rails("form_pill", props: {
    name: "Anna Black",
+   tabindex: 0,
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_user.jsx
@@ -9,6 +9,7 @@ const FormPillDefault = (props) => {
           avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
           name="Anna Black"
           onClick={() => alert('Click!')}
+          tabIndex={0}
           {...props}
       />
       <br />
@@ -16,6 +17,7 @@ const FormPillDefault = (props) => {
       <FormPill
           name="Anna Black"
           onClick={() => alert('Click!')}
+          tabIndex={0}
           {...props}
       />
     </div>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag(:div, id: object.id, data: object.data, class: object.classname + object.size_class, **combined_html_options) do %>
+<%= content_tag(:div, id: object.id, data: object.data, class: object.classname + object.size_class, tabindex: object.tabindex, **combined_html_options) do %>
   <% if object.name.present? %>
     <%= pb_rails("avatar", props: { name: object.name, image_url: object.avatar_url, size: "xs" }) %>
       <%= pb_rails("title", props: { text: object.name, size: 4, classname: "pb_form_pill_text" }) %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.rb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.rb
@@ -14,6 +14,7 @@ module Playbook
       prop :color, type: Playbook::Props::Enum,
                    values: %w[primary neutral],
                    default: "primary"
+      prop :tabindex
 
       def classname
         generate_classname("pb_form_pill_kit", color, name, text, text_transform)

--- a/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.rb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.rb
@@ -11,9 +11,12 @@ module Playbook
       prop :text_transform, type: Playbook::Props::Enum,
                             values: %w[none lowercase],
                             default: "none"
+      prop :color, type: Playbook::Props::Enum,
+                   values: %w[primary neutral],
+                   default: "primary"
 
       def classname
-        generate_classname("pb_form_pill_kit", "primary", name, text, text_transform)
+        generate_classname("pb_form_pill_kit", color, name, text, text_transform)
       end
 
       def display_text

--- a/playbook/spec/pb_kits/playbook/kits/form_pill_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/form_pill_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe Playbook::PbFormPill::FormPill do
   it { is_expected.to define_prop(:name) }
   it { is_expected.to define_prop(:avatar_url) }
   it { is_expected.to define_prop(:size) }
+  it { is_expected.to define_prop(:color) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_form_pill_kit_primary_none"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_form_pill_kit_primary_none additional_class"
+      expect(subject.new(color: "neutral").classname).to eq "pb_form_pill_kit_neutral_none"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-882](https://runway.powerhrg.com/backlog_items/PLAY-882) begins the efforts (ticket 1 of 4 at the moment) to match the updated Form Pill/Typeahead [handoff](https://www.figma.com/file/79KJo0Jl8HSNOBQPJo5MSp/Typeahead-Dropdowns?type=design&node-id=240%3A7600&mode=design&t=f7VGtBFjzitLydyF-1) by:

- adding the color prop
- including neutral as an option in addition to the current default primary
- setting up background, hover, and active states for both colors
- setting focus-ability via adding tabIndex prop
- adding jest tests and updating rspec tests (involved adding data prop to react version in order for jest tests to work like other kit tests do)

Here is a [Codesandbox with alpha](https://codesandbox.io/p/sandbox/play-882-alpha-ntmj62?file=%2Fsrc%2FApp.js%3A82%2C37) wherein one can see the applied changes to the Form Pill kit examples (includes default size with avatar, small size with avatar, default size with text only) displaying Primary and Neutral versions, as well as the primary version within the Typeahead and MultiLevelSelect kits.

Here is the [nitro-web milano review env](https://pr40906.nitro-web.beta.hq.powerapp.cloud/).

**Screenshots:** Screenshots to visualize your addition/change
The screenshots below have all the examples from the Form Pill doc examples within one card for ease of screenshotting - first two are Form Pill User Primary, second two are Form Pill User Neutral, fifth is Form Pill Size Primary, sixth is Form Pill Size Neutral, seventh is Form Pill Tag Primary, eighth is Form Pill Tag Neutral.
<img width="412" alt="for PR rails primary local" src="https://github.com/powerhome/playbook/assets/83474365/be446d3e-9db7-47da-bbbf-af660c4d8171">
<img width="389" alt="for PR rails neutral local" src="https://github.com/powerhome/playbook/assets/83474365/0414b873-57ee-45ef-9685-d449a8942021">
<img width="423" alt="for PR react primary local" src="https://github.com/powerhome/playbook/assets/83474365/8f99be98-835c-49d1-937d-b1aef1efb24f">
<img width="439" alt="for PR react neutral local" src="https://github.com/powerhome/playbook/assets/83474365/67ff1170-6a76-4851-9109-6174158f9e7e">
Screenshot from codesandbox showing new form pills and within Typeahead/MultiLevelSelect
<img width="776" alt="CSB screenshot for PR" src="https://github.com/powerhome/playbook/assets/83474365/6dfcb105-17d3-475c-a30d-c27073b0d937">
Screenshot from nitro-web milano review env showing new form pills within Typeahead
![image](https://github.com/powerhome/playbook/assets/83474365/dd47b8fb-c647-466c-9468-208f6cbd12a7)


**How to test?** Steps to confirm the desired behavior:
1. Go to [CSB with alpha](https://codesandbox.io/p/sandbox/play-882-alpha-ntmj62?file=%2Fsrc%2FApp.js%3A82%2C37).
2. Examine formpill function - see new color options and hover/active/X hover states, as well as focus mode (and focus+hover, focus+active).
3. See how new formpill looks within Typeahead and MultiLevelSelect (active/hover states only, no new colors within other kits yet).
4. Go to [playbook review env](https://pr3505.playbook.beta.px.powerapp.cloud/).
5. Go to kit pages for [formpill](https://pr3505.playbook.beta.px.powerapp.cloud/kits/form_pill)/[typeahead](https://pr3505.playbook.beta.px.powerapp.cloud/kits/typeahead#with-pills)/[multilevelselect](https://pr3505.playbook.beta.px.powerapp.cloud/kits/multi_level_select/rails) -  test their appearance and function like in steps 2 and 3 for CSB, primary color only will be visible here as doc examples not yet adjusted to show color prop.
6. Go to [nitro-web milano review env](https://pr40906.nitro-web.beta.hq.powerapp.cloud/).
7. Go to pages with formpill/typeahead/mutlilevel select - test their appearance and function like in steps 2 and 3 for CSB (primary color only).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.