### PR TITLE
[PLAY-1412] Bubble Variant to Multiple Users Stacked

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
@@ -75,8 +75,8 @@
     }
 
     [class^=pb_avatar_kit].first_item {
-      top: 3px;
-      left: 5px;
+      top: 4px;
+      left: 3px;
       height: 20px;
       width: 20px;
       .avatar_wrapper {
@@ -84,7 +84,20 @@
         width: 20px;
       }
 
-      &.three_or_more {
+      &.triple_bubble {
+        top: 4px;
+        left: 4px;
+        height: 16px;
+        width: 16px;
+        .avatar_wrapper {
+          height: 16px;
+          width: 16px;
+        }
+      }
+
+      &.quadruple_bubble {
+        top: 5px;
+        left: 3px;
         height: 16px;
         width: 16px;
         .avatar_wrapper {
@@ -95,8 +108,8 @@
     }
 
     [class^=pb_avatar_kit].second_item {
-      bottom: 7px;
-      right: 5px;
+      bottom: 5px;
+      right: 4px;
       height: 12px;
       width: 12px;
       .avatar_wrapper {
@@ -104,28 +117,38 @@
         width: 12px;
       }
 
-      &.double {
-        bottom: 5px;
-        right: 5px;
+      &.triple_bubble {
+        top: 13px;
+        right: 2px;
+      }
+
+      &.quadruple_bubble {
+        bottom: 9px;
+        right: 4px;
       }
     }
 
     [class^=pb_avatar_kit].third_item {
       position: absolute;
-      bottom: 5px;
-      left: 8px;
+      bottom: 3px;
+      left: 11px;
       height: 10px;
       width: 10px;
       .avatar_wrapper {
         height: 10px;
         width: 10px;
       }
+
+      &.quadruple_bubble {
+        bottom: 3px;
+        left: 9px;
+      }
     }
 
     [class^=pb_avatar_kit].fourth_item {
       position: absolute;
-      top: 7px;
-      right: 4px;
+      top: 5px;
+      right: 6px;
       height: 8px;
       width: 8px;
       .avatar_wrapper {

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
@@ -3,12 +3,6 @@
 @import "../tokens/opacity";
 @import "../pb_avatar/avatar";
 
-@mixin avatar-wrapper($size, $border-color: $white) {
-  height: $size;
-  width: $size;
-  border: $border_size solid $border-color;
-}
-
 [class^=pb_multiple_users_stacked_kit] {
   $container_size: map-get($avatar-sizes, "xs");
   $bubble_container_size: map-get($avatar-sizes, "sm");
@@ -24,26 +18,31 @@
   flex-shrink: 0;
   flex-grow: 0;
   [class^=pb_avatar_kit].pb_multiple_users_stacked_item {
-    @include avatar-wrapper($stacked_size);
-
-    &.dark {
+    height: $stacked_size;
+    width: $stacked_size;
+      &.dark {
+        .avatar_wrapper {
+          border: $pb_multiple_users_border_size solid $bg_dark;
+        }
+      }
       .avatar_wrapper {
-        border-color: $bg_dark;
+        border: $border_size solid $white;
+        height: $stacked_size;
+        width: $stacked_size;
+        img {
+          z-index: 0;
+        }
       }
     }
-    .avatar_wrapper {
-      @include avatar-wrapper($stacked_size);
-      img {
-        z-index: 0;
-      }
-    }
-  }
   &[class*=_single] .pb_multiple_users_stacked_item {
-    @include avatar-wrapper($container_size);
+    width: $container_size;
+    height: $container_size;
+    .avatar_wrapper {
+      width: $container_size;
+      height: $container_size;
+    }
   }
-
-  [class^=pb_avatar_kit].second_item,
-  [class^=pb_badge_kit].second_item {
+  [class^=pb_avatar_kit].second_item, [class^=pb_badge_kit].second_item {
     position: absolute;
     bottom: 0;
     right: 0;
@@ -54,10 +53,13 @@
     span {
       transform: translateY(0);
     }
+    .avatar_wrapper {
+      border: $border_size solid $white;
+      height: $stacked_size;
+      width: $stacked_size;
 
-    @include avatar-wrapper($stacked_size);
+    }
   }
-
   .stacked_item .avatar_wrapper::before {
     font-size: 0;
     color: transparent;
@@ -72,40 +74,63 @@
       background-color: $card_dark;
     }
 
-    [class^=pb_avatar_kit] {
-      &.first_item {
-        top: 3px;
-        left: 5px;
-        @include avatar-wrapper(20px);
-
-        &.three_or_more {
-          @include avatar-wrapper(16px);
-        }
+    [class^=pb_avatar_kit].first_item {
+      top: 3px;
+      left: 5px;
+      height: 20px;
+      width: 20px;
+      .avatar_wrapper {
+        height: 20px;
+        width: 20px;
       }
 
-      &.second_item {
-        bottom: 7px;
-        right: 5px;
-        @include avatar-wrapper(12px);
-
-        &.double {
-          bottom: 5px;
-          right: 5px;
+      &.three_or_more {
+        height: 16px;
+        width: 16px;
+        .avatar_wrapper {
+          height: 16px;
+          width: 16px;
         }
       }
+    }
 
-      &.third_item {
-        position: absolute;
+    [class^=pb_avatar_kit].second_item {
+      bottom: 7px;
+      right: 5px;
+      height: 12px;
+      width: 12px;
+      .avatar_wrapper {
+        height: 12px;
+        width: 12px;
+      }
+
+      &.double {
         bottom: 5px;
-        left: 8px;
-        @include avatar-wrapper(10px);
+        right: 5px;
       }
+    }
 
-      &.fourth_item {
-        position: absolute;
-        top: 7px;
-        right: 4px;
-        @include avatar-wrapper(8px);
+    [class^=pb_avatar_kit].third_item {
+      position: absolute;
+      bottom: 5px;
+      left: 8px;
+      height: 10px;
+      width: 10px;
+      .avatar_wrapper {
+        height: 10px;
+        width: 10px;
+      }
+    }
+
+    [class^=pb_avatar_kit].fourth_item {
+      position: absolute;
+      top: 7px;
+      right: 4px;
+      height: 8px;
+      width: 8px;
+      .avatar_wrapper {
+        height: 8px;
+        width: 8px;
       }
     }
   }
@@ -114,7 +139,10 @@
     [class^=pb_avatar_kit].first_item {
       top: 0;
       left: 0;
-      @include avatar-wrapper($bubble_container_size);
+      .avatar_wrapper {
+        height: $bubble_container_size;
+        width: $bubble_container_size;
+      }
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
@@ -5,6 +5,7 @@
 
 [class^=pb_multiple_users_stacked_kit] {
   $container_size: map-get($avatar-sizes, "xs");
+  $bubble_container_size: map-get($avatar-sizes, "sm");
   $overlap: -15px;
   $border_size: 1px;
   $stacked_size: 18px;
@@ -62,5 +63,86 @@
   .stacked_item .avatar_wrapper::before {
     font-size: 0;
     color: transparent;
+  }
+
+  &[class*=_bubble] {
+    width: $bubble_container_size;
+    height: $bubble_container_size;
+    background-color: $bg_light;
+    border-radius: 50%;
+    &.dark {
+      background-color: $card_dark;
+    }
+
+    [class^=pb_avatar_kit].first_item {
+      top: 3px;
+      left: 5px;
+      height: 20px;
+      width: 20px;
+      .avatar_wrapper {
+        height: 20px;
+        width: 20px;
+      }
+
+      &.three_or_more {
+        height: 16px;
+        width: 16px;
+        .avatar_wrapper {
+          height: 16px;
+          width: 16px;
+        }
+      }
+    }
+
+    [class^=pb_avatar_kit].second_item {
+      bottom: 7px;
+      right: 5px;
+      height: 12px;
+      width: 12px;
+      .avatar_wrapper {
+        height: 12px;
+        width: 12px;
+      }
+
+      &.double {
+        bottom: 5px;
+        right: 5px;
+      }
+    }
+
+    [class^=pb_avatar_kit].third_item {
+      position: absolute;
+      bottom: 5px;
+      left: 8px;
+      height: 10px;
+      width: 10px;
+      .avatar_wrapper {
+        height: 10px;
+        width: 10px;
+      }
+    }
+
+    [class^=pb_avatar_kit].fourth_item {
+      position: absolute;
+      top: 7px;
+      right: 4px;
+      height: 8px;
+      width: 8px;
+      .avatar_wrapper {
+        height: 8px;
+        width: 8px;
+      }
+    }
+  }
+
+  &[class*=_single_bubble] {
+    [class^=pb_avatar_kit].first_item {
+      top: 0;
+      left: 0;
+      .avatar_wrapper {
+        height: $bubble_container_size;
+        width: $bubble_container_size;
+      }
+    }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
@@ -3,6 +3,12 @@
 @import "../tokens/opacity";
 @import "../pb_avatar/avatar";
 
+@mixin avatar-wrapper($size, $border-color: $white) {
+  height: $size;
+  width: $size;
+  border: $border_size solid $border-color;
+}
+
 [class^=pb_multiple_users_stacked_kit] {
   $container_size: map-get($avatar-sizes, "xs");
   $bubble_container_size: map-get($avatar-sizes, "sm");
@@ -18,31 +24,26 @@
   flex-shrink: 0;
   flex-grow: 0;
   [class^=pb_avatar_kit].pb_multiple_users_stacked_item {
-    height: $stacked_size;
-    width: $stacked_size;
-      &.dark {
-        .avatar_wrapper {
-          border: $pb_multiple_users_border_size solid $bg_dark;
-        }
-      }
+    @include avatar-wrapper($stacked_size);
+
+    &.dark {
       .avatar_wrapper {
-        border: $border_size solid $white;
-        height: $stacked_size;
-        width: $stacked_size;
-        img {
-          z-index: 0;
-        }
+        border-color: $bg_dark;
       }
     }
-  &[class*=_single] .pb_multiple_users_stacked_item {
-    width: $container_size;
-    height: $container_size;
     .avatar_wrapper {
-      width: $container_size;
-      height: $container_size;
+      @include avatar-wrapper($stacked_size);
+      img {
+        z-index: 0;
+      }
     }
   }
-  [class^=pb_avatar_kit].second_item, [class^=pb_badge_kit].second_item {
+  &[class*=_single] .pb_multiple_users_stacked_item {
+    @include avatar-wrapper($container_size);
+  }
+
+  [class^=pb_avatar_kit].second_item,
+  [class^=pb_badge_kit].second_item {
     position: absolute;
     bottom: 0;
     right: 0;
@@ -53,13 +54,10 @@
     span {
       transform: translateY(0);
     }
-    .avatar_wrapper {
-      border: $border_size solid $white;
-      height: $stacked_size;
-      width: $stacked_size;
 
-    }
+    @include avatar-wrapper($stacked_size);
   }
+
   .stacked_item .avatar_wrapper::before {
     font-size: 0;
     color: transparent;
@@ -74,63 +72,40 @@
       background-color: $card_dark;
     }
 
-    [class^=pb_avatar_kit].first_item {
-      top: 3px;
-      left: 5px;
-      height: 20px;
-      width: 20px;
-      .avatar_wrapper {
-        height: 20px;
-        width: 20px;
-      }
+    [class^=pb_avatar_kit] {
+      &.first_item {
+        top: 3px;
+        left: 5px;
+        @include avatar-wrapper(20px);
 
-      &.three_or_more {
-        height: 16px;
-        width: 16px;
-        .avatar_wrapper {
-          height: 16px;
-          width: 16px;
+        &.three_or_more {
+          @include avatar-wrapper(16px);
         }
       }
-    }
 
-    [class^=pb_avatar_kit].second_item {
-      bottom: 7px;
-      right: 5px;
-      height: 12px;
-      width: 12px;
-      .avatar_wrapper {
-        height: 12px;
-        width: 12px;
-      }
-
-      &.double {
-        bottom: 5px;
+      &.second_item {
+        bottom: 7px;
         right: 5px;
-      }
-    }
+        @include avatar-wrapper(12px);
 
-    [class^=pb_avatar_kit].third_item {
-      position: absolute;
-      bottom: 5px;
-      left: 8px;
-      height: 10px;
-      width: 10px;
-      .avatar_wrapper {
-        height: 10px;
-        width: 10px;
+        &.double {
+          bottom: 5px;
+          right: 5px;
+        }
       }
-    }
 
-    [class^=pb_avatar_kit].fourth_item {
-      position: absolute;
-      top: 7px;
-      right: 4px;
-      height: 8px;
-      width: 8px;
-      .avatar_wrapper {
-        height: 8px;
-        width: 8px;
+      &.third_item {
+        position: absolute;
+        bottom: 5px;
+        left: 8px;
+        @include avatar-wrapper(10px);
+      }
+
+      &.fourth_item {
+        position: absolute;
+        top: 7px;
+        right: 4px;
+        @include avatar-wrapper(8px);
       }
     }
   }
@@ -139,10 +114,7 @@
     [class^=pb_avatar_kit].first_item {
       top: 0;
       left: 0;
-      .avatar_wrapper {
-        height: $bubble_container_size;
-        width: $bubble_container_size;
-      }
+      @include avatar-wrapper($bubble_container_size);
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
@@ -3,6 +3,22 @@
 @import "../tokens/opacity";
 @import "../pb_avatar/avatar";
 
+@mixin avatar-size($size) {
+  height: $size;
+  width: $size;
+  .avatar_wrapper {
+    width: $size;
+    height: $size;
+  }
+}
+
+@mixin position($position) {
+  position: absolute;
+  @each $pos, $val in $position {
+    #{$pos}: $val;
+  }
+}
+
 [class^=pb_multiple_users_stacked_kit] {
   $container_size: map-get($avatar-sizes, "xs");
   $bubble_container_size: map-get($avatar-sizes, "sm");
@@ -18,34 +34,24 @@
   flex-shrink: 0;
   flex-grow: 0;
   [class^=pb_avatar_kit].pb_multiple_users_stacked_item {
-    height: $stacked_size;
-    width: $stacked_size;
-      &.dark {
-        .avatar_wrapper {
-          border: $pb_multiple_users_border_size solid $bg_dark;
-        }
-      }
+    @include avatar-size($stacked_size);
+    &.dark {
       .avatar_wrapper {
-        border: $border_size solid $white;
-        height: $stacked_size;
-        width: $stacked_size;
-        img {
-          z-index: 0;
-        }
+        border: $border_size solid $bg_dark;
       }
     }
-  &[class*=_single] .pb_multiple_users_stacked_item {
-    width: $container_size;
-    height: $container_size;
     .avatar_wrapper {
-      width: $container_size;
-      height: $container_size;
+      border: $border_size solid $white;
+      img {
+        z-index: 0;
+      }
     }
   }
+  &[class*=_single] .pb_multiple_users_stacked_item {
+    @include avatar-size($container_size);
+  }
   [class^=pb_avatar_kit].second_item, [class^=pb_badge_kit].second_item {
-    position: absolute;
-    bottom: 0;
-    right: 0;
+    @include position((bottom: 0, right: 0));
     z-index: 2;
     background: tint($primary, 90%);
     border-radius: $border_rad_mega;
@@ -66,106 +72,71 @@
   }
 
   &[class*=_bubble] {
-    width: $bubble_container_size;
-    height: $bubble_container_size;
+    @include avatar-size($bubble_container_size);
     background-color: $bg_light;
     border-radius: 50%;
+
     &.dark {
       background-color: $card_dark;
     }
-
-    [class^=pb_avatar_kit].first_item {
-      top: 4px;
-      left: 3px;
-      height: 20px;
-      width: 20px;
-      .avatar_wrapper {
-        height: 20px;
-        width: 20px;
-      }
-
-      &.triple_bubble {
-        top: 4px;
-        left: 4px;
-        height: 16px;
-        width: 16px;
+    
+    [class^=pb_avatar_kit].pb_multiple_users_stacked_item {
+      &.dark {
         .avatar_wrapper {
-          height: 16px;
-          width: 16px;
-        }
-      }
-
-      &.quadruple_bubble {
-        top: 5px;
-        left: 3px;
-        height: 16px;
-        width: 16px;
-        .avatar_wrapper {
-          height: 16px;
-          width: 16px;
+          border: $border_size solid $border_dark;
         }
       }
     }
 
-    [class^=pb_avatar_kit].second_item {
-      bottom: 5px;
-      right: 4px;
-      height: 12px;
-      width: 12px;
-      .avatar_wrapper {
-        height: 12px;
-        width: 12px;
+    [class^=pb_avatar_kit] {
+      &.first_item {
+        @include position((top: 4px, left: 3px));
+        @include avatar-size(20px);
+
+        &.triple_bubble {
+          @include position((top: 4px, left: 4px));
+          @include avatar-size(16px);
+        }
+
+        &.quadruple_bubble {
+          @include position((top: 5px, left: 3px));
+          @include avatar-size(16px);
+        }
       }
 
-      &.triple_bubble {
-        top: 13px;
-        right: 2px;
+      &.second_item {
+        @include position((bottom: 5px, right: 4px));
+        @include avatar-size(12px);
+
+        &.triple_bubble {
+          @include position((top: 13px, right: 2px));
+        }
+
+        &.quadruple_bubble {
+          @include position((bottom: 9px, right: 4px));
+        }
       }
 
-      &.quadruple_bubble {
-        bottom: 9px;
-        right: 4px;
-      }
-    }
+      &.third_item {
+        @include position((bottom: 3px, left: 11px));
+        @include avatar-size(10px);
 
-    [class^=pb_avatar_kit].third_item {
-      position: absolute;
-      bottom: 3px;
-      left: 11px;
-      height: 10px;
-      width: 10px;
-      .avatar_wrapper {
-        height: 10px;
-        width: 10px;
+        &.quadruple_bubble {
+          @include position((bottom: 3px, left: 9px));
+        }
       }
 
-      &.quadruple_bubble {
-        bottom: 3px;
-        left: 9px;
-      }
-    }
-
-    [class^=pb_avatar_kit].fourth_item {
-      position: absolute;
-      top: 5px;
-      right: 6px;
-      height: 8px;
-      width: 8px;
-      .avatar_wrapper {
-        height: 8px;
-        width: 8px;
+      &.fourth_item {
+        @include position((top: 5px, right: 6px));
+        @include avatar-size(8px);
       }
     }
   }
 
   &[class*=_single_bubble] {
     [class^=pb_avatar_kit].first_item {
-      top: 0;
-      left: 0;
-      .avatar_wrapper {
-        height: $bubble_container_size;
-        width: $bubble_container_size;
-      }
+      @include position((top: 0, left: 0));
+      @include avatar-size($bubble_container_size);
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.test.js
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.test.js
@@ -59,3 +59,169 @@ test('should pass aria prop', () => {
     const kit = screen.getByTestId(testId)
     expect(kit).toHaveAttribute('aria-label', testId)
 })
+
+const MultipleUsersStackedSingleBubble = () => {
+    return (
+        <MultipleUsersStacked
+            aria={{ label: testId }}
+            className={className}
+            data={{ testid: testId }}
+            users={[
+                {
+                    name: "user1",
+                    imageUrl: "imageUser1",
+                    imageAlt: "nameUser1",
+                }
+            ]}
+            variant="bubble"
+        />
+    )
+}
+
+test('should have a single bubble', () => {
+    render(<MultipleUsersStackedSingleBubble />)
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass("pb_multiple_users_stacked_kit_single_bubble")
+
+    const firstItem = kit.querySelector('.first_item');
+    expect(firstItem).toBeInTheDocument();
+})
+
+const MultipleUsersStackedDoubleBubble = () => {
+    return (
+        <MultipleUsersStacked
+            aria={{ label: testId }}
+            className={className}
+            data={{ testid: testId }}
+            users={[
+                {
+                    name: "user1",
+                    imageUrl: "imageUser1",
+                    imageAlt: "nameUser1",
+                },
+                {
+                    name: "user2",
+                    imageUrl: "imageUser2",
+                    imageAlt: "nameUser2",
+                },
+            ]}
+            variant="bubble"
+        />
+    )
+}
+
+test('should have a double bubble', () => {
+    render(<MultipleUsersStackedDoubleBubble />)
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass("pb_multiple_users_stacked_kit_bubble")
+
+    const firstItem = kit.querySelector('.first_item');
+    expect(firstItem).toBeInTheDocument();
+
+    const secondItem = kit.querySelector('.second_item');
+    expect(secondItem).toBeInTheDocument();
+})
+
+const MultipleUsersStackedTripleBubble = () => {
+    return (
+        <MultipleUsersStacked
+            aria={{ label: testId }}
+            className={className}
+            data={{ testid: testId }}
+            users={[
+                {
+                    name: "user1",
+                    imageUrl: "imageUser1",
+                    imageAlt: "nameUser1",
+                },
+                {
+                    name: "user2",
+                    imageUrl: "imageUser2",
+                    imageAlt: "nameUser2",
+                },
+                {
+                    name: "user3",
+                    imageUrl: "imageUser3",
+                    imageAlt: "nameUser3",
+                },
+            ]}
+            variant="bubble"
+        />
+    )
+}
+
+test('should have a triple bubble', () => {
+    render(<MultipleUsersStackedTripleBubble />)
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass("pb_multiple_users_stacked_kit_bubble")
+
+    const firstItem = kit.querySelector('.first_item');
+    expect(firstItem).toBeInTheDocument();
+    expect(firstItem).toHaveClass("triple_bubble")
+
+    const secondItem = kit.querySelector('.second_item');
+    expect(secondItem).toBeInTheDocument();
+    expect(secondItem).toHaveClass("triple_bubble")
+
+    const thirdItem = kit.querySelector('.third_item');
+    expect(thirdItem).toBeInTheDocument();
+})
+
+const MultipleUsersStackedQuadrupleBubble = () => {
+    return (
+        <MultipleUsersStacked
+            aria={{ label: testId }}
+            className={className}
+            data={{ testid: testId }}
+            users={[
+                {
+                    name: "user1",
+                    imageUrl: "imageUser1",
+                    imageAlt: "nameUser1",
+                },
+                {
+                    name: "user2",
+                    imageUrl: "imageUser2",
+                    imageAlt: "nameUser2",
+                },
+                {
+                    name: "user3",
+                    imageUrl: "imageUser3",
+                    imageAlt: "nameUser3",
+                },
+                {
+                    name: "user4",
+                    imageUrl: "imageUser4",
+                    imageAlt: "nameUser4",
+                },
+                {
+                    name: "user5",
+                    imageUrl: "imageUser5",
+                    imageAlt: "nameUser5",
+                },
+            ]}
+            variant="bubble"
+        />
+    )
+}
+
+test('should have a quadruple bubble', () => {
+    render(<MultipleUsersStackedQuadrupleBubble />)
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass("pb_multiple_users_stacked_kit_bubble")
+
+    const firstItem = kit.querySelector('.first_item');
+    expect(firstItem).toBeInTheDocument();
+    expect(firstItem).toHaveClass("quadruple_bubble")
+
+    const secondItem = kit.querySelector('.second_item');
+    expect(secondItem).toBeInTheDocument();
+    expect(secondItem).toHaveClass("quadruple_bubble")
+
+    const thirdItem = kit.querySelector('.third_item');
+    expect(thirdItem).toBeInTheDocument();
+    expect(thirdItem).toHaveClass("quadruple_bubble")
+
+    const fourthItem = kit.querySelector('.fourth_item');
+    expect(fourthItem).toBeInTheDocument();
+})

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
@@ -33,8 +33,8 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
   const moreThanTwo = users.length > 2
   const onlyOne = users.length == 1
   const isBubble = variant === "bubble"
-  const bubbleThreeOrMore = isBubble && users.length > 2
-  const bubbleDouble = isBubble && users.length === 2
+  const tripleBubble = isBubble && users.length === 3
+  const quadrupleBubble = isBubble && users.length > 3
   const displayCount = () => {
     return moreThanTwo ? 1 : users.length
   }
@@ -50,7 +50,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
       return (
         <Avatar
             {...userObject}
-            className={`pb_multiple_users_stacked_item first_item${bubbleThreeOrMore ? " three_or_more" : ""}`}
+            className={`pb_multiple_users_stacked_item first_item${tripleBubble ? " triple_bubble" : ""}${quadrupleBubble ? " quadruple_bubble" : ""}`}
             dark={dark}
             key={index}
             size={isBubble ? "sm" : "xs"}
@@ -65,7 +65,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
         return (
           <Avatar
               {...userObject}
-              className={`pb_multiple_users_stacked_item second_item${bubbleDouble ? " double" : ""}`}
+              className={`pb_multiple_users_stacked_item second_item${tripleBubble ? " triple_bubble" : ""}${quadrupleBubble ? " quadruple_bubble" : ""}`}
               dark={dark}
               key={index}
               size="xs"
@@ -81,7 +81,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
         return (
           <Avatar
               {...userObject}
-              className="pb_multiple_users_stacked_item third_item"
+              className={`pb_multiple_users_stacked_item third_item${quadrupleBubble ? " quadruple_bubble" : ""}`}
               dark={dark}
               key={index}
               size="xs"

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
@@ -50,7 +50,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
       return (
         <Avatar
             {...userObject}
-            className={`pb_multiple_users_stacked_item first_item${bubbleThreeOrMore && " three_or_more"}`}
+            className={`pb_multiple_users_stacked_item first_item${bubbleThreeOrMore ? " three_or_more" : ""}`}
             dark={dark}
             key={index}
             size={isBubble ? "sm" : "xs"}
@@ -65,7 +65,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
         return (
           <Avatar
               {...userObject}
-              className={`pb_multiple_users_stacked_item second_item${bubbleDouble && " double"}`}
+              className={`pb_multiple_users_stacked_item second_item${bubbleDouble ? " double" : ""}`}
               dark={dark}
               key={index}
               size="xs"

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.tsx
@@ -15,6 +15,7 @@ type MultipleUsersStackedProps = {
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   users: Array<{ [key: string]: string }>,
+  variant: "default" | "bubble",
 }
 
 const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
@@ -26,10 +27,14 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
     htmlOptions = {},
     id,
     users,
+    variant = "default",
   } = props
 
   const moreThanTwo = users.length > 2
   const onlyOne = users.length == 1
+  const isBubble = variant === "bubble"
+  const bubbleThreeOrMore = isBubble && users.length > 2
+  const bubbleDouble = isBubble && users.length === 2
   const displayCount = () => {
     return moreThanTwo ? 1 : users.length
   }
@@ -38,29 +43,61 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
   const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(buildCss(
     'pb_multiple_users_stacked_kit',
-    { single: onlyOne }), globalProps(props), className)
+    { single: onlyOne, bubble: isBubble }), globalProps(props), className)
 
   const firstUser = () => {
     return users.slice(0, 1).map((userObject, index) => {
       return (
         <Avatar
             {...userObject}
-            className="pb_multiple_users_stacked_item"
+            className={`pb_multiple_users_stacked_item first_item${bubbleThreeOrMore && " three_or_more"}`}
             dark={dark}
             key={index}
-            size="xs"
+            size={isBubble ? "sm" : "xs"}
         />
       )
     })
   }
 
   const secondUser = () => {
-    if (moreThanTwo === false) {
+    if (!moreThanTwo || (isBubble && users.length > 1)) {
       return users.slice(1, 2).map((userObject, index) => {
         return (
           <Avatar
               {...userObject}
-              className="pb_multiple_users_stacked_item second_item"
+              className={`pb_multiple_users_stacked_item second_item${bubbleDouble && " double"}`}
+              dark={dark}
+              key={index}
+              size="xs"
+          />
+        )
+      })
+    }
+  }
+
+  const thirdUser = () => {
+    if (isBubble && users.length > 2) {
+      return users.slice(2, 3).map((userObject, index) => {
+        return (
+          <Avatar
+              {...userObject}
+              className="pb_multiple_users_stacked_item third_item"
+              dark={dark}
+              key={index}
+              size="xs"
+          />
+        )
+      })
+    }
+  }
+
+  const fourthUser = () => {
+    if (isBubble && users.length > 3) {
+      return users.slice(3, 4).map((userObject, index) => {
+        return (
+          <Avatar
+              {...userObject}
+              className="pb_multiple_users_stacked_item fourth_item"
               dark={dark}
               key={index}
               size="xs"
@@ -71,7 +108,7 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
   }
 
   const plusUsers = () => {
-    if (moreThanTwo === true) {
+    if (moreThanTwo && !isBubble) {
       return (
         <Badge
             className="pb_multiple_users_stacked_item second_item"
@@ -94,6 +131,8 @@ const MultipleUsersStacked = (props: MultipleUsersStackedProps) => {
     >
       {firstUser()}
       {secondUser()}
+      {thirdUser()}
+      {fourthUser()}
       {plusUsers()}
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_bubble.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_bubble.html.erb
@@ -1,0 +1,73 @@
+<%= pb_rails("multiple_users_stacked", props: {
+  variant: "bubble",
+  users: [
+    {
+      name: "Patrick Welch",
+      image_url: "https://randomuser.me/api/portraits/men/9.jpg",
+    }
+  ]
+}) %>
+
+<br/><br/>
+
+<%= pb_rails("multiple_users_stacked", props: {
+  variant: "bubble",
+  users: [
+    {
+      name: "Patrick Welch",
+      image_url: "https://randomuser.me/api/portraits/men/9.jpg",
+    },
+    {
+      name: "Lucille Sanchez",
+      image_url: "https://randomuser.me/api/portraits/women/6.jpg",
+    }
+  ]
+}) %>
+
+<br/><br/>
+
+<%= pb_rails("multiple_users_stacked", props: {
+  variant: "bubble",
+  users: [
+    {
+      name: "Patrick Welch",
+      image_url: "https://randomuser.me/api/portraits/men/9.jpg",
+    },
+    {
+      name: "Lucille Sanchez",
+      image_url: "https://randomuser.me/api/portraits/women/6.jpg",
+    },
+    {
+      name: "Beverly Reyes",
+      image_url: "https://randomuser.me/api/portraits/women/74.jpg",
+    },
+  ]
+}) %>
+
+<br/><br/>
+
+<%= pb_rails("multiple_users_stacked", props: {
+  variant: "bubble",
+  users: [
+    {
+      name: "Patrick Welch",
+      image_url: "https://randomuser.me/api/portraits/men/9.jpg",
+    },
+    {
+      name: "Lucille Sanchez",
+      image_url: "https://randomuser.me/api/portraits/women/6.jpg",
+    },
+    {
+      name: "Beverly Reyes",
+      image_url: "https://randomuser.me/api/portraits/women/74.jpg",
+    },
+    {
+      name: "Keith Craig",
+      image_url: "https://randomuser.me/api/portraits/men/40.jpg",
+    },
+    {
+      name: "Alicia Cooper",
+      image_url: "https://randomuser.me/api/portraits/women/46.jpg",
+    }
+  ]
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_bubble.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/_multiple_users_stacked_bubble.jsx
@@ -1,0 +1,86 @@
+import React from 'react'
+
+import MultipleUsersStacked from '../_multiple_users_stacked'
+
+const MultipleUsersStackedBubble = (props) => {
+  return (
+    <div>
+      <MultipleUsersStacked
+          users={[
+        {
+          name: 'Patrick Welch',
+          imageUrl: 'https://randomuser.me/api/portraits/men/9.jpg',
+        },
+      ]}
+          variant="bubble"
+          {...props}
+      />
+      <br />
+      <br />
+      <MultipleUsersStacked
+          users={[
+        {
+          name: 'Patrick Welch',
+          imageUrl: 'https://randomuser.me/api/portraits/men/9.jpg',
+        },
+        {
+          name: 'Lucille Sanchez',
+          imageUrl: 'https://randomuser.me/api/portraits/women/6.jpg',
+        },
+      ]}
+          variant="bubble"
+          {...props}
+      />
+      <br />
+      <br />
+      <MultipleUsersStacked
+          users={[
+        {
+          name: 'Patrick Welch',
+          imageUrl: 'https://randomuser.me/api/portraits/men/9.jpg',
+        },
+        {
+          name: 'Lucille Sanchez',
+          imageUrl: 'https://randomuser.me/api/portraits/women/6.jpg',
+        },
+        {
+          name: 'Beverly Reyes',
+          imageUrl: 'https://randomuser.me/api/portraits/women/74.jpg',
+        },
+      ]}
+          variant="bubble"
+          {...props}
+      />
+      <br />
+      <br />
+      <MultipleUsersStacked
+          users={[
+        {
+          name: 'Patrick Welch',
+          imageUrl: 'https://randomuser.me/api/portraits/men/9.jpg',
+        },
+        {
+          name: 'Lucille Sanchez',
+          imageUrl: 'https://randomuser.me/api/portraits/women/6.jpg',
+        },
+        {
+          name: 'Beverly Reyes',
+          imageUrl: 'https://randomuser.me/api/portraits/women/74.jpg',
+        },
+        {
+          name: 'Keith Craig',
+          imageUrl: 'https://randomuser.me/api/portraits/men/40.jpg',
+        },
+        {
+          name: 'Alicia Cooper',
+          imageUrl: 'https://randomuser.me/api/portraits/women/46.jpg',
+        },
+      ]}
+          variant="bubble"
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default MultipleUsersStackedBubble

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/example.yml
@@ -2,10 +2,12 @@ examples:
 
   rails:
   - multiple_users_stacked_default: Default
+  - multiple_users_stacked_bubble: Bubble
 
 
   react:
   - multiple_users_stacked_default: Default
+  - multiple_users_stacked_bubble: Bubble
 
   swift: 
   - multiple_users_stacked_default_swift: Default

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/docs/index.js
@@ -1,1 +1,2 @@
 export { default as MultipleUsersStackedDefault } from './_multiple_users_stacked_default.jsx'
+export { default as MultipleUsersStackedBubble } from './_multiple_users_stacked_bubble.jsx'

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.html.erb
@@ -1,17 +1,17 @@
 <%= pb_content_tag do %>
-  <%= pb_rails("avatar", props: object.users[0].merge({size: object.variant == "bubble" ? "sm" : "xs", classname: "pb_multiple_users_stacked_item first_item#{object.variant == "bubble" && object.users.count > 2 ? " three_or_more" : ""}", dark: object.dark}) ) %>
+  <%= pb_rails("avatar", props: object.users[0].merge({size: object.bubble ? "sm" : "xs", classname: "pb_multiple_users_stacked_item first_item#{object.triple_bubble ? " triple_bubble" : ""}#{object.quadruple_bubble ? " quadruple_bubble" : ""}", dark: object.dark}) ) %>
 
   <% unless object.only_one %>
-    <% if object.more_than_two && object.variant != "bubble" %>
+    <% if object.more_than_two && !object.bubble %>
       <%= pb_rails("badge", props: {
         dark: object.dark,
         text: "+#{object.users.count - object.display_count}",
         variant: "primary",
         rounded: true,
         classname: "pb_multiple_users_stacked_item second_item" }) %>
-    <% elsif object.variant == "bubble" %>
-      <% object.users.slice(1,4).each_with_index do |item, idx| %>
-        <%= pb_rails("avatar", props: item.merge({size: "xs", classname: "pb_multiple_users_stacked_item #{idx == 0 ? "second_item#{object.users.count === 2 ? " double" : ""}" : idx == 1 ? "third_item" : "fourth_item"}", dark: object.dark}) ) %>
+    <% elsif object.bubble %>
+      <% object.users.slice(1,3).each_with_index do |item, idx| %>
+        <%= pb_rails("avatar", props: item.merge({size: "xs", classname: "pb_multiple_users_stacked_item #{idx == 0 ? "second_item#{object.triple_bubble ? " triple_bubble" : ""}#{object.quadruple_bubble ? " quadruple_bubble" : ""}" : idx == 1 ? "third_item#{object.quadruple_bubble ? " quadruple_bubble" : ""}" : "fourth_item"}", dark: object.dark}) ) %>
       <% end %>
     <% else %>
       <%= pb_rails("avatar", props: object.users[1].merge({size: "xs", classname: "pb_multiple_users_stacked_item second_item", dark: object.dark}) ) %>

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.html.erb
@@ -1,14 +1,18 @@
 <%= pb_content_tag do %>
-  <%= pb_rails("avatar", props: object.users[0].merge({size: "xs", classname: "pb_multiple_users_stacked_item", dark: object.dark}) ) %>
+  <%= pb_rails("avatar", props: object.users[0].merge({size: object.variant == "bubble" ? "sm" : "xs", classname: "pb_multiple_users_stacked_item first_item#{object.variant == "bubble" && object.users.count > 2 ? " three_or_more" : ""}", dark: object.dark}) ) %>
 
   <% unless object.only_one %>
-    <% if object.more_than_two %>
+    <% if object.more_than_two && object.variant != "bubble" %>
       <%= pb_rails("badge", props: {
         dark: object.dark,
         text: "+#{object.users.count - object.display_count}",
         variant: "primary",
         rounded: true,
         classname: "pb_multiple_users_stacked_item second_item" }) %>
+    <% elsif object.variant == "bubble" %>
+      <% object.users.slice(1,4).each_with_index do |item, idx| %>
+        <%= pb_rails("avatar", props: item.merge({size: "xs", classname: "pb_multiple_users_stacked_item #{idx == 0 ? "second_item#{object.users.count === 2 ? " double" : ""}" : idx == 1 ? "third_item" : "fourth_item"}", dark: object.dark}) ) %>
+      <% end %>
     <% else %>
       <%= pb_rails("avatar", props: object.users[1].merge({size: "xs", classname: "pb_multiple_users_stacked_item second_item", dark: object.dark}) ) %>
     <% end %>

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.rb
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.rb
@@ -21,6 +21,18 @@ module Playbook
         more_than_two ? 1 : users.count
       end
 
+      def bubble
+        variant == "bubble"
+      end
+
+      def triple_bubble
+        bubble && users.count === 3
+      end
+
+      def quadruple_bubble
+        bubble && users.count > 3
+      end
+
       def classname
         generate_classname("pb_multiple_users_stacked_kit", single_class, bubble_class)
       end
@@ -32,7 +44,7 @@ module Playbook
       end
 
       def bubble_class
-        variant == "bubble" ? "bubble" : nil
+        bubble ? "bubble" : nil
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.rb
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/multiple_users_stacked.rb
@@ -5,6 +5,10 @@ module Playbook
     class MultipleUsersStacked < Playbook::KitBase
       prop :users, type: Playbook::Props::HashArray, required: true
 
+      prop :variant, type: Playbook::Props::Enum,
+                     values: %w[default bubble],
+                     default: "default"
+
       def more_than_two
         users.count > 2
       end
@@ -18,13 +22,17 @@ module Playbook
       end
 
       def classname
-        generate_classname("pb_multiple_users_stacked_kit", single_class)
+        generate_classname("pb_multiple_users_stacked_kit", single_class, bubble_class)
       end
 
     private
 
       def single_class
         only_one ? "single" : nil
+      end
+
+      def bubble_class
+        variant == "bubble" ? "bubble" : nil
       end
     end
   end

--- a/playbook/spec/pb_kits/playbook/kits/multiple_users_stacked_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/multiple_users_stacked_spec.rb
@@ -13,8 +13,11 @@ RSpec.describe Playbook::PbMultipleUsersStacked::MultipleUsersStacked do
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new(users: []).classname).to eq "pb_multiple_users_stacked_kit"
+      expect(subject.new(users: [{ name: "1", image_url: "1" }]).classname).to eq "pb_multiple_users_stacked_kit_single"
       expect(subject.new(users: [], classname: "additional_class").classname).to eq "pb_multiple_users_stacked_kit additional_class"
       expect(subject.new(users: [], dark: true).classname).to eq "pb_multiple_users_stacked_kit dark"
+      expect(subject.new(users: [], variant: "bubble").classname).to eq "pb_multiple_users_stacked_kit_bubble"
+      expect(subject.new(users: [{ name: "1", image_url: "1" }], variant: "bubble").classname).to eq "pb_multiple_users_stacked_kit_single_bubble"
     end
   end
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Add a "Bubble" Multiple Users Stacked variant which can fit four avatars
- Position and size avatars based on the amount of avatars
- Use position and size mixins
- Update spec and jest tests

**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2024-09-17 at 8 14 16 AM](https://github.com/user-attachments/assets/aa7ee921-672b-47b3-b13b-93670979f399)![Screenshot 2024-09-17 at 8 14 36 AM](https://github.com/user-attachments/assets/880d48a7-f7cf-4c64-bb32-f46cff8893c1)


**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/multiple_users_stacked/react
2. Compare the [handoff](https://huddle.powerapp.cloud/projects/626/handoffs/1337/handoff_items/5655) to the bubble variant
3. Turn on dark mode and compare. Note- the background of the container circle matches the background of the card, so it blends in.
4. Go to https://playbook.powerapp.cloud/kits/multiple_users_stacked/react and make sure the "default" example of Multiple Users Stacked has not changed from the test env
5. Repeat the above, but with Rails


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.