### PR TITLE
[PBNTR-471] React pagination glitchiness

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
+++ b/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
@@ -33,6 +33,7 @@ $top_bottom_radius: 0px;
     border-top-right-radius: $top_bottom_radius;
     border-bottom-right-radius: $top_bottom_radius;
     cursor: pointer;
+    transition: background-color $transition_default ease-out, color $transition_default ease-out;
   }
   li:last-child > a, li:last-child > span, .pagination-number, .pagination-right {
     padding: $pagination_padding;
@@ -40,6 +41,7 @@ $top_bottom_radius: 0px;
     z-index: 2;
     border-top-left-radius: $top_bottom_radius;
     border-bottom-left-radius: $top_bottom_radius;
+    transition: background-color $transition_default ease-out, color $transition_default ease-out;
   }
   a, .pagination-number {
     color: $text_lt_default;

--- a/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
+++ b/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
@@ -46,6 +46,7 @@ $top_bottom_radius: 0px;
     font-size: $text_small;
     font-weight: $regular;
     border: none;
+    transition: background-color $transition_default ease-out, color $transition_default ease-out, border-color $transition_default ease-out;
 
     &:hover {
       @include hover-state;

--- a/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
+++ b/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
@@ -46,7 +46,6 @@ $top_bottom_radius: 0px;
     font-size: $text_small;
     font-weight: $regular;
     border: none;
-    transition: all $transition_default ease-out;
 
     &:hover {
       @include hover-state;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-471](https://runway.powerhrg.com/backlog_items/PBNTR-471) addresses the visual stutter observed when going from page to page on the recently developed React Pagination kit. The solution was to alter a line of scss causing an `ease-out` transition too all elements, so that it just affects background-color, color, and border-color. This code was present from back when the kit was Rails only, but the border shaking (aka, "all" elements responding) was never visually apparent since the rails version of the kit has a full page refresh upon each page change (this PR adds additional transition code to preserve current Rails appearance since it is no longer using the catch all `all` in the transition). Additionally, the double click effect should happen less - sometimes a double click can happen if a user is clicking very fast repeatedly but that can happen anywhere.

**Screenshots:** Screenshots to visualize your addition/change
Video of new React kit function - no glitchiness https://imgur.com/a/7TdbIyR
Video of Rails kit in production vs locally with this change - no difference (page just refreshes) https://imgur.com/a/JwJySpM


**How to test?** Steps to confirm the desired behavior:
1. Go to the [react pagination kit page](https://pr3647.playbook.beta.hq.powerapp.cloud/kits/pagination/react) either Default or Page Change doc example.
2. Click around on the doc example - the blue "active" square should move from number to number smoothly. 
3. Go to the rails pagination kit page and compare [production](https://playbook.powerapp.cloud/kits/pagination) vs [review env](https://pr3647.playbook.beta.hq.powerapp.cloud/kits/pagination) function/behavior - should be the same.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~