### PR TITLE
[PLAY-1708] Skip RC process with 'Inactive RC' label

### DIFF
--- a/.github/workflows/github-actions-release-candidate.yml
+++ b/.github/workflows/github-actions-release-candidate.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
           if echo "$LABELS" | grep -iq "Inactive RC"; then
-            echo "⛔ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
             exit 0  # Exit the job early, skipping the rest of the workflow
           fi
 

--- a/.github/workflows/github-actions-release-candidate.yml
+++ b/.github/workflows/github-actions-release-candidate.yml
@@ -37,31 +37,6 @@ jobs:
         run: |
           git config --local user.name "${{ github.actor }}"
           git config --local user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Check for "Inactive RC" label
-        id: check-inactive-rc
-        run: |
-          PR_NUMBER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-            | jq '.[0].number')
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-          
-          if [ ! -z "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
-            echo "✅ Successfully found PR number: $PR_NUMBER"
-          else
-            echo "❌ Unable to find PR number"
-            exit 1
-          fi
-
-          echo "Fetching labels for PR #$PR_NUMBER..."
-          LABELS=$(gh pr view $PR_NUMBER --json labels -q '.labels[].name' || echo "Failed to fetch labels")
-          echo "Found labels: $LABELS"
-
-          if echo "$LABELS" | grep -iq "Inactive RC"; then
-            echo "⛔ PR has the 'Inactive RC' label. Skipping the release candidate process."
-            exit 0 
-          fi
-
       - name: Get Semver Label
         id: get-label
         run: |

--- a/.github/workflows/github-actions-release-candidate.yml
+++ b/.github/workflows/github-actions-release-candidate.yml
@@ -37,6 +37,31 @@ jobs:
         run: |
           git config --local user.name "${{ github.actor }}"
           git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Check for "Inactive RC" label
+        id: check-inactive-rc
+        run: |
+          PR_NUMBER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            | jq '.[0].number')
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          
+          if [ ! -z "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            echo "✅ Successfully found PR number: $PR_NUMBER"
+          else
+            echo "❌ Unable to find PR number"
+            exit 1
+          fi
+
+          echo "Fetching labels for PR #$PR_NUMBER..."
+          LABELS=$(gh pr view $PR_NUMBER --json labels -q '.labels[].name' || echo "Failed to fetch labels")
+          echo "Found labels: $LABELS"
+
+          if echo "$LABELS" | grep -iq "Inactive RC"; then
+            echo "⛔ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0 
+          fi
+
       - name: Get Semver Label
         id: get-label
         run: |
@@ -58,6 +83,11 @@ jobs:
           if [ -z "$LABELS" ]; then
             echo "⛔ Error: Failed to fetch PR labels"
             exit 1
+          fi
+
+          if echo "$LABELS" | grep -iq "Inactive RC"; then
+            echo "⛔ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0  # Exit the job early, skipping the rest of the workflow
           fi
 
           SEMVER_LABEL=$(echo "$LABELS" | grep -iE '^(major|minor|patch)$' || true)


### PR DESCRIPTION
**What does this PR do?**
Skip RC process with 'Inactive RC' label.

**How to test?** Steps to confirm the desired behavior:
After this is merged, RCs should work as normal. 
This PR has the 'Inactive RC' label, so an RC should not be generated.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.