### PR TITLE
[PLAY-1547] Upgrade react-zoom-pan-pinch to 3.6.1

### DIFF
--- a/playbook/package.json
+++ b/playbook/package.json
@@ -87,7 +87,7 @@
     "react-popper": "^2.3.0",
     "react-select": "5.8.0",
     "react-trix": "0.10.1",
-    "react-zoom-pan-pinch": "^2.6.1",
+    "react-zoom-pan-pinch": "^3.6.1",
     "rollup-plugin-copy": "^3.5.0",
     "sass": "^1.77.6",
     "terser": "^5.31.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10190,10 +10190,10 @@ react-trix@0.10.1:
   dependencies:
     trix "^1.3.1"
 
-react-zoom-pan-pinch@^2.6.1:
-  version "2.6.1"
-  resolved "https://npm.powerapp.cloud/react-zoom-pan-pinch/-/react-zoom-pan-pinch-2.6.1.tgz#5719fdd9515dc1f379a23350cbf99edd540b1281"
-  integrity sha512-4Cgdnn6OwN4DomY/E9NpAf0TyCtslEgwdYn96ZV/f5LKuw/FE3gcIBJiaKFmMGThDGV0yKN5mzO8noi34+UE4Q==
+react-zoom-pan-pinch@^3.6.1:
+  version "3.6.1"
+  resolved "https://npm.powerapp.cloud/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.6.1.tgz#fb68b879b66f029f1f89986810fc2e0ac34fa48a"
+  integrity sha512-SdPqdk7QDSV7u/WulkFOi+cnza8rEZ0XX4ZpeH7vx3UZEg7DoyuAy3MCmm+BWv/idPQL2Oe73VoC0EhfCN+sZQ==
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
**What does this PR do?**
Upgrade react-zoom-pan-pinch from 2.6.1 to 3.6.1

**How to test?** Steps to confirm the desired behavior:
1. Go through the Lightbox kit for any regressions

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.