### PR TITLE
[PLAY-1635] Bread Crumbs Dark Mode Fix

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
@@ -1,55 +1,68 @@
-import React from 'react'
-import classnames from 'classnames'
-import { globalProps, domSafeProps } from '../utilities/globalProps'
+import React from "react"
+import classnames from "classnames"
+import { globalProps, domSafeProps } from "../utilities/globalProps"
 
 import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-  buildHtmlProps } from '../utilities/props'
+  buildHtmlProps,
+} from "../utilities/props"
 
 type BreadCrumbItemProps = {
-  aria?: {[key: string]: string},
-  className?: string,
-  data?: {[key: string]: string},
-  htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
-  id?: string,
-  component?: "a" | "span",
-  [x:string]: any;
+  aria?: { [key: string]: string }
+  children?: React.ReactNode
+  className?: string
+  data?: { [key: string]: string }
+  htmlOptions?: { [key: string]: string | number | boolean | (() => void) }
+  id?: string
+  component?: "a" | "span"
+  [x: string]: any
 }
 
 const BreadCrumbItem = (props: BreadCrumbItemProps): React.ReactElement => {
   const {
     aria = {},
+    children,
     className,
     data = {},
     htmlOptions = {},
     id,
-    component = 'a',
+    component = "a",
     ...rest
   } = props
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
-  const Component = component || 'span';
+  const Component = component || "span"
   const css = classnames(
-    buildCss('pb_bread_crumb_item_kit'),
+    buildCss("pb_bread_crumb_item_kit"),
     globalProps(props),
     className
   )
-  
+
+  const processedChildren = React.Children.map(children, (child) => {
+    if (React.isValidElement<{ className?: string }>(child)) {
+      return React.cloneElement(child, {
+        className: classnames(child.props.className, globalProps(props)),
+      })
+    }
+    return child
+  })
+
   return (
-    <div
-        {...ariaProps}
+    <div {...ariaProps}
         {...dataProps}
         {...htmlProps}
         className={css}
         id={id}
     >
       <Component
-          className="pb_bread_crumb_item"
+          className={classnames("pb_bread_crumb_item", globalProps(props))}
           {...domSafeProps(rest)}
-      />
+      >
+        {processedChildren}
+      </Component>
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
@@ -37,7 +37,7 @@ const BreadCrumbItem = (props: BreadCrumbItemProps): React.ReactElement => {
     globalProps(props),
     className
   )
-
+  
   return (
     <div
         {...ariaProps}

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
@@ -1,69 +1,55 @@
-import React from "react"
-import classnames from "classnames"
-import { globalProps, domSafeProps } from "../utilities/globalProps"
+import React from 'react'
+import classnames from 'classnames'
+import { globalProps, domSafeProps } from '../utilities/globalProps'
 
 import {
   buildAriaProps,
   buildCss,
   buildDataProps,
-  buildHtmlProps,
-} from "../utilities/props"
+  buildHtmlProps } from '../utilities/props'
 
 type BreadCrumbItemProps = {
-  aria?: { [key: string]: string }
-  children?: React.ReactNode
-  className?: string
-  component?: "a" | "span"
-  data?: { [key: string]: string }
-  htmlOptions?: { [key: string]: string | number | boolean | (() => void) }
-  id?: string
-  [x: string]: any
+  aria?: {[key: string]: string},
+  className?: string,
+  data?: {[key: string]: string},
+  htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
+  id?: string,
+  component?: "a" | "span",
+  [x:string]: any;
 }
 
 const BreadCrumbItem = (props: BreadCrumbItemProps): React.ReactElement => {
   const {
     aria = {},
-    children,
     className,
-    component = "a",
     data = {},
     htmlOptions = {},
     id,
+    component = 'a',
     ...rest
   } = props
-
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
-  const Component = component || "span"
+  const Component = component || 'span';
   const css = classnames(
-    buildCss("pb_bread_crumb_item_kit"),
+    buildCss('pb_bread_crumb_item_kit'),
     globalProps(props),
     className
   )
 
-  const processedChildren = React.Children.map(children, (child) => {
-    if (React.isValidElement<{ className?: string }>(child)) {
-      return React.cloneElement(child, {
-        className: classnames(child.props.className, globalProps(props)),
-      })
-    }
-    return child
-  })
-
   return (
-    <div {...ariaProps}
+    <div
+        {...ariaProps}
         {...dataProps}
         {...htmlProps}
         className={css}
         id={id}
     >
       <Component
-          className={classnames("pb_bread_crumb_item", globalProps(props))}
+          className="pb_bread_crumb_item"
           {...domSafeProps(rest)}
-      >
-        {processedChildren}
-      </Component>
+      />
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumb_item.tsx
@@ -13,10 +13,10 @@ type BreadCrumbItemProps = {
   aria?: { [key: string]: string }
   children?: React.ReactNode
   className?: string
+  component?: "a" | "span"
   data?: { [key: string]: string }
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) }
   id?: string
-  component?: "a" | "span"
   [x: string]: any
 }
 
@@ -25,12 +25,13 @@ const BreadCrumbItem = (props: BreadCrumbItemProps): React.ReactElement => {
     aria = {},
     children,
     className,
+    component = "a",
     data = {},
     htmlOptions = {},
     id,
-    component = "a",
     ...rest
   } = props
+
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/docs/_bread_crumbs_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/docs/_bread_crumbs_default.jsx
@@ -13,6 +13,7 @@ const BreadCrumbsDefault = (props) => {
       <Icon
           icon="home"
           size="1x"
+          {...props}
       />
       <BreadCrumbItem
           {...props}
@@ -28,6 +29,7 @@ const BreadCrumbsDefault = (props) => {
       <Icon
           icon="users"
           size="1x"
+          {...props}
       />
       <Link
           {...props}
@@ -43,6 +45,7 @@ const BreadCrumbsDefault = (props) => {
       <Icon
           icon="user"
           size="1x"
+          {...props}
       />
       <Link {...props}>
         <Title

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/docs/_bread_crumbs_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/docs/_bread_crumbs_default.jsx
@@ -22,6 +22,7 @@ const BreadCrumbsDefault = (props) => {
             size="4"
             tag="span"
             text="Home"
+            {...props}
         />
       </BreadCrumbItem>
       <Icon
@@ -36,6 +37,7 @@ const BreadCrumbsDefault = (props) => {
             size="4"
             tag="span"
             text="Users"
+            {...props}
         />
       </Link>
       <Icon
@@ -47,6 +49,7 @@ const BreadCrumbsDefault = (props) => {
             size="4"
             tag="span"
             text="User"
+            {...props}
         />
       </Link>
     </BreadCrumbs>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This updates the dark mode styling color for React Kit's inner Title Component. 

[Story 1635](https://runway.powerhrg.com/backlog_items/PLAY-1635)

**Screenshots:** Screenshots to visualize your addition/change
Before:
<img width="678" alt="Screenshot 2024-12-04 at 4 53 23 PM" src="https://github.com/user-attachments/assets/737b8a3e-df86-4c2d-92f1-cec548ce9a2a">

After:
<img width="851" alt="Screenshot 2024-12-04 at 4 53 41 PM" src="https://github.com/user-attachments/assets/71c1f9ef-70ce-4ef6-ba00-84fdc1e3a09e">


**How to test?** Steps to confirm the desired behavior:
1. Go to '/kits/bread_crumbs/react'
2. Click on 'night mode'
3. Scroll down to 'stroll down to to see in Nav colored white'
4. See in inspector tool see span element child have class with dark appended


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
