### PR TITLE
[PLAY-1405] Create a Doc for Border Radius Global Props

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
@@ -3,13 +3,16 @@ import React from 'react'
 import {
   Background,
   Body,
+  Button,
   Caption,
   Flex,
+  Icon,
   Title,
 } from 'playbook-ui'
 
 import Example from '../Templates/Example'
 
+const BORDER_RADIUS_VALUES = [ "none", "extra small", "small", "medium", "large", "extra large", "rounded" ]
 const TOKENS = {
   'Rounded': '$border_radius_rounded',
   'Extra Large': '$border_radius_xl',
@@ -30,7 +33,7 @@ const DATASET = [
   { name: 'None', class: 'border_radius_none' },
 ]
 
-const BorderRadius = ({ tokensExample }: { tokensExample: string }) => (
+const BorderRadius = ({ example, tokensExample }: { example: string, tokensExample: string }) => (
   <React.Fragment>
     <Background
       className="token-wrapper"
@@ -43,11 +46,34 @@ const BorderRadius = ({ tokensExample }: { tokensExample: string }) => (
         text='Border Radius'
       />
       <Body
-        marginBottom='lg'
+        marginBottom='xxs'
         marginTop='xs'
         text='We have very specific settings for border radius to keep the interface looking consistent and clean. If you ever need to access these to build new things here are examples for how to do that.'
       />
+      <Button
+        link="https://playbook.powerapp.cloud/kits/card/react#border-radius"
+        newWindow
+        padding="none"
+        tabIndex={0}
+        variant="link"
+      >
+        <Body
+          variant="link"
+        >
+          {'See this prop in action in our Card Kit'}
+          <Icon
+            fixedWidth
+            icon="angle-right"
+          />
+        </Body>
+      </Button>
     </Background>
+    <Example
+        example={example}
+        globalProps={{
+          borderRadius: BORDER_RADIUS_VALUES,
+        }}
+    />
     <Example
       example={tokensExample}
       tokens={TOKENS}

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/BorderRadius.tsx
@@ -12,7 +12,7 @@ import {
 
 import Example from '../Templates/Example'
 
-const BORDER_RADIUS_VALUES = [ "none", "extra small", "small", "medium", "large", "extra large", "rounded" ]
+const BORDER_RADIUS_VALUES = [ "none", "xs", "sm", "md", "lg", "xl", "rounded" ]
 const TOKENS = {
   'Rounded': '$border_radius_rounded',
   'Extra Large': '$border_radius_xl',

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -60,7 +60,9 @@ const VisualGuidelines = ({
       case "typography":
         return <Typography example={examples.typography_tokens}/>;
       case "border_radius":
-        return <BorderRadius tokensExample={examples.border_radius_tokens}/>;
+        return <BorderRadius example={examples.border_radius_jsx}
+                  tokensExample={examples.border_radius_tokens}
+                />;
       case "display":
         return <Display example={examples.display_in_use_jsx}/>;
       case "cursor":

--- a/playbook-website/app/views/pages/code_snippets/border_radius_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/border_radius_jsx.txt
@@ -1,0 +1,12 @@
+<Card borderRadius="md"> {'Medium (6px)'} </Card>
+
+<Card
+  borderRadius={{
+    none: "none",
+    xs: "extra small",
+    sm: "small",
+    lg: "large",
+    xl: "extra large",
+    rounded: "rounded"
+  }}
+/>

--- a/playbook-website/app/views/pages/code_snippets/border_radius_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/border_radius_jsx.txt
@@ -1,12 +1,1 @@
-<Card borderRadius="md"> {'Medium (6px)'} </Card>
-
-<Card
-  borderRadius={{
-    none: "none",
-    xs: "extra small",
-    sm: "small",
-    lg: "large",
-    xl: "extra large",
-    rounded: "rounded"
-  }}
-/>
+<Card borderRadius="md"> Card Content </Card>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1405](https://runway.powerhrg.com/backlog_items/PLAY-1405) updates the [Border Radius](https://playbook.powerapp.cloud/visual_guidelines/border_radius) Tokens and Guidelines page to include more information about how to use this global prop on our kits by including a global prop table and an "example in use." It now also links to the Card kit's border radius [doc example](https://playbook.powerapp.cloud/kits/card/react#border-radius).

**Screenshots:** Screenshots to visualize your addition/change
<img width="1163" alt="border radius global props section" src="https://github.com/user-attachments/assets/f4177775-5ca4-4310-b444-b4d02bc6a566">


**How to test?** Steps to confirm the desired behavior:
1. Go to the Border Radius page in Tokens & Guidelines in the review environment [here](https://pr3534.playbook.beta.hq.powerapp.cloud/visual_guidelines/border_radius).
2. See addition of link to Card kit's border radius doc examples and the new global props section with the border radius token values and an example in use.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~