### PR TITLE
[PLAY-1490] Dialog Kit Loading state buttons

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -25,7 +25,8 @@
                             cancel_button_id: object.cancel_button_id,
                             confirm_button: object.confirm_button,
                             confirm_button_id: object.confirm_button_id,
-                            id: object.id
+                            id: object.id,
+                            loading: object.loading
                         }) %>
             <% end %>
 

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -22,6 +22,7 @@
             <% if object.cancel_button && object.confirm_button %>
                         <%= pb_rails("dialog/dialog_footer", props: {
                             cancel_button: object.cancel_button,
+                            cancel_button_id: object.cancel_button_id,
                             confirm_button: object.confirm_button,
                             confirm_button_id: object.confirm_button_id,
                             id: object.id

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -23,6 +23,7 @@
                         <%= pb_rails("dialog/dialog_footer", props: {
                             cancel_button: object.cancel_button,
                             confirm_button: object.confirm_button,
+                            confirm_button_id: object.confirm_button_id,
                             id: object.id
                         }) %>
             <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
@@ -15,6 +15,8 @@ module Playbook
       prop :text
       prop :confirm_button
       prop :cancel_button
+      prop :confirm_button_id
+      prop :cancel_button_id
       prop :status, type: Playbook::Props::Enum,
                     values: ["info", "caution", "delete", "error", "success", "default", ""],
                     default: ""

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
@@ -14,8 +14,8 @@ module Playbook
       prop :title
       prop :text
       prop :confirm_button
-      prop :cancel_button
       prop :confirm_button_id
+      prop :cancel_button
       prop :cancel_button_id
       prop :status, type: Playbook::Props::Enum,
                     values: ["info", "caution", "delete", "error", "success", "default", ""],

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
@@ -13,6 +13,7 @@ module Playbook
       prop :should_close_on_overlay_click, type: Playbook::Props::Boolean, default: true
       prop :title
       prop :text
+      prop :loading
       prop :confirm_button
       prop :confirm_button_id
       prop :cancel_button

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialogHelper.js
@@ -3,6 +3,27 @@ const dialogHelper = () => {
   const closeTrigger = document.querySelectorAll("[data-close-dialog]");
   const dialogs = document.querySelectorAll(".pb_dialog_rails")
 
+  const loadingButton = document.querySelector('[data-disable-with="Loading"]');
+  if (loadingButton) {
+    loadingButton.addEventListener("click", function() {
+      const okayLoadingButton = document.querySelector('[data-disable-with="Loading"]');
+      const cancelButton = document.querySelector('[data-disable-cancel-with="Loading"]');
+      let currentClass = okayLoadingButton.className;
+      let cancelClass = cancelButton ? cancelButton.className : "";
+
+      let newClass = currentClass.replace("_enabled", "_disabled_loading");
+      let newCancelClass = cancelClass.replace("_enabled", "_disabled");
+
+      // Disable the buttons
+      okayLoadingButton.disabled = true;
+      if (cancelButton) cancelButton.disabled = true;
+
+      okayLoadingButton.className = newClass;
+      if (cancelButton) cancelButton.className = newCancelClass;
+    });
+  }
+
+
   openTrigger.forEach((open) => {
     open.addEventListener("click", () => {
       var openTriggerData = open.dataset.openDialog;

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
@@ -4,10 +4,11 @@
         <div class="dialog-pseudo-footer"></div>
         <%= pb_rails("flex", props: { classname:object.classname, spacing:"between", padding_x:"sm", padding:"sm", padding_bottom:"sm" }) do %>
             
-            <%= pb_rails("button", props: { type: "submit", id: object.confirm_button_id }) do %>
+          <%= pb_rails("button", props: { type: "submit", id: object.confirm_button_id, data: loading_data,
+            }) do %>
                 <%= object.confirm_button %>
             <% end %>
-            <%= pb_rails("button", props: { type: "button", data: {"close-dialog": "#{object.id}" }, id: object.cancel_button_id, variant: "link"}) do %>
+            <%= pb_rails("button", props: { type: "button", data: {"close-dialog": "#{object.id}" }, id: object.cancel_button_id, variant: "link", data: cancel_loading}) do %>
                 <%= object.cancel_button %>
             <% end %>
         <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.html.erb
@@ -3,6 +3,7 @@
     <% if object.confirm_button && object.cancel_button %>
         <div class="dialog-pseudo-footer"></div>
         <%= pb_rails("flex", props: { classname:object.classname, spacing:"between", padding_x:"sm", padding:"sm", padding_bottom:"sm" }) do %>
+            
             <%= pb_rails("button", props: { type: "submit", id: object.confirm_button_id }) do %>
                 <%= object.confirm_button %>
             <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.rb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.rb
@@ -7,9 +7,18 @@ module Playbook
       prop :cancel_button_id
       prop :confirm_button
       prop :confirm_button_id
+      prop :loading
 
       def classname
         generate_classname("dialog_footer")
+      end
+
+      def cancel_loading
+        loading ? { disable_cancel_with: "Loading" } : {}
+      end
+
+      def loading_data
+        loading ? { disable_with: "Loading" } : {}
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.rb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog_footer.rb
@@ -4,9 +4,9 @@ module Playbook
   module PbDialog
     class DialogFooter < Playbook::KitBase
       prop :cancel_button
+      prop :cancel_button_id
       prop :confirm_button
       prop :confirm_button_id
-      prop :cancel_button_id
 
       def classname
         generate_classname("dialog_footer")

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.html.erb
@@ -6,6 +6,7 @@
     title: "Loading Exmaple", 
     text: "Make a 3 second request?", 
     cancel_button: "Cancel Button", 
+    cancel_button_id: "cancel-button-loading",
     confirm_button: "Okay", 
     confirm_button_id: "confirm-button-loading",
 }) %>
@@ -13,11 +14,27 @@
 <script>
   document.getElementById("confirm-button-loading").addEventListener("click", function() {
     let okayLoadingButton = document.getElementById("confirm-button-loading");
+    let cancelButton = document.getElementById("cancel-button-loading");
     let currentClass = okayLoadingButton.className;
+    let cancelClass = cancelButton.className;
     let newClass = currentClass.replace("_enabled", "_disabled_loading");
+    let newCancelClass = cancelClass.replace("_enabled", "_disabled");
+
+    // Disable the buttons
+    okayLoadingButton.disabled = true;
+    cancelButton.disabled = true;
+
     okayLoadingButton.className = newClass;
+    cancelButton.className = newCancelClass;
+
     setTimeout(() => {
+      // Re-enable the buttons
+      okayLoadingButton.disabled = false;
+      cancelButton.disabled = false;
+
+      // Restore original classes
       okayLoadingButton.className = currentClass;
+      cancelButton.className = cancelClass;
     }, 3000);
   });
 </script>

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.html.erb
@@ -1,0 +1,23 @@
+<%= pb_rails("button", props: { text: "Open Dialog", data: {"open-dialog": "dialog-loading"} }) %>
+
+<%= pb_rails("dialog", props: { 
+    id:"dialog-loading", 
+    size: "sm", 
+    title: "Loading Exmaple", 
+    text: "Make a 3 second request?", 
+    cancel_button: "Cancel Button", 
+    confirm_button: "Okay", 
+    confirm_button_id: "confirm-button-loading",
+}) %>
+
+<script>
+  document.getElementById("confirm-button-loading").addEventListener("click", function() {
+    let okayLoadingButton = document.getElementById("confirm-button-loading");
+    let currentClass = okayLoadingButton.className;
+    let newClass = currentClass.replace("_enabled", "_disabled_loading");
+    okayLoadingButton.className = newClass;
+    setTimeout(() => {
+      okayLoadingButton.className = currentClass;
+    }, 3000);
+  });
+</script>

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.html.erb
@@ -4,37 +4,10 @@
     id:"dialog-loading", 
     size: "sm", 
     title: "Loading Exmaple", 
-    text: "Make a 3 second request?", 
+    text: "Make a loading request?", 
     cancel_button: "Cancel Button", 
     cancel_button_id: "cancel-button-loading",
     confirm_button: "Okay", 
     confirm_button_id: "confirm-button-loading",
+    loading: true,
 }) %>
-
-<script>
-  document.getElementById("confirm-button-loading").addEventListener("click", function() {
-    let okayLoadingButton = document.getElementById("confirm-button-loading");
-    let cancelButton = document.getElementById("cancel-button-loading");
-    let currentClass = okayLoadingButton.className;
-    let cancelClass = cancelButton.className;
-    let newClass = currentClass.replace("_enabled", "_disabled_loading");
-    let newCancelClass = cancelClass.replace("_enabled", "_disabled");
-
-    // Disable the buttons
-    okayLoadingButton.disabled = true;
-    cancelButton.disabled = true;
-
-    okayLoadingButton.className = newClass;
-    cancelButton.className = newCancelClass;
-
-    setTimeout(() => {
-      // Re-enable the buttons
-      okayLoadingButton.disabled = false;
-      cancelButton.disabled = false;
-
-      // Restore original classes
-      okayLoadingButton.className = currentClass;
-      cancelButton.className = cancelClass;
-    }, 3000);
-  });
-</script>

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.md
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.md
@@ -1,0 +1,3 @@
+After pressing the okay button. The okay button will enter a loading state with the spinner and the other buttons will be disalbed.
+
+Currently the loading state cannot be undone and will require a page refresh to reset the dialog.

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.md
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_loading.md
@@ -1,3 +1,3 @@
-After pressing the okay button. The okay button will enter a loading state with the spinner and the other buttons will be disalbed.
+Pressing the "Okay" button will trigger a loading state where the button content is replaced by a spinner icon and both buttons are disabled.
 
-Currently the loading state cannot be undone and will require a page refresh to reset the dialog.
+Currently, the loading state cannot be undone and will require a page refresh to reset the dialog.

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/example.yml
@@ -10,7 +10,7 @@ examples:
   - dialog_stacked_alert: Stacked Button Alert
   - dialog_full_height: Full Height
   - dialog_full_height_placement: Full Height Placement
-
+  - dialog_loading: Loading
 
   react:
   - dialog_default: Simple


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Runway https://runway.powerhrg.com/backlog_items/PLAY-1490

Adds a prop to the dialog kit that makes the buttons go into a "loading state" when pressed

[screencast-127.0.0.1_3000-2024.08.15-14_05_54.webm](https://github.com/user-attachments/assets/6c9ec27b-d8a8-43cb-8443-fcb0865b2e94)

**How to test?** Steps to confirm the desired behavior:
1. Go to[ /kits/dialog](https://pr3599.playbook.beta.hq.powerapp.cloud/kits/dialog/rails#loading)
2. Click Open Dialog
3. click Okay
4. Notice the loading state of the buttons and admire how nice they communicate that something is loading and that you can't press the buttons again

