### PR TITLE
Fix staging and production deployments

### DIFF
--- a/playbook-website/config/deploy/production/secrets.yaml
+++ b/playbook-website/config/deploy/production/secrets.yaml
@@ -1,6 +1,7 @@
 appConfig:
     secretKeyBase: ENC[AES256_GCM,data:pTc2zofEnukd275BCaIpHOM5LokYsaYdgyGPHH6tggclP8Fj2S3/s7UREfDDuNZdAWAelmfWj3AY6xhtmdNRXt0F1UDvrNw0aCDAUqQK/jfHvgCtPQ2ncdZdpoUeEzmTaHUu3JVCphrCBFWxYrSvQg5qfx/docSiGR/PtaWTgOA=,iv:NwUXrRidkh5gT0E90h8CH9qtddboQnd2uvQfPXVkfM0=,tag:vJ5vPuSFeiRc+kDX5tY3Jg==,type:str]
     sentry_dsn: ENC[AES256_GCM,data:pnb9JEfwZ0wCe+eh1CChiKiYAyyMeRtMvJEy9HyY9HFyleFB336Q6nVFx1D74LSxgNbrZiBqg/aA1ZysYCIDRciN6LOMlFAn5AAbMhpYcdNbLQ==,iv:j8l3ISTxrLVF21VRTDkqcmxeMt8jPrZDzDW9rHZ84lc=,tag:eMnHnxYQ+uAIhba0bDNuAA==,type:str]
+    open_ai: ENC[AES256_GCM,data:He7ruscMUMlif05pZhA7f0/rjVt1oG8qzJKGXO6SxHVKZ5t062dD3covgJAGqjCh9aH4wcjCS2xyhBNJWbqjcLhrYsLHuZB4URLfA1CyhJa+maReOCOH88vTutFdIYY=,iv:cZBzbIWxtp+sq3mcE+YGeHeALlSADsU7uXgmKgbmQc8=,tag:a09iJDiJRQ5ImhndwPeYkA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c
@@ -21,8 +22,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-09T14:15:48Z"
-    mac: ENC[AES256_GCM,data:8Rq2gIcrWSNzsI79Lo/UOU5wZnyPG/AwODq2K6mYlPwBK0BhkAxKKMmMBCJzBNMWEFX33loqXnPjLE2Y6Cx8WSuI7EvISIzv6ekoRR5n8QnCOarH8zz/DZOnjgQI9F+fn0kRUEMIdyIduiDjAafXyp6RDlHUl7JxxSKaObFQoL0=,iv:xGadGENEQ4RE1GKuJTh0xeZ8hlWr7dSvwYHGTUIcTeM=,tag:r0j68SWB1Fl82iH8KjK0zw==,type:str]
+    lastmodified: "2024-10-09T15:15:57Z"
+    mac: ENC[AES256_GCM,data:VXYQZHkMLlAppSm5tEbLSEVJtjaPzgW3ePN8tzvoxyIsGe/zr8QkuP7EcXbPdk3HxOwcSh+X0TfF/AOi2cZHChQYH6I69JgbXuYp5dHRWymGe9TIF0GbaChyWK1tbfSadty9BOqb6CtzwD/tMF59G8BvLElqekpTf71h2IaFC8k=,iv:7wbclLhQrBJJ8+M8lGJSUr6Td4YjSYitX4AUmZmp7XE=,tag:jbFgriGrENcoKHxR5jqC5w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/playbook-website/config/deploy/staging/secrets.yaml
+++ b/playbook-website/config/deploy/staging/secrets.yaml
@@ -1,6 +1,7 @@
 appConfig:
     secretKeyBase: ENC[AES256_GCM,data:kOsJ3LgAPCPZ4Vdm/EBFksqneV7tSeFqKrI965UEqkZ7EQ7n/STuE0vte90/oMF1C0eBYzwHEsnT/1kPirKn5/Rz4np2M1jQIvucTfk7QMd76fueIS2lXtLw155rYL8iEh5JyxviOJNfL93U3FiySo1Fa8+1FoOqvlnHa4+/Uoo=,iv:pjEQHF499TYjNEe+O95G3VgqpAfUyJPtVws8nl3zw4k=,tag:38L8NgqyGQu8ueIBS8NcmQ==,type:str]
     sentry_dsn: ENC[AES256_GCM,data:8vuODktXtDvYOUKS5XR7JJ0t9sX0urMWdmIeu66wwvqfGNJogacXj097PqM4MHLIsl0DICJen/2xA+uvUSV+ZVqJH7gCqeY3fH4XwMhE8dKZZA==,iv:5NYs+MiDZiR41cuazIFPXC3IKJsJgbl4eoRvTym0dTo=,tag:XP1rGTjYcl5nMUScJ/3w/A==,type:str]
+    open_ai: ENC[AES256_GCM,data:XX6uvmMSXUvaZFcLR4o5zOmZaQDodlRP4tpZ9Od73pnk4sA6VEaPoqBk3AHr0Ret5KD0WhE2TLnMt2UVEv4+xeRcct0lJtN/n+xXODXsGXoRYRRF7hiYGTJJewT5glY=,iv:tOWyS9Ep+TmP4MtY6LEez9XcD/mWERVV2sbEXQU8rrc=,tag:v3sv3+FzybiKijYY7ncqYg==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
@@ -21,8 +22,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-09T14:15:37Z"
-    mac: ENC[AES256_GCM,data:XOHOpmOsuCjeaB+85g3SyDw5FtA+PakIGJURGMQhKXQtT/OHjAgepUDhloI8b92RntAOIRqD1GhB5lwHpfNUk0ZVVIQ/uwwwIOuQWZLhq3c+V+ItcPyCQgF2GCy9yTxaiyNABBDpGRPeLFr+kP2R2Yri9mROhuHaNmkdCp1ftbc=,iv:iRlk5I0cdM5H42YKnsgpg3F9/rs1lvWy6y8TIXKvhqU=,tag:7JSWiFdFTGyvXBMuvd0XMw==,type:str]
+    lastmodified: "2024-10-09T15:15:44Z"
+    mac: ENC[AES256_GCM,data:zU8gmGa8a6HK0pC9Vn8za0W33frXOcQwSpfGJg0XVE2688PvAIp1D7yHPGS/ncZ56geVr9AGAlScwiAnhG1SVwUPUEi2ryfRCvyrlXwHlwvVP1/bmehmF7MP6jbfj4r6XRjdcKI6fTpkPsNdZ7718VAqxh8VFNNcuHU9NoXGTBM=,iv:sgQStIeMoF15XjH6FgOKIng5nqOhYeeqRAu7AeyrVz4=,tag:coDyxtBzfaTR5ERuC3Azbw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/playbook-website/config/deploy/templates/deployment.yaml.erb
+++ b/playbook-website/config/deploy/templates/deployment.yaml.erb
@@ -50,7 +50,7 @@ spec:
                 secretKeyRef:
                   name: playbook
                   key: sentry-dsn
-            - name: OPEN_AI
+            - name: OPEN_AI_KEY
               valueFrom:
                 secretKeyRef:
                   name: playbook
@@ -77,4 +77,4 @@ spec:
               "memory" => "256Mi",
               "ephemeral-storage" => "100Mi"
             }
-          } %> 
+          } %>

--- a/playbook-website/config/deploy/templates/shell.yaml.erb
+++ b/playbook-website/config/deploy/templates/shell.yaml.erb
@@ -41,7 +41,7 @@ template:
             value: "true"
           - name: RAILS_LOG_TO_STDOUT
             value: "true"
-          - name: OPEN_AI
+          - name: OPENAI_API_KEY
             valueFrom:
               secretKeyRef:
                 name: playbook


### PR DESCRIPTION
Deployments to non-pr environments are broken.

- https://milano.powerapp.cloud/powerhome/playbook/staging/deploys/9880200#

```
key not found: "open_ai"
```

First, https://github.com/powerhome/playbook/pull/3776 only added
values for the `open_ai` value to the `prs` environment - IE review
stacks. The project still needs valaues for staging and production.

Second, even if these values were present, the env var name the
application is looking for and the env var name used by the deployment
are different.

https://github.com/powerhome/playbook/blob/ddf4db1da92383ac58e8c6f17669a0d38629c7c2/playbook-website/config/initializers/openai.rb#L3