### PR TITLE
[PLAY-1603] Add color hover docs and fix background hover

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Hover.tsx
@@ -112,6 +112,22 @@ const Hover = ({ example }: { example: string }) => (
             <tr>
               <td>
                 <Pill
+                  text="color"
+                  textTransform="none"
+                  variant="warning"
+                />
+              </td>
+              <td>
+                <Pill
+                  text="${color}"
+                  textTransform="none"
+                  variant="warning"
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <Pill
                   text="background"
                   textTransform="none"
                   variant="warning"
@@ -199,6 +215,12 @@ const Hover = ({ example }: { example: string }) => (
               gap="sm"
               wrap
             >
+              <Card padding="xs" >
+                <Body
+                  text="Text Color"
+                  hover={{ color: 'data_1' }}
+                />
+              </Card>
               <Card
                 hover={{ background: 'success_subtle' }}
                 padding="xs"

--- a/playbook-website/app/views/pages/code_snippets/hover_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/hover_jsx.txt
@@ -15,3 +15,8 @@
     label='Anna Black'
     message='How can we assist you today?'
 />
+
+<Body
+    hover={{ color: "success" }}
+    text='Hover to change color'
+/>

--- a/playbook/app/pb_kits/playbook/utilities/_hover.scss
+++ b/playbook/app/pb_kits/playbook/utilities/_hover.scss
@@ -2,11 +2,11 @@
 
 @mixin hover-color-classes($colors-list) {
     @each $name, $color in $colors-list {
-      .hover_background_#{"" + $name}:hover {
+      .hover_background-#{"" + $name}:hover {
         background-color: $color !important;
         transition: background-color $transition-speed ease;
       }
-      .hover_color_#{"" + $name}:hover {
+      .hover_color-#{"" + $name}:hover {
         color: $color !important;
         transition: color $transition-speed ease;
       }

--- a/playbook/app/pb_kits/playbook/utilities/globalProps.ts
+++ b/playbook/app/pb_kits/playbook/utilities/globalProps.ts
@@ -213,9 +213,9 @@ const PROP_CATEGORIES: {[key:string]: (props: {[key: string]: any}) => string} =
       let css = '';
       if (!hover) return css;
       css += hover.shadow ? `hover_shadow_${hover.shadow} ` : '';
-      css += hover.background ? `hover_background_${hover.background } ` : '';
+      css += hover.background ? `hover_background-${hover.background } ` : '';
       css += hover.scale ? `hover_scale_${hover.scale} ` : '';
-      css += hover.color ? `hover_color_${hover.color } ` : '';
+      css += hover.color ? `hover_color-${hover.color } ` : '';
       return css;
   },
 

--- a/playbook/app/pb_kits/playbook/utilities/test/globalProps/hover.test.js
+++ b/playbook/app/pb_kits/playbook/utilities/test/globalProps/hover.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '../../test-utils';
+import Body from '../../../pb_body/_body';
+
+const testSubject = 'body';
+
+test('Hover Props: returns proper class name', () => {
+  const testIdColor = `${testSubject}-hover-color-red`;
+  render(
+    <Body
+        data={{ testid: testIdColor }}
+        hover={{ color: 'red' }}
+        text="Hi"
+    />
+  );
+
+  let kit = screen.getByTestId(testIdColor);
+  let expectedClassName = `hover_color-red`;
+  expect(kit).toHaveClass(expectedClassName);
+
+  const testIdBackground = `${testSubject}-hover-background-blue`;
+  render(
+    <Body
+        data={{ testid: testIdBackground }}
+        hover={{ background: 'blue' }}
+        text="Hi"
+    />
+  );
+
+  kit = screen.getByTestId(testIdBackground);
+  expectedClassName = `hover_background-blue`;
+  expect(kit).toHaveClass(expectedClassName);
+
+  const testIdShadow = `${testSubject}-hover-shadow-deep`;
+  render(
+    <Body
+        data={{ testid: testIdShadow }}
+        hover={{ shadow: 'deep' }}
+        text="Hi"
+    />
+  );
+
+  kit = screen.getByTestId(testIdShadow);
+  expectedClassName = `hover_shadow_deep`;
+  expect(kit).toHaveClass(expectedClassName);
+
+  const testIdScale = `${testSubject}-hover-scale`;
+  render(
+    <Body
+        data={{ testid: testIdScale }}
+        hover={{ scale: 'xl' }}
+        text="Test"
+    />
+  );
+
+  kit = screen.getByTestId(testIdScale);
+  expectedClassName = `hover_scale_xl`;
+  expect(kit).toHaveClass(expectedClassName);
+
+  const testIdMultiple = `${testSubject}-hover-multiple`;
+  render(
+    <Body
+        data={{ testid: testIdMultiple }}
+        hover={{
+        color: 'green',
+        background: 'error',
+        shadow: 'deeper',
+        scale: 'xl',
+      }}
+        text="Hi"
+    />
+  );
+
+  kit = screen.getByTestId(testIdMultiple);
+  expect(kit).toHaveClass('hover_color-green');
+  expect(kit).toHaveClass('hover_background-error');
+  expect(kit).toHaveClass('hover_shadow_deeper');
+  expect(kit).toHaveClass('hover_scale_xl');
+});

--- a/playbook/lib/playbook/hover.rb
+++ b/playbook/lib/playbook/hover.rb
@@ -48,7 +48,7 @@ module Playbook
         if responsive
           value.each do |key, val|
             if %i[background color].include?(key)
-              css += "#{prefix}_#{key}_#{val} " if hover_attributes.include?(key.to_s)
+              css += "#{prefix}_#{key}-#{val} " if hover_attributes.include?(key.to_s)
             elsif hover_attributes.include?(key.to_s) && send("hover_#{key}_values").include?(val.to_s)
               css += "#{prefix}_#{key}_#{val} "
             end

--- a/playbook/spec/playbook/global_props/hover_spec.rb
+++ b/playbook/spec/playbook/global_props/hover_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../../../app/pb_kits/playbook/pb_body/body"
+
+RSpec.describe Playbook::PbBody::Body do
+  subject { Playbook::PbBody::Body }
+
+  describe "#classname" do
+    it "returns correct hover classnames", :aggregate_failures do
+      %w[deep deeper deepest].each do |value|
+        instance = subject.new({ hover: { shadow: value } })
+        expect(instance.classname).to include("hover_shadow_#{value}")
+      end
+
+      %w[sm md lg].each do |value|
+        instance = subject.new({ hover: { scale: value } })
+        expect(instance.classname).to include("hover_scale_#{value}")
+      end
+
+      %w[red blue green].each do |value|
+        instance = subject.new({ hover: { background: value } })
+        expect(instance.classname).to include("hover_background-#{value}")
+
+        instance = subject.new({ hover: { color: value } })
+        expect(instance.classname).to include("hover_color-#{value}")
+      end
+
+      hover_props = {
+        shadow: "deep",
+        scale: "sm",
+        background: "red",
+        color: "blue",
+      }
+      instance = subject.new({ hover: hover_props })
+      expect(instance.classname).to include("hover_shadow_deep")
+      expect(instance.classname).to include("hover_scale_sm")
+      expect(instance.classname).to include("hover_background-red")
+      expect(instance.classname).to include("hover_color-blue")
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
runway https://runway.powerhrg.com/backlog_items/PLAY-1603

Add a "Text Color" hover prop option is the ask in this story 

because color is already a hover option i just used that. The Background and color hover props weren't working because a lot of our kits are listening for classnames that are "_error", "_success" or "_#{any_color_token}"

so i changed the classname to not trigger the pre existing css by making the syntax "hover_color-#{any_color_token}". Doing this to the background kit fixes it too

Checkout the page here https://pr3874.playbook.beta.gm.powerapp.cloud/visual_guidelines/hover

![screenshot-127_0_0_1_3000-2024_11_01-09_29_40](https://github.com/user-attachments/assets/c3346cb5-019a-401f-9bbb-b3e45901c08f)


