### PR TITLE
[PLAY-1678] Dark Mode Audit - Gauge

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
@@ -33,20 +33,5 @@
     .pb_caption_kit_xs {
         color: $text_dk_light;
     }
-    .fix {
-      fill: orange;
-      stroke: none;
-      font: $regular $font_larger $font_family_base;
-    }
-    .suffix {
-      fill: orange;
-      stroke: none;
-      font: $regular $font_larger $font_family_base;
-    }
-    .prefix {
-      fill: orange;
-      stroke: none;
-      font: $regular $font_base $font_family_base;
-    }
-}
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
@@ -6,16 +6,29 @@
     fill: $text_lt_light;
     stroke: none;
     font: $regular $font_larger $font_family_base;
+
+    &[class*=dark] {
+      fill: $text_dk_light;
+    }
   }
+
   .suffix {
     fill: $text_lt_light;
     stroke: none;
     font: $regular $font_larger $font_family_base;
+
+    &[class*=dark] {
+      fill: $text_dk_light;
+    }
   }
   .prefix {
     fill: $text_lt_light;
     stroke: none;
     font: $regular $font_base $font_family_base;
+
+    &[class*=dark] {
+      fill: $text_dk_light;
+    }
   }
 
   rect.highcharts-background {

--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
@@ -1,11 +1,20 @@
+@import "../tokens/colors";
+
 [class^=pb_gauge_kit] {
 
+  .fix {
+    fill: $text_lt_light;
+    stroke: none;
+    font: $regular $font_larger $font_family_base;
+  }
   .suffix {
     fill: $text_lt_light;
+    stroke: none;
     font: $regular $font_larger $font_family_base;
   }
   .prefix {
     fill: $text_lt_light;
+    stroke: none;
     font: $regular $font_base $font_family_base;
   }
 
@@ -16,4 +25,28 @@
   .gauge-pane {
     stroke-linejoin: round;
   }
+
+  &[class*=dark] {
+    color: $text_dk_light;
+
+    .pb_title_kit_size_1,
+    .pb_caption_kit_xs {
+        color: $text_dk_light;
+    }
+    .fix {
+      fill: orange;
+      stroke: none;
+      font: $regular $font_larger $font_family_base;
+    }
+    .suffix {
+      fill: orange;
+      stroke: none;
+      font: $regular $font_larger $font_family_base;
+    }
+    .prefix {
+      fill: orange;
+      stroke: none;
+      font: $regular $font_base $font_family_base;
+    }
+}
 }

--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
@@ -7,7 +7,7 @@
     stroke: none;
 
     &[class*=dark] {
-      fill: $text_dk_light;
+      fill: $text_dk_default;
     }
   }
 
@@ -39,7 +39,7 @@
   }
 
   &[class*=dark] {
-    color: $text_dk_light;
+    color: $text_dk_default;
 
     .pb_title_kit_size_1,
     .pb_caption_kit_xs {

--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
@@ -5,7 +5,6 @@
   .fix {
     fill: $text_lt_default;
     stroke: none;
-    font: $regular $font_larger $font_family_base;
 
     &[class*=dark] {
       fill: $text_dk_light;

--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.scss
@@ -3,7 +3,7 @@
 [class^=pb_gauge_kit] {
 
   .fix {
-    fill: $text_lt_light;
+    fill: $text_lt_default;
     stroke: none;
     font: $regular $font_larger $font_family_base;
 

--- a/playbook/app/pb_kits/playbook/pb_gauge/_gauge.tsx
+++ b/playbook/app/pb_kits/playbook/pb_gauge/_gauge.tsx
@@ -164,9 +164,9 @@ const Gauge = ({
             color: defaultColors.text_lt_default,
             enabled: true,
             format:
-              `<span class="prefix">${prefix}</span>` +
-              '<span class="fix">{y:,f}</span>' +
-              `<span class="suffix">${suffix}</span>`,
+              `<span class="prefix${dark ? " dark" : ""}">${prefix}</span>` +
+              `<span class="fix${dark ? " dark" : ""}">{y:,f}</span>` +
+              `<span class="suffix${dark ? " dark" : ""}">${suffix}</span>`,
             style: {
               fontFamily: typography.font_family_base,
               fontWeight: typography.regular,

--- a/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_complex.jsx
+++ b/playbook/app/pb_kits/playbook/pb_gauge/docs/_gauge_complex.jsx
@@ -17,47 +17,60 @@ const GaugeComplex = (props) => (
       gap="sm"
       padding="xl"
       wrap
+      {...props}
   >
     <FlexItem
         flex={1}
         grow
+        {...props}
     >
       <Card
           maxWidth="xs"
           padding="md"
+          {...props}
       >
         <Title
             paddingBottom="sm"
             size={4}
             text="Abandoned Calls"
+            {...props}
         />
-        <Flex align="stretch">
+        <Flex
+            align="stretch"
+            {...props}
+        >
           <Flex
               marginRight="sm"
               orientation="column"
+              {...props}
           >
             <Body
                 color="light"
                 paddingBottom="sm"
                 text="Total Abandoned"
+                {...props}
             />
             <Flex
                 align="baseline"
                 paddingBottom="xs"
+                {...props}
             >
               <Title
                   size={1}
                   text="39"
+                  {...props}
               />
               <Title
                   color="light"
                   size={3}
                   text="calls"
+                  {...props}
               />
             </Flex>
             <Caption
                 size="xs"
                 text="of 390"
+                {...props}
             />
           </Flex>
 
@@ -65,22 +78,29 @@ const GaugeComplex = (props) => (
               alignSelf="stretch"
               marginRight="sm"
               orientation="vertical"
+              {...props}
           />
 
           <Flex
               orientation="column"
               wrap
+              {...props}
           >
               <Body
                   color="light"
                   text="% Abandoned"
-               />
-            <Flex wrap>
+                  {...props}
+              />
+            <Flex
+                wrap
+                {...props}
+            >
               <FlexItem
                   fixedSize="150px"
                   overflow="hidden"
                   shrink
-              > 
+                  {...props}
+              >
                 <Gauge
                     chartData={data}
                     disableAnimation
@@ -90,7 +110,7 @@ const GaugeComplex = (props) => (
                     {...props}
                 />
                </FlexItem>
-            </Flex>  
+            </Flex>
           </Flex>
         </Flex>
       </Card>


### PR DESCRIPTION
**What does this PR do?**

Updates Darkmode styling for the Gauge component

![Screenshot 2024-12-18 at 10 56 17 AM](https://github.com/user-attachments/assets/c12fdd7f-c397-41e1-a3e2-475e0ac12d48)
![Screenshot 2024-12-18 at 10 55 28 AM](https://github.com/user-attachments/assets/f505021d-9e79-4fe8-b0e1-93056b5977de)


**How to test?** 
1. Go to 'kits/gauge/react/#complex'
2. Observe improved darkmode styling


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.