### PR TITLE
[PLAY-1740] Fix Sort Function on Rails Advanced Table

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.html.erb
@@ -4,8 +4,10 @@
                 <%= pb_rails("table/table_header", props: { tag: "div", id: item[:accessor], classname: object.th_classname, sort_menu: item[:sort_menu] }) do %>
                     <%= pb_rails("flex", props:{ align: "center", justify: index.zero? ? "start" : "end", text_align: "end" }) do %>
                         <% if index.zero? && (object.enable_toggle_expansion == "header" || object.enable_toggle_expansion == "all") %>
-                            <button class="gray-icon toggle-all-icon" onclick="expandAllRows(this)">
-                                <%= pb_rails("icon", props: { icon: "arrows-from-line", cursor: "pointer", fixed_width: true, padding_right: "xs" }) %>
+                            <button
+                              class="gray-icon toggle-all-icon"
+                              onclick="expandAllRows(this); event.preventDefault();">
+                              <%= pb_rails("icon", props: { icon: "arrows-from-line", cursor: "pointer", fixed_width: true, padding_right: "xs" }) %>
                             </button>
                         <% end %>
                         <%= item[:label] %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fix a bug with the collapsible button and sort button where both functionalities happen when either button is clicked.

[PLAY-1740](https://runway.powerhrg.com/backlog_items/PLAY-1740)

**Screenshots:** Screenshots to visualize your addition/change
There are no visual changes

**How to test?** Steps to confirm the desired behavior:
1. Go to advanced table kit rails doc page - kits/advanced_table/rails
2. Scroll down to Enable Sorting example on the page
3. Clicking the sort button will refresh and sort the table. 
4. Clicking the collapsible button will expand the table and close the table if pressed again. 
5. Both of the buttons above should act independently of each other now. 
6. Check each collapsible button on each of the rails advanced tables to double check they still work with the most recent changes. 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.