### PR TITLE
[PBNTR-286] RTE Advanced Previewer + output styles (React)

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_previewer_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_previewer_mixin.scss
@@ -18,11 +18,9 @@
     font-family: monospace;
     background: $bg_light;
     padding: 0.1rem 0.3rem;
-    margin: 0 5px;
     box-shadow: 0 2px 10px $shadow;
     border-radius: 0.25rem;
     overflow: hidden;
-    font-size: ($text_small - 1px);
 }
 
 @mixin preview_pre_codeblock {

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_previewer_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_previewer_mixin.scss
@@ -3,6 +3,16 @@
 @import "../tokens/spacing";
 @import "../tokens/typography";
 
+@mixin preview_first_child {
+    :first-child {
+        margin-top: 0;
+    }
+}
+
+@mixin preview_p {
+    margin: 1rem 0 0 0;
+    min-height: 1rem;
+}
 
 @mixin preview_code {
     font-family: monospace;
@@ -49,6 +59,7 @@
     font-size: $font_larger;
     padding: $space_sm $space_md;
     font-style: italic;
+    margin: 1rem 0 0 0;
     p {
         margin: 0;
     }
@@ -83,6 +94,7 @@
     line-height: $text_base;
     letter-spacing: $lspace_tight;
     font-weight: $bolder;
+    margin: 1rem 0 0 0;
 }
 
 @mixin preview_hr {

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_mixin.scss
@@ -1,0 +1,34 @@
+@import "../tokens/border_radius";
+@import "../tokens/colors";
+@import "../tokens/spacing";
+@import "../tokens/typography";
+
+@mixin preview_blockquote {
+    font-size: $font_larger;
+    padding: $space_sm $space_md;
+    font-style: italic;
+    p {
+        margin: 0;
+    }
+}
+
+@mixin preview_codeblock {
+    display: inline-block;
+    width: 100%;
+    vertical-align: top;
+    font-family: monospace;
+    font-size: 0.9em;
+    padding: 0.5em;
+    overflow-x: auto;
+    background: $bg_dark;
+    padding: $space_sm;
+    border-radius: $border_rad_heaviest;
+    margin: 1.5rem 0 2rem 0;
+
+    code {
+        background: transparent !important;
+        box-shadow: none;
+        border: 0;
+        color: #faf6e4;
+    }
+}

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_mixin.scss
@@ -3,16 +3,19 @@
 @import "../tokens/spacing";
 @import "../tokens/typography";
 
-@mixin preview_blockquote {
-    font-size: $font_larger;
-    padding: $space_sm $space_md;
-    font-style: italic;
-    p {
-        margin: 0;
-    }
+
+@mixin preview_code {
+    font-family: monospace;
+    background: $bg_light;
+    padding: 0.1rem 0.3rem;
+    margin: 0 5px;
+    box-shadow: 0 2px 10px $shadow;
+    border-radius: 0.25rem;
+    overflow: hidden;
+    font-size: ($text_small - 1px);
 }
 
-@mixin preview_codeblock {
+@mixin preview_pre_codeblock {
     display: inline-block;
     width: 100%;
     vertical-align: top;
@@ -30,5 +33,90 @@
         box-shadow: none;
         border: 0;
         color: #faf6e4;
+    }
+}
+
+@mixin preview_a {
+    color: $primary;
+    border-bottom: 1px solid $primary;
+    &:hover {
+      color: $text_lt_default;
+      border-bottom: 1px solid $text_lt_default;
+    }
+}
+
+@mixin preview_blockquote {
+    font-size: $font_larger;
+    padding: $space_sm $space_md;
+    font-style: italic;
+    p {
+        margin: 0;
+    }
+}
+
+@mixin preview_h1 {
+    font-size: $text_largest;
+    line-height: $text_larger;
+    font-weight: $bolder;
+    letter-spacing: $lspace_tight;
+    margin: 2.1rem 0 0 0;
+}
+
+@mixin preview_h2 {
+    font-size: $text_larger;
+    line-height: $text_larger;
+    font-weight: $bolder;
+    letter-spacing: $lspace_tight;
+    margin: 1.9rem 0 0 0;
+}
+
+@mixin preview_h3 {
+    font-size: $text_large;
+    line-height: $text_large;
+    font-weight: $bolder;
+    letter-spacing: $lspace_tight;
+    margin: 1.7rem 0 0 0;
+}
+
+@mixin preview_smaller_headings {
+    font-size: $text_base;
+    line-height: $text_base;
+    letter-spacing: $lspace_tight;
+    font-weight: $bolder;
+}
+
+@mixin preview_hr {
+    margin: 2.2rem 0;
+    box-sizing: content-box;
+    overflow: hidden;
+    background: transparent;
+    border-bottom: 1px solid $transparent;
+    height: 1px;
+    padding: 0;
+    background-color: $border_light;
+    border: 0; 
+}
+
+@mixin preview_ol {
+    margin: 1rem 0 0 0;
+    padding-left: $space_md;
+    list-style: decimal;
+    li {
+      margin: 2px 0;
+      p {
+        margin: 0;
+      }
+    }
+}
+
+@mixin preview_ul {
+    list-style-position: disc;
+    margin: 1rem 0 0 0;
+    padding-left: $space_md;
+    li {
+      margin: 2px 0;
+      p {
+        margin: 0;
+      }
     }
 }

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
@@ -86,109 +86,44 @@
     }
 
     code {
-      font-family: monospace;
-      background: $bg_light;
-      padding: 0.1rem 0.3rem;
-      margin: 0 5px;
-      box-shadow: 0 2px 10px $shadow;
-      border-radius: 0.25rem;
-      overflow: hidden;
-      font-size: ($text_small - 1px);
+      @include preview_code;
     }
 
     pre {
-      background: $bg_dark;
-      padding: $space_sm;
-      border-radius: $border_rad_heaviest;
-      margin: 1.5rem 0 2rem 0;
-      code {
-        background: transparent;
-        box-shadow: none;
-        border: 0;
-        color: #faf6e4;
-      }
+      @include preview_pre_codeblock;
     }
     a {
-      color: $primary;
-      border-bottom: 1px solid $primary;
-      &:hover {
-        color: $text_lt_default;
-        border-bottom: 1px solid $text_lt_default;
-      }
+      @include preview_a;
     }
     blockquote {
-      font-size: $font_larger;
-      padding: $space_sm $space_md;
-      font-style: italic;
-      p {
-        margin: 0;
-      }
+      @include preview_blockquote;
     }
     &:focus-visible {
       outline: unset;
       @include transition_default;
     }
     h1 {
-      font-size: $text_largest;
-      line-height: $text_larger;
-      font-weight: $bolder;
-      letter-spacing: $lspace_tight;
-      margin: 2.1rem 0 0 0;
+      @include preview_h1;
     }
     h2 {
-      font-size: $text_larger;
-      line-height: $text_larger;
-      font-weight: $bolder;
-      letter-spacing: $lspace_tight;
-      margin: 1.9rem 0 0 0;
+      @include preview_h2;
     }
     h3 {
-      font-size: $text_large;
-      line-height: $text_large;
-      font-weight: $bolder;
-      letter-spacing: $lspace_tight;
-      margin: 1.7rem 0 0 0;
+      @include preview_h3;
     }
     h4,
     h5,
     h6 {
-      font-size: $text_base;
-      line-height: $text_base;
-      letter-spacing: $lspace_tight;
-      font-weight: $bolder;
+      @include preview_smaller_headings;
     }
     hr {
-      margin: 2.2rem 0;
-      box-sizing: content-box;
-      overflow: hidden;
-      background: transparent;
-      border-bottom: 1px solid $transparent;
-      height: 1px;
-      padding: 0;
-      background-color: $border_light;
-      border: 0;
+      @include preview_hr;
     }
     ol {
-      margin: 1rem 0 0 0;
-      padding-left: $space_md;
-      list-style: decimal;
-      li {
-        margin: 2px 0;
-        p {
-          margin: 0;
-        }
-      }
+      @include preview_ol;
     }
     ul {
-      list-style-position: disc;
-      margin: 1rem 0 0 0;
-      padding-left: $space_md;
-      li {
-        margin: 2px 0;
-        p {
-          margin: 0;
-        }
-      }
+      @include preview_ul;
     }
   }
 
@@ -197,7 +132,7 @@
       @include preview_blockquote;
     }
     pre {
-      @include preview_codeblock;
+      @include preview_pre_codeblock;
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
@@ -6,7 +6,7 @@
 @import "../tokens/typography";
 @import "../tokens/shadows";
 @import "../tokens/transition";
-@import "tiptap_mixin";
+@import "previewer_mixin";
 
 [class^="pb_rich_text_editor_kit"] {
   .toolbar_button {
@@ -126,15 +126,6 @@
       @include preview_ul;
     }
   }
-
-  .tiptap-content {
-    blockquote {
-      @include preview_blockquote;
-    }
-    pre {
-      @include preview_pre_codeblock;
-    }
-  }
 }
 
 .pb_tiptap_toolbar_dropdown_list_item {
@@ -176,5 +167,43 @@
       border-top-left-radius: initial;
       border-top-right-radius: initial;
     }
+  }
+}
+.tiptap-content {
+  @include preview_first_child;
+  a {
+    @include preview_a;
+  }
+  blockquote {
+    @include preview_blockquote;
+  }
+  h1 {
+    @include preview_h1;
+  }
+  h2 {
+    @include preview_h2;
+  }
+  h3 {
+    @include preview_h3;
+  }
+  h4,
+  h5,
+  h6 {
+    @include preview_smaller_headings;
+  }
+  hr {
+    @include preview_hr;
+  }
+  ol {
+    @include preview_ol;
+  }
+  p {
+    @include preview_p;
+  }
+  pre {
+    @include preview_pre_codeblock;
+  }
+  ul {
+    @include preview_ul;
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
@@ -233,3 +233,35 @@
     }
   }
 }
+
+.tiptap-content {
+  blockquote {
+    font-size: $font_larger;
+    padding: $space_sm $space_md;
+    font-style: italic;
+    p {
+      margin: 0;
+    }
+  }
+  
+  pre {
+    display: inline-block;
+    width: 100%;
+    vertical-align: top;
+    font-family: monospace;
+    font-size: 0.9em;
+    padding: 0.5em;
+    overflow-x: auto;
+    background: $bg_dark;
+    padding: $space_sm;
+    border-radius: $border_rad_heaviest;
+    margin: 1.5rem 0 2rem 0;
+
+    code {
+      background: transparent !important;
+      box-shadow: none;
+      border: 0;
+      color: #faf6e4;
+    }
+  }
+}

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
@@ -6,6 +6,7 @@
 @import "../tokens/typography";
 @import "../tokens/shadows";
 @import "../tokens/transition";
+@import "tiptap_mixin";
 
 [class^="pb_rich_text_editor_kit"] {
   .toolbar_button {
@@ -190,6 +191,15 @@
       }
     }
   }
+
+  .tiptap-content {
+    blockquote {
+      @include preview_blockquote;
+    }
+    pre {
+      @include preview_codeblock;
+    }
+  }
 }
 
 .pb_tiptap_toolbar_dropdown_list_item {
@@ -230,38 +240,6 @@
       border-top: none;
       border-top-left-radius: initial;
       border-top-right-radius: initial;
-    }
-  }
-}
-
-.tiptap-content {
-  blockquote {
-    font-size: $font_larger;
-    padding: $space_sm $space_md;
-    font-style: italic;
-    p {
-      margin: 0;
-    }
-  }
-  
-  pre {
-    display: inline-block;
-    width: 100%;
-    vertical-align: top;
-    font-family: monospace;
-    font-size: 0.9em;
-    padding: 0.5em;
-    overflow-x: auto;
-    background: $bg_dark;
-    padding: $space_sm;
-    border-radius: $border_rad_heaviest;
-    margin: 1.5rem 0 2rem 0;
-
-    code {
-      background: transparent !important;
-      box-shadow: none;
-      border: 0;
-      color: #faf6e4;
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
@@ -12,7 +12,6 @@ const RichTextEditorAdvancedPreview = (props) => {
           StarterKit,
           Link
       ],
-      content:"Add your text here. You can format your text, add links, quotes, and bullets."
   })
 
   const [showPreview, setShowPreview] = useState(false)
@@ -41,20 +40,20 @@ const RichTextEditorAdvancedPreview = (props) => {
           {...props}
       >
         <EditorContent editor={editor}/>
+        {showPreview && (
+          <Card marginTop="md">
+            <div
+                className="tiptap-content"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: previewText }}
+                id="advanced-preview-content"
+            />
+          </Card>
+        )}
+        {!showPreview && (
+          <div />
+        )}
       </RichTextEditor>
-      {showPreview && (
-        <Card marginTop="md">
-          <div
-              className="tiptap-content"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: previewText }}
-              id="advanced-preview-content"
-          />
-        </Card>
-      )}
-      {!showPreview && (
-        <div />
-      )}
       <Button
           id="preview-button"
           marginTop="md"

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react'
+import { Button, Card, RichTextEditor } from 'playbook-ui'
+import { useEditor, EditorContent } from "@tiptap/react"
+import StarterKit from "@tiptap/starter-kit"
+import Link from '@tiptap/extension-link'
+
+
+const RichTextEditorAdvancedPreview = (props) => {
+
+  const editor = useEditor({
+      extensions: [
+          StarterKit,
+          Link
+      ],
+      content:"Add your text here. You can format your text, add links, quotes, and bullets."
+  })
+
+  const [showPreview, setShowPreview] = useState(false)
+  const [previewText, setPreviewText] = useState(<div />)
+
+  const handleChange = () => {
+    if (editor) {
+      setPreviewText(editor.getHTML())
+    }
+  }
+  const handleClick = () => {
+    handleChange()
+    setShowPreview(true)
+  }
+  if (!editor) {
+    return null
+  } 
+      
+
+  return (
+    <div>
+      <RichTextEditor
+          advancedEditor={editor}
+          id="content-advanced-preview-editor"
+          onChange={handleChange}
+          {...props}
+      >
+        <EditorContent editor={editor}/>
+      </RichTextEditor>
+      {showPreview && (
+        <Card marginTop="md">
+          <div
+              className="tiptap-content"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: previewText }}
+              id="advanced-preview-content"
+          />
+        </Card>
+      )}
+      {!showPreview && (
+        <div />
+      )}
+      <Button
+          id="preview-button"
+          marginTop="md"
+          onClick={handleClick}
+          text="Preview Output"
+          variant="secondary"
+      />
+    </div>
+  )
+}
+
+export default RichTextEditorAdvancedPreview

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
@@ -23,6 +23,7 @@ const RichTextEditorAdvancedPreview = (props) => {
       setPreviewText(editor.getHTML())
     }
   }
+
   const handleClick = () => {
     handleChange()
     setShowPreview(true)
@@ -41,20 +42,23 @@ const RichTextEditorAdvancedPreview = (props) => {
           {...props}
       >
         <EditorContent editor={editor}/>
-        {showPreview && (
-          <Card marginTop="md">
-            <div
-                className="tiptap-content"
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{ __html: previewText }}
-                id="advanced-preview-content"
-            />
-          </Card>
-        )}
-        {!showPreview && (
-          <div />
-        )}
       </RichTextEditor>
+      {showPreview && (
+        <Card 
+            marginTop="md"
+            maxWidth="md"
+        >
+          <div
+              className="tiptap-content"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: previewText }}
+              id="advanced-preview-content"
+          />
+        </Card>
+      )}
+      {!showPreview && (
+        <div />
+      )}
       <Button
           id="preview-button"
           marginTop="md"

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_rich_text_editor_advanced_preview.jsx
@@ -12,6 +12,7 @@ const RichTextEditorAdvancedPreview = (props) => {
           StarterKit,
           Link
       ],
+      content: "Add text here, format it, and press \"Preview Output\" to see what your stylized output will look like on the page."
   })
 
   const [showPreview, setShowPreview] = useState(false)

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/example.yml
@@ -24,3 +24,4 @@ examples:
   - rich_text_editor_toolbar_bottom: Toolbar Bottom
   - rich_text_editor_inline: Inline
   - rich_text_editor_preview: Preview
+  - rich_text_editor_advanced_preview: Advanced Preview

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/index.js
@@ -10,3 +10,4 @@ export { default as RichTextEditorPreview } from './_rich_text_editor_preview.js
 export { default as RichTextEditorAdvancedDefault } from './_rich_text_editor_advanced_default.jsx'
 export { default as RichTextEditorMoreExtensions } from './_rich_text_editor_more_extensions.jsx'
 export { default as RichTextEditorToolbarDisabled } from './_rich_text_editor_toolbar_disabled.jsx'
+export { default as RichTextEditorAdvancedPreview } from './_rich_text_editor_advanced_preview.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-286](https://runway.powerhrg.com/backlog_items/PBNTR-286) creates a preview doc example for the Advanced editor in React (one already exists for the default editor). It uses a mixin file to incorporate the expected styles into the output on the preview card. The new default content text in the editor serves as instructions for how to use the previewer.

**Screenshots:** Screenshots to visualize your addition/change
Editor:
<img width="772" alt="for PR example text 1" src="https://github.com/user-attachments/assets/c27176f4-b8f1-46fd-a9e6-41e641260431">
Preview Card:
<img width="754" alt="for PR example text 2" src="https://github.com/user-attachments/assets/8c40d4f9-545e-4667-bcd9-0026264663dc">



**How to test?** Steps to confirm the desired behavior:
1. Go to the new advanced preview doc example in the milano review environment [here](https://pr3578.playbook.beta.px.powerapp.cloud/kits/rich_text_editor/react#advanced-preview).
2. Alter the text in the editor with styles in the editor toolbar, and hit preview output to see the result (aka, how the text output will look on the page once saved outside of the editor).
3. Do this multiple times, see the results of several combinations. Editor options include font size (Paragraph, Heading 1, Heading 2, Heading 3), display type (bullet list, ordered list, block quote, code block), text appearance changes (bold, italicized, strike-through, link).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~