### PR TITLE
[PLAY-1614] Icon Circle Size Bug Fix

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
@@ -57,13 +57,11 @@ $pb_icon_circle_sizes: (
       border-radius: $size/2;
       background: $silver;
       color: $text_lt_light;
-      font-size: $size * 0.38;
+      font-size: if($name == "xxs", $size - 6px, $size * 0.38);
       line-height: $size;
       flex-shrink: 0;
       flex-grow: 0;
       flex-basis: $size;
-
-      @include svg_size($name, "xxs", $size - 6px);
     }
   }
 

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
@@ -14,16 +14,6 @@ $pb_icon_circle_sizes: (
   "xl":   100px,
 );
 
-@mixin svg_size($name, $match, $adjust) {
-  @if $name == $match {
-    $svg_xy: $adjust;
-    & > svg {
-      width: #{$svg_xy};
-      height: #{$svg_xy};
-    }
-  }
-}
-
 [class^=pb_icon_circle_kit] {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR address sizing of the icon on the xxs variant for the icon circle kit. Adjusted icon to match desired 10px size set by design standards.

[Story 1614](https://runway.powerhrg.com/backlog_items/PLAY-1614)


**Screenshots:** Screenshots to visualize your addition/change
Before:
![Screenshot 2024-12-20 at 3 26 44 PM](https://github.com/user-attachments/assets/76cc0831-4aa8-4f6c-b8a6-f9f7f9160fff)

After:
![Screenshot 2024-12-20 at 3 27 27 PM](https://github.com/user-attachments/assets/f5be7ade-df99-4370-bd37-45dddab57eef)

**How to test?** Steps to confirm the desired behavior:
1. kits/icon_circle/react
2. Scroll down to size varients
3. Observe that xxs icon is not 10px
4. See both React and Rails Kit


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.