### PR TITLE
[PLAY-1402] hide beta versions of kits within Kit Categories (with menu.yml)

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -240,7 +240,8 @@ private
 
   def kit_categories
     @category = params[:category]
-    aggregate_kits.find { |item| item["category"] == @category }["components"].map { |component| component["name"] }
+    components = aggregate_kits.find { |item| item["category"] == @category }["components"]
+    components.reject { |component| component["status"] == "beta" }.map { |component| component["name"] }
   end
 
   def set_kit

--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -241,7 +241,11 @@ private
   def kit_categories
     @category = params[:category]
     components = aggregate_kits.find { |item| item["category"] == @category }["components"]
-    components.reject { |component| component["status"] == "beta" }.map { |component| component["name"] }
+    filter_kits_by_status(components, status: "beta").map { |component| component["name"] }
+  end
+
+  def filter_kits_by_status(components, status: nil)
+    components.reject { |component| status && component["status"] == status }
   end
 
   def set_kit

--- a/playbook-website/app/javascript/components/Website/src/components/CategoryTitle/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/CategoryTitle/index.tsx
@@ -6,13 +6,14 @@ import { linkFormat } from "../../../../../utilities/website_sidebar_helper";
 import "./styles.scss";
 
 type CategoryTitleProps = {
-  name: string;
+  category: string;
 };
 
-export const CategoryTitle = ({ name }: CategoryTitleProps): React.ReactElement => {
+export const CategoryTitle = ({ category }: CategoryTitleProps): React.ReactElement => {
+  
   return (
     <Flex align="center" className="category-title" gap="xs" marginBottom="md">
-      <Title size={{ xs: 3, sm: 2, md: 2, lg: 2, xl: 2 }} tag="h1" text={linkFormat(name)} />
+      <Title size={{ xs: 3, sm: 2, md: 2, lg: 2, xl: 2 }} tag="h1" text={linkFormat(category)} />
       <Icon className="icon mobile" icon="circle-arrow-right" size="sm" />
       <Icon className="icon desktop" icon="circle-arrow-right" size="xl" />
     </Flex>

--- a/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
+++ b/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
@@ -7,13 +7,14 @@ interface ComponentTypes {
 }
 
 interface CategoryTypes {
-  name: string;
+  category: string;
   description: string;
   components: ComponentTypes[];
 }
 
-const sortByName = (a: ComponentTypes, b: ComponentTypes) =>
-  a.name.localeCompare(b.name);
+const sortByName = (a: ComponentTypes, b: ComponentTypes): number => {
+  return a.name.localeCompare(b.name);
+}
 
 const sortComponentsByName = (kitCategory: CategoryTypes) => {
   kitCategory.components.sort(sortByName);
@@ -22,8 +23,8 @@ const sortComponentsByName = (kitCategory: CategoryTypes) => {
 export const ComponentsLoader: () => Promise<CategoryTypes[]> = async () => {
   const response = await fetch("/beta/kits.json");
   const data = await response.json();
- 
-  data.kits.sort(sortByName).forEach(sortComponentsByName);
+
+  data.kits.forEach(sortComponentsByName);
 
   return data;
 };
@@ -40,9 +41,9 @@ export const CategoryLoader: (
   const response = await fetch("/beta/kits.json");
   const { kits } = await response.json();
 
-  const filteredData = kits.filter(
-    (kit: ComponentTypes) => kit.name === params.name
-  )[0];
+  const filteredData = kits.find(
+    (kit: CategoryTypes) => kit.category === params.category
+  );
 
   filteredData.components.sort(sortByName);
 

--- a/playbook-website/app/javascript/components/Website/src/pages/CategoryShow/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/CategoryShow/index.tsx
@@ -13,13 +13,13 @@ import { Kit } from "../ComponentList"
 import "./styles.scss"
 
 export default function CategoryShow() {
-  const { components, name, description } = useLoaderData()
+  const { components, category, description } = useLoaderData()
   const [kitsToShow, setKitsToShow] = useState(components)
   const [platform, setPlatform] = useState('react')
 
   return (
     <>
-      <Hero description={description} title={linkFormat(name)} />
+      <Hero description={description} title={linkFormat(category)} />
 
       <Flex
         align="center"
@@ -39,7 +39,7 @@ export default function CategoryShow() {
             <Body className="previous-route" color="light">Components</Body>
           </NavLink>
           <Icon className="category-breadcrumb-icon" icon="angle-right" />
-          <Body text={linkFormat(name)} />
+          <Body text={linkFormat(category)} />
         </Flex>
 
         {!kitsToShow.length && (
@@ -54,14 +54,17 @@ export default function CategoryShow() {
           )}
 
         <KitGrid>
-          {kitsToShow.map(({ description, name }: Kit, index: number) => (
-            <KitCard
-              description={description}
-              name={name}
-              key={`category-${name}-${index}`}
-              platform={platform}
-            />
-          ))}
+          {kitsToShow.filter(component => component.status === "stable")
+          .map(({ description, name }: Kit, index: number) => {
+            return(
+              <KitCard
+                description={description}
+                name={name}
+                key={`category-${name}-${index}`}
+                platform={platform}
+              />
+            )
+          })}
         </KitGrid>
       </PageContainer>
     </>

--- a/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
@@ -10,7 +10,7 @@ import { PageContainer } from "../components/PageContainer"
 import { CategoryTitle } from "../components/CategoryTitle"
 
 export type Kit = {
-  name: string;
+  category: string;
   components: {
     name: string;
     description: string;
@@ -65,14 +65,14 @@ export default function ComponentList() {
                 />
               </Flex>
             ) : (
-              kitsToShow.map(({ name, components }: Kit, index: number) => (
+              kitsToShow.map(({ category, components }: Kit, index: number) => (
                 <section
                   className="category mb_xl"
-                  key={`${name}-${index}`}
-                  id={name}
+                  key={`${category}-${index}`}
+                  id={category}
                 >
-                  <NavLink to={`/beta/kit_category/${name}`}>
-                    <CategoryTitle name={name} />
+                  <NavLink to={`/beta/kit_category/${category}`}>
+                    <CategoryTitle category={category} />
                   </NavLink>
                   <KitGrid>
                     {components

--- a/playbook-website/app/javascript/packs/app.js
+++ b/playbook-website/app/javascript/packs/app.js
@@ -40,7 +40,7 @@ const router = createBrowserRouter(
       <Route
           element={<CategoryShow />}
           loader={CategoryLoader}
-          path="kit_category/:name"
+          path="kit_category/:category"
       />
       <Route
           element={<IconList />}

--- a/playbook-website/test/menu_yml_spec.rb
+++ b/playbook-website/test/menu_yml_spec.rb
@@ -2,7 +2,7 @@
 
 require "yaml"
 
-yaml_file_path = File.expand_path("../../config/menu.yml", __dir__)
+yaml_file_path = File.expand_path("../../../playbook/playbook-website/config/menu.yml", __dir__)
 
 RSpec.describe "Menu YAML File" do
   let(:data) { YAML.safe_load(File.read(yaml_file_path), aliases: true) }

--- a/playbook-website/test/menu_yml_spec.rb
+++ b/playbook-website/test/menu_yml_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+yaml_file_path = File.expand_path("../../config/menu.yml", __dir__)
+
+RSpec.describe "Menu YAML File" do
+  let(:data) { YAML.safe_load(File.read(yaml_file_path), aliases: true) }
+
+  it "should load YAML file without errors" do
+    expect(data).to_not be_nil
+  end
+
+  it "should have categories defined" do
+    expect(data).to have_key("kits")
+    expect(data["kits"]).to be_an(Array)
+    expect(data["kits"]).to_not be_empty
+  end
+
+  it "should have components defined for each category" do
+    data["kits"].each do |kit|
+      expect(kit).to have_key("category")
+      expect(kit["category"]).to be_a(String)
+      expect(kit).to have_key("components")
+      expect(kit["components"]).to be_an(Array)
+      expect(kit["components"]).to_not be_empty
+
+      kit["components"].each do |component|
+        expect(component).to have_key("name")
+        expect(component["name"]).to be_a(String)
+        expect(component).to have_key("platforms")
+        expect(component["platforms"]).to be_an(Array)
+        expect(component["platforms"]).to_not be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1402](https://runway.powerhrg.com/backlog_items/PLAY-1402) ensures that beta kits are not visible on the kit_category pages of the Playbook website. This includes both PB/kit_category/category_title and PB/beta/kit_category/category_title endpoints. This PR also continues some work started in PLAY-1391 [runway](https://runway.powerhrg.com/backlog_items/PLAY-1391)/[PR](https://github.com/powerhome/playbook/pull/3488) to fully update name -> category for beta website pages based on the change to menu.yml.

The stretch goal 🌟 in the runway ticket was also achieved: `menu_yml_spec.rb` contains some basic tests to confirm the YAML file loads without errors, that categories and components are properly defined, and that each component has a name and a platform. Runs with `rspec playbook-website/test/menu_yml_spec.rb` from playbook folder.

**Screenshots:** Screenshots to visualize your addition/change: 
Note - for these screenshots I temporarily made several kits beta on my local for the sake of a clear visual demonstration. Dialog, Button Toolbar, and Circle Icon Button are beta in the examples below.
Kits are beta - Dialog and Button Toolbar kit pages have beta kit card, not listed on sidebar:
<img width="1333" alt="for PR dialog is beta" src="https://github.com/powerhome/playbook/assets/83474365/4207a201-0e01-44b0-bbe9-42b59e21cea0">
<img width="1444" alt="for PR button toolbar is beta" src="https://github.com/powerhome/playbook/assets/83474365/1f866bdb-8074-4ae2-9d0e-3b1f0f909835">
All Kits pages - beta kits do not appear:
<img width="708" alt="for PR all kits no dialog" src="https://github.com/powerhome/playbook/assets/83474365/a65f634f-74cc-4006-be21-0537b38aed55">
<img width="1172" alt="for PR all kits no buttons" src="https://github.com/powerhome/playbook/assets/83474365/f543f741-702e-41ea-af50-25bee164316f">
Kit Category pages - beta kits do not appear:
<img width="758" alt="for PR kit category no dialog" src="https://github.com/powerhome/playbook/assets/83474365/db0ab81d-fb3f-48cc-a679-5b5ed591020e">
<img width="910" alt="for PR kit category no buttons" src="https://github.com/powerhome/playbook/assets/83474365/fb78c63e-18c2-47bf-b3f3-429f06d2dd78">
Beta All Kits page - beta kits do not appear, even when searched for in the filter input:
<img width="1254" alt="for PR beta all kits no dialog or buttons" src="https://github.com/powerhome/playbook/assets/83474365/99e820fd-3e0f-4c5f-925b-bcfdc0777467">
<img width="1159" alt="for PR beta all kits search buttons" src="https://github.com/powerhome/playbook/assets/83474365/3a7f744e-53c2-44b4-b6da-7d645fb554e1">
Beta Kit Category pages - beta kits do not appear:
<img width="1239" alt="for PR beta kit category no dialog" src="https://github.com/powerhome/playbook/assets/83474365/b476465b-76a0-41c1-b4c8-b2c80133ad4f">
<img width="1178" alt="for PR beta kit category no buttons" src="https://github.com/powerhome/playbook/assets/83474365/8db124ff-c8d0-4bd2-84aa-a352f25cc512">

**How to test?** Steps to confirm the desired behavior:
Note: in the milano review environment, Draggable is the only beta kit and should be used as the test kit.
1. Go to [beta kit page in review env](https://pr3513.playbook.beta.gm.powerapp.cloud/kits/draggable/react).
2. See that Draggable has the beta kit card and is not listed on sidebar under the "Layout & Structure" category.
3. Click on the "Layout & Structure" sidebar or go to [kit category page in review env](https://pr3513.playbook.beta.gm.powerapp.cloud/kit_category/layout_and_structure?type=react)
4. Scroll down the page and see that Draggable is not present on the kit_category page.
5. Go to the [beta kits website page](https://pr3513.playbook.beta.gm.powerapp.cloud/beta/kits) and scroll down to the "Layout & Structure" category section.
6. Click on the "Layout & Structure" category title (URL will display https://pr3513.playbook.beta.gm.powerapp.cloud/beta/kit_category/layout_and_structure), see that Draggable is not present on the beta/kit_category page.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.