### PR TITLE
[PLAY-1700] Bug - Remove Default Padding in Section Separator When Children are Passed

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.scss
@@ -19,8 +19,11 @@ $section_colors_dark: (
   align-items: center;
   position: relative;
   span {
-    padding: 0 $space_xs;
+    padding: 0;
     display: flex;
+    [class*="pb_caption_kit"] {
+      padding: 0 $space_xs;
+    }
   }
   &::before {
     content: "";


### PR DESCRIPTION
**What does this PR do?** 
Removes the default padding for all children in the section separator, except for the caption kit. 


**Screenshots:**

Before Change:
![Screenshot 2024-12-18 at 3 33 41 PM](https://github.com/user-attachments/assets/90328cf9-9cae-4766-9791-e13c2e792814)

After Change:
![Screenshot 2024-12-18 at 3 34 27 PM](https://github.com/user-attachments/assets/87558032-44c0-4374-b70a-43eb7a4386ef)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.