### PR TITLE
[PBNTR-713] Fixes for Custom Trigger not Working

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/utilities/subComponentHelper.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/utilities/subComponentHelper.tsx
@@ -18,9 +18,19 @@ export const separateChildComponents = (children: React.ReactChild[] | React.Rea
   const otherChildren: React.ReactChild[] = [];
 
   React.Children.forEach(children, (child) => {
-    if (child && (child as ReactElement).type === DropdownTrigger) {
+    const element = child as ReactElement;
+    const childType = element?.type;
+    const childDisplayName = (childType as any)?.displayName || (childType as any)?.name;
+
+    if (
+      childType === DropdownTrigger ||
+      childDisplayName === "DropdownTrigger"
+    ) {
       trigger = child;
-    } else if (child && (child as ReactElement).type === DropdownContainer) {
+    } else if (
+      childType === DropdownContainer ||
+      childDisplayName === "DropdownContainer"
+    ) {
       container = child;
     } else {
       otherChildren.push(child);
@@ -29,6 +39,7 @@ export const separateChildComponents = (children: React.ReactChild[] | React.Rea
 
   return { trigger, container, otherChildren };
 };
+
 
 export const prepareSubcomponents = ({
   children,


### PR DESCRIPTION
[Runway story](https://runway.powerhrg.com/backlog_items/PBNTR-713)

Issue was related to the Dropdown now being wrapped in a ForwardRef. This ForwardRef is read as the Dropdown being wrapped in proxies or a HOC which means the type does not match the DropdwnTrigger or DropdownContainer. So the separateChildComponents function was returning Trigger and Container as 'null' and pushing all children to otherChildren. 

### Before fix:
![Screenshot 2024-11-26 at 4 39 40 PM](https://github.com/user-attachments/assets/113f20ae-0a4d-48ce-9484-a66ab6d28eeb)


### After fix:

![Screenshot 2024-11-27 at 9 43 22 AM](https://github.com/user-attachments/assets/0ae9bc49-cf4e-4b0e-b728-beff1656002b)
