### PR TITLE
[PLAY-1703 ] Form Group Error State Alignment

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_error_state_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_error_state_mixin.scss
@@ -20,12 +20,20 @@
   }
 }
 
-@mixin error-state-left-side-select-kit {
+@mixin error-state-right-side-select-kit {
   &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error),
   &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
     align-items: flex-start;
 
-    .pb_select_kit_wrapper,
+    .pb_select_kit_wrapper {
+      padding-top: $space_md;
+      margin-top: 2px;
+
+      .pb_select_kit_caret {
+        padding-top: $space_md;
+      }
+    }
+
     .pb_select_kit_wrapper.error {
       padding-top: $space_md;
       margin-top: 2px;
@@ -37,7 +45,7 @@
   }
 }
 
-@mixin error-state-right-side-select-kit {
+@mixin error-state-left-side-select-kit {
   &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
     align-items: flex-start;
 

--- a/playbook/app/pb_kits/playbook/pb_form_group/_error_state_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_error_state_mixin.scss
@@ -1,0 +1,49 @@
+@mixin error-state-flex-start-selectors {
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit),
+  &:has(.pb_text_input_kit):has(.pb_date_picker_kit.error),
+  &:has(.pb_text_input_kit):has(.pb_select_kit_wrapper.error),
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
+    align-items: flex-start;
+  }
+}
+
+@mixin error-state-center-selectors {
+  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input),
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has([class^=pb_button_kit]) {
+    align-items: center;
+  }
+}
+
+@mixin error-state-flex-end-selectors {
+  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
+    align-items: flex-end;
+  }
+}
+
+@mixin error-state-left-side-select-kit {
+  &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error),
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
+    align-items: flex-start;
+
+    .pb_select_kit_wrapper,
+    .pb_select_kit_wrapper.error {
+      padding-top: $space_md;
+      margin-top: 2px;
+
+      .pb_select_kit_caret {
+        padding-top: $space_xl;
+      }
+    }
+  }
+}
+
+@mixin error-state-right-side-select-kit {
+  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
+    align-items: flex-start;
+
+    .pb_text_input_kit.error {
+      padding-top: $space_md;
+      margin-top: 2px;
+    }
+  }
+}

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -14,52 +14,29 @@
     }
   }
 
-
-  // This is handeling the misalignment of the buttons when the text input has an error and/or label
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has([class^=pb_button_kit]) {
-    align-items: center;
-  }
-
-  &:has(.pb_text_input_kit.error):has([class^=pb_button_kit]) {
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit),
+  &:has(.pb_text_input_kit):has(.pb_date_picker_kit.error),
+  &:has(.pb_text_input_kit):has(.pb_select_kit_wrapper.error),
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
     align-items: flex-start;
   }
 
-  //This is handeling when two text inputs next to each other with and without an error
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit) {
-    align-items: flex-start;
-  }
-
-  //This is handeling when a text input and a date kit next to each other with and without an error
-  &:has(.pb_text_input_kit):has(.pb_date_picker_kit.error) {
-    align-items: flex-start;
-  }
-
-  //This is handeling when a text input and select kit are next to each other with and without an error
-  &:has(.pb_text_input_kit):has(.pb_select_kit_wrapper.error) {
-    align-items: flex-start;
-  }
-
-  &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
+  &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error),
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
     position: relative;
     align-items: flex-start;
+    .pb_select_kit_wrapper,
     .pb_select_kit_wrapper.error {
       padding-top: $space_md;
       margin-top: 2px;
-      .pb_select_kit_caret{
+      .pb_select_kit_caret {
         padding-top: $space_xl;
       }
     }
   }
 
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
-    align-items: flex-end;
-  }
-
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
-    align-items: center;
-  }
-
-  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input) {
+  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input),
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has([class^=pb_button_kit]) {
     align-items: center;
   }
 

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -21,43 +21,6 @@
 @include error-state-left-side-select-kit;
 @include error-state-right-side-select-kit;
 
-  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit),
-  // &:has(.pb_text_input_kit):has(.pb_date_picker_kit.error),
-  // &:has(.pb_text_input_kit):has(.pb_select_kit_wrapper.error),
-  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
-  //   align-items: flex-start;
-  // }
-
-  // &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error),
-  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
-  //   align-items: flex-start;
-  //   .pb_select_kit_wrapper,
-  //   .pb_select_kit_wrapper.error {
-  //     padding-top: $space_md;
-  //     margin-top: 2px;
-  //     .pb_select_kit_caret {
-  //       padding-top: $space_xl;
-  //     }
-  //   }
-  // }
-
-  // &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input),
-  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has([class^=pb_button_kit]) {
-  //   align-items: center;
-  // }
-
-  // &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
-  //   align-items: flex-end;
-  // }
-
-  // &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
-  //   align-items: flex-start;
-  //   .pb_text_input_kit.error {
-  //     padding-top: $space_md;
-  //     margin-top: 2px;
-  //   }
-  // }
-
   & [class^=pb_text_input_kit] .text_input_wrapper,
   & [class^=pb_date_picker_kit] .input_wrapper,
   & [class^=pb_select] {

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -1,7 +1,7 @@
 [class^=pb_form_group_kit] {
   display: inline-flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: flex-start;
   justify-content: flex-start;
 
   &[class*=_full] {
@@ -10,6 +10,18 @@
     & > div {
       width: 100%;
     }
+  }
+
+  &:has(.pb_text_input_kit):has(.pb_text_input_kit_label){
+    align-items: flex-end;
+  }
+
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label){
+    align-items: center;
+  }
+
+  &:has(.pb_phone_number_input):has(.pb_text_input_kit.error):has(.pb_text_input_kit_label){
+    align-items: center;
   }
 
   & [class^=pb_text_input_kit] .text_input_wrapper,
@@ -27,7 +39,7 @@
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
       border-right-width: 0;
-    
+
       &:focus {
         outline: $primary solid 1px;
         outline-offset: -1px;
@@ -150,7 +162,7 @@
   & > [class^=pb_selectable_card_kit] input[type="checkbox"]:not(:checked) ~ label, [class^=pb_selectable_card_kit] input[type="radio"]:not(:checked) ~ label {
     &:hover {
       border-right-color: $slate;
-    } 
+    }
   }
 
   & > [class^=pb_selectable_card_kit]:not(:first-child) label {

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -1,4 +1,5 @@
 @import "../tokens/spacing";
+@import "./error_state_mixin";
 
 [class^=pb_form_group_kit] {
   display: inline-flex;
@@ -14,43 +15,48 @@
     }
   }
 
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit),
-  &:has(.pb_text_input_kit):has(.pb_date_picker_kit.error),
-  &:has(.pb_text_input_kit):has(.pb_select_kit_wrapper.error),
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
-    align-items: flex-start;
-  }
+@include error-state-flex-start-selectors;
+@include error-state-center-selectors;
+@include error-state-flex-end-selectors;
+@include error-state-left-side-select-kit;
+@include error-state-right-side-select-kit;
 
-  &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error),
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
-    position: relative;
-    align-items: flex-start;
-    .pb_select_kit_wrapper,
-    .pb_select_kit_wrapper.error {
-      padding-top: $space_md;
-      margin-top: 2px;
-      .pb_select_kit_caret {
-        padding-top: $space_xl;
-      }
-    }
-  }
+  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit),
+  // &:has(.pb_text_input_kit):has(.pb_date_picker_kit.error),
+  // &:has(.pb_text_input_kit):has(.pb_select_kit_wrapper.error),
+  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
+  //   align-items: flex-start;
+  // }
 
-  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input),
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has([class^=pb_button_kit]) {
-    align-items: center;
-  }
+  // &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error),
+  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
+  //   align-items: flex-start;
+  //   .pb_select_kit_wrapper,
+  //   .pb_select_kit_wrapper.error {
+  //     padding-top: $space_md;
+  //     margin-top: 2px;
+  //     .pb_select_kit_caret {
+  //       padding-top: $space_xl;
+  //     }
+  //   }
+  // }
 
-  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
-    align-items: flex-end;
-  }
+  // &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input),
+  // &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has([class^=pb_button_kit]) {
+  //   align-items: center;
+  // }
 
-  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
-    align-items: flex-start;
-    .pb_text_input_kit.error {
-      padding-top: $space_md;
-      margin-top: 2px;
-    }
-  }
+  // &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
+  //   align-items: flex-end;
+  // }
+
+  // &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
+  //   align-items: flex-start;
+  //   .pb_text_input_kit.error {
+  //     padding-top: $space_md;
+  //     margin-top: 2px;
+  //   }
+  // }
 
   & [class^=pb_text_input_kit] .text_input_wrapper,
   & [class^=pb_date_picker_kit] .input_wrapper,

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -1,7 +1,9 @@
+@import "../tokens/spacing";
+
 [class^=pb_form_group_kit] {
   display: inline-flex;
   flex-direction: row;
-  align-items: flex-start;
+  align-items: flex-end;
   justify-content: flex-start;
 
   &[class*=_full] {
@@ -12,16 +14,65 @@
     }
   }
 
-  &:has(.pb_text_input_kit):has(.pb_text_input_kit_label){
+
+  // This is handeling the misalignment of the buttons when the text input has an error and/or label
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has([class^=pb_button_kit]) {
+    align-items: center;
+  }
+
+  &:has(.pb_text_input_kit.error):has([class^=pb_button_kit]) {
+    align-items: flex-start;
+  }
+
+  //This is handeling when two text inputs next to each other with and without an error
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit) {
+    align-items: flex-start;
+  }
+
+  //This is handeling when a text input and a date kit next to each other with and without an error
+  &:has(.pb_text_input_kit):has(.pb_date_picker_kit.error) {
+    align-items: flex-start;
+  }
+
+  //This is handeling when a text input and select kit are next to each other with and without an error
+  &:has(.pb_text_input_kit):has(.pb_select_kit_wrapper.error) {
+    align-items: flex-start;
+  }
+
+  &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
+    position: relative;
+    align-items: flex-start;
+    .pb_select_kit_wrapper.error {
+      padding-top: $space_md;
+      margin-top: 2px;
+      .pb_select_kit_caret{
+        padding-top: $space_xl;
+      }
+    }
+  }
+
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error) {
     align-items: flex-end;
   }
 
-  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label){
+  &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
     align-items: center;
   }
 
-  &:has(.pb_phone_number_input):has(.pb_text_input_kit.error):has(.pb_text_input_kit_label){
+  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input) {
     align-items: center;
+  }
+
+  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper.error):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
+    align-items: flex-end;
+  }
+
+  &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper):has(.pb_phone_number_input):has(.pb_text_input_kit.error) {
+    align-items: flex-start;
+    .pb_text_input_kit.error {
+      padding-top: $space_md;
+      margin-top: 2px;
+    }
   }
 
   & [class^=pb_text_input_kit] .text_input_wrapper,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fixes the alignments of the form group items when there are validation errors being displayed on the kit and when a label is used in some of the form group kits. 

[PLAY-1703](https://runway.powerhrg.com/backlog_items/PLAY-1703)

**Screenshots:** Screenshots to visualize your addition/change

<img width="1235" alt="Screenshot 2024-12-11 at 10 19 36 AM" src="https://github.com/user-attachments/assets/fff6b296-0c11-4f08-bd98-ce42eb44ea4e" />

<img width="1235" alt="Screenshot 2024-12-11 at 10 19 54 AM" src="https://github.com/user-attachments/assets/fe1a0bb8-c9dc-4a29-9cdf-214a2a077292" />

<img width="1230" alt="Screenshot 2024-12-11 at 10 20 52 AM" src="https://github.com/user-attachments/assets/b7516d70-4368-40d3-9328-52c020c0b72a" />


**How to test?** Steps to confirm the desired behavior:
1. Go to 'kits/form_group 
2. Scroll down to the phone number kit
3. Click into the kit and then click out, should see validation error message in red around the kit
4. The form group should still be aligned with and without the error. 
5. Should work for both React and Rails


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.