### PR TITLE
[PLAY-1431] Update Highcharts CustomOptions Formatting Note

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.md
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.md
@@ -1,3 +1,6 @@
+The `customOptions` prop provides comprehensive access to additional [Highcharts options](https://api.highcharts.com/highcharts/) that are not explicitly defined as props.
+ It's important to note that certain options may require specific script imports to function properly.
+
 Note: If you are having trouble getting any Highcharts options to work, please match the formatting of our [staticOptions](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx#L85-L141). For example, `yAxis` will need to be wrapped with square brackets.
 
 You may also need to override any of the [defaults](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx#L45-L73) in order to get that options to work.

--- a/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.md
+++ b/playbook/app/pb_kits/playbook/pb_bar_graph/docs/_bar_graph_custom.md
@@ -1,2 +1,3 @@
-The `customOptions` prop provides comprehensive access to additional [Highcharts options](https://api.highcharts.com/highcharts/) that are not explicitly defined as props.
- It's important to note that certain options may require specific script imports to function properly.
+Note: If you are having trouble getting any Highcharts options to work, please match the formatting of our [staticOptions](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx#L85-L141). For example, `yAxis` will need to be wrapped with square brackets.
+
+You may also need to override any of the [defaults](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_bar_graph/_bar_graph.tsx#L45-L73) in order to get that options to work.


### PR DESCRIPTION
[PLAY-1431](https://runway.powerhrg.com/backlog_items/PLAY-1431)

**What does this PR do?**
Updates Highcharts CustomOption Formatting note discrepancy in docs

**Screenshots:**
New Message:
<img width="1479" alt="Screenshot 2024-07-09 at 2 41 53 PM" src="https://github.com/powerhome/playbook/assets/129005183/db544c16-6965-404b-aa28-da053baedae7">

**How to test?** Steps to confirm the desired behavior:
1. Go to Playbook components, data visualizers, bar graph
2. Scroll down to "CUSTOM OVERRIDES"
4. See addition/change

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.