### PR TITLE
Change Draggable Kit status to Stable

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -427,7 +427,7 @@ kits:
   - name: draggable
     platforms: *2
     description:
-    status: beta
+    status: stable
 - category: message_text_patterns
   description:
   components:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,10 +2842,10 @@
   resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/261d2f40561f1d4d0505e4af18892916941ed1a0#261d2f40561f1d4d0505e4af18892916941ed1a0"
   integrity sha512-LtnN8E/yHaXzjQG+sZfpUbGA9Xdqpwhx8aFSPvg0lGf7phOoNFHSmjXhK0a36bZnPn0tIGBct9LhSzp6zhyVBA==
 
-"@powerhome/power-fonts@0.0.1-alpha.4":
-  version "0.0.1-alpha.4"
-  resolved "https://npm.powerapp.cloud/@powerhome/power-fonts/-/2db6ab57032de4685fb9d221fd92b4a4aca7f92e#2db6ab57032de4685fb9d221fd92b4a4aca7f92e"
-  integrity sha512-Oc6KNQt6kw8AKFMK8oPWTkUQotRkqvawzAWiYXDlP2cdoxIyTfBEqtYgQj8MbLcpYynPm0WjQHegQnxAwtNorQ==
+"@powerhome/power-fonts@0.0.1-alpha.6":
+  version "0.0.1-alpha.6"
+  resolved "https://npm.powerapp.cloud/@powerhome/power-fonts/-/aa26f705183fa213bd4488fa53772f2c28bb9edf#aa26f705183fa213bd4488fa53772f2c28bb9edf"
+  integrity sha512-kGv2t8SF8aW5WuRkia8Q0SqbGiJtv34dcy2ckPT0O+a6D4PLrAhtBB5B1sI69/IDZy6CfrjKC/6TIQjDSyx75Q==
 
 "@rails/actioncable@^7.0":
   version "7.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2842,10 +2842,10 @@
   resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/261d2f40561f1d4d0505e4af18892916941ed1a0#261d2f40561f1d4d0505e4af18892916941ed1a0"
   integrity sha512-LtnN8E/yHaXzjQG+sZfpUbGA9Xdqpwhx8aFSPvg0lGf7phOoNFHSmjXhK0a36bZnPn0tIGBct9LhSzp6zhyVBA==
 
-"@powerhome/power-fonts@0.0.1-alpha.6":
-  version "0.0.1-alpha.6"
-  resolved "https://npm.powerapp.cloud/@powerhome/power-fonts/-/aa26f705183fa213bd4488fa53772f2c28bb9edf#aa26f705183fa213bd4488fa53772f2c28bb9edf"
-  integrity sha512-kGv2t8SF8aW5WuRkia8Q0SqbGiJtv34dcy2ckPT0O+a6D4PLrAhtBB5B1sI69/IDZy6CfrjKC/6TIQjDSyx75Q==
+"@powerhome/power-fonts@0.0.1-alpha.4":
+  version "0.0.1-alpha.4"
+  resolved "https://npm.powerapp.cloud/@powerhome/power-fonts/-/2db6ab57032de4685fb9d221fd92b4a4aca7f92e#2db6ab57032de4685fb9d221fd92b4a4aca7f92e"
+  integrity sha512-Oc6KNQt6kw8AKFMK8oPWTkUQotRkqvawzAWiYXDlP2cdoxIyTfBEqtYgQj8MbLcpYynPm0WjQHegQnxAwtNorQ==
 
 "@rails/actioncable@^7.0":
   version "7.1.3"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Fixes kit status that accidentally got put bsck into beta on [this PR](https://github.com/powerhome/playbook/pull/3488)
