### PR TITLE
[PLAY-1548] Upgrade intl-tel-input to Latest and Make Fixes

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -6,6 +6,18 @@ $dropdown-min-width: 340px;
 $flag-min-resolution: 192dpi;
 
 .pb_phone_number_input {
+  .iti {
+    width: 100%;
+  }
+
+  .iti__flag {
+    margin-right: 6px;
+  }
+
+  .iti__a11y-text {
+    display: none;
+  }
+
   input::placeholder {
     color: $focus_input_light;
   }
@@ -29,7 +41,24 @@ $flag-min-resolution: 192dpi;
     border-bottom: 1px solid $border_light !important;  
   }
 
+  .iti__selected-country-primary {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: 10px;
+  }
+
   .iti__selected-country {
+    position: absolute;
+    z-index: 2;
+    top: 0;
+    display: flex;
+    // The dropdown should automatically appear above/below the input depending on the available space. For this to work properly, you must only initialise the plugin after the <input> has been added to the DOM.
+    height: 45px;
+    justify-content: center;
+    align-items: center;
+    border-width: 0;
+
     padding: 0 $space_xxs 0 $space_sm;
     border-radius: $space_xxs; 
 
@@ -64,11 +93,7 @@ $flag-min-resolution: 192dpi;
     border-radius: 1px;
   }
 
-  .iti--separate-dial-code {
-    width: 100%;
-  }
-
-  .iti--separate-dial-code .iti__selected-country {
+  .iti--show-flags .iti__selected-country {
     background-color: rgba($white, $opacity_1);
   }
 
@@ -136,6 +161,10 @@ $flag-min-resolution: 192dpi;
   .iti__dropdown-content {
     border-radius: $space_xs; 
     border: 1px solid $border_light !important;
+    position: absolute;
+    z-index: 2;
+    // The dropdown should automatically appear above/below the input depending on the available space. For this to work properly, you must only initialise the plugin after the <input> has been added to the DOM.
+    top: 45px;
   }
 
   &.dark {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -126,7 +126,7 @@ $flag-min-resolution: 192dpi;
     position: relative;
     vertical-align: top;
     width: $space_xxs + 1px;
-    top: $space_xs + 2px;
+    top: $space_xs - 1px;
     transform: rotate($transform-rotate-deg);
     color: $slate;
   }

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -93,10 +93,11 @@ $flag-min-resolution: 192dpi;
     border-radius: 1px;
   }
 
-  .iti__globe {
+  .iti__flag.iti__globe {
     background-image: url("https://unpkg.com/intl-tel-input@21.1.4/build/img/globe.png");
     background-position: center;
     height: 20px;
+    background-size: 20px 20px;
   }
 
   .iti--show-flags .iti__selected-country {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -15,7 +15,7 @@ $flag-min-resolution: 192dpi;
       border-color: $primary !important;
     }
 
-    .iti__selected-flag:focus-visible {
+    .iti__selected-country:focus-visible {
       outline-style: none;
     }
   }
@@ -29,7 +29,7 @@ $flag-min-resolution: 192dpi;
     border-bottom: 1px solid $border_light !important;  
   }
 
-  .iti__selected-flag {
+  .iti__selected-country {
     padding: 0 $space_xxs 0 $space_sm;
     border-radius: $space_xxs; 
 
@@ -51,7 +51,7 @@ $flag-min-resolution: 192dpi;
     }
   }
 
-  .iti--allow-dropdown .iti__country-container:hover .iti__selected-flag {
+  .iti--allow-dropdown .iti__country-container:hover .iti__selected-country {
     background-color: $focus_input_light;
   }
 
@@ -68,7 +68,7 @@ $flag-min-resolution: 192dpi;
     width: 100%;
   }
 
-  .iti--separate-dial-code .iti__selected-flag {
+  .iti--separate-dial-code .iti__selected-country {
     background-color: rgba($white, $opacity_1);
   }
 
@@ -149,13 +149,13 @@ $flag-min-resolution: 192dpi;
           background-color: rgba($white, 0.15);
         }
 
-        .iti__selected-flag {
+        .iti__selected-country {
           background-color: rgba($white, 0);
         }
       }
     }
 
-    .iti__selected-flag {
+    .iti__selected-country {
       background-color: rgba($white, 0);
       color: $white;
     }

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -51,11 +51,11 @@ $flag-min-resolution: 192dpi;
     }
   }
 
-  .iti--allow-dropdown .iti__flag-container:hover .iti__selected-flag {
+  .iti--allow-dropdown .iti__country-container:hover .iti__selected-flag {
     background-color: $focus_input_light;
   }
 
-  .iti__flag-container:hover + .text_input {
+  .iti__country-container:hover + .text_input {
     background-color: $focus_input_light;
   }
 
@@ -139,7 +139,7 @@ $flag-min-resolution: 192dpi;
   }
 
   &.dark {
-    .iti--allow-dropdown .iti__flag-container {
+    .iti--allow-dropdown .iti__country-container {
       background-color: rgba($white, 0);
 
       &:hover {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -93,6 +93,12 @@ $flag-min-resolution: 192dpi;
     border-radius: 1px;
   }
 
+  .iti__globe {
+    background-image: url("https://unpkg.com/intl-tel-input@21.1.4/build/img/globe.png");
+    background-position: center;
+    height: 20px;
+  }
+
   .iti--show-flags .iti__selected-country {
     background-color: rgba($white, $opacity_1);
   }

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -50,7 +50,7 @@ const formatToGlobalCountryName = (countryName: string) => {
 }
 
 const formatAllCountries = () => {
-  const countryData = window.intlTelInputGlobals.getCountryData()
+  const countryData = intlTelInput.getCountryData()
 
   for (let i = 0; i < countryData.length; i++) {
     const country = countryData[i]

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -217,7 +217,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
   useEffect(() => {
     const telInputInit = intlTelInput(inputRef.current, {
       separateDialCode: true,
-      preferredCountries,
+      countryOrder: preferredCountries,
       allowDropdown: !disabled,
       autoInsertDialCode: false,
       initialCountry,

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -223,6 +223,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
       initialCountry,
       onlyCountries,
       countrySearch: false,
+      fixDropdownWidth: false,
     })
 
     inputRef.current.addEventListener("countrychange", (evt: Event) => {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -221,7 +221,8 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
       allowDropdown: !disabled,
       autoInsertDialCode: false,
       initialCountry,
-      onlyCountries
+      onlyCountries,
+      countrySearch: false,
     })
 
     inputRef.current.addEventListener("countrychange", (evt: Event) => {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useEffect, useRef, useState, useImperativeHandle } from 'react'
 import classnames from 'classnames'
 
-import intlTelInput from 'intl-tel-input'
+import intlTelInput from 'intl-tel-input/intlTelInputWithUtils'
 import 'intl-tel-input/build/js/utils.js'
 
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'

--- a/playbook/package.json
+++ b/playbook/package.json
@@ -39,7 +39,7 @@
     "flatpickr": "^4.6.13",
     "highcharts": "^11.4.8",
     "highcharts-react-official": "^3.2.1",
-    "intl-tel-input": "^18.0.15"
+    "intl-tel-input": "^24.5.2"
   },
   "devDependencies": {
     "@actions/core": "1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7324,10 +7324,10 @@ intersection-observer@^0.10.0:
   resolved "https://npm.powerapp.cloud/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
   integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
 
-intl-tel-input@^18.0.15:
-  version "18.5.3"
-  resolved "https://npm.powerapp.cloud/intl-tel-input/-/intl-tel-input-18.5.3.tgz#20b18431cb802d33c118f52e332e218e641ec09b"
-  integrity sha512-ncFqSpkdGf2YC/FvAiwBH44KAeRG8L7aqDODEpOvMAT3ZpBtvc/WtwaQ/6X4+HKDTlGkobdBjr6P3nAMwO8jtA==
+intl-tel-input@^24.5.2:
+  version "24.5.2"
+  resolved "https://npm.powerapp.cloud/intl-tel-input/-/intl-tel-input-24.5.2.tgz#975458e66a1c5e16ea50d2f38955420b898c6347"
+  integrity sha512-5oR3iR2Nsi3VYE5uylT7HNZzlJ+t/rO/2N/9xyEaSmYXgX1bUsUEVa/lD4lrcukntnwRylzvECbYPc2AR+uRyg==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"


### PR DESCRIPTION
**IN PROGRESS - DO NOT MERGE**

**What does this PR do?**

- Bump intl-tel-input from 18.0.15 to 24.5.2
- Use intlTelInput from package instead of window
- Update class names (e.g., flag -> country)
- Turn off "country search" default
- Change dropdown to not be the full width of the input
- Use utils so a placeholder is added
- Make various CSS fixes
- Add a "globe" default
- Change "preferredCountries" to new "countryOrder" prop

**Screenshots:** Screenshots to visualize your addition/change
![Playbook Design System 2024-10-11 at 3 10 31 PM](https://github.com/user-attachments/assets/0fff110e-e293-4bed-960d-192d2f5ae4b2)


**How to test?** Steps to confirm the desired behavior:
1. Go to the Phone Number Input Kit
2. Test all doc examples for both Rails and React
3. Test on Nitro.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.