### PR TITLE
[PLAY-1668] Dark Mode Audit - Selectable Card

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/_card_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_card/_card_mixin.scss
@@ -32,7 +32,7 @@ $pb_card_header_colors: map-merge(map-merge($product_colors, $additional_colors)
 }
 
 @mixin pb_card_selected_dark {
-  @include pb_card_selected($primary_action);
+  @include pb_card_selected($primary_action_dark);
 }
 
 @mixin pb_card($background: $card_light, $border_color: $border_light) {

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -174,8 +174,6 @@ $pb_selectable_paddings: (
       &:checked ~ label {
         @include pb_card_selected_dark;
         background: $bg_dark_card;
-        border-width: $pb_card_border_width;
-        outline: 1px solid $primary_action_dark;
       }
     }
 

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -149,7 +149,7 @@ $pb_selectable_paddings: (
     &.dark {
       input[type="checkbox"],
       input[type="radio"] {
-        &:checked ~ label ~ enabled {
+        &:checked ~ label {
           border-width: $pb_card_border_width;
           outline: 1px solid $primary_action_dark;
         }

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -149,9 +149,9 @@ $pb_selectable_paddings: (
     &.dark {
       input[type="checkbox"],
       input[type="radio"] {
-        &:checked ~ label {
+        &:checked ~ label ~ enabled {
           border-width: $pb_card_border_width;
-          outline: 1px solid $primary;
+          outline: 1px solid $primary_action_dark;
         }
       }
     }
@@ -161,11 +161,11 @@ $pb_selectable_paddings: (
     color: $white;
     > label {
       @include pb_card_dark;
-      background: transparent;
+      background: $bg_dark_card;
 
       .pb_selectable_card_circle {
         border-color: $bg_dark;
-        background: $primary-action;
+        background: $primary_action_dark;
       }
     }
 
@@ -173,7 +173,7 @@ $pb_selectable_paddings: (
     input[type="radio"] {
       &:checked ~ label {
         @include pb_card_selected_dark;
-        background: transparent;
+        background: $bg_dark_card;
       }
     }
 

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -174,6 +174,8 @@ $pb_selectable_paddings: (
       &:checked ~ label {
         @include pb_card_selected_dark;
         background: $bg_dark_card;
+        border-width: $pb_card_border_width;
+        outline: 1px solid $primary_action_dark;
       }
     }
 

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.html.erb
@@ -35,7 +35,7 @@
         <% end %>
       <% else %>
         <% if content.nil? %>
-          <%= pb_rails("body", props: { text: object.text }) %>
+          <%= pb_rails("body", props: { text: object.text, dark: object.dark }) %>
         <% else %>
           <%= content %>
         <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Updates to dark mode styling based on audit for the Select-able Card component.

[PLAY-1668](https://runway.powerhrg.com/backlog_items/PLAY-1668)

**Screenshots:** Screenshots to visualize your addition/change
<img width="1382" alt="Screenshot 2024-11-26 at 2 19 39 PM" src="https://github.com/user-attachments/assets/bffba8c6-21ef-4a1d-a7a9-6fc44a3fcefd">

<img width="1435" alt="Screenshot 2024-11-26 at 2 20 47 PM" src="https://github.com/user-attachments/assets/3530ddc6-b857-472f-b3da-ac730a3e3c55">

**How to test?** Steps to confirm the desired behavior:
1. Go to 'kits/selectable_card/rails'
2. Scroll down to 'Selected, with icon' -- Border and check circle colors should be changed. 
3. Scroll down to 'Block and With Options' -- All variants should now support dark mode 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.