### PR TITLE
[PLAY-1364] Date Year Stacked Left Align Text Color Bug

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_year_stacked/docs/_date_year_stacked_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_year_stacked/docs/_date_year_stacked_default.jsx
@@ -4,7 +4,11 @@ import { DateYearStacked } from '../../'
 const DateYearStackedDefault = (props) => {
   return (
     <div>
-      <DateYearStacked date={new Date()} />
+      <DateYearStacked
+          align="left"
+          date={new Date()}
+          {...props}
+      />
       <DateYearStacked
           align="center"
           date={new Date()}

--- a/playbook/app/pb_kits/playbook/pb_date_year_stacked/docs/_date_year_stacked_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_year_stacked/docs/_date_year_stacked_default.jsx
@@ -5,7 +5,6 @@ const DateYearStackedDefault = (props) => {
   return (
     <div>
       <DateYearStacked
-          align="left"
           date={new Date()}
           {...props}
       />


### PR DESCRIPTION
[Play-1364](https://runway.powerhrg.com/backlog_items/PLAY-1364)

**What does this PR do?** 
Fixes darkmode conversion with left aligned date year stacked.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1418" alt="Screenshot 2024-07-05 at 10 38 44 AM" src="https://github.com/powerhome/playbook/assets/129005183/ff17df65-8e84-4df7-a0c1-3c29d3b5e509">

**How to test?** Steps to confirm the desired behavior:
1. Go to date year stacked kit, confirm styles/colors are correct
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.