### PR TITLE
[PBNTR-600] Filter Kit - Filter Kit displaying zero results

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_filter/Filter/ResultsCount.tsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/Filter/ResultsCount.tsx
@@ -13,6 +13,7 @@ type ResultsCountProps = {
 const ResultsCount = ({ dark, results, title }: ResultsCountProps): React.ReactElement => {
   
   const resultTitle = () => {
+    if (results == null) return null
     return (
       <TitleCount
           align="center"
@@ -24,6 +25,7 @@ const ResultsCount = ({ dark, results, title }: ResultsCountProps): React.ReactE
   }
 
   const justResults = () => {
+    if (results == null) return null
     return (
       <Caption
           className="filter-results"
@@ -35,13 +37,13 @@ const ResultsCount = ({ dark, results, title }: ResultsCountProps): React.ReactE
   }
 
   const displayResultsCount = () => {
-    if (results && title) {
+    if (results != null && results >=0 && title) {
       return (
         <>
           {resultTitle()}
         </>
       )
-    } else if (results) {
+    } else if (results !=null && results >=0 ) {
       return (
         <>
           {justResults()}

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_default.jsx
@@ -25,7 +25,7 @@ const FilterDefault = (props) => {
           marginBottom="xl"
           minWidth="375px"
           onSortChange={SortingChangeCallback}
-          results={1}
+          // results={1}
           sortOptions={{
             popularity: 'Popularity',
             // eslint-disable-next-line
@@ -78,7 +78,7 @@ const FilterDefault = (props) => {
           double
           minWidth="375px"
           onSortChange={SortingChangeCallback}
-          results={1}
+          results={0}
           sortOptions={{
             popularity: 'Popularity',
             // eslint-disable-next-line


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-600](https://runway.powerhrg.com/backlog_items/PBNTR-600) improves the React Filter kit's UI so it more closely matches the Rails side. Specifically, this code update allows for "Results: 0" to appear in the context of the filter kit if there are no results for a filtered search; previously, the "Results: " TitleCount component would just disappear if there were no Results. If the Filter's results prop is undefined, the "Results: " TitleCount component will not appear, which is logical behavior. 

**Screenshots:** Screenshots to visualize your addition/change
_Screenshots on their way_

**How to test?** Steps to confirm the desired behavior:
1. Go to review env [react filter kit default doc example](linktocome)- see "Results: 0" in second filter in example.
2. Compare to current React Filter kit implementation - can test by going to [React Basic Table template](https://nitroqa.powerhrg.com/dev_docs/playbook/templates/demos/basic_table/react) and searching something that will have no results like "first name=elisashapiro". Observe how the "Results: " section just disappears.
3. Compare to Rails Filter kit behavior in current production Playbook [Rails default doc example](http://localhost:3000/kits/filter/rails#default) and the [Rails Basic Table template](https://nitroqa.powerhrg.com/dev_docs/playbook/templates/demos/basic_table/rails) - "Results: 0" appears for in both places.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~