### PR TITLE
[PLAY-1532] Improve Dependency Display on PB Website

### DIFF
--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -43,7 +43,9 @@
             <%= pb_rails("icon", props: { icon: "question-circle" }) %>
           <% end %>
           <%= pb_rails("flex/flex_item", props: { align_items: "start", flex: "8" }) do %>
-            <%= pb_rails("detail", props: { text: "Uses Icons", size: 'xs', margin: "xxs" }) %>
+            <a href="/kits/icon/" target="_blank">
+              <%= pb_rails("detail", props: { text: "Uses Icons", size: 'xs', margin: "xxs" }) %>
+            </a>
           <% end %>
           <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
             <%= pb_rails("icon", props: { icon: "chevron-right", size: "xs" }) %>
@@ -55,7 +57,9 @@
             <%= pb_rails("icon", props: { icon: "question-circle" }) %>
           <% end %>
           <%= pb_rails("flex/flex_item", props: { align_items: "start", flex: "8" }) do %>
-            <%= pb_rails("detail", props: { text: "React Rendered", size: 'xs', margin: "xxs" }) %>
+            <a href="/guides/getting_started/rails_&_react_setup" target="_blank">
+              <%= pb_rails("detail", props: { text: "React Rendered", size: 'xs', margin: "xxs" }) %>
+            </a>
           <% end %>
           <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
             <%= pb_rails("icon", props: { icon: "chevron-right", size: "xs" }) %>
@@ -67,7 +71,9 @@
             <%= pb_rails("icon", props: { icon: "question-circle" }) %>
           <% end %>
           <%= pb_rails("flex/flex_item", props: { align_items: "start", flex: "8" }) do %>
-            <%= pb_rails("detail", props: { text: "Javascript Enhanced", size: 'xs', margin: "xxs" }) %>
+            <a href="/guides/getting_started/rails_&_react_setup#Javascript-Enabled-Rails-Kits" target="_blank">
+              <%= pb_rails("detail", props: { text: "Javascript Enhanced", size: 'xs', margin: "xxs" }) %>
+            </a>
           <% end %>
           <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
             <%= pb_rails("icon", props: { icon: "chevron-right", size: "xs" }) %>

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -4,28 +4,79 @@
       <%= react_component("DarkModeToggle", initMode: cookies[:dark_mode] )%>
     </div>
   <% end %>
-  <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin_top: "xl" }) %>
+  <%= pb_rails("flex", props: { justify: "between", align_items: "center" }) do %>
+    <%= pb_rails("flex/flex_item", props: { flex: "9"}) do %>
+      <%= pb_rails("flex", props: { orientation: "column"}) do %>
+        <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin_top: "xl" }) %>
 
-  <% if @kit_status === "beta" %> 
-    <%= pb_rails("card", props: {highlight: {position: "side", color:"primary", shadow:"deep"}, margin_y: "md", padding: "sm"}) do %>
-      <%= pb_rails("flex", props:{ align: "center" }) do %>
-        <%= pb_rails("body", props:{color: "light"}) do %>
-        <%= pb_rails("icon", props: { icon: "info-circle", fixed_width: true, padding_right:"xs" }) %>
+        <% if @kit_status === "beta" %>
+          <%= pb_rails("card", props: {highlight: {position: "side", color:"primary", shadow:"deep"}, margin_y: "md", padding: "sm"}) do %>
+            <%= pb_rails("flex", props:{ align: "center" }) do %>
+              <%= pb_rails("body", props:{color: "light"}) do %>
+              <%= pb_rails("icon", props: { icon: "info-circle", fixed_width: true, padding_right:"xs" }) %>
+              <% end %>
+              <%= pb_rails("flex/flex_item") do %>
+                <%= pb_rails("title", props: { text: "Beta Kit", tag: "h4", size: 4 , padding_bottom:"xxs"}) %>
+                <%= pb_rails("body", props: {
+                  text: "This kit is currently under development. Some features may not work as expected, and breaking changes may still occur; use with caution.",
+                  color: "light"
+                }) %>
+              <% end %>
+            <% end %>
+          <% end %>
         <% end %>
-        <%= pb_rails("flex/flex_item") do %>
-          <%= pb_rails("title", props: { text: "Beta Kit", tag: "h4", size: 4 , padding_bottom:"xxs"}) %>
-          <%= pb_rails("body", props: {
-            text: "This kit is currently under development. Some features may not work as expected, and breaking changes may still occur; use with caution.",
-            color: "light"
-          }) %>
+
+        <div class="markdown kit-show-description <%= cookies[:dark_mode] == "true" ? 'dark' : '' %>">
+          <%= render_markdown(pb_doc_kit_description(@kit)) %>
+        </div>
+      <% end %>
+    <% end %>
+    <%= pb_rails("flex/flex_item", props: { flex: "2" }) do %>
+      <%= pb_rails("flex", props: { orientation: "column", align: "stretch" }) do %>
+        <%= pb_rails("caption", props: { size: 'sm', margin: "xxs" }) do %>
+          Summary
         <% end %>
+
+        <!-- Condition to check menu.yml if icon_use is true -->
+        <%= pb_rails("flex", props: { inline: true, align: "center" }) do %>
+          <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
+            <%= pb_rails("icon", props: { icon: "question-circle" }) %>
+          <% end %>
+          <%= pb_rails("flex/flex_item", props: { align_items: "start", flex: "8" }) do %>
+            <%= pb_rails("detail", props: { text: "Uses Icons", size: 'xs', margin: "xxs" }) %>
+          <% end %>
+          <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
+            <%= pb_rails("icon", props: { icon: "chevron-right", size: "xs" }) %>
+          <% end %>
+        <% end %>
+        <!-- Condition to check menu.yml if react_use is true -->
+        <%= pb_rails("flex", props: { inline: true, align: "center" }) do %>
+          <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
+            <%= pb_rails("icon", props: { icon: "question-circle" }) %>
+          <% end %>
+          <%= pb_rails("flex/flex_item", props: { align_items: "start", flex: "8" }) do %>
+            <%= pb_rails("detail", props: { text: "React Rendered", size: 'xs', margin: "xxs" }) %>
+          <% end %>
+          <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
+            <%= pb_rails("icon", props: { icon: "chevron-right", size: "xs" }) %>
+          <% end %>
+        <% end %>
+        <!-- Condition to check menu.yml if javascript_use is true -->
+        <%= pb_rails("flex", props: { inline: true, align: "center" }) do %>
+          <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
+            <%= pb_rails("icon", props: { icon: "question-circle" }) %>
+          <% end %>
+          <%= pb_rails("flex/flex_item", props: { align_items: "start", flex: "8" }) do %>
+            <%= pb_rails("detail", props: { text: "Javascript Enhanced", size: 'xs', margin: "xxs" }) %>
+          <% end %>
+          <%= pb_rails("flex/flex_item", props: { flex: "1" }) do %>
+            <%= pb_rails("icon", props: { icon: "chevron-right", size: "xs" }) %>
+          <% end %>
+        <% end %>
+
       <% end %>
     <% end %>
   <% end %>
-
-  <div class="markdown kit-show-description <%= cookies[:dark_mode] == "true" ? 'dark' : '' %>">
-    <%= render_markdown(pb_doc_kit_description(@kit)) %>
-  </div>
 </div>
 <div class="kit-show-wrapper">
   <div class="pb--kit-type-nav">


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-1532

As a Playbook dev, I want to improve the way we are displaying kit dependencies on the Playbook website, so that there is no confusion when implementing our kits into Nitro.

Design will be based off of this [handoff](https://huddle.powerapp.cloud/projects/664/handoffs/1444/handoff_items/6072).

This PR is meant to be used as an example of how to implement these changes within Playbook and should NOT be merged.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2024-09-18 at 8 43 20 AM](https://github.com/user-attachments/assets/0d07fdaf-d50d-4506-9c4f-703d29e0a7d0)



## Problem
We want to improve the way we are display the dependencies of our kits on the Playbook website. The design of this dependency display will be based off of this [handoff](https://huddle.powerapp.cloud/projects/664/handoffs/1444/handoff_items/6072).


## Solution

- Updating "playbook-website/config/menu.yml” to include three new columns to track information regarding a kits dependency. This would allow us to easily pull the dependencies information of each kit to utilize in the summary display.
  - icons_used
  - react_rendered
  - enhanced_element_used
  - _"playbook-website/config/menu.yml”_
```
  // How kits are currently setup in yml
  - name: dialog
    platforms: *1
    description:
    status: stable
    // Proposed additions to yml for dependency display
    icons_used: true
    react_rendered: true
    enhanced_element_used: true
```

- Updating "playbook-website/app/views/pages/kit_show.html.erb” to include a flex section for the summary display in the header portion of each kit page. We would use updated information from “menu.yml” proposed above to set a series of if conditions to track which dependencies should be displayed.

- To make these changes more managable, we can shift the header view into its own partial (ie. "_kit_show_header.html.erb”).

- In the case that no dependencies are used, we can set the summary flex to not be shown.


## Alternative

- An alternative solution to the above would be setting up “kit_show.html.erb” to display header partials that would be pulled from each kits directory in “playbook/pb_kits/“.
  - This change would not require anything to be updated in “menu.yml”, as we can manually set which dependencies to show in the individual partials.
  - While this should work as a solution, it is not recommended as it would add over 100 files in Playbook (currently proposed solution would only update two existing files and potentially create one new file).


## Resources
- [Playbook Kits Dependecy Spreadsheet](https://docs.google.com/spreadsheets/d/1Lk5E_p0M0vX5D6Zlu9dZI3ppidjElqwzSaoxBslLRms/edit?usp=sharing)
- [Designer Handoff](https://huddle.powerapp.cloud/projects/664/handoffs/1444/handoff_items/6072)
