### PR TITLE
Re-encrypt secrets for FVR access

### DIFF
--- a/playbook-website/bin/deployer
+++ b/playbook-website/bin/deployer
@@ -7,7 +7,7 @@ if [ -t 0 ]; then
   AWS_CREDS_MOUNT="--mount type=bind,source=${HOME}/.aws/credentials,destination=/root/.aws/credentials,readonly"
 fi
 
-DEPLOYER_IMAGE="image-registry.powerapp.cloud/app/deployer:master-467d8015ffc91fc62c347367db792bb6de0eeea8-1439"
+DEPLOYER_IMAGE="image-registry.powerapp.cloud/app/deployer:main-559f8a815f07c3e04dc82bf416c403ef80f6eacb-42"
 DEPLOYER_MOUNTS="${AWS_CREDS_MOUNT} --mount type=bind,source=$(pwd),destination=/app --mount type=bind,source=${HOME}/.kube,destination=/root/.kube"
 RUN_DEPLOYER="docker run --tty ${INTERACTIVE} ${EXTRA_ARGS} --rm --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY ${DEPLOYER_MOUNTS} ${DEPLOYER_IMAGE}"
 

--- a/playbook-website/config/deploy/production/secrets.yaml
+++ b/playbook-website/config/deploy/production/secrets.yaml
@@ -1,23 +1,28 @@
 appConfig:
-    secretKeyBase: ENC[AES256_GCM,data:utBa4kM3fNPxfLSDALiJvOz6KVlzSefm/K3xDLrKQYypDY2TbreTY5QpeOH6l49D9zMD5i8XGwn3p9f6OEDg4uwzWLSUw0c6U7EcQkrxmRpvOLiOKz2SX8B3xWv3rdLwNs50LHINvjQcjdJviAo9R/oxLxEs6Ds/snSxYXbKQcs=,iv:p0zTY4f3gXqTLJRSjdhX+WsO2/eA6d/rh3S38O4XvuE=,tag:QjENfqpSSZ4hlvvoAuzRJA==,type:str]
-    sentry_dsn: ENC[AES256_GCM,data:p1TU1BvZqZyqo3WPVhGQKqT5IB9zsdA/LkEltdp2zNir3Xub7+yKWg5PXVhjCkDii90MPXSEd08zZYUHZQsTdWI6A/f/jMj1DepJhhPq7H8hpQ==,iv:NHG0oirvwkU2dRh9K0eyEjxyA8WAXRXt9HCGyOmKkrg=,tag:kDJqiCE+n5XoSJMVYqbFBQ==,type:str]
+    secretKeyBase: ENC[AES256_GCM,data:pTc2zofEnukd275BCaIpHOM5LokYsaYdgyGPHH6tggclP8Fj2S3/s7UREfDDuNZdAWAelmfWj3AY6xhtmdNRXt0F1UDvrNw0aCDAUqQK/jfHvgCtPQ2ncdZdpoUeEzmTaHUu3JVCphrCBFWxYrSvQg5qfx/docSiGR/PtaWTgOA=,iv:NwUXrRidkh5gT0E90h8CH9qtddboQnd2uvQfPXVkfM0=,tag:vJ5vPuSFeiRc+kDX5tY3Jg==,type:str]
+    sentry_dsn: ENC[AES256_GCM,data:pnb9JEfwZ0wCe+eh1CChiKiYAyyMeRtMvJEy9HyY9HFyleFB336Q6nVFx1D74LSxgNbrZiBqg/aA1ZysYCIDRciN6LOMlFAn5AAbMhpYcdNbLQ==,iv:j8l3ISTxrLVF21VRTDkqcmxeMt8jPrZDzDW9rHZ84lc=,tag:eMnHnxYQ+uAIhba0bDNuAA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c
-          created_at: "2023-09-12T17:54:03Z"
-          enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgGYWcyxf9B5fC0BIXbcdcWHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMTtG/4IC1DRbS0sO0AgEQgDtkAetmvS1Gc4T4SBgXkXzEtZ11EIGuPKbxG4IHpv/Lf1taPKmf02QDhxEiMWCc57jkeWwCSLapvSTIQQ==
+          created_at: "2024-10-09T14:15:47Z"
+          enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgE1qwTrUkCGbpiPQPZ2Wy+lAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM5uYzVUOAppdO0PKyAgEQgDtfwSqTGPBcAQB/DMjvu5ePLTHSR+Yb8KhkFICf598s5H4VonhIO7zQROhfUurkPSXK9omJ2WMGuULDiQ==
           aws_profile: ""
         - arn: arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c
           role: arn:aws:iam::205083374951:role/playbook-admins
-          created_at: "2023-09-12T17:54:03Z"
-          enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgEAsmw6mIADb67KveUG6MUfAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMkfv8wA9Ec5IztTyEAgEQgDuXn1EN5zG2dP7pJpU4nE/KiJ1krq+UizveI0mSylzpKmRz0BFPtpj6kNv/pANo+YwCNKm5uVOGSkBfRw==
+          created_at: "2024-10-09T14:15:47Z"
+          enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgEzvPVSKC0gdgIl7GsNe51uAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMJfl/u6aJQu7MHZ5XAgEQgDu7iEdG6TL87qMoOGrGyEK1jcRq12uyCzOyAGhqkcE7XaWFuqP6ukaU2J12ZHVqAGHQNyhdqGN3sGQSOw==
+          aws_profile: ""
+        - arn: arn:aws:kms:us-east-1:205083374951:key/405f40cd-a18a-40ed-bf2f-a0e7816a9a5c
+          role: arn:aws:iam::205083374951:role/forever-people
+          created_at: "2024-10-09T14:15:47Z"
+          enc: AQICAHgujLkoWj/2YBLvu57MUrNOqZOY5uV5l5pH7MV/vzKMBgF0x/5dkX78lPXUwfrdoJ7JAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMX2NSksmyhVS1j4q5AgEQgDsx23n3n0AtKWp7logPrzOrVwBMD8zhzC3QJyV6iDk7ia4Wk0OubJd84MPo4thMo1HPd0Xjhy4oXBTjUw==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-09-12T19:35:17Z"
-    mac: ENC[AES256_GCM,data:GBtmDnvvc+KwYkBML0M8+e02FgpfbY68FfCGSHxMUuAvjPYLHLZVA99pMtsKsFWdSiwRsZLcU6xoJm3y9YRLSGSJ0/7NzdVM5386tuSSm+RdqdcYNYU9hrcf1XhmMDT/enyjYsUP9p5f6sAPorQgj9VHv/1yV6ppZ5SRfrNr8v4=,iv:l7Wt0uqtrEeIAa9CWB7HPpnPJPPbYoAYzD7jIzw3/ao=,tag:ooQCNoR0QdBYsv/tOiLRqA==,type:str]
+    lastmodified: "2024-10-09T14:15:48Z"
+    mac: ENC[AES256_GCM,data:8Rq2gIcrWSNzsI79Lo/UOU5wZnyPG/AwODq2K6mYlPwBK0BhkAxKKMmMBCJzBNMWEFX33loqXnPjLE2Y6Cx8WSuI7EvISIzv6ekoRR5n8QnCOarH8zz/DZOnjgQI9F+fn0kRUEMIdyIduiDjAafXyp6RDlHUl7JxxSKaObFQoL0=,iv:xGadGENEQ4RE1GKuJTh0xeZ8hlWr7dSvwYHGTUIcTeM=,tag:r0j68SWB1Fl82iH8KjK0zw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1

--- a/playbook-website/config/deploy/prs/secrets.yaml
+++ b/playbook-website/config/deploy/prs/secrets.yaml
@@ -1,24 +1,29 @@
 appConfig:
-    secretKeyBase: ENC[AES256_GCM,data:ydJ6vKcPVMp9SxRCxgKH3AgAX5JjeoGn7fDKf77XkhODoTZnRHpkyiAezdhFhakCajJFHmaOttWytEVJiMg9DoW111f4AWsNQ+awVztblsCUmT1ZPgZtAGH8H76RKzl3adRy466E3FFoBzQf2FZhP5fdDRSmhzlHWUZdtrfDt/g=,iv:fDmiR4EzqRJ72pl4xLjG5Lv3bw6ijE7hqDHY9HqBcF8=,tag:vzpbilZlEFKlKrt9Rl9zvA==,type:str]
-    sentry_dsn: ENC[AES256_GCM,data:ufQrClZMvpS72OLyRqlO4jisNfnC793ASma61YUOssmQ2gUb/H/U5loD731e4a1fI6dADN66cjQbEnBGwNz0tU58dPMFlR5wSf+bs+JH2Jgn+w==,iv:m3oKFJrByerC7/DPezR0j98Jsolqp8IOm67trL0zJwc=,tag:JAGhc5ts+QBO+DDttXgSVw==,type:str]
-    open_ai: ENC[AES256_GCM,data:duAVK9S9gDz3XkzzP7b/mfUuOU+PEGTXXL9e7y8puhs1eJbaCTavKpdWeRJLlGZEDTW3KlyBl/WBcfSRrPEwIX4BOqiiYUin2TwTSyhsGIenUbka05CalBmq1T/H0Js=,iv:GP0Ug3Z0iWP8cpeFOyG6eyuovcfNs1K7/Q7CoNsZXZU=,tag:IH1NqrIksHBgRjpUv4sTLA==,type:str]
+    secretKeyBase: ENC[AES256_GCM,data:tX9TTqw+teUH3ugGOXIfCMSE1fofM8YBfei2cXLB8Wbmsxp+bsoIgByMtgAbyHzov73P2PaJhQWWo/fG2W7Zj8T0gQ5BcK9mVFUkbt/+SmQpbbprLeIpauN4Gar2QWzyzJPIVEUopf3gdEERx3a+2rbMotJ4rB8Xfvv9OO4sOy4=,iv:H7nM7+ERPsNpehyuaAXSotrG8YCMhL1VSNAmFggs+Q4=,tag:eE+MuzvnCuQ6XKAKMMkrsA==,type:str]
+    sentry_dsn: ENC[AES256_GCM,data:9k5OGZqUcLote0IAJt7GJBsDxN3iJxoVtfPn9RKYfV1KZzNNWyeTZKC/PmjdjKotNbXzLPUSIPbtV8bk2DmttOwQr/r0xbnaTcRT2CWh/4XwVA==,iv:qML16zZMGBSO9nz7kSihlvn5uLj1s+RDSSqOb1jivGw=,tag:XvsrAuIAgAboayg2ZN1KZQ==,type:str]
+    open_ai: ENC[AES256_GCM,data:ewKDrouP0ZuMNAr19DvqBIzYdRInruWH7GxPX2ZH79DVJkT53qLFqzQMIBScqai40WXQmFLNicLnnbHVK+Xcv0tq/xBHtS7BANIwa5XJnWo56jYR3mOdbAcw+ZNFrks=,iv:c5veWRGGydflJ38TFf56ei9GI0tCnE24TLxJGFHscdE=,tag:rGLKDJesBs5JTNt83dsmoA==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
-          created_at: "2023-09-12T17:53:37Z"
-          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgHC1WOVOEbBuNn+YEN+OKiFAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMGQ04cBdxcLtN+PMRAgEQgDvbxveKjEU0mIfKAh7I3yjnnrUSDl1UymkOJYlz4MaKw+MNze2Q1zIX0FzkwSFLFcW/7NguN5/FQ1thZw==
+          created_at: "2024-10-09T14:15:23Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgFd2W8ic6/TkyA8p8wcv5IGAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMPj5cEbt+ndJRHdEMAgEQgDuThOL+h28iSGmeB/TcKDZZ61OXEzoWxD3Io9pC63eWkHhJjcQJO/Cklequ8L43LZh9ISXUhWBdm7Nlbg==
           aws_profile: ""
         - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
           role: arn:aws:iam::205083374951:role/playbook-admins
-          created_at: "2023-09-12T17:53:37Z"
-          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgHs+bIDMZJ9K5YoWkyxqXpxAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMv1q+HlWt0cTzINo0AgEQgDuDojVpcg6NuTpVs8Q2ojw9MnIGfuQ4OI14tvSE78863Esk0Tvgno/oqxDjSfWqIV0kmV/h5hapIm/C3w==
+          created_at: "2024-10-09T14:15:23Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgFTilLgQ0cpyV0/bCSqiidWAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMHJQrlVXmV3auRC97AgEQgDuvJdg6V6f/H15ui2BVgII+a7sUe4I3Suwcjy/Jl4o9+E7GKETkWm8RLpWdwI0yP65GmjLRkmoqnGERlg==
+          aws_profile: ""
+        - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
+          role: arn:aws:iam::205083374951:role/forever-people
+          created_at: "2024-10-09T14:15:23Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgFNq+jUXbUie4tTLRqUg0niAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMBG8uY6UVCCS+9t0lAgEQgDsURce9Oc/zXJFhLivk3rJP4KZRsUrc5qB/6z43P0c3IXvNN3PtTLl+/yPGpZ1zmukv4aBBU0GuVOh0Bw==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-08T14:44:56Z"
-    mac: ENC[AES256_GCM,data:lABCE3dB+TN7l0SB13j0/pEE++5wYiL7Hr7yC93S7q6ehFXpPQBXHzZnWJnFzW2+Qi774hR5C04jypCWpcrbNr6hb6l8EM27ssp1NJFC/SBGdPaLgUiiuJcHoCGfhF0T4VgaYZc/sATiYCyfvQn9h9W7+XkakCQyD5GVuqXf07c=,iv:gxeGlWZEtVHO68kAtdz7bJCNGzbcanUzqX73lYeDMwo=,tag:5z//KnPmKcWdWhc9yGBLNg==,type:str]
+    lastmodified: "2024-10-09T14:15:23Z"
+    mac: ENC[AES256_GCM,data:Sm8hMCHoRGSVa+0/QbBWk60xkl0vn2pHk061liryW8OyAw7brVakAndBgReYeVlks1OS+fuKfc4RsoU3qJWBStJyffxNS5vbXWCugW+HnmbTNK3jBO++Ij2X8qXceWVYQnNXR3N0BTYx9YdyriGNtbtF6jz6PSZN3pUBcpbgLn8=,iv:2tg6O2Tg+o7myXbYlhd/36y1d25fB3h0UuxWXQZWv4Y=,tag:0wJnXb4pXZiUYQWdZSr2ng==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1

--- a/playbook-website/config/deploy/staging/secrets.yaml
+++ b/playbook-website/config/deploy/staging/secrets.yaml
@@ -1,23 +1,28 @@
 appConfig:
-    secretKeyBase: ENC[AES256_GCM,data:T9rr+yNvQIiOKYgGO8p2MM+iqDius270ooqlHTwNDMMXrApWsybNBLIy88tupU/FDm01/FI7ggUZXKbO7WJvBFyxnY/nAQFbw5Xv58lsEGjIrIWAfwANd96NuCOjahnG6PRnICyLbxenQfK7gjXzdxNzRWeRhGFHp/hj29JVx9k=,iv:wB2eCtbFsCXXrPgCOUj2abpBdgsq0iOxL8AiN7wL/Hs=,tag:B3ZaXCT2IlcLmKhR/XrQ4Q==,type:str]
-    sentry_dsn: ENC[AES256_GCM,data:mZ68vE4jCVVi+xrOBnhldUwvObAIdo4HzAXg/r7J+x0BdYTH7SMQWL70mNdVyjbW+KA6aYq6VY6kOIa4FgcUfgBP6cmNDoE4SwTSosUTBm0r3Q==,iv:vqtZKpp7ALuQJYrkDpgn+sjvmEMq9tzBVlc/2hcj8qE=,tag:JByaTyGLemz1Z0wuqzjVBg==,type:str]
+    secretKeyBase: ENC[AES256_GCM,data:kOsJ3LgAPCPZ4Vdm/EBFksqneV7tSeFqKrI965UEqkZ7EQ7n/STuE0vte90/oMF1C0eBYzwHEsnT/1kPirKn5/Rz4np2M1jQIvucTfk7QMd76fueIS2lXtLw155rYL8iEh5JyxviOJNfL93U3FiySo1Fa8+1FoOqvlnHa4+/Uoo=,iv:pjEQHF499TYjNEe+O95G3VgqpAfUyJPtVws8nl3zw4k=,tag:38L8NgqyGQu8ueIBS8NcmQ==,type:str]
+    sentry_dsn: ENC[AES256_GCM,data:8vuODktXtDvYOUKS5XR7JJ0t9sX0urMWdmIeu66wwvqfGNJogacXj097PqM4MHLIsl0DICJen/2xA+uvUSV+ZVqJH7gCqeY3fH4XwMhE8dKZZA==,iv:5NYs+MiDZiR41cuazIFPXC3IKJsJgbl4eoRvTym0dTo=,tag:XP1rGTjYcl5nMUScJ/3w/A==,type:str]
 sops:
     kms:
         - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
-          created_at: "2023-09-12T17:53:51Z"
-          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgFAHaaoyZIhorapEiPc+qICAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMX8BKJ5TiL9Pi1CvvAgEQgDuKgTNkmLECrXQsOPMINqkAT5HzdOqKY/7QT3wS6+EcgVF/kVSD++0yceqYZY6urOFZs9AcPoffFghlGw==
+          created_at: "2024-10-09T14:15:36Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgF5FR6Zmbb2LmX/Ok1UTBQ1AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMGDGnVWMmvb8v8r8JAgEQgDt6so3JsL9WSkXPw1VsgKL0K1S5G0J1of4jczsf7uJp4lCWyzYzN3iK0aD/ZMDQfq/CHkAo3da9NodoZg==
           aws_profile: ""
         - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
           role: arn:aws:iam::205083374951:role/playbook-admins
-          created_at: "2023-09-12T17:53:51Z"
-          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgEkSuHel9uABP7kWsy3YHNXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMjUBIc+aCDRrVDqTOAgEQgDu8ZcejevO0RMIsndJbpN47yZ/kCIhfsLGv7YQ2CamhWhAP5b4V3Bz7aY+bFkXEmsumaSbQB2j+e+vL5Q==
+          created_at: "2024-10-09T14:15:36Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgE7Au4PrldyBvUsxJu2XM0WAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM6DF1DaKLw/6qWGHAAgEQgDsjGaEv60fzlf3o7oHNGPanagVIHk7eNWBzpgjAH256rJoC7mXeSn2qFEnRjLYOA1/4LeLgXD3B0+bHAQ==
+          aws_profile: ""
+        - arn: arn:aws:kms:us-east-1:205083374951:key/d46e780d-ee0a-4a7d-b049-0443e1b91d41
+          role: arn:aws:iam::205083374951:role/forever-people
+          created_at: "2024-10-09T14:15:36Z"
+          enc: AQICAHjD4+PGrfNOURZm5p39Rxa0oVLr81xX3U8gvQwj2QeLTgG3HMs993vA2J7ym2Gaf0jXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMg1PVXgdv92RavP2NAgEQgDvx4LuwYEmnAGtCR1j8B0DhkL0sIowwUrJgQKcpf3453ixUzxs+vnILsUajTxm3RVpWxoPV1OjNxRfLew==
           aws_profile: ""
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-09-12T19:36:52Z"
-    mac: ENC[AES256_GCM,data:7fTUBII1iCtdGe4QZFkXw5j+P2vUhRJF6Ny4CxeTzZctRi+upYME23maBPpzEFjKU0J9S1jLl1XFodOSZe5Sc3E1UEOBhs1/J7rvuEhWZC5QkKXVrq/UzNkDPO9eTQmE7XA6/w0TLx++xcy9iSHIsrLubidAU3EO5R4eaiaT3gw=,iv:zfDYlma2ltcRHWw47rn/kSJjJX3s95Xg5kvBM96Koz4=,tag:GiHRN/m9Q6GAITAFmPZobg==,type:str]
+    lastmodified: "2024-10-09T14:15:37Z"
+    mac: ENC[AES256_GCM,data:XOHOpmOsuCjeaB+85g3SyDw5FtA+PakIGJURGMQhKXQtT/OHjAgepUDhloI8b92RntAOIRqD1GhB5lwHpfNUk0ZVVIQ/uwwwIOuQWZLhq3c+V+ItcPyCQgF2GCy9yTxaiyNABBDpGRPeLFr+kP2R2Yri9mROhuHaNmkdCp1ftbc=,iv:iRlk5I0cdM5H42YKnsgpg3F9/rs1lvWy6y8TIXKvhqU=,tag:7JSWiFdFTGyvXBMuvd0XMw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1


### PR DESCRIPTION
Updates the deployer image, and re-encrypts the secrets files to grant the `forever-people` ARN access to the secrets. This unlocks FVR's ability to place MySQL user secrets for https://github.com/powerhome/playbook/pull/3778