### PR TITLE
[PLAY-1440] Add Toggle ("Show More") Example to Overlay kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_toggle.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_toggle.html.erb
@@ -1,0 +1,61 @@
+<div id="outer-container">
+    <%= pb_rails("overlay", props: { id: "overlay-container", overflow: "hidden" }) do %>
+        <div id="underlying-table">
+        <%= pb_rails("table", props: { size: "sm" }) do %>
+            <thead>
+                <tr>
+                    <th>Column 1</th>
+                    <th>Column 2</th>
+                    <th>Column 3</th>
+                    <th>Column 4</th>
+                    <th>Column 5</th>
+                </tr>
+            </thead>
+            <tbody>
+                <% 7.times do %>
+                    <tr>
+                        <td>Value 1</td>
+                        <td>Value 2</td>
+                        <td>Value 3</td>
+                        <td>Value 4</td>
+                        <td>Value 5</td>
+                    </tr>
+                <% end %>   
+            </tbody>
+        <% end %>
+        </div>
+    <% end %>
+    <%= pb_rails("button", props: { text: "Show More", id: "show-more-button", full_width: true, icon: "chevron-down", icon_right: true, variant: "link" }) %>
+    <%= pb_rails("button", props: { text: "Show Less", id: "show-less-button", full_width: true, icon: "chevron-up", icon_right: true, variant: "link" }) %>
+</div>
+
+<script type="text/javascript">
+document.addEventListener("DOMContentLoaded", () => {
+  const showMoreButton = document.getElementById("show-more-button");
+  const showLessButton = document.getElementById("show-less-button");
+  const overlayContainer = document.getElementById("overlay-container");
+  const underlyingTable = document.getElementById("underlying-table");
+  const outerContainer = document.getElementById("outer-container");
+
+  showLessButton.style.display = "none";
+  underlyingTable.style.height = "200px";
+
+  const showMore = () => {
+    outerContainer.appendChild(underlyingTable);
+    outerContainer.appendChild(showLessButton);
+    showMoreButton.style.display = "none";
+    showLessButton.style.display = "flex";
+    underlyingTable.style.height = "auto";
+  };
+
+  const showLess = () => {
+    overlayContainer.appendChild(underlyingTable);
+    showLessButton.style.display = "none";
+    showMoreButton.style.display = "flex";
+    underlyingTable.style.height = "200px";
+  };
+
+  showMoreButton.addEventListener("click", showMore);
+  showLessButton.addEventListener("click", showLess);
+});
+</script>

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_toggle.jsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_toggle.jsx
@@ -1,0 +1,71 @@
+/* eslint-disable react/no-multi-comp */
+
+import React, { useState } from "react";
+import { Overlay, Table, Button } from "playbook-ui";
+
+const TableExample = () => {
+    return (
+        <Table size="sm">
+            <thead>
+                <tr>
+                    <th>{"Column 1"}</th>
+                    <th>{"Column 2"}</th>
+                    <th>{"Column 3"}</th>
+                    <th>{"Column 4"}</th>
+                    <th>{"Column 5"}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {Array.from({ length: 7 }, (_, index) => (
+                    <tr key={index}>
+                        {Array.from({ length: 5 }, (_, columnIndex) => (
+                            <td key={columnIndex}>{`Value ${columnIndex + 1}`}</td>
+                        ))}
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    );
+};
+
+const OverlayToggle = () => {
+    const [showOverlay, setShowOverlay] = useState(true);
+
+    return (
+        <>
+            {showOverlay ? (
+                <>
+                    <Overlay overflow="hidden">
+                        <div style={{ height: 200 }}>
+                            <TableExample />
+                        </div>
+                    </Overlay>
+                    <Button
+                        fullWidth
+                        icon="chevron-down"
+                        iconRight
+                        key="chevron-down"
+                        onClick={() => setShowOverlay(false)}
+                        text="Show More"
+                        variant="link"
+                    />
+                </>
+            ) : (
+                <>
+                    <TableExample />
+                    <Button
+                        fullWidth
+                        icon="chevron-up"
+                        iconRight
+                        key="chevron-up"
+                        onClick={() => setShowOverlay(true)}
+                        text="Show Less"
+                        variant="link"
+                    />
+                </>
+            )}
+        </>
+    );
+};
+
+export default OverlayToggle;

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/example.yml
@@ -2,6 +2,7 @@ examples:
   react:
   - overlay_default: Default
   - overlay_multi_directional: Multi-directional
+  - overlay_toggle: Toggle Example
 
   rails:
     - overlay_default: Default

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/example.yml
@@ -5,5 +5,6 @@ examples:
   - overlay_toggle: Toggle Example
 
   rails:
-    - overlay_default: Default
-    - overlay_multi_directional: Multi-directional
+  - overlay_default: Default
+  - overlay_multi_directional: Multi-directional
+  - overlay_toggle: Toggle Example

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/index.js
@@ -1,2 +1,3 @@
 export { default as OverlayDefault } from './_overlay_default.jsx'
 export { default as OverlayMultiDirectional } from './_overlay_multi_directional.jsx'
+export { default as OverlayToggle } from './_overlay_toggle.jsx'


### PR DESCRIPTION
**What does this PR do?**

- ✅ Add Toggle example for React and Rails

**Screenshots:** Screenshots to visualize your addition/change
![Zight 2024-08-09 at 10 59 19 AM](https://github.com/user-attachments/assets/048722f8-99d9-408b-ad81-e68a12330500)
![Zight 2024-08-09 at 10 59 33 AM](https://github.com/user-attachments/assets/ea06e434-5662-4d3b-9dd3-8a6aff0f944e)


**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/overlay/react#toggle-example
2. Scroll down to the "Toggle Example"
3. Toggle "Show More" and "Show Less"
4. Test the rails example as well.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.