### PR TITLE
[PBNTR-576] Tooltip for Truncated Form Pills

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
@@ -142,7 +142,9 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
     height: 12px !important;
     width: 12px !important;
     padding-right: $space_xs;
-    + .pb_form_pill_text, + .pb_form_pill_tag {
+    + .pb_form_pill_text, + .pb_form_pill_tag, 
+    + .pb_tooltip_kit .pb_form_pill_text, + .pb_tooltip_kit .pb_form_pill_tag,
+    + div .pb_form_pill_text, + div .pb_form_pill_tag {
       padding-left: 0;
     }
   }
@@ -169,7 +171,9 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
     }
     .pb_form_pill_icon {
       padding-right: $space_xxs;
-      + .pb_form_pill_text, + .pb_form_pill_tag {
+      + .pb_form_pill_text, + .pb_form_pill_tag, 
+      + .pb_tooltip_kit .pb_form_pill_text, + .pb_tooltip_kit .pb_form_pill_tag,
+      + div .pb_form_pill_text, + div .pb_form_pill_tag {
         padding-left: 0;
       }
     }

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames'
 import Title from '../pb_title/_title'
 import Icon from '../pb_icon/_icon'
 import Avatar from '../pb_avatar/_avatar'
+import Tooltip from '../pb_tooltip/_tooltip'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 import { buildDataProps, buildHtmlProps } from '../utilities/props'
 
@@ -21,6 +22,7 @@ type FormPillProps = {
   data?: {[key: string]: string},
   tabIndex?: number,
   icon?: string,
+  truncate?: number,
   closeProps?: {
     onClick?: React.MouseEventHandler<HTMLSpanElement>,
     onMouseDown?: React.MouseEventHandler<HTMLSpanElement>,
@@ -43,6 +45,7 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
     data = {},
     tabIndex,
     icon = "",
+    truncate,
   } = props
 
   const iconClass = icon ? "_icon" : ""
@@ -62,6 +65,30 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
 
+  const renderTitle = (content: string, className: string) => {
+    const titleComponent = (
+      <Title
+          className={className}
+          size={4}
+          text={content}
+          truncate={truncate}
+      />
+    )
+    if (truncate) {
+      return (
+        <Tooltip
+            interaction
+            placement="top"
+            position="fixed"
+            text={content}
+        >
+          {titleComponent}
+        </Tooltip>
+      )
+    }
+    return titleComponent
+  }
+
   return (
     <div className={css}
         id={id}
@@ -77,12 +104,7 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
               size="xxs"
               status={null}
           />
-          <Title
-              className="pb_form_pill_text"
-              size={4}
-              text={name}
-              truncate={props.truncate}
-          />
+          {renderTitle(name, "pb_form_pill_text")}
         </>
       )}
       {((name && icon && !text) || (name && icon && text)) && (
@@ -93,12 +115,7 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
               size="xxs"
               status={null}
           />
-          <Title
-              className="pb_form_pill_text"
-              size={4}
-              text={name}
-              truncate={props.truncate}
-          />
+          {renderTitle(name, "pb_form_pill_text")}
           <Icon
               className="pb_form_pill_icon"
               color={color}
@@ -113,22 +130,10 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
               color={color}
               icon={icon}
           />
-          <Title
-              className="pb_form_pill_tag"
-              size={4}
-              text={text}
-              truncate={props.truncate}
-          />
+          {renderTitle(text, "pb_form_pill_tag")}
         </>
       )}
-      {(!name && !icon && text) && (
-        <Title
-            className="pb_form_pill_tag"
-            size={4}
-            text={text}
-            truncate={props.truncate}
-        />
-      )}
+      {(!name && !icon && text) && renderTitle(text, "pb_form_pill_tag")}
       <div
           className="pb_form_pill_close"
           onClick={onClick}
@@ -143,4 +148,5 @@ const FormPill = (props: FormPillProps): React.ReactElement => {
     </div>
   )
 }
+
 export default FormPill

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_truncated_text.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_truncated_text.html.erb
@@ -13,7 +13,28 @@
     id: "typeahead-form-pill",
     is_multi: true,
     options: names,
-    label: "Names",
+    label: "Truncation Within Typeahead",
     pills: true,
     truncate: 1,
 }) %>
+
+<%= pb_rails("caption", props: { text: "Form Pill Truncation" }) %>
+<%= pb_rails("card", props: { max_width: "xs" })  do %>
+  <%= pb_rails("form_pill", props: {
+      name: "Princess Amelia Mignonette Grimaldi Thermopolis Renaldo",
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg",
+      tabindex: 0,
+      truncate: 1,
+  }) %>
+  <%= pb_rails("form_pill", props: {
+      icon: "badge-check",
+      text: "icon and a very long tag to show truncation",
+      tabindex: 0,
+      truncate: 1,
+  }) %>
+  <%= pb_rails("form_pill", props: {
+      text: "form pill with a very long tag to show truncation",
+      tabindex: 0,
+      truncate: 1,
+  }) %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_truncated_text.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_truncated_text.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Typeahead from '../../pb_typeahead/_typeahead'
+import { Card, Caption, FormPill, Typeahead } from 'playbook-ui'
 
 const names = [
   { label: 'Alexander Nathaniel Montgomery', value: 'Alexander Nathaniel Montgomery' },
@@ -15,11 +15,34 @@ const FormPillTruncatedText = (props) => {
       <Typeahead
           htmlOptions={{ style: { maxWidth: "240px" }}}
           isMulti
-          label="Names"
+          label="Truncation Within Typeahead"
           options={names}
           truncate={1}
           {...props}
       />
+      <Caption text="Form Pill Truncation"/>
+      <Card maxWidth="xs">
+        <FormPill
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            name="Princess Amelia Mignonette Grimaldi Thermopolis Renaldo"
+            onClick={() => alert('Click!')}
+            tabIndex={0}
+            truncate={1}
+        />
+        <FormPill
+            icon="badge-check"
+            onClick={() => {alert('Click!')}}
+            tabIndex={0}
+            text="icon and a very long tag to show truncation"
+            truncate={1}
+        />
+        <FormPill
+            onClick={() => {alert('Click!')}}
+            tabIndex={0}
+            text="form pill with a very long tag to show truncation"
+            truncate={1}
+        />
+      </Card>
     </>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_truncated_text.md
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/docs/_form_pill_truncated_text.md
@@ -1,1 +1,1 @@
-For pills with longer text, the `truncate` global prop can be used to truncate the label within each Form Pill. See [here](https://playbook.powerapp.cloud/visual_guidelines/truncate) for more information on the truncate global prop.
+For pills with longer text, the `truncate` global prop can be used to truncate the label within each Form Pill. Hover over the truncated Form Pill and a Tooltip containing the text or tag section of the Form Pill will appear. See [here](https://playbook.powerapp.cloud/visual_guidelines/truncate) for more information on the truncate global prop.

--- a/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
@@ -1,17 +1,49 @@
 <%= content_tag(:div, id: object.id, data: object.data, class: object.classname + object.size_class, tabindex: object.tabindex, **combined_html_options) do %>
   <% if object.name.present? %>
     <%= pb_rails("avatar", props: { name: object.name, image_url: object.avatar_url, size: "xxs" }) %>
-    <%= pb_rails("title", props: { text: object.name, size: 4, classname: "pb_form_pill_text" }) %>
+    <% element_id = "pill_#{object.name.parameterize}" %>
+    <div>
+      <%= pb_rails("title", props: { 
+        classname: "pb_form_pill_text #{object.truncate ? "truncate_#{object.truncate}" : ""}",
+        id: element_id,
+        size: 4, 
+        text: object.name,
+      }) %>
+      <% if object.truncate %>
+        <%= pb_rails("tooltip", props: {
+          position: "top",
+          tooltip_id: "tooltip-#{element_id}",
+          trigger_element_selector: "##{element_id}"
+        }) do %>
+          <%= object.name %>
+        <% end %>
+      <% end %>
+    </div>
     <% if object.icon.present? %>
       <%= pb_rails("icon", props: { classname: "pb_form_pill_icon", color: object.color, icon: object.icon }) %>
     <% end %>
   <% elsif object.text.present? %>
-      <% if object.icon.present? %>
-        <%= pb_rails("icon", props: { classname: "pb_form_pill_icon", color: object.color, icon: object.icon }) %>
+    <% if object.icon.present? %>
+      <%= pb_rails("icon", props: { classname: "pb_form_pill_icon", color: object.color, icon: object.icon }) %>
+    <% end %>
+    <% element_id = "pill_#{object.text.parameterize}" %>
+    <div>
+      <%= pb_rails("title", props: { 
+        classname: "pb_form_pill_tag #{object.truncate ? "truncate_#{object.truncate}" : ""}",
+        id: element_id,
+        size: 4, 
+        text: object.text
+      }) %>
+      <% if object.truncate %>
+        <%= pb_rails("tooltip", props: {
+          position: "top",
+          tooltip_id: "tooltip-#{element_id}",
+          trigger_element_selector: "##{element_id}"
+        }) do %>
+          <%= object.text %>
+        <% end %>
       <% end %>
-      <% if object.text.present? %>
-        <%= pb_rails("title", props: { text: object.text, size: 4, classname: "pb_form_pill_tag" }) %>
-      <% end %>
+    </div>
   <% end %>
   <%= pb_rails("body", props: { classname: "pb_form_pill_close" }) do %>
     <%= pb_rails("icon", props: { icon: 'times', fixed_width: true, size: object.close_icon_size }) %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.rb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.rb
@@ -16,6 +16,8 @@ module Playbook
                    default: "primary"
       prop :tabindex
       prop :icon
+      prop :truncate, type: Playbook::Props::Number,
+                      default: nil
 
       def classname
         generate_classname("pb_form_pill_kit", color, icon_class, name, text, text_transform)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-576](https://runway.powerhrg.com/backlog_items/PBNTR-576) follows up [PBNTR-550](https://runway.powerhrg.com/backlog_items/PBNTR-550) by adding a Tooltip containing text or tag content in full of a truncated Form Pill. 

This PR does the following:

- Adds a Tooltip to the text, tag, or avatar name component of a truncated Form Pill. The Tooltip contains the entirety of the text content (does not include avatar image or icon)
- Expands upon PBNTR-550 by adding the truncate prop to Rails Form Pills as well - all Rails Typeaheads With Pills are react-rendered-rails, so this expands the behavior so React/Rails are consistent. (**Note**: there are no solo rails form pills in use in [Nitro](https://github.com/search?q=repo%3Apowerhome%2Fnitro-web+pb_rails%28%22form_pill&type=code)).
- Updates the Truncated Text Rails and React doc examples to include several form pill variations (an avatar, an icon+text tag, and a text tag only) within a Card of a small width to demonstrate the truncation/tooltip in a non-Typeahead environment. Locally I tested many variations (including truncation on a small Form Pill, or one with customized color).

**Screenshots:** Screenshots to visualize your addition/change
Screenshots to come

**How to test?** Steps to confirm the desired behavior:
1. Go to the truncated text doc example ([rails](link to come)/[react](link to come).
2. Go to the Typeahead in the "Truncation Within Typeahead" section and select a name. Hover over the Form Pill that appears with their truncated name and observe the Tooltip in action displaying their full name.
3. Hover over one/all of the truncated Form Pills in the "Form Pill Truncation" section. Observe the Tooltip in action.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~