### PR TITLE
[PLAY-1477] Timestamp Kit Rails: Elapsed Time Variant Issue

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_elapsed.html.erb
@@ -8,7 +8,7 @@
 <br>
 
 <%= pb_rails("timestamp", props: {
-  timestamp: DateTime.now,
+  timestamp: DateTime.now - 3.months,
   variant: "elapsed",
   show_user: false
 }) %>
@@ -16,7 +16,7 @@
 <br>
 
 <%= pb_rails("timestamp", props: {
-  timestamp: DateTime.now,
+  timestamp: DateTime.now - 320.days,
   variant: "elapsed",
   show_user: false,
   hide_updated: true

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
@@ -92,25 +92,25 @@ module Playbook
         time_ago = DateTime.now.to_i - value.to_i
         case time_ago
         when (0...SECS_PER_MIN)
-          time_ago == 1 ? "1 second" : "#{time_ago} seconds"
+          "A few seconds ago"
         when (SECS_PER_MIN...SECS_PER_HOUR)
           time = time_ago / SECS_PER_MIN
-          time == 1 ? "1 minute" : "#{time_ago / SECS_PER_MIN} minutes"
+          time == 1 ? "a minute" : "#{time_ago / SECS_PER_MIN} minutes"
         when (SECS_PER_HOUR...SECS_PER_DAY)
           time = time_ago / SECS_PER_HOUR
-          time == 1 ? "1 hour" : "#{time_ago / SECS_PER_HOUR} hours"
+          time == 1 ? "an hour" : "#{time_ago / SECS_PER_HOUR} hours"
         when (SECS_PER_DAY...SECS_PER_WEEK)
           time = time_ago / SECS_PER_DAY
-          time == 1 ? "1 day" : "#{time_ago / SECS_PER_DAY} days"
+          time == 1 ? "a day" : "#{time_ago / SECS_PER_DAY} days"
         when (SECS_PER_WEEK...SECS_PER_MONTH)
           time = time_ago / SECS_PER_WEEK
-          time == 1 ? "1 week" : "#{time_ago / SECS_PER_WEEK} weeks"
+          time == 1 ? "a week" : "#{time_ago / SECS_PER_WEEK} weeks"
         when (SECS_PER_MONTH...SECS_PER_YEAR)
           time = time_ago / SECS_PER_MONTH
-          time == 1 ? "1 month" : "#{time_ago / SECS_PER_MONTH} months"
+          time == 1 ? "a month" : "#{time_ago / SECS_PER_MONTH} months"
         when (SECS_PER_YEAR...SECS_PER_CENT)
           time = time_ago / SECS_PER_YEAR
-          time == 1 ? "1 year" : "#{time_ago / SECS_PER_YEAR} years"
+          time == 1 ? "a year" : "#{time_ago / SECS_PER_YEAR} years"
         end
       end
 

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
@@ -83,8 +83,8 @@ module Playbook
       def format_elapsed_string
         user_string = show_user ? " by #{text}" : ""
         datetime_string = " #{pb_time_ago(pb_date_time.convert_to_timestamp)} ago"
+        datetime_string[0] = hide_updated ? datetime_string[0].upcase : datetime_string[0]
         updated_string = hide_updated ? "" : "Last updated"
-
         "#{updated_string}#{user_string}#{datetime_string}"
       end
 
@@ -92,7 +92,7 @@ module Playbook
         time_ago = DateTime.now.to_i - value.to_i
         case time_ago
         when (0...SECS_PER_MIN)
-          "A few seconds ago"
+          "a few seconds"
         when (SECS_PER_MIN...SECS_PER_HOUR)
           time = time_ago / SECS_PER_MIN
           time == 1 ? "a minute" : "#{time_ago / SECS_PER_MIN} minutes"

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
@@ -27,6 +27,15 @@ module Playbook
                      values: %w[default elapsed updated],
                      default: "default"
 
+      # Variables to use with pb_time_ago method
+      SECS_PER_MIN  = 60
+      SECS_PER_HOUR = 60 * SECS_PER_MIN
+      SECS_PER_DAY  = 24 * SECS_PER_HOUR
+      SECS_PER_WEEK = 7 * SECS_PER_DAY
+      SECS_PER_MONTH = 4 * SECS_PER_WEEK
+      SECS_PER_YEAR = 12 * SECS_PER_MONTH
+      SECS_PER_CENT = 100 * SECS_PER_YEAR
+
       def classname
         generate_classname("pb_timestamp_kit", variant_class, align)
       end
@@ -73,10 +82,36 @@ module Playbook
 
       def format_elapsed_string
         user_string = show_user ? " by #{text}" : ""
-        datetime_string = " #{time_ago_in_words(pb_date_time.convert_to_timestamp)} ago"
+        datetime_string = " #{pb_time_ago(pb_date_time.convert_to_timestamp)} ago"
         updated_string = hide_updated ? "" : "Last updated"
 
         "#{updated_string}#{user_string}#{datetime_string}"
+      end
+
+      def pb_time_ago(value)
+        time_ago = DateTime.now.to_i - value.to_i
+        case time_ago
+        when (0...SECS_PER_MIN)
+          time_ago == 1 ? "1 second" : "#{time_ago} seconds"
+        when (SECS_PER_MIN...SECS_PER_HOUR)
+          time = time_ago / SECS_PER_MIN
+          time == 1 ? "1 minute" : "#{time_ago / SECS_PER_MIN} minutes"
+        when (SECS_PER_HOUR...SECS_PER_DAY)
+          time = time_ago / SECS_PER_HOUR
+          time == 1 ? "1 hour" : "#{time_ago / SECS_PER_HOUR} hours"
+        when (SECS_PER_DAY...SECS_PER_WEEK)
+          time = time_ago / SECS_PER_DAY
+          time == 1 ? "1 day" : "#{time_ago / SECS_PER_DAY} days"
+        when (SECS_PER_WEEK...SECS_PER_MONTH)
+          time = time_ago / SECS_PER_WEEK
+          time == 1 ? "1 week" : "#{time_ago / SECS_PER_WEEK} weeks"
+        when (SECS_PER_MONTH...SECS_PER_YEAR)
+          time = time_ago / SECS_PER_MONTH
+          time == 1 ? "1 month" : "#{time_ago / SECS_PER_MONTH} months"
+        when (SECS_PER_YEAR...SECS_PER_CENT)
+          time = time_ago / SECS_PER_YEAR
+          time == 1 ? "1 year" : "#{time_ago / SECS_PER_YEAR} years"
+        end
       end
 
       def datetime_or_text

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
@@ -83,7 +83,7 @@ module Playbook
       def format_elapsed_string
         user_string = show_user ? " by #{text}" : ""
         datetime_string = " #{pb_time_ago(pb_date_time.convert_to_timestamp)} ago"
-        datetime_string[0] = hide_updated ? datetime_string[0].upcase : datetime_string[0]
+        datetime_string[1] = hide_updated ? datetime_string[1].upcase : datetime_string[1]
         updated_string = hide_updated ? "" : "Last updated"
         "#{updated_string}#{user_string}#{datetime_string}"
       end

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.rb
@@ -28,13 +28,16 @@ module Playbook
                      default: "default"
 
       # Variables to use with pb_time_ago method
+      SECS_FORTY_FIVE = 45
       SECS_PER_MIN  = 60
-      SECS_PER_HOUR = 60 * SECS_PER_MIN
-      SECS_PER_DAY  = 24 * SECS_PER_HOUR
-      SECS_PER_WEEK = 7 * SECS_PER_DAY
-      SECS_PER_MONTH = 4 * SECS_PER_WEEK
-      SECS_PER_YEAR = 12 * SECS_PER_MONTH
-      SECS_PER_CENT = 100 * SECS_PER_YEAR
+      SECS_PER_HOUR = 60 * SECS_PER_MIN # 3,600 seconds
+      SECS_PER_DAY  = 24 * SECS_PER_HOUR # 86,400 seconds
+      SECS_PER_WEEK = 7 * SECS_PER_DAY # 604,800 seconds
+      SECS_PER_26 = 26 * SECS_PER_DAY # 26 days = 2,246,400 seconds
+      SECS_PER_MONTH = 4 * SECS_PER_WEEK # 2,419,200 seconds
+      SECS_PER_YEAR = 12 * SECS_PER_MONTH # 29,030,400 seconds
+      SECS_PER_320 = 320 * SECS_PER_DAY # 320 days = 27,648,000 seconds
+      SECS_PER_CENT = 100 * SECS_PER_YEAR # 3,153,600,000 seconds
 
       def classname
         generate_classname("pb_timestamp_kit", variant_class, align)
@@ -91,8 +94,10 @@ module Playbook
       def pb_time_ago(value)
         time_ago = DateTime.now.to_i - value.to_i
         case time_ago
-        when (0...SECS_PER_MIN)
+        when (0...SECS_FORTY_FIVE)
           "a few seconds"
+        when (SECS_FORTY_FIVE...SECS_PER_MIN)
+          "a minute"
         when (SECS_PER_MIN...SECS_PER_HOUR)
           time = time_ago / SECS_PER_MIN
           time == 1 ? "a minute" : "#{time_ago / SECS_PER_MIN} minutes"
@@ -102,12 +107,16 @@ module Playbook
         when (SECS_PER_DAY...SECS_PER_WEEK)
           time = time_ago / SECS_PER_DAY
           time == 1 ? "a day" : "#{time_ago / SECS_PER_DAY} days"
-        when (SECS_PER_WEEK...SECS_PER_MONTH)
+        when (SECS_PER_WEEK...SECS_PER_26)
           time = time_ago / SECS_PER_WEEK
           time == 1 ? "a week" : "#{time_ago / SECS_PER_WEEK} weeks"
-        when (SECS_PER_MONTH...SECS_PER_YEAR)
+        when (SECS_PER_26...SECS_PER_MONTH)
+          "a month"
+        when (SECS_PER_MONTH...SECS_PER_320)
           time = time_ago / SECS_PER_MONTH
           time == 1 ? "a month" : "#{time_ago / SECS_PER_MONTH} months"
+        when (SECS_PER_320...SECS_PER_YEAR)
+          "a year"
         when (SECS_PER_YEAR...SECS_PER_CENT)
           time = time_ago / SECS_PER_YEAR
           time == 1 ? "a year" : "#{time_ago / SECS_PER_YEAR} years"

--- a/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
         it "returns time elaspsed string including user's name" do
           timestamp = DateTime.new(2020, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
 
-          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user, text: name).send(:format_elapsed_string)).to eq("Last updated by #{name} #{time_ago_in_words(timestamp)} ago")
+          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user, text: name).send(:format_elapsed_string)).to eq("Last updated by #{name} #{subject.new.send(:pb_time_ago, timestamp)} ago")
         end
       end
 
@@ -137,7 +137,7 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
         it "returns time elaspsed string sans user's name" do
           timestamp = DateTime.new(2020, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
 
-          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user).send(:format_elapsed_string)).to eq("Last updated #{time_ago_in_words(timestamp)} ago")
+          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user).send(:format_elapsed_string)).to eq("Last updated #{subject.new.send(:pb_time_ago, timestamp)} ago")
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-1477

Creating private method in the PbTimestamp module to replace the "time_ago_in_words" ruby method to resolve issue in Nitro where the latter method conflicts with our Nitro behavior.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.