### PR TITLE
[PBNTR-606] Add Reset Functionality to Rails side of MultiLevelSelect

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -205,7 +205,7 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
   useEffect(() => {
     if (id) {
       // Attach the clear function to the window, scoped by the id
-      window[`clearMultiLevelSelect_${id}`] = () => {
+      (window as any)[`clearMultiLevelSelect_${id}`] = () => {
         const resetData = modifyRecursive(formattedData, false);
         setFormattedData(resetData);
         setReturnedArray([]);
@@ -214,7 +214,7 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
         onSelect([]);
       };
       return () => {
-        delete window[`clearMultiLevelSelect_${id}`];
+        delete (window as any)[`clearMultiLevelSelect_${id}`];
       };
     }
   }, [formattedData, id, onSelect]);

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -202,6 +202,23 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     };
   }, []);
 
+  useEffect(() => {
+    if (id) {
+      // Attach the clear function to the window, scoped by the id
+      window[`clearMultiLevelSelect_${id}`] = () => {
+        const resetData = modifyRecursive(formattedData, false);
+        setFormattedData(resetData);
+        setReturnedArray([]);
+        setDefaultReturn([]);
+        setSingleSelectedItem({ id: [], value: "", item: [] });
+        onSelect([]);
+      };
+      return () => {
+        delete window[`clearMultiLevelSelect_${id}`];
+      };
+    }
+  }, [formattedData, id, onSelect]);
+
   // Iterate over tree, find item and set checked or unchecked
   const modifyValue = (
     id: string,

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_reset.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_reset.html.erb
@@ -1,0 +1,93 @@
+<% treeData = [{
+    label: "Power Home Remodeling",
+    value: "Power Home Remodeling",
+    id: "100",
+    expanded: true,
+    children: [
+      {
+        label: "People",
+        value: "People",
+        id: "101",
+        expanded: true,
+        children: [
+          {
+            label: "Talent Acquisition",
+            value: "Talent Acquisition",
+            id: "102",
+          },
+          {
+            label: "Business Affairs",
+            value: "Business Affairs",
+            id: "103",
+            children: [
+              {
+                label: "Initiatives",
+                value: "Initiatives",
+                id: "104",
+              },
+              {
+                label: "Learning & Development",
+                value: "Learning & Development",
+                id: "105",
+              },
+            ],
+          },
+          {
+            label: "People Experience",
+            value: "People Experience",
+            id: "106",
+          },
+        ],
+      },
+      {
+        label: "Contact Center",
+        value: "Contact Center",
+        id: "107",
+        children: [
+          {
+            label: "Appointment Management",
+            value: "Appointment Management",
+            id: "108",
+          },
+          {
+            label: "Customer Service",
+            value: "Customer Service",
+            id: "109",
+          },
+          {
+            label: "Energy",
+            value: "Energy",
+            id: "110",
+          },
+        ],
+      },
+    ],
+}] %>
+
+<%= pb_rails("multi_level_select", props: {
+    id: "multi-level-select-reset-example",
+    name: "my_array",
+    tree_data: treeData,
+    return_all_selected: true
+}) %>
+
+<%= pb_rails("button", props: { text: "Reset", margin_top: "lg", id:"multilevelselect-reset-button" }) %>
+
+
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    const exampleResetButton = document.querySelector("#multilevelselect-reset-button");
+
+    exampleResetButton.addEventListener("click", () => {
+        clearMultiLevelSelectById('multi-level-select-reset-example');
+      });
+    function clearMultiLevelSelectById(id) {
+      const clearFunction = window[`clearMultiLevelSelect_${id}`];
+      if (clearFunction) {
+        clearFunction();
+      } else {
+        console.warn(`No clear function found for MultiLevelSelect with id: ${id}`);
+      }
+    }
+  })
+</script>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_reset.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_reset.md
@@ -1,0 +1,1 @@
+In order to clear the multilevelselect selection using an external trigger (like a reset button), the `clearMultiLevelSelect` function can be used. See the code snippet below to see this in action. The function is scoped by id so an id MUST be used on the multilevelselect kit and passed to the function as shown for it to work. 

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
@@ -7,6 +7,7 @@ examples:
   - multi_level_select_selected_ids: Selected Ids
   - multi_level_select_with_form: With Form
   - multi_level_select_color: With Pills (Custom Color)
+  - multi_level_select_reset: Reset Selection
 
   react:
   - multi_level_select_default: Default


### PR DESCRIPTION
[Runway Story](https://runway.powerhrg.com/backlog_items/PBNTR-606)

This PR:
- ✅ Adds reset functionality to rails side of kit so it can be used within nitro_search_playbook_filter in Nitro
- ✅ Unblocks [this work](https://runway.powerhrg.com/backlog_items/FIRST-1537) for First Contact
- ✅ Creates reset doc example on rails side to showcase how to use exposed function