### PR TITLE
[PLAY-1422] Improve Kit Prop Display: Show htmlOptions as a Global Prop [INVESTIGATION]

### DIFF
--- a/playbook-website/app/javascript/components/AvailableProps/globalPropsValues.ts
+++ b/playbook-website/app/javascript/components/AvailableProps/globalPropsValues.ts
@@ -79,6 +79,11 @@ const globalPropsValues = [
     values: '"wrap" | "nowrap" | "wrapReverse"'
   },
   {
+    prop: "htmlOptions",
+    type: "object",
+    values: "{ [key: string]: string | number | boolean | (() => void); }"
+  },
+  {
     prop: "id",
     type: "string",
     values: []

--- a/playbook-website/app/javascript/components/AvailableProps/index.tsx
+++ b/playbook-website/app/javascript/components/AvailableProps/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Card, Nav, SectionSeparator, NavItem } from 'playbook-ui'
 import GlobalProps from './globalProps'
 import KitProps from './kitProps'
+import globalPropsValues from './globalPropsValues'
 
 type AvailablePropsType = {
   availableProps: any,
@@ -10,8 +11,15 @@ type AvailablePropsType = {
 
 const AvailableProps = ({ availableProps, darkMode }: AvailablePropsType) => {
   const props = JSON.parse(availableProps)
-  const [showKitTab, setShowKitTab] = useState(true)
+  const globalPropsNames = globalPropsValues.map(prop => prop.prop)
 
+  for(var propName in props) {
+    if(globalPropsNames.includes(propName)) {
+      delete props[propName]
+    }
+  }
+
+  const [showKitTab, setShowKitTab] = useState(true)
   return (
     <>
       <Card padding="none" dark={darkMode}>

--- a/playbook-website/app/javascript/components/AvailableProps/kitProps.tsx
+++ b/playbook-website/app/javascript/components/AvailableProps/kitProps.tsx
@@ -56,55 +56,55 @@ const KitProps = ({ kitPropsValues, darkMode }: KitPropsType) => {
           <tbody>
             {Object.entries(kitPropsValues).map(([propName, propsValue]) => (
               <>
-                  <tr>
-                    <td>
-                      <Title
+                <tr>
+                  <td>
+                    <Title
+                        dark={darkMode}
+                        size={4}
+                        tag="h4"
+                        text={propName}
+                    />
+                  </td>
+                  <td>
+                    <Card
+                        background={darkMode ? 'dark' : 'light'}
+                        borderNone
+                        borderRadius="sm"
+                        display="inline_block"
+                        padding="xxs"
+                    >
+                      <Body
+                          className="kearning"
                           dark={darkMode}
-                          size={4}
-                          tag="h4"
-                          text={propName}
-                      />
-                    </td>
-                    <td>
-                      <Card
-                          background={darkMode ? 'dark' : 'light'}
-                          borderNone
-                          borderRadius="sm"
-                          display="inline_block"
-                          padding="xxs"
                       >
-                        <Body
-                            className="kearning"
-                            dark={darkMode}
+                        {getTypeName(propsValue.type.name)}
+                      </Body>
+                    </Card>
+                  </td>
+                  <td>
+                    {
+                      propsValue.type.name ? (
+                        <Card
+                            background={darkMode ? 'dark' : 'light'}
+                            borderNone
+                            borderRadius="sm"
+                            display="inline_block"
+                            flexDirection="row"
+                            margin="xxs"
+                            padding="xxs"
                         >
-                          {getTypeName(propsValue.type.name)}
-                        </Body>
-                      </Card>
-                    </td>
-                    <td>
-                      {
-                        propsValue.type.name ? (
-                          <Card
-                              background={darkMode ? 'dark' : 'light'}
-                              borderNone
-                              borderRadius="sm"
-                              display="inline_block"
-                              flexDirection="row"
-                              margin="xxs"
-                              padding="xxs"
+                          <Body
+                              className="kearning"
+                              dark={darkMode}
                           >
-                            <Body
-                                className="kearning"
-                                dark={darkMode}
-                            >
-                            {getTypeValue(propsValue)}
-                            </Body>
-                          </Card>
-                          ) : null
-                      }
+                           {getTypeValue(propsValue)}
+                          </Body>
+                        </Card>
+                        ) : null
+                    }
 
-                    </td>
-                  </tr>
+                  </td>
+                </tr>
               </>
             ))}
           </tbody>

--- a/playbook-website/app/javascript/components/AvailableProps/kitProps.tsx
+++ b/playbook-website/app/javascript/components/AvailableProps/kitProps.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Body, Card, Table, Title } from 'playbook-ui'
+import globalPropsValues from './globalPropsValues'
 
 type KitPropsType = {
   kitPropsValues: {[key: string]: any},
   darkMode: boolean
 }
+
+const globalPropNames = globalPropsValues.map(prop => prop.prop)
 
 const KitProps = ({ kitPropsValues, darkMode }: KitPropsType) => {
   const getTypeName = (typeName: string) => {
@@ -56,55 +59,57 @@ const KitProps = ({ kitPropsValues, darkMode }: KitPropsType) => {
           <tbody>
             {Object.entries(kitPropsValues).map(([propName, propsValue]) => (
               <>
-                <tr>
-                  <td>
-                    <Title
-                        dark={darkMode}
-                        size={4}
-                        tag="h4"
-                        text={propName}
-                    />
-                  </td>
-                  <td>
-                    <Card
-                        background={darkMode ? 'dark' : 'light'}
-                        borderNone
-                        borderRadius="sm"
-                        display="inline_block"
-                        padding="xxs"
-                    >
-                      <Body
-                          className="kearning"
+               { globalPropNames.includes(propName) ? null :
+                  <tr>
+                    <td>
+                      <Title
                           dark={darkMode}
+                          size={4}
+                          tag="h4"
+                          text={propName}
+                      />
+                    </td>
+                    <td>
+                      <Card
+                          background={darkMode ? 'dark' : 'light'}
+                          borderNone
+                          borderRadius="sm"
+                          display="inline_block"
+                          padding="xxs"
                       >
-                        {getTypeName(propsValue.type.name)}
-                      </Body>
-                    </Card>
-                  </td>
-                  <td>
-                    {
-                      propsValue.type.name ? (
-                        <Card
-                            background={darkMode ? 'dark' : 'light'}
-                            borderNone
-                            borderRadius="sm"
-                            display="inline_block"
-                            flexDirection="row"
-                            margin="xxs"
-                            padding="xxs"
+                        <Body
+                            className="kearning"
+                            dark={darkMode}
                         >
-                          <Body
-                              className="kearning"
-                              dark={darkMode}
+                          {getTypeName(propsValue.type.name)}
+                        </Body>
+                      </Card>
+                    </td>
+                    <td>
+                      {
+                        propsValue.type.name ? (
+                          <Card
+                              background={darkMode ? 'dark' : 'light'}
+                              borderNone
+                              borderRadius="sm"
+                              display="inline_block"
+                              flexDirection="row"
+                              margin="xxs"
+                              padding="xxs"
                           >
-                           {getTypeValue(propsValue)}
-                          </Body>
-                        </Card>
-                        ) : null
-                    }
+                            <Body
+                                className="kearning"
+                                dark={darkMode}
+                            >
+                            {getTypeValue(propsValue)}
+                            </Body>
+                          </Card>
+                          ) : null
+                      }
 
-                  </td>
-                </tr>
+                    </td>
+                  </tr>
+                }
               </>
             ))}
           </tbody>

--- a/playbook-website/app/javascript/components/AvailableProps/kitProps.tsx
+++ b/playbook-website/app/javascript/components/AvailableProps/kitProps.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import { Body, Card, Table, Title } from 'playbook-ui'
-import globalPropsValues from './globalPropsValues'
 
 type KitPropsType = {
   kitPropsValues: {[key: string]: any},
   darkMode: boolean
 }
-
-const globalPropNames = globalPropsValues.map(prop => prop.prop)
 
 const KitProps = ({ kitPropsValues, darkMode }: KitPropsType) => {
   const getTypeName = (typeName: string) => {
@@ -59,7 +56,6 @@ const KitProps = ({ kitPropsValues, darkMode }: KitPropsType) => {
           <tbody>
             {Object.entries(kitPropsValues).map(([propName, propsValue]) => (
               <>
-               { globalPropNames.includes(propName) ? null :
                   <tr>
                     <td>
                       <Title
@@ -109,7 +105,6 @@ const KitProps = ({ kitPropsValues, darkMode }: KitPropsType) => {
 
                     </td>
                   </tr>
-                }
               </>
             ))}
           </tbody>


### PR DESCRIPTION
**What does this PR do?** 
https://runway.powerhrg.com/backlog_items/PLAY-1422

As a Playbook dev, I want the _htmlOptions_ prop to appear under the Global Props table of our kits rather than the Kit Props table.

## Problem

Currently, out htmlOptions prop is being passed through to kits and presented as a “Kit Prop” when looking through React documentation. This is confusing to our users as it is presented as a regular prop in documentation, when in our system, htmlOptions is a “Global Prop”.



## Solution

After looking through and testing, I suggest the following solution to resolve the issue.

- Updating 'playbook-website/app/javascript/components/AvailableProps/globalPropsValues.ts’ to include htmlOptions as a global prop value as we do with our other global props. This will render htmlOptions under the global tab of the Available Props table.

- Updating 'playbook-website/app/javascript/components/AvailableProps/index.tsx’ with the following changes:
  - Adding 'import globalPropsValues from './globalPropsValues’’ to index.tsx to bring in our list of global props.
  - Including 'const globalPropsNames = globalPropsValues.map(prop => prop.prop)’ to apply our global props list to an array object.
  - Including the following logic prior to rendering the table in the return statement: 
```
         for(var propName in props) {
           if(globalPropsNames.includes(propName)) {
               delete props[propName]
         } }
```
   - This logic cycles through the list of props that is available for the kit (parsed through 'const props = JSON.parse(availableProps)’ on line 13) and compares each prop with the global prop array we set up. If the prop matches an item in the array, we remove that prop from available props list. 
   - This solution not only resolves the issue with htmlOptions appearing as a kit prop, but also resolves it for other global props with the same issue (ex. “Id”, etc.) as we are comparing available props for the kit to all of our global props.

With this solution, it should only require one story to implement, as we would only be updating two files (globalPropsValues.ts and index.tsx). If this issue comes up for any future global prop, then we should only need to update our list of available global props in globalPropsValues.ts to resolve.




