### PR TITLE
[PLAY-1701] Change Playground Key

### DIFF
--- a/playbook-website/app/javascript/components/MainSidebar/MenuData/SidebarNavItems.ts
+++ b/playbook-website/app/javascript/components/MainSidebar/MenuData/SidebarNavItems.ts
@@ -44,7 +44,7 @@ export const SideBarNavItems = [
 
     {
       name: "Playground",
-      key: "top-nav-item-6",
+      key: "top-nav-item-7",
       link: "/kit_playground_rails",
       children: false,
       leftIcon:"laptop-code"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Stops "Warning: Encountered two children with the same key, 'top-nav-item-6'" from appearing in the console when loading playbook. 

[PLAY-1701](https://runway.powerhrg.com/backlog_items/PLAY-1701)

**How to test?** Steps to confirm the desired behavior:
1. Go to [playbook website](https://playbook.powerapp.cloud/), basically any page, with the console open.
2. Check for "Warning: Encountered two children with the same key, 'top-nav-item-6'"

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.