### PR TITLE
[PLAY-1500] Home Address Street: "none" Emphasis Prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
@@ -131,12 +131,15 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
       }
       {emphasis == 'none' &&
         <div>
-          <Body>
+          <Body dark={dark}>
             {joinPresent([titleize(address), houseStyle], ' · ')}
           </Body>
-          <Body>{titleize(addressCont)}</Body>
+          <Body dark={dark}>{titleize(addressCont)}</Body>
           <div>
-            <Body color="light">
+            <Body
+                color="light"
+                dark={dark}
+              >
             {`${titleize(city)}, ${state} ${zipcode}`}
           </Body>
           </div>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
@@ -18,7 +18,7 @@ type HomeAddressStreetProps = {
   className?: string,
   data?: { [key: string]: string },
   dark?: boolean,
-  emphasis: "street" | "city",
+  emphasis: "street" | "city" | "none",
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   homeId: string,
   houseStyle: string,
@@ -126,6 +126,19 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
             >
               {` ${zipcode}`}
             </Body>
+          </div>
+        </div>
+      }
+      {emphasis == 'none' &&
+        <div>
+          <Body>
+            {joinPresent([titleize(address), houseStyle], ' · ')}
+          </Body>
+          <Body>{titleize(addressCont)}</Body>
+          <div>
+            <Body color="light">
+            {`${titleize(city)}, ${state} ${zipcode}`}
+          </Body>
           </div>
         </div>
       }

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.html.erb
@@ -25,3 +25,19 @@
   zipcode: "19382",
   territory: "PHL",
 }) %>
+
+<br>
+<br>
+
+<%= pb_rails("home_address_street", props: {
+  address: "70 Prospect Ave",
+  address_cont: "Apt M18",
+  city: "West Chester",
+  emphasis: "none",
+  home_id: 8250263,
+  home_url: "https://powerhrg.com/",
+  house_style: "Colonial",
+  state: "PA",
+  zipcode: "19382",
+  territory: "PHL",
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.jsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.jsx
@@ -32,6 +32,21 @@ const HomeAddressStreetEmphasis = (props) => {
           zipcode="19382"
           {...props}
       />
+      <br />
+      <br />
+      <HomeAddressStreet
+          address="70 Prospect Ave"
+          addressCont="Apt M18"
+          city="West Chester"
+          emphasis="none"
+          homeId="8250263"
+          homeUrl="https://powerhrg.com/"
+          houseStyle="Colonial"
+          state="PA"
+          territory="PHL"
+          zipcode="19382"
+          {...props}
+      />
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.md
@@ -1,3 +1,3 @@
 Emphasis on street happens by default. (no prop needed)
 Emphasis on "city" makes the city emphasized, rather than the street.
-Adding "none" prop to kit will provide no emphasis.
+Adding "none" to emphasis prop will provide no emphasis.

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_emphasis.md
@@ -1,2 +1,3 @@
 Emphasis on street happens by default. (no prop needed)
 Emphasis on "city" makes the city emphasized, rather than the street.
+Adding "none" prop to kit will provide no emphasis.

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -7,7 +7,7 @@ module Playbook
       prop :address_cont
       prop :city
       prop :emphasis, type: Playbook::Props::Enum,
-                      values: %w[street city],
+                      values: %w[street city none],
                       default: "street"
       prop :home_id, type: Playbook::Props::Number
       prop :home_url
@@ -64,6 +64,20 @@ module Playbook
       end
 
       def street_emphasis_props
+        {
+          address_house_style: address_house_style,
+          address_house_style2: address_house_style2,
+          city_state_zip: city_state_zip,
+          dark: dark,
+          home_id: home_id,
+          home_url: home_url,
+          target: target_option,
+          new_window: new_window,
+          territory: territory,
+        }
+      end
+
+      def none_emphasis_props
         {
           address_house_style: address_house_style,
           address_house_style2: address_house_style2,

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/none_emphasis.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/none_emphasis.html.erb
@@ -1,0 +1,32 @@
+<%= pb_rails "body", props: {
+  classname: "pb_home_address_street_address",
+  size: 4,
+  text: object.address_house_style,
+  dark: object.dark
+} %>
+<%= pb_rails "body", props: {
+  classname: "pb_home_address_street_address",
+  size: 4,
+  text: object.address_house_style2,
+  dark: object.dark
+} %>
+<%= pb_rails "body", props: {
+  color: "light",
+  text: object.city_state_zip,
+  dark: object.dark
+} %>
+
+<% if object.home_id %>
+  <%= pb_rails("hashtag", props: {
+    text: "#{object.home_id}",
+    url: object.home_url || "#",
+    type: "home",
+    dark: object.dark,
+    classname: "home-hashtag",
+    new_window: object.new_window,
+    target: object.target_option}) %>
+<% end %>
+
+<%= pb_rails "body", props: { color: "light", tag: "span", dark: object.dark } do %>
+  <small><%= object.territory %></small>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/none_emphasis.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/none_emphasis.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbHomeAddressStreet
+    class NoneEmphasis < Playbook::KitBase
+      prop :address_house_style
+      prop :address_house_style2
+      prop :city_state_zip
+      prop :home_id, type: Playbook::Props::Number
+      prop :home_url
+      prop :new_window, type: Playbook::Props::Boolean,
+                        default: false
+      prop :target
+      prop :territory
+      prop :dark, type: Playbook::Props::Boolean,
+                  default: false
+
+      def target_option
+        if target && home_url
+          target
+        elsif new_window
+          "_blank"
+        else
+          "_self"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Added a "none" option to emphasis prop in Home Address Kit so there can be an emphasized version of the kit. 

[PLAY-1500](https://runway.powerhrg.com/backlog_items/PLAY-1500)

**Screenshots:** Screenshots to visualize your addition/change

<img width="1305" alt="Screenshot 2024-12-12 at 1 13 49 PM" src="https://github.com/user-attachments/assets/f7d4503e-b5d8-45c9-b97a-97e57c2a2a89" />

**How to test?** Steps to confirm the desired behavior:
1. kits/home_address_street/
2. Scroll down to emphasis example
3. See new none emphasis example with documentation underneath 
4. Check both react and rails. 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.