### PR TITLE
[PLAY-1420] Add "loading" variant to Circle Icon Button

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
@@ -16,6 +16,7 @@ type CircleIconButtonProps = {
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   link?: string,
+  loading?: boolean,
   onClick?: React.MouseEventHandler<HTMLElement>,
   newWindow?: boolean,
   type?: 'button' | 'submit' | 'reset' | undefined,
@@ -32,6 +33,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
     htmlOptions = {},
     icon,
     id,
+    loading = false,
     onClick = noop,
     type,
     link,
@@ -61,6 +63,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
           disabled={disabled}
           htmlType={type}
           link={link}
+          loading={loading}
           newWindow={newWindow}
           onClick={onClick}
           text={null}

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
@@ -1,5 +1,5 @@
 <%= pb_content_tag do %>
-  <%= pb_rails("button", props: {type: object.type, link: object.link, new_window:object.new_window, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
+  <%= pb_rails("button", props: {type: object.type, loading: object.loading, link: object.link, new_window:object.new_window, variant: object.variant, disabled: object.disabled, dark: object.dark}) do %>
     <%= pb_rails("icon", props: {icon: object.icon, fixed_width: true, dark: object.dark}) %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
@@ -12,6 +12,8 @@ module Playbook
       prop :disabled, type: Playbook::Props::Boolean,
                       default: false
       prop :icon, required: true
+      prop :loading, type: Playbook::Props::Boolean,
+                     default: false
       prop :link
       prop :new_window, type: Playbook::Props::Boolean,
                         default: false

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -15,3 +15,18 @@ test('default test', () => {
 
   expect(kit).toHaveClass('pb_circle_icon_button_kit')
 })
+
+test('passes loading prop to button', () => {
+  render(
+    <CircleIconButton
+        data={{ testid: 'loading-test' }}
+        icon="plus"
+        loading
+    />
+  )
+
+  const kit = screen.getByTestId('loading-test')
+  const button = kit.querySelector('.pb_button_kit_primary_inline_enabled_loading')
+  
+  expect(button).toBeInTheDocument()
+})

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_loading.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_loading.html.erb
@@ -1,0 +1,29 @@
+<%= pb_rails("circle_icon_button", props: {
+  variant: "primary",
+  icon: "plus",
+  loading: true
+}) %>
+
+<br/>
+
+<%= pb_rails("circle_icon_button", props: {
+  variant: "secondary",
+  icon: "pen",
+  loading: true
+}) %>
+
+<br/>
+
+<%= pb_rails("circle_icon_button", props: {
+  disabled: true,
+  icon: "times",
+  loading: true
+}) %>
+
+<br/>
+
+<%= pb_rails("circle_icon_button", props: {
+  variant: "link",
+  icon: "user",
+  loading: true
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_loading.jsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_loading.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import CircleIconButton from '../_circle_icon_button'
+
+const CircleIconButtonLoading = (props) => (
+  <div>
+    <CircleIconButton
+        icon="plus"
+        loading
+        variant="primary"
+        {...props}
+    />
+
+    <br />
+
+    <CircleIconButton
+        icon="pen"
+        loading
+        variant="secondary"
+        {...props}
+    />
+
+    <br />
+
+    <CircleIconButton
+        disabled
+        icon="times"
+        loading
+        {...props}
+    />
+
+    <br />
+
+    <CircleIconButton
+        icon="user"
+        loading
+        variant="link"
+        {...props}
+    />
+  </div>
+)
+
+export default CircleIconButtonLoading

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/example.yml
@@ -3,8 +3,10 @@ examples:
   rails:
   - circle_icon_button_default: Default
   - circle_icon_button_link: Link
+  - circle_icon_button_loading: Loading
   
   react:
   - circle_icon_button_default: Default
   - circle_icon_button_click: Click Handler
   - circle_icon_button_link: Link
+  - circle_icon_button_loading: Loading

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/index.js
@@ -1,3 +1,4 @@
 export { default as CircleIconButtonDefault } from './_circle_icon_button_default.jsx'
 export { default as CircleIconButtonClick } from './_circle_icon_button_click.jsx'
 export { default as CircleIconButtonLink } from './_circle_icon_button_link.jsx'
+export { default as CircleIconButtonLoading } from './_circle_icon_button_loading.jsx'

--- a/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Playbook::PbCircleIconButton::CircleIconButton do
   it { is_expected.to define_boolean_prop(:dark).with_default(false) }
   it { is_expected.to define_boolean_prop(:disabled).with_default(false) }
   it { is_expected.to define_prop(:icon).that_is_required }
+  it { is_expected.to define_boolean_prop(:loading).with_default(false) }
   it { is_expected.to define_boolean_prop(:new_window).with_default(false) }
   it { is_expected.to define_prop(:link) }
   describe "#classname" do


### PR DESCRIPTION
**What does this PR do?**

- ✅ Expose loading prop in Circle Icon kit for underlying Button kit
- ✅ Add examples and tests

**Screenshots:**

![Screenshot 2024-08-26 at 9 48 19 AM](https://github.com/user-attachments/assets/368dd489-927e-4d43-940e-f474d20446aa)

**How to test?**
1. Go to the Circle Icon Button kit page on Playbook
2. Review the "loading" example
3. There should be a pulse animation
4. Review both Rails and React


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.