### PR TITLE
[PLAY-1519] Return empty string for SVG with HTTP errors (404s, timeouts)

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon/icon.rb
+++ b/playbook/app/pb_kits/playbook/pb_icon/icon.rb
@@ -102,6 +102,11 @@ module Playbook
       def render_svg
         doc = Nokogiri::XML(URI.open(asset_path || icon || custom_icon)) # rubocop:disable Security/Open
         svg = doc.at_css "svg"
+
+        unless svg
+          return "" # Return an empty string if SVG element is not found
+        end
+
         svg["class"] = %w[pb_custom_icon svg-inline--fa].concat([object.custom_icon_classname]).join(" ")
         svg["id"] = object.id
         svg["data"] = object.data
@@ -112,6 +117,9 @@ module Playbook
         fill_color = object.color || "currentColor"
         doc.at_css("path")["fill"] = fill_color
         raw doc
+      rescue OpenURI::HTTPError, StandardError
+        # Handle any exceptions and return an empty string
+        ""
       end
 
       def is_svg?


### PR DESCRIPTION
**What does this PR do?**

- ✅ Handle custom icon SVGs HTTP errors gracefully- substitute an empty string
- ✅ Fix Nitro test suites from crashing with errors like "Failed to open TCP connection to upload.wikimedia.org:443"

**Screenshots:**

Show blank icons with HTTP errors:
![Playbook Design System 2024-09-05 at 9 11 24 AM](https://github.com/user-attachments/assets/5033018e-ffd0-4c5d-acc8-4759306e1622)
![Playbook Design System 2024-09-05 at 9 12 22 AM](https://github.com/user-attachments/assets/5a9cc0d1-fe95-4ed6-aba3-f3c6bcae24af)

Nav bar custom icons use image tags, so they show broken images:
![Playbook Design System 2024-09-05 at 9 12 56 AM](https://github.com/user-attachments/assets/1cc17950-f500-487a-be20-a8d775a22979)

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/icon#icon-custom
2. The wrench icon (from wikipedia) should show as normal
3. Go to /kits/selectable_card_icon#custom-icon
4. The wrench icon should show as normal
5. Go to /kits/nav/rails#with-custom-icon
6. The news feed icon should show as normal

I tested HTTP errors on my end (I made 404 icon links), and it shows as empty strings as expected. 

If you want to test to make sure, I can start a test environment to show it in action.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.