### PR TITLE
[PLAY-1634] Avatar Badge Overlay Border Bug Fix

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar/_avatar.scss
+++ b/playbook/app/pb_kits/playbook/pb_avatar/_avatar.scss
@@ -31,14 +31,12 @@ $avatar-sizes: (
         [class^=pb_card_kit].overlay_top_center {
           left: 50%;
           transform: translateX(-50%);
-          padding: 2px !important;
         }
 
         [class^=pb_card_kit].overlay_left_center,
         [class^=pb_card_kit].overlay_right_center {
           top: 50%;
           transform: translateY(-50%);
-          padding: 2px !important;
         }
       }
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This pr addresses the bug occurring on Overlay boarder for positioning of icon or badge overlay when positioned top center, bottom center, left center, or right center. Removed padding that was only present for centered positions

[Story 1634 ](https://runway.powerhrg.com/backlog_items/PLAY-1634)


**Screenshots:** Screenshots to visualize your addition/change
Before:
![Screenshot 2024-12-05 at 4 50 41 PM](https://github.com/user-attachments/assets/e6e5710f-8f81-4f06-9709-13eaa8d8de97)

After:

<img width="280" alt="Screenshot 2024-12-05 at 4 54 51 PM" src="https://github.com/user-attachments/assets/ccc3aca2-b2a0-4b1c-a6d0-943fb442dcd1">

**How to test?** Steps to confirm the desired behavior:
1. Go to '/kits/avatar/react'
2. Scroll down to 'Badge Component Overlay'
3. See that border is same for center positions and all other position placement.


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.