### PR TITLE
[PLAY-1467] Horizontal default nav - fix alignment

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_nav/_horizontal_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_horizontal_nav.scss
@@ -11,7 +11,7 @@ $selector: ".pb_nav_list";
 [class^="pb_nav_list"][class*="_horizontal"] {
   .pb_nav_wrapper {
     display: flex;
-    align-items: center;
+    align-items: end;
     padding: 0;
     margin: 0;
     list-style: none;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-1467
This PR fixes an issue with the default variant for horizontal navigation. When the screen is shrunk to a certain size, the nav items will become mis-aligned due line/text wrapping.

**Screenshots:** Screenshots to visualize your addition/change
![image](https://github.com/user-attachments/assets/b13ca646-8d20-4bb8-b73c-cf4248e21b4f)


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.