### PR TITLE
[PLAY-1551] Bump @tiptap/extension-document from 2.1.12 to 2.6.6

### DIFF
--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -22,7 +22,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@hotwired/turbo-rails": "^7.3.0",
     "@originjs/vite-plugin-commonjs": "^1.0.3",
-    "@tiptap/extension-document": "^2.1.12",
+    "@tiptap/extension-document": "^2.6.6",
     "@tiptap/extension-highlight": "^2.0.3",
     "@tiptap/extension-horizontal-rule": "^2.0.3",
     "@tiptap/extension-link": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3520,10 +3520,10 @@
   resolved "https://npm.powerapp.cloud/@tiptap/extension-document/-/extension-document-2.0.2.tgz#b07a4062cc0772e4129621b9b9a2e043a05395a1"
   integrity sha512-rY87m1sezlD37v5hGndiA/B/3upR3hQurSEsWhWyQE/11lOshPQKCCHfDV6KLwKdjd8lfwfbXueH/SBFHtrYAQ==
 
-"@tiptap/extension-document@^2.1.12":
-  version "2.1.12"
-  resolved "https://npm.powerapp.cloud/@tiptap/extension-document/-/extension-document-2.1.12.tgz#e19e4716dfad60cbeb6abaf2f362fed759963529"
-  integrity sha512-0QNfAkCcFlB9O8cUNSwTSIQMV9TmoEhfEaLz/GvbjwEq4skXK3bU+OQX7Ih07waCDVXIGAZ7YAZogbvrn/WbOw==
+"@tiptap/extension-document@^2.6.6":
+  version "2.9.1"
+  resolved "https://npm.powerapp.cloud/@tiptap/extension-document/-/extension-document-2.9.1.tgz#ea65a86a4d2524ec65fc4775122f652840a89386"
+  integrity sha512-1a+HCoDPnBttjqExfYLwfABq8MYdiowhy/wp8eCxVb6KGFEENO53KapstISvPzqH7eOi+qRjBB1KtVYb/ZXicg==
 
 "@tiptap/extension-dropcursor@^2.0.2":
   version "2.0.2"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1551](https://runway.powerhrg.com/teams/432/backlog/sprints/active#open-backlog-item-71524)

Bumping dependency to latest version
2.1.12 -> 2.6.6

#### Checklist:
- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **DEPLOY** I have added the `milano` label to show I'm ready for a review.