### PR TITLE
[PLAY-877] RTE Custom Extenion Dropdown Button Bug Fix

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/MoreExtensionsDropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/MoreExtensionsDropdown.tsx
@@ -10,7 +10,7 @@ const MoreExtensionsDropdown = ({extensions}: any) => {
   const [showPopover, setShowPopover] = useState(false)
 
   const handleTogglePopover = () => {
-    setShowPopover(true)
+    setShowPopover(!showPopover)
   }
 
   const handlePopoverClose = (shouldClosePopover: boolean) => {

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarDropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarDropdown.tsx
@@ -67,7 +67,7 @@ const toolbarDropdownItems = [
 
 
   const handleTogglePopover = () => {
-    setShowPopover(true)
+    setShowPopover(!showPopover)
   }
 
   const handlePopoverClose = (shouldClosePopover: boolean) => {


### PR DESCRIPTION
[PLAY-877](https://runway.powerhrg.com/backlog_items/PLAY-877)

**What does this PR do?**
The "..." button on the top toolbar of the RTE should toggle its popover dropdown. When clicked again while the dropdown is open, it should close. The same behavior applies to the paragraph formatting dropdown. Although the paragraph formatting dropdown was not mentioned in the provided bug story, the fix involved replicating the functionality of the "..." button in a different file.

**Screenshots:**
![image](https://github.com/user-attachments/assets/c41dcc25-ae02-4823-87b0-9c16fe311266)
![image](https://github.com/user-attachments/assets/deee8615-90a7-46f2-bf9d-05e874ef1118)

**How to test?** Steps to confirm the desired behavior:
1. Go to Playbook Components -> Format Input -> Rich Text Editor
2. Click the "..." extensions button in the RTE toolbar once to verify that the dropdown opens, and click it again to confirm that it closes. Repeat the same process for the paragraph formatting button also located in the RTE toolbar.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.