### PR TITLE
[PLAY-1619] Font Awesome Setup Docs: JS Bundle and Asset Pipeline - Phase 2

### DIFF
--- a/playbook-website/app/views/guides/getting_started/font_awesome.md
+++ b/playbook-website/app/views/guides/getting_started/font_awesome.md
@@ -59,3 +59,64 @@ Integrating Font Awesome with Playbook ensures that you have access to these ben
 
   <pre><code class="rb">&lt;%= pb_rails("icon", props: { icon: "font-awesome", fixed_width: true }) %&gt;</code></pre>
 </details>
+
+<details class="mt_sm">
+  <summary class="mb_sm"><strong>With a JavaScript Bundler</strong></summary>
+  <strong>Make sure you are on Rails 7 or higher.</strong>
+  <p>
+    <strong>1.</strong> Follow the <a href="/guides/getting_started/ruby_on_rails_setup">Ruby on Rails Setup getting started page</a> to setup Playbook with your Rails project. 
+  </p>
+  <p>
+    Use your desired bundler:
+    <pre><code class="sh">rails new CoolNewApp -j webpack</code></pre>
+  </p>
+  <p>
+    <strong>2.</strong> Follow the <a href="/guides/getting_started/rails_&_react_setup">Ruby & React page</a> if you want to use React with your project. 
+  </p>
+  <p>
+    <strong>3.</strong> Setup Pro or Free Font Awesome to use our Icon Component.
+  </p>
+  <p><strong>Pro:</strong></p>
+  <pre><code class="rb"># app/assets/stylesheets/application.scss
+ @import "font-awesome-pro";
+ @import "font-awesome-pro/solid";
+ @import "font-awesome-pro/regular";
+ @import "playbook";</code></pre>
+  <pre><code class="rb"># app/Gemfile
+ source "https://token:TOKEN@dl.fontawesome.com/basic/fontawesome-pro/ruby/" do
+   gem "font-awesome-pro-sass", "6.2.0"
+ end</code></pre>
+ <strong>Free:</strong>
+  <p><em>Currently only <a href="https://fontawesome.com/search?o=r&m=free&s=regular">Free Regular</a> icons are supported in our icon component structure.</em></p>
+
+  <pre><code class="rb"># app/assets/stylesheets/application.scss
+ @import "font-awesome";</code></pre>
+
+  <pre><code class="rb"># app/Gemfile
+ source "https://token:TOKEN@dl.fontawesome.com/basic/fontawesome-pro/ruby/" do
+   gem "font-awesome-pro-sass", "6.2.0"
+ end</code></pre>
+
+  <strong>4.</strong> Bundle all the things!
+
+  <pre><code class="sh">bundle install</code></pre>
+
+  <pre><code class="sh">yarn</code></pre>
+
+  <pre><code class="sh">npm install</code></pre>
+
+  <strong>5.</strong> Build JavaScript for development
+  <p>When using a bundling option, use <code>bin/dev</code> to start the Rails server and build JavaScript for development. Don't forget to add a build script in your package.json file:</p>
+
+  <pre><code class="js">"scripts": {
+   "build": "webpack"
+ },</code></pre>
+
+  <strong>6.</strong> <strong>Go build awesome stuff!</strong>
+
+  <p>Refer to our <a href="/kits/icon">Icon kit</a> to get started with Font Awesome icons in Playbook.</p>
+
+  <pre><code class="rb">&lt;%= pb_rails("icon", props: { icon: "font-awesome", fixed_width: true }) %&gt;</code></pre>
+
+  <pre><code class="react">&lt;Icon fixedWidth icon="font-awesome" /&gt;</code></pre>
+</details>

--- a/playbook-website/app/views/guides/getting_started/font_awesome.md
+++ b/playbook-website/app/views/guides/getting_started/font_awesome.md
@@ -20,7 +20,7 @@ Integrating Font Awesome with Playbook ensures that you have access to these ben
 ### Ruby on Rails Setup
 
 <details class="mt_sm">
-  <summary class="mb_sm"><strong>Default with an Asset Pipeline</strong></summary>
+  <summary class="mb_sm"><strong><img src="https://github.com/user-attachments/assets/781b1ec8-954c-4919-a79c-7009521849a6" alt="rails logo" class="pb_custom_icon svg-inline--fa svg_fw mr_xxs" style="margin: 0;" />Default with an Asset Pipeline</strong></summary>
   <strong>Make sure you are on Rails 7 or higher.</strong>
   <p>
     <strong>1.</strong> Follow the <a href="/guides/getting_started/ruby_on_rails_setup">Ruby on Rails Setup getting started page</a> to setup Playbook with your Rails project.
@@ -61,7 +61,7 @@ Integrating Font Awesome with Playbook ensures that you have access to these ben
 </details>
 
 <details class="mt_sm">
-  <summary class="mb_sm"><strong>With a JavaScript Bundler</strong></summary>
+  <summary class="mb_sm"><strong><img src="https://github.com/user-attachments/assets/781b1ec8-954c-4919-a79c-7009521849a6" alt="rails logo" class="pb_custom_icon svg-inline--fa svg_fw mr_xxs" style="margin: 0;" />With a JavaScript Bundler</strong></summary>
   <strong>Make sure you are on Rails 7 or higher.</strong>
   <p>
     <strong>1.</strong> Follow the <a href="/guides/getting_started/ruby_on_rails_setup">Ruby on Rails Setup getting started page</a> to setup Playbook with your Rails project. 

--- a/playbook-website/app/views/guides/getting_started/font_awesome.md
+++ b/playbook-website/app/views/guides/getting_started/font_awesome.md
@@ -17,57 +17,45 @@ Integrating Font Awesome with Playbook ensures that you have access to these ben
 
 ![fontawesome](https://github.com/user-attachments/assets/638b63ad-56d3-4819-8e05-fcbb175bedc7)
 
-## Ruby on Rails Setup (default with asset pipeline)
+### Ruby on Rails Setup
 
-**Make sure you are on Rails 7 or higher.**
-
-**1.** Follow the [Ruby on Rails Setup getting started page](/guides/getting_started/ruby_on_rails_setup) to setup Playbook with your Rails project.
-
-**2.** Setup Pro or Free Font Awesome to use our Icon Component.
-
-**Pro:**
-
-```rb
-# app/assets/stylesheets/application.scss
+<details class="mt_sm">
+  <summary class="mb_sm"><strong>Default with an Asset Pipeline</strong></summary>
+  <strong>Make sure you are on Rails 7 or higher.</strong>
+  <p>
+    <strong>1.</strong> Follow the <a href="/guides/getting_started/ruby_on_rails_setup">Ruby on Rails Setup getting started page</a> to setup Playbook with your Rails project.
+  </p>
+  <p>
+    <strong>2.</strong> Setup Pro or Free Font Awesome to use our Icon Component.
+  </p>
+  <p><strong>Pro:</strong></p>
+  <pre><code class="rb"># app/assets/stylesheets/application.scss
  @import "font-awesome-pro";
  @import "font-awesome-pro/solid";
  @import "font-awesome-pro/regular";
- @import "playbook";
-```
-
-```rb
-# app/Gemfile
+ @import "playbook";</code></pre>
+  <pre><code class="rb"># app/Gemfile
  source "https://token:TOKEN@dl.fontawesome.com/basic/fontawesome-pro/ruby/" do
    gem "font-awesome-pro-sass", "6.2.0"
- end
-```
+ end</code></pre>
+ <strong>Free:</strong>
+  <p><em>Currently only <a href="https://fontawesome.com/search?o=r&m=free&s=regular">Free Regular</a> icons are supported in our icon component structure.</em></p>
 
-**Free:**
+  <pre><code class="rb"># app/assets/stylesheets/application.scss
+ @import "font-awesome";</code></pre>
 
-*Currently only [Free Regular](https://fontawesome.com/search?o=r&m=free&s=regular) icons are supported in our icon component structure.*
-
-```rb
-# app/assets/stylesheets/application.scss
- @import "font-awesome";
-```
-
-```rb
-# app/Gemfile
+  <pre><code class="rb"># app/Gemfile
  source "https://token:TOKEN@dl.fontawesome.com/basic/fontawesome-pro/ruby/" do
    gem "font-awesome-pro-sass", "6.2.0"
- end
-```
+ end</code></pre>
 
-**3.** Bundle all the things!
+  <strong>3.</strong> Bundle all the things!
 
-```sh
-bundle install
-```
+  <pre><code class="sh">bundle install</code></pre>
 
-**4.** **Go build awesome stuff!**
+  <strong>4.</strong> <strong>Go build awesome stuff!</strong>
 
-Refer to our [Icon kit](/kits/icon) to get started with Font Awesome icons in Playbook. 
+  <p>Refer to our <a href="/kits/icon">Icon kit</a> to get started with Font Awesome icons in Playbook.</p>
 
-```rb
-<%= pb_rails("icon", props: { icon: "font-awesome", fixed_width: true }) %>
-```
+  <pre><code class="rb">&lt;%= pb_rails("icon", props: { icon: "font-awesome", fixed_width: true }) %&gt;</code></pre>
+</details>

--- a/playbook-website/app/views/guides/getting_started/font_awesome.md
+++ b/playbook-website/app/views/guides/getting_started/font_awesome.md
@@ -86,7 +86,9 @@ Integrating Font Awesome with Playbook ensures that you have access to these ben
  source "https://token:TOKEN@dl.fontawesome.com/basic/fontawesome-pro/ruby/" do
    gem "font-awesome-pro-sass", "6.2.0"
  end</code></pre>
- <strong>Free:</strong>
+  <p>If you prefer, you can install with JavaScript:</p>
+  <pre><code class="sh">FONTAWESOME_PACKAGE_TOKEN=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX yarn add @fortawesome/fontawesome-pro</code></pre>
+  <strong>Free:</strong>
   <p><em>Currently only <a href="https://fontawesome.com/search?o=r&m=free&s=regular">Free Regular</a> icons are supported in our icon component structure.</em></p>
 
   <pre><code class="rb"># app/assets/stylesheets/application.scss
@@ -96,6 +98,9 @@ Integrating Font Awesome with Playbook ensures that you have access to these ben
  source "https://token:TOKEN@dl.fontawesome.com/basic/fontawesome-pro/ruby/" do
    gem "font-awesome-pro-sass", "6.2.0"
  end</code></pre>
+
+  <p>If you prefer, you can install with JavaScript:</p>
+  <pre><code class="sh">yarn add @fortawesome/fontawesome-free</code></pre>
 
   <strong>4.</strong> Bundle all the things!
 


### PR DESCRIPTION
**What does this PR do?**

- Use `<details>` and `<summary>` to make collapsibles for different methods to install Font Awesome
- Convert the existing Asset Pipeline docs to html to be used with `<details>` and `<summary>`
- Add a new "With a JavaScript Bundler" section

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2024-11-04 at 9 04 48 AM](https://github.com/user-attachments/assets/32e99faf-2370-4214-9101-fb8a23333bc2)


**How to test?** Steps to confirm the desired behavior:
1. Go to /guides/getting_started/font_awesome
2. There should be two "collapsibles": Default with an Asset Pipeline and With a JavaScript Bundler
3. When you click it, the sections should expand and contract with details
4. Review the new "With a JavaScript Bundler" section

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.