### PR TITLE
[PBNTR-666] Custom Cells for Advanced Table First Column 

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/CustomCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/CustomCell.tsx
@@ -16,6 +16,7 @@ interface CustomCellProps {
   onRowToggleClick?: (arg: Row<GenericObject>) => void
   row: Row<GenericObject>
   value?: string
+  customRenderer?: any,
 } 
 
 export const CustomCell = ({
@@ -23,6 +24,7 @@ export const CustomCell = ({
   onRowToggleClick,
   row,
   value,
+  customRenderer,
 }: CustomCellProps & GlobalProps) => {
   const { setExpanded, expanded, expandedControl, inlineRowLoading } = useContext(AdvancedTableContext);
 
@@ -61,7 +63,12 @@ export const CustomCell = ({
           </button>
         ) : null}
         <FlexItem paddingLeft={renderButton? "none" : "xs"}>
-          {row.depth === 0 ? getValue() : value}
+          {row.depth === 0 ? (
+            customRenderer ? customRenderer(row, getValue()) : getValue()
+           ) :(
+            customRenderer ? customRenderer(row, value) : value
+           )
+           }
         </FlexItem>
       </Flex>
     </div>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/CustomCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/CustomCell.tsx
@@ -16,7 +16,7 @@ interface CustomCellProps {
   onRowToggleClick?: (arg: Row<GenericObject>) => void
   row: Row<GenericObject>
   value?: string
-  customRenderer?: any,
+  customRenderer?: (row: Row<GenericObject>, value: string | undefined) => React.ReactNode
 } 
 
 export const CustomCell = ({

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -17,7 +17,6 @@ import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../uti
 import { globalProps, GlobalProps } from "../utilities/globalProps"
 
 import Table from "../pb_table/_table"
-import Flex from "../pb_flex/_flex"
 
 import AdvancedTableContext from "./Context/AdvancedTableContext"
 
@@ -106,22 +105,12 @@ const AdvancedTable = (props: AdvancedTableProps) => {
       switch (row.depth) {
         case 0: {
           return (
-              customRenderer ? (
-                <Flex>
                 <CustomCell
+                    customRenderer={customRenderer}
                     getValue={getValue}
                     onRowToggleClick={onRowToggleClick}
                     row={row}
                 />
-                  {customRenderer(row, getValue())}
-                </Flex>
-              ) : (
-                <CustomCell
-                    getValue={getValue}
-                    onRowToggleClick={onRowToggleClick}
-                    row={row}
-                />
-              )
           )
         }
         default: {
@@ -129,22 +118,12 @@ const AdvancedTable = (props: AdvancedTableProps) => {
           const depthAccessor = cellAccessors[row.depth - 1] // Adjust index for depth
           const accessorValue = rowData[depthAccessor]
           return accessorValue ? (
-            customRenderer ? (
-              <Flex>
-                <CustomCell
-                    onRowToggleClick={onRowToggleClick}
-                    row={row} 
-                    value={accessorValue} 
-                />
-                  {customRenderer(row, getValue())}
-                </Flex>
-            ) : (
             <CustomCell
+                customRenderer={customRenderer}
                 onRowToggleClick={onRowToggleClick}
                 row={row} 
                 value={accessorValue} 
             />
-            )
           ) : (
             "N/A"
           )

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -136,8 +136,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     }
     return columnCells
   }
- 
-//   //Create column array in format needed by Tanstack
+//Create column array in format needed by Tanstack
   const columns =
     columnDefinitions &&
       columnDefinitions.map((column, index) => {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -90,7 +90,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
 
   const columnHelper = createColumnHelper()
 
-  //Create cells for first columns
+  //Create cells for columns, with customization for first column
   const createCellFunction = (cellAccessors: string[], customRenderer?: (row: Row<GenericObject>, value: any) => JSX.Element, index:number) => {
     const columnCells = ({
       row,
@@ -133,14 +133,10 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     return customRenderer
     ? customRenderer(row, getValue())
     : getValue()
-
     }
-
     return columnCells
   }
-
-
-  
+ 
 //   //Create column array in format needed by Tanstack
   const columns =
     columnDefinitions &&

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -91,7 +91,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
   const columnHelper = createColumnHelper()
 
   //Create cells for columns, with customization for first column
-  const createCellFunction = (cellAccessors: string[], customRenderer?: (row: Row<GenericObject>, value: any) => JSX.Element, index:number) => {
+  const createCellFunction = (cellAccessors: string[], customRenderer?: (row: Row<GenericObject>, value: any) => JSX.Element, index?: number) => {
     const columnCells = ({
       row,
       getValue,

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from "react"
 import { render, screen, waitFor } from "../utilities/test-utils"
 
-import { AdvancedTable } from "playbook-ui"
+import { AdvancedTable, Pill } from "playbook-ui"
 
 const MOCK_DATA = [
   {
@@ -87,6 +87,28 @@ const columnDefinitions = [
     label: "Scheduled Meetings",
   },
 ]
+
+const columnDefinitionsCustomRenderer = [
+  {
+    accessor: "year",
+    label: "Year",
+    cellAccessors: ["quarter", "month", "day"],
+  },
+  {
+    accessor: "newEnrollments",
+    label: "New Enrollments",
+    customRenderer: (row, value) => (
+      <Pill text={value} 
+          variant="success"    
+      />
+    ),
+  },
+  {
+    accessor: "scheduledMeetings",
+    label: "Scheduled Meetings",
+  },
+]
+
 
 const subRowHeaders = ["Quarter"]
 
@@ -462,4 +484,18 @@ test("responsive none prop functions as expected", () => {
 
   const kit = screen.getByTestId(testId)
   expect(kit).toHaveClass("pb_advanced_table table-responsive-none")
+})
+
+test("customRenderer prop functions as expected", () => {
+  render(
+    <AdvancedTable
+        columnDefinitions={columnDefinitionsCustomRenderer}
+        data={{ testid: testId }}
+        tableData={MOCK_DATA}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  const pill = kit.querySelector(".pb_pill_kit_success_lowercase")
+  expect(pill).toBeInTheDocument()
 })

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_cell.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_cell.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AdvancedTable, Pill, Body, Flex, Detail, Caption } from "playbook-ui"
+import { AdvancedTable, Pill, Body, Flex, Detail, Caption, Badge } from "playbook-ui"
 import MOCK_DATA from "./advanced_table_mock_data.json"
 
 const AdvancedTableCustomCell = (props) => {
@@ -8,6 +8,11 @@ const AdvancedTableCustomCell = (props) => {
       accessor: "year",
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
+      customRenderer: (row, value) => (
+        <Badge text={value} 
+            variant="neutral"    
+        />
+      ), 
 
     },
     {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_cell.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_cell.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AdvancedTable, Pill, Body, Flex, Detail, Caption, Badge } from "playbook-ui"
+import { AdvancedTable, Pill, Body, Flex, Detail, Caption, Badge, Title } from "playbook-ui"
 import MOCK_DATA from "./advanced_table_mock_data.json"
 
 const AdvancedTableCustomCell = (props) => {
@@ -9,11 +9,17 @@ const AdvancedTableCustomCell = (props) => {
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
       customRenderer: (row, value) => (
-        <Badge text={value} 
-            variant="neutral"    
-        />
+        <Flex>
+          <Title size={4}
+              text={value} 
+          />
+          <Badge 
+              marginLeft="sm"
+              text={row.original.newEnrollments > 20 ? "High" : "Low"}
+              variant="neutral"
+          />
+        </Flex>
       ), 
-
     },
     {
       accessor: "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_cell.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_cell.jsx
@@ -13,8 +13,8 @@ const AdvancedTableCustomCell = (props) => {
           <Title size={4}
               text={value} 
           />
-          <Badge 
-              marginLeft="sm"
+          <Badge dark
+              marginLeft="xxs"
               text={row.original.newEnrollments > 20 ? "High" : "Low"}
               variant="neutral"
           />

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -6,14 +6,14 @@ examples:
 
   react:
   - advanced_table_default: Default (Required Props)
-  - advanced_table_loading: Loading State
-  - advanced_table_sort: Enable Sorting
-  - advanced_table_sort_control: Sort Control
-  - advanced_table_expanded_control: Expanded Control
-  - advanced_table_subrow_headers: SubRow Headers
-  - advanced_table_collapsible_trail: Collapsible Trail
-  - advanced_table_table_options: Table Options
-  - advanced_table_table_props: Table Props
-  - advanced_table_inline_row_loading: Inline Row Loading
-  - advanced_table_responsive: Responsive Tables
+  # - advanced_table_loading: Loading State
+  # - advanced_table_sort: Enable Sorting
+  # - advanced_table_sort_control: Sort Control
+  # - advanced_table_expanded_control: Expanded Control
+  # - advanced_table_subrow_headers: SubRow Headers
+  # - advanced_table_collapsible_trail: Collapsible Trail
+  # - advanced_table_table_options: Table Options
+  # - advanced_table_table_props: Table Props
+  # - advanced_table_inline_row_loading: Inline Row Loading
+  # - advanced_table_responsive: Responsive Tables
   - advanced_table_custom_cell: Custom Components for Cells

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -6,14 +6,14 @@ examples:
 
   react:
   - advanced_table_default: Default (Required Props)
-  # - advanced_table_loading: Loading State
-  # - advanced_table_sort: Enable Sorting
-  # - advanced_table_sort_control: Sort Control
-  # - advanced_table_expanded_control: Expanded Control
-  # - advanced_table_subrow_headers: SubRow Headers
-  # - advanced_table_collapsible_trail: Collapsible Trail
-  # - advanced_table_table_options: Table Options
-  # - advanced_table_table_props: Table Props
-  # - advanced_table_inline_row_loading: Inline Row Loading
-  # - advanced_table_responsive: Responsive Tables
+  - advanced_table_loading: Loading State
+  - advanced_table_sort: Enable Sorting
+  - advanced_table_sort_control: Sort Control
+  - advanced_table_expanded_control: Expanded Control
+  - advanced_table_subrow_headers: SubRow Headers
+  - advanced_table_collapsible_trail: Collapsible Trail
+  - advanced_table_table_options: Table Options
+  - advanced_table_table_props: Table Props
+  - advanced_table_inline_row_loading: Inline Row Loading
+  - advanced_table_responsive: Responsive Tables
   - advanced_table_custom_cell: Custom Components for Cells


### PR DESCRIPTION
[Runway Story](https://runway.powerhrg.com/backlog_items/PBNTR-666)

- This story adds the ability to have custom cells for the first column of the advanced table.
- This functionality was added for the rest of the columns on [this PR](https://github.com/powerhome/playbook/pull/3821)
- To test, scroll down to the last doc example on the React side

[csb here](https://codesandbox.io/p/sandbox/advanced-table-custom-cell-gjzxtw)