### PR TITLE
[PLAY-1613] Fix Dark Mode Date Colors- Dots, Icons, and Captions

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date/_date.scss
+++ b/playbook/app/pb_kits/playbook/pb_date/_date.scss
@@ -25,8 +25,11 @@
         margin-left: 4px !important;
     }
     &.dark {
-        [class^=pb_title_kit], [class^=pb_body_kit], [class^=pb_caption_kit] {
+        [class^=pb_title_kit] {
             color: $text_dk_default !important;
+        }
+        [class^=pb_body_kit], [class^=pb_caption_kit] {
+            color: $text_dk_light !important;
         }
     }
 }

--- a/playbook/app/pb_kits/playbook/pb_date/_date.scss
+++ b/playbook/app/pb_kits/playbook/pb_date/_date.scss
@@ -25,7 +25,7 @@
         margin-left: 4px !important;
     }
     &.dark {
-        [class^=pb_title_kit] {
+        [class^=pb_title_kit], [class^=pb_body_kit], [class^=pb_caption_kit] {
             color: $text_dk_default !important;
         }
     }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Use $text_dk_light for dark mode Date kit caption and body: fix dots, icons, and captions.

**Screenshots:** Screenshots to visualize your addition/change
<img width="152" alt="Screenshot 2024-11-07 at 2 53 21 PM" src="https://github.com/user-attachments/assets/caa2537d-ea19-4b77-b668-f8e415755b90">

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/date/
2. Turn on dark mode
3. Look at the variants doc example
4. The "dot" should be a dark mode color
5. Same for the calendar icon, and the first example listed
6. Review React, Rails, and make sure the light mode isn't affected at all.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.