### PR TITLE
[PLAY-1538] Add README.md to root in dist for NPM

### DIFF
--- a/playbook/vite.config.ts
+++ b/playbook/vite.config.ts
@@ -75,6 +75,11 @@ export default defineConfig({
           dest: 'dist/tokens',
           rename: (name, extension) => `${name.replace('_', '')}.${extension}`
         },
+        {
+          src: resolve(__dirname, '../docs/README.md'),
+          dest: resolve(__dirname, 'dist'),
+          rename: 'README.md'
+        },
       ]
     }),
     typescript({


### PR DESCRIPTION
**What does this PR do?**
Add a README.md to root in dist build so NPM shows a README.md.

**Screenshots:** Screenshots to visualize your addition/change
TK

**How to test?** Steps to confirm the desired behavior:
1. Check the alpha NPM release and make sure there is a README
2. Make sure Portal documentation works as expected


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.