### PR TITLE
[PLAY-1429] Improve consistency in docs for default variant of Typeahead

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_default.html.erb
@@ -1,63 +1,28 @@
+<%
+  options = [
+    { label: 'Orange', value: '#FFA500' },
+    { label: 'Red', value: '#FF0000' },
+    { label: 'Green', value: '#00FF00' },
+    { label: 'Blue', value: '#0000FF' },
+  ]
+%>
+
 <%= pb_rails("typeahead", props: {
-  label: "user",
-  name: :foo,
-  data: { typeahead_example: true },
-  input_options: {
-    classname: "my-typeahead-class",
-    data: {
-      typeahead_testing: "data field test"
-    },
-    id: "typeahead-input-id-test",
-  },
-})%>
-
-<br><br><br>
-
-<%= pb_rails("card", props: { padding: "xl", data: { typeahead_example_selected_option: true } }) do %>
-  <%= pb_rails("body") do %>
-    Use the above input to search for users on Github, and see the results as you type.
-  <% end %>
-
-  <%= pb_rails("body") do %>
-    When you make a selection, you will see it appear in the list below
-  <% end %>
-
-  <div data-selected-option></div>
-<% end %>
-
-<template data-typeahead-example-result-option>
-  <%= pb_rails("user", props: {
-    name: tag(:slot, name: "name"),
-    orientation: "horizontal",
-    align: "left",
-    avatar_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGP6zwAAAgcBApocMXEAAAAASUVORK5CYII=",
-    avatar: true
-    }) %>
-</template>
+    id: "typeahead-default",
+    placeholder: "All Colors",
+    options: options,
+    label: "Colors",
+    name: :foo,
+    is_multi: false
+  })
+%>
 
 <%= javascript_tag defer: "defer" do %>
-  document.addEventListener("pb-typeahead-kit-search", function(event) {
-    if (!event.target.dataset || !event.target.dataset.typeaheadExample) return;
-
-    fetch(`https://api.github.com/search/users?q=${encodeURIComponent(event.detail.searchingFor)}`)
-      .then(response => response.json())
-      .then((result) => {
-        const resultOptionTemplate = document.querySelector("[data-typeahead-example-result-option]")
-
-        event.detail.setResults((result.items || []).map((user) => {
-          const wrapper = resultOptionTemplate.content.cloneNode(true)
-          wrapper.querySelector('slot[name="name"]').replaceWith(user.login)
-          wrapper.querySelector('img').dataset.src = user.avatar_url
-          return wrapper
-        }))
-      })
+  document.addEventListener("pb-typeahead-kit-typeahead-default-result-option-select", function(event) {
+    console.log('Single Option selected')
+    console.dir(event.detail)
   })
-
-
-  document.addEventListener("pb-typeahead-kit-result-option-selected", function(event) {
-    if (!event.target.dataset.typeaheadExample) return;
-
-    document.querySelector("[data-typeahead-example-selected-option] [data-selected-option]").innerHTML = ""
-    document.querySelector("[data-typeahead-example-selected-option] [data-selected-option]").innerHTML = event.detail.selected.innerHTML
+  document.addEventListener("pb-typeahead-kit-typeahead-default-result-clear", function() {
+    console.log('All options cleared')
   })
 <% end %>


### PR DESCRIPTION
[PLAY-1429](https://runway.powerhrg.com/backlog_items/PLAY-1429)

**What does this PR do?**
Updated the default Typeahead variant in the Rails display of Playbook to match the default provided in React.

**Screenshots:**
<img width="1463" alt="Screenshot 2024-07-08 at 3 44 22 PM" src="https://github.com/powerhome/playbook/assets/129005183/7d8d629f-8f8c-463b-aa70-0065a1fa5d19">

**How to test?** Steps to confirm the desired behavior:
1. Go to Components in Playbook, Form Inputs, Typehead
2. Click on Rails (if not deafulted) and verify Typehead drop down single selection works. Compare with react default.
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.