### PR TITLE
[PLAY-1667] Dark Mode Audit - Nav

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_nav/_bold_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_bold_mixin.scss
@@ -6,7 +6,7 @@
       &[class*=_active] {
         background-color: $primary;
         color: $white;
-        box-shadow: $shadow_deep;
+        box-shadow: 0 2px 10px 0 $shadow_dark;
         @media (hover:hover) {
           &:hover {
             background-color: darken($primary, 4%);

--- a/playbook/app/pb_kits/playbook/pb_nav/_bold_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_bold_mixin.scss
@@ -6,7 +6,7 @@
       &[class*=_active] {
         background-color: $primary;
         color: $white;
-        box-shadow: 0 2px 10px 0 $shadow_dark;
+        box-shadow: $shadow_deep;
         @media (hover:hover) {
           &:hover {
             background-color: darken($primary, 4%);
@@ -19,6 +19,16 @@
           font-weight: $bolder;
         }
       }
-   }
+    }
+  }
+
+  .dark & {
+    [class*=pb_nav_list_kit_item][class*=pb_nav_list_item] {
+      &[class*=_link] {
+        &[class*=_active] {
+          box-shadow: 0 2px 10px 0 $shadow_dark;
+        }
+      }
+    }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_nav/_collapsible_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_collapsible_nav.scss
@@ -223,6 +223,7 @@
         }
       }
       [class*="pb_collapsible_nav_item"][class*="pb_nav_list_item_link_collapsible"][class*="pb_nav_list_kit_item"] {
+        box-shadow: unset !important;
         .pb_nav_list_item_text_collapsible {
           color: $white !important;
         }
@@ -260,6 +261,13 @@
           &::after {
             background-color: $border_dark;
           }
+        }
+      }
+
+      &[class*="_active"] {
+        > .pb_collapsible_main_kit {
+          background-color: $primary;
+          box-shadow: 0 2px 10px 0 $shadow_dark;
         }
       }
     }

--- a/playbook/app/pb_kits/playbook/pb_nav/_collapsible_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_collapsible_nav.scss
@@ -245,6 +245,13 @@
           color: $white !important;
         }
       }
+
+      .pb_collapsible_main_kit {
+        svg {
+          color: $text_dk_default !important;
+        }
+      }
+
       .icon_wrapper:hover {
         background-color: mix($white, $card_dark, 40%);
       }

--- a/playbook/app/pb_kits/playbook/pb_nav/_collapsible_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_collapsible_nav.scss
@@ -240,8 +240,7 @@
 
       .pb_collapsible_main_kit:hover {
         background-color: mix($white, $card_dark, 20%);
-        .pb_nav_list_item_text_collapsible,
-        svg {
+        .pb_nav_list_item_text_collapsible {
           color: $white !important;
         }
       }

--- a/playbook/app/pb_kits/playbook/pb_nav/_vertical_nav.scss
+++ b/playbook/app/pb_kits/playbook/pb_nav/_vertical_nav.scss
@@ -115,7 +115,7 @@ $selector: ".pb_nav_list";
       }
       [class*="_item_text"],
       [class*="_item_icon"] {
-        color: $text_dk_lighter !important;
+        color: $text_dk_light !important;
       }
       &[class*="_link"] {
         &:hover {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Updates to dark mode styling based on audit for the Nav component. 

[PLAY-1667](https://runway.powerhrg.com/backlog_items/PLAY-1667)

**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2024-11-25 at 3 17 05 PM](https://github.com/user-attachments/assets/a1253ae4-1998-4d02-9e19-1f4970a6683b)

![Screenshot 2024-11-25 at 3 21 51 PM](https://github.com/user-attachments/assets/bf10c32a-5bb4-4937-abb0-693d41bc2a78)

![Screenshot 2024-11-25 at 3 20 01 PM](https://github.com/user-attachments/assets/b00a7f6c-ed4e-498e-a576-1ab3259871a0)

**How to test?** Steps to confirm the desired behavior:
1. Go to kits/nav
2. Turn on Dark Mode
3. Look at Default Variant, bold horizontal and vertical variants, and collapsible variant 
4. Check both react and rails versions for changes mentioned in the story card

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.