### PR TITLE
Expose Gantt Chart's ref prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import classnames from "classnames";
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
-import HighchartsReact, { HighchartsReactRefObject } from "highcharts-react-official";
+import HighchartsReact from "highcharts-react-official";
 import Highcharts from "highcharts/highcharts-gantt";
 
 import { highchartsTheme } from "../pb_dashboard/pbChartsLightTheme";
@@ -16,7 +16,7 @@ type GanttChartProps = {
   data?: { [key: string]: string };
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
-  ref?: React.RefAttributes<HighchartsReactRefObject>;
+  ref?: HighchartsReact.RefObject;
 };
 
 const GanttChart = (props: GanttChartProps) => {

--- a/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
@@ -16,7 +16,7 @@ type GanttChartProps = {
   data?: { [key: string]: string };
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
-  ref?: HighchartsReact.RefObject;
+  ref?: any
 };
 
 const GanttChart = (props: GanttChartProps) => {

--- a/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import classnames from "classnames";
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps } from "../utilities/globalProps";
-import HighchartsReact from "highcharts-react-official";
+import HighchartsReact, { HighchartsReactRefObject } from "highcharts-react-official";
 import Highcharts from "highcharts/highcharts-gantt";
 
 import { highchartsTheme } from "../pb_dashboard/pbChartsLightTheme";
@@ -16,6 +16,7 @@ type GanttChartProps = {
   data?: { [key: string]: string };
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
+  ref?: HighchartsReactRefObject;
 };
 
 const GanttChart = (props: GanttChartProps) => {
@@ -64,6 +65,7 @@ const GanttChart = (props: GanttChartProps) => {
           }}
           highcharts={Highcharts}
           options={options}
+          ref={ref}
       />
     </div>
   );

--- a/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
@@ -10,7 +10,7 @@ import { highchartsDarkTheme } from "../pb_dashboard/pbChartsDarkTheme";
 
 type GanttChartProps = {
   aria?: { [key: string]: string };
-  chartRef?: any;
+  chartRef?: { chart: Highcharts.Chart, container: React.RefObject<HTMLDivElement> };
   className?: string;
   customOptions: Partial<Highcharts.Options>;
   dark?: boolean;

--- a/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
@@ -10,13 +10,13 @@ import { highchartsDarkTheme } from "../pb_dashboard/pbChartsDarkTheme";
 
 type GanttChartProps = {
   aria?: { [key: string]: string };
+  chartRef?: any;
   className?: string;
   customOptions: Partial<Highcharts.Options>;
   dark?: boolean;
   data?: { [key: string]: string };
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
-  ref?: any
 };
 
 const GanttChart = (props: GanttChartProps) => {
@@ -28,7 +28,7 @@ const GanttChart = (props: GanttChartProps) => {
     data = {},
     htmlOptions = {},
     id,
-    ref,
+    chartRef,
   } = props;
 
   const ariaProps = buildAriaProps(aria);
@@ -66,7 +66,7 @@ const GanttChart = (props: GanttChartProps) => {
           }}
           highcharts={Highcharts}
           options={options}
-          ref={ref}
+          ref={chartRef}
       />
     </div>
   );

--- a/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gantt_chart/_gantt_chart.tsx
@@ -16,7 +16,7 @@ type GanttChartProps = {
   data?: { [key: string]: string };
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
-  ref?: HighchartsReactRefObject;
+  ref?: React.RefAttributes<HighchartsReactRefObject>;
 };
 
 const GanttChart = (props: GanttChartProps) => {
@@ -28,6 +28,7 @@ const GanttChart = (props: GanttChartProps) => {
     data = {},
     htmlOptions = {},
     id,
+    ref,
   } = props;
 
   const ariaProps = buildAriaProps(aria);


### PR DESCRIPTION
**What does this PR do?**
We need to be able to access the Gantt Chart instance after it has been rendered to add functionality such as horizontal scroll via mouseWheel. 

https://github.com/highcharts/highcharts-react?tab=readme-ov-file#how-to-get-a-chart-instance

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.