### PR TITLE
[PLAY-1539] Playbook Website Redirects - Go to Parent not Home

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -106,7 +106,10 @@ const VisualGuidelines = ({
         return <Truncate example={examples.truncate_jsx} />
 
       default:
-        return <Colors/>;
+        if (window.location.pathname !== "/visual_guidelines/colors") {
+          window.history.pushState(null, "", "/visual_guidelines/colors");
+        }
+        return <Colors />;
     }
   }
   return <div className="visual_guidelines_individual">{getComponent(result)}</div>;

--- a/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/index.tsx
@@ -107,7 +107,7 @@ const VisualGuidelines = ({
 
       default:
         if (window.location.pathname !== "/visual_guidelines/colors") {
-          window.history.pushState(null, "", "/visual_guidelines/colors");
+          window.history.replaceState(null, "", "/visual_guidelines/colors");
         }
         return <Colors />;
     }

--- a/playbook-website/config/routes.rb
+++ b/playbook-website/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   get "changelog/figma",          to: "pages#changelog_figma"
   get "changelog",                to: redirect("changelog/web")
 
+  get "changelog/*path", to: redirect("changelog/web")
+
   # Kits
 
   ## Beta View


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This fixes the redirection of none sense urls to the parent page if there is one otherwise, it sends the user home. 

[PLAY-1539](https://runway.powerhrg.com/backlog_items/PLAY-1539)


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to links listed on Story card
2. Should see appropriate redirects


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.