### PR TITLE
[PLAY-1599] Set Total Tickets Hero Gauge Height to 150px instead of 25%

### DIFF
--- a/playbook-website/app/javascript/components/HomepageHero/HeroComponents/TicketsChart.tsx
+++ b/playbook-website/app/javascript/components/HomepageHero/HeroComponents/TicketsChart.tsx
@@ -45,7 +45,7 @@ const TicketsChartCard = () => {
                 hover={{ scale: "lg" }}
                 chartData={data}
                 fullCircle
-                height="25%"
+                height="150px"
                 id="gauge-full-circle"
                 suffix="%"
                 paddingLeft="md"


### PR DESCRIPTION
**What does this PR do?**
With the upgrade to Highcharts, using a height of "25%" doesn't work as expected before. 
Set to "150px" to correct. 

**Screenshots:**
![Screenshot 2024-10-01 at 5 38 14 PM](https://github.com/user-attachments/assets/585ad36c-cca8-48ab-a412-023c772943da)

**How to test?** Steps to confirm the desired behavior:
1. Go to the home page for Playbook in the test env. Compare to a version of PB's website which works. (e.g., this [older test env](https://pr3739.playbook.beta.gm.powerapp.cloud/))
2. Make sure the "Total Tickets Sold" gauge looks OK.
3. Check on mobile, tablet, and desktop.
4. Note: on mobile, this hero component doesn't show. 

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.