### PR TITLE
[PLAY-1465] Fix Linting Errors - Typeahead Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -4,7 +4,7 @@ import AsyncSelect from 'react-select/async'
 import CreateableSelect from 'react-select/creatable'
 import AsyncCreateableSelect from 'react-select/async-creatable'
 import { get, isString, uniqueId } from 'lodash'
-import { globalProps, GlobalProps } from '../utilities/globalProps'
+import { globalProps } from '../utilities/globalProps'
 import classnames from 'classnames'
 
 import {
@@ -42,18 +42,15 @@ type TypeaheadProps = {
   id?: string,
   label?: string,
   loadOptions?: string | Noop,
-  getOptionLabel?: string | (() => any),
-  getOptionValue?: string | (() => any),
+  getOptionLabel?: string | (() => string),
+  getOptionValue?: string | (() => string),
   name?: string,
-  marginBottom?: "none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl",
-  pillColor?: "primary" | "neutral" | "success" | "warning" | "error" | "info" | "data_1" | "data_2" | "data_3" | "data_4" | "data_5" | "data_6" | "data_7" | "data_8" | "windows" | "siding" | "roofing" | "doors" | "gutters" | "solar" | "insulation" | "accessories",
-} & GlobalProps
+}
 
 export type SelectValueType = {
   label: string,
   value: string,
   imageUrl?: string,
-  pillColor?: string,
 }
 
 type TagOnChangeValues = {
@@ -79,10 +76,8 @@ const Typeahead = ({
   htmlOptions = {},
   id,
   loadOptions = noop,
-  marginBottom = "sm",
-  pillColor,
   ...props
-}: TypeaheadProps) => {
+}: TypeaheadProps): React.ReactElement => {
   const selectProps = {
     cacheOptions: true,
     components: {
@@ -109,8 +104,8 @@ const Typeahead = ({
     multiKit: '',
     onCreateOption: null as null,
     plusIcon: false,
-    onMultiValueClick: (_option: SelectValueType): any => undefined,
-    pillColor: pillColor,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onMultiValueClick: (_option: SelectValueType): void => undefined,
     ...props,
   }
 
@@ -136,15 +131,11 @@ const Typeahead = ({
     }
   }
 
-  const filteredProps: TypeaheadProps = {...props}
-  delete filteredProps.truncate
-
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
   const classes = classnames(
     'pb_typeahead_kit react-select',
-    `mb_${marginBottom}`,
-    globalProps(filteredProps),
+    globalProps(props),
     className
   )
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
@@ -1,10 +1,19 @@
 import React, { useEffect } from 'react'
 import { components } from 'react-select'
 
-const ClearContainer = (props: any): JSX.Element => {
+type ClearContainerProps = {
+  children: React.ReactNode,
+  selectProps?: {
+    id: string,
+  },
+  clearValue: () => void,
+}
+
+const ClearContainer = (props: ClearContainerProps): React.ReactElement => {
   const { selectProps, clearValue } = props
   useEffect(() => {
-    document.addEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, clearValue)})
+    document.addEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, clearValue)
+  }, [clearValue, selectProps.id])
 
   return (
     <components.ClearIndicator

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
@@ -1,13 +1,10 @@
 import React, { useEffect } from 'react'
 import { components } from 'react-select'
 
-import { ClearIndicatorProps } from 'react-select'
-
-const ClearContainer = (props: ClearIndicatorProps<unknown>): JSX.Element => {
+const ClearContainer = (props: any): JSX.Element => {
   const { selectProps, clearValue } = props
   useEffect(() => {
-    document.addEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, clearValue)
-  })
+    document.addEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, clearValue)})
 
   return (
     <components.ClearIndicator

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
@@ -9,8 +9,8 @@ const ClearContainer = (props: any) => {
 
   return (
     <components.ClearIndicator
-      className="clear_indicator"
-      {...props}
+        className="clear_indicator"
+        {...props}
     />
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ClearIndicator.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect } from 'react'
 import { components } from 'react-select'
 
-const ClearContainer = (props: any) => {
+import { ClearIndicatorProps } from 'react-select'
+
+const ClearContainer = (props: ClearIndicatorProps<unknown>): JSX.Element => {
   const { selectProps, clearValue } = props
   useEffect(() => {
     document.addEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, clearValue)
-  }, [true])
+  })
 
   return (
     <components.ClearIndicator

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Control.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Control.tsx
@@ -1,14 +1,17 @@
-import React from 'react'
-import { components } from 'react-select'
+import React from 'react';
+import { components, ControlProps, GroupBase } from 'react-select';
+import Flex from '../../pb_flex/_flex';
+import TextInput from '../../pb_text_input/_text_input';
 
-import Flex from '../../pb_flex/_flex'
-import TextInput from '../../pb_text_input/_text_input'
+type Props = ControlProps<unknown, boolean, GroupBase<unknown>> & {
+  selectProps: {
+    dark: boolean;
+    error: boolean;
+    label: string;
+  };
+};
 
-type Props = {
-  selectProps: any,
-}
-
-const TypeaheadControl = (props: Props) => (
+const TypeaheadControl = (props: Props): JSX.Element => (
   <div className="pb_typeahead_wrapper">
     <TextInput
         dark={props.selectProps.dark}
@@ -17,13 +20,15 @@ const TypeaheadControl = (props: Props) => (
         marginBottom="none"
     >
       <Flex>
-        <components.Control
+        <components.Control<unknown, boolean, GroupBase<unknown>>
             className="text_input"
             {...props}
-        />
+        >
+          {props.children}
+        </components.Control>
       </Flex>
     </TextInput>
   </div>
-)
+);
 
-export default TypeaheadControl
+export default TypeaheadControl;

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Control.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Control.tsx
@@ -1,15 +1,12 @@
-import React from 'react';
-import { components, ControlProps, GroupBase } from 'react-select';
-import Flex from '../../pb_flex/_flex';
-import TextInput from '../../pb_text_input/_text_input';
+import React from 'react'
+import { components } from 'react-select'
 
-type Props = ControlProps<unknown, boolean, GroupBase<unknown>> & {
-  selectProps: {
-    dark: boolean;
-    error: boolean;
-    label: string;
-  };
-};
+import Flex from '../../pb_flex/_flex'
+import TextInput from '../../pb_text_input/_text_input'
+
+type Props = {
+  selectProps: any,
+}
 
 const TypeaheadControl = (props: Props): JSX.Element => (
   <div className="pb_typeahead_wrapper">
@@ -20,15 +17,13 @@ const TypeaheadControl = (props: Props): JSX.Element => (
         marginBottom="none"
     >
       <Flex>
-        <components.Control<unknown, boolean, GroupBase<unknown>>
+        <components.Control
             className="text_input"
             {...props}
-        >
-          {props.children}
-        </components.Control>
+        />
       </Flex>
     </TextInput>
   </div>
-);
+)
 
-export default TypeaheadControl;
+export default TypeaheadControl

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Control.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Control.tsx
@@ -5,16 +5,19 @@ import Flex from '../../pb_flex/_flex'
 import TextInput from '../../pb_text_input/_text_input'
 
 type Props = {
-  selectProps: any,
+  selectProps: {
+    dark?: boolean,
+    label: string,
+    error?: string,
+  },
 }
 
-const TypeaheadControl = (props: Props): JSX.Element => (
+const TypeaheadControl = (props: Props): React.ReactElement => (
   <div className="pb_typeahead_wrapper">
     <TextInput
         dark={props.selectProps.dark}
         error={props.selectProps.error}
         label={props.selectProps.label}
-        marginBottom="none"
     >
       <Flex>
         <components.Control

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { components } from 'react-select'
 
-import { IndicatorsContainerProps } from 'react-select'
-
-const IndicatorsContainer = (props: IndicatorsContainerProps<unknown>): JSX.Element => (
+const IndicatorsContainer = (props: any): JSX.Element => (
   <components.IndicatorsContainer
       className="text_input_indicators"
       {...props}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
@@ -3,8 +3,8 @@ import { components } from 'react-select'
 
 const IndicatorsContainer = (props: any) => (
   <components.IndicatorsContainer
-    className="text_input_indicators"
-    {...props}
+      className="text_input_indicators"
+      {...props}
   />
 )
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { components } from 'react-select'
 
-const IndicatorsContainer = (props: any): JSX.Element => (
+type IndicatorsContainerProps = {
+  children: React.ReactNode,
+}
+
+
+const IndicatorsContainer = (props: IndicatorsContainerProps): React.ReactElement => (
   <components.IndicatorsContainer
       className="text_input_indicators"
       {...props}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { components } from 'react-select'
 
-const IndicatorsContainer = (props: any) => (
+import { IndicatorsContainerProps } from 'react-select'
+
+const IndicatorsContainer = (props: IndicatorsContainerProps<unknown>): JSX.Element => (
   <components.IndicatorsContainer
       className="text_input_indicators"
       {...props}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/MenuList.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/MenuList.tsx
@@ -1,14 +1,7 @@
 import React from 'react'
 import { components } from 'react-select'
 
-import { MenuListProps, GroupBase } from 'react-select'
-
-
-interface ExtendedMenuListProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> extends MenuListProps<Option, IsMulti, Group> {
-  footer?: JSX.Element;
-}
-
-const MenuList = (props: ExtendedMenuListProps<unknown, boolean, GroupBase<unknown>>): JSX.Element => {
+const MenuList = (props: any): JSX.Element => {
   return (
   <components.MenuList {...props}>
     {props.children}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/MenuList.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/MenuList.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import { components } from 'react-select'
 
-const MenuList = (props: any) => {
+import { MenuListProps, GroupBase } from 'react-select'
+
+
+interface ExtendedMenuListProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> extends MenuListProps<Option, IsMulti, Group> {
+  footer?: JSX.Element;
+}
+
+const MenuList = (props: ExtendedMenuListProps<unknown, boolean, GroupBase<unknown>>): JSX.Element => {
   return (
   <components.MenuList {...props}>
     {props.children}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/MenuList.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/MenuList.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { components } from 'react-select'
 
-const MenuList = (props: any): JSX.Element => {
+type MenuListProps = {
+  children: React.ReactNode,
+  footer: React.ReactNode,
+}
+
+const MenuList = (props: MenuListProps): React.ReactElement => {
   return (
   <components.MenuList {...props}>
     {props.children}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.tsx
@@ -7,26 +7,25 @@ import { SelectValueType } from '../_typeahead'
 
 type Props = {
   data: SelectValueType,
-  multiValueTemplate: React.ReactNode,
-  pillColor?: "primary" | "neutral" | "success" | "warning" | "error" | "info" | "data_1" | "data_2" | "data_3" | "data_4" | "data_5" | "data_6" | "data_7" | "data_8" | "windows" | "siding" | "roofing" | "doors" | "gutters" | "solar" | "insulation" | "accessories",
-  removeProps: {
-    onClick: () => void,
-    onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void,
-    onTouchEnd: (event: React.TouchEvent<HTMLDivElement>) => void,
+  removeProps?: {
+    onClick?: React.MouseEventHandler<HTMLSpanElement>,
+    onMouseDown?: React.MouseEventHandler<HTMLSpanElement>,
+    onTouchEnd?: React.TouchEventHandler<HTMLSpanElement>,
   },
-  selectProps: any,
+  selectProps: {
+    multiKit?: string,
+  },
 }
 
-const MultiValue = (props: Props): JSX.Element => {
+const MultiValue = (props: Props): React.ReactElement => {
   const { removeProps } = props
   const { imageUrl, label } = props.data
-  const { dark, multiKit, pillColor, truncate } = props.selectProps
+  const { multiKit } = props.selectProps
 
   const formPillProps = {
     marginRight: 'xs',
     name: label,
     avatarUrl: '',
-    dark,
   }
 
   if (typeof imageUrl === 'string') formPillProps.avatarUrl = imageUrl
@@ -49,28 +48,20 @@ const MultiValue = (props: Props): JSX.Element => {
         <FormPill
             avatarUrl={imageUrl}
             closeProps={removeProps}
-            color={pillColor}
-            dark={dark}
             marginRight="xs"
             name={label}
             size={multiKit === 'smallPill' ? 'small' : ''}
             text=''
-            truncate={truncate}
-            {...props}
         />
       }
 
       {multiKit !== 'badge' && !imageUrl &&
         <FormPill
             closeProps={removeProps}
-            color={pillColor}
-            dark={dark}
             marginRight="xs"
             name=''
             size={multiKit === 'smallPill' ? 'small' : ''}
             text={label}
-            truncate={truncate}
-            {...props}
         />
       }
     </components.MultiValueContainer>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/MultiValue.tsx
@@ -7,13 +7,17 @@ import { SelectValueType } from '../_typeahead'
 
 type Props = {
   data: SelectValueType,
-  multiValueTemplate: any,
+  multiValueTemplate: React.ReactNode,
   pillColor?: "primary" | "neutral" | "success" | "warning" | "error" | "info" | "data_1" | "data_2" | "data_3" | "data_4" | "data_5" | "data_6" | "data_7" | "data_8" | "windows" | "siding" | "roofing" | "doors" | "gutters" | "solar" | "insulation" | "accessories",
-  removeProps: any,
+  removeProps: {
+    onClick: () => void,
+    onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void,
+    onTouchEnd: (event: React.TouchEvent<HTMLDivElement>) => void,
+  },
   selectProps: any,
 }
 
-const MultiValue = (props: Props) => {
+const MultiValue = (props: Props): JSX.Element => {
   const { removeProps } = props
   const { imageUrl, label } = props.data
   const { dark, multiKit, pillColor, truncate } = props.selectProps

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
@@ -3,7 +3,22 @@ import { components } from 'react-select'
 
 import User from '../../pb_user/_user'
 
-const Option = (props: any): JSX.Element => {
+type OptionProps = {
+  children: React.ReactNode,
+  label?: string,
+  data: {
+    imageUrl?: string,
+  },
+  selectProps: {
+    dark?: boolean,
+    valueComponent?: (data: {
+      imageUrl?: string,
+    }) => React.ReactNode,
+  },
+}
+
+
+const Option = (props: OptionProps): React.ReactElement => {
   const {
     imageUrl,
   } = props.data

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
@@ -3,20 +3,7 @@ import { components } from 'react-select'
 
 import User from '../../pb_user/_user'
 
-import { OptionProps, GroupBase } from 'react-select'
-import SelectProps from 'react-select'
-
-interface OptionData {
-  imageUrl?: string;
-  label: string;
-  dark?: boolean;
-}
-
-interface CustomSelectProps extends SelectProps {
-  valueComponent?: (data: OptionData) => JSX.Element;
-}
-
-const Option = (props: OptionProps<OptionData, boolean, GroupBase<OptionData>> & { selectProps: CustomSelectProps }): JSX.Element => {
+const Option = (props: any): JSX.Element => {
   const {
     imageUrl,
   } = props.data
@@ -29,7 +16,7 @@ const Option = (props: OptionProps<OptionData, boolean, GroupBase<OptionData>> &
           <User
               align="left"
               avatarUrl={imageUrl}
-              dark={props.data.dark}
+              dark={props.selectProps.dark}
               name={props.label}
               orientation="horizontal"
           />

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
@@ -14,11 +14,11 @@ const Option = (props: any) => {
       <>
         {!valueComponent && imageUrl &&
           <User
-            align="left"
-            avatarUrl={imageUrl}
-            dark={props.selectProps.dark}
-            name={props.label}
-            orientation="horizontal"
+              align="left"
+              avatarUrl={imageUrl}
+              dark={props.selectProps.dark}
+              name={props.label}
+              orientation="horizontal"
           />
         }
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Option.tsx
@@ -3,7 +3,20 @@ import { components } from 'react-select'
 
 import User from '../../pb_user/_user'
 
-const Option = (props: any) => {
+import { OptionProps, GroupBase } from 'react-select'
+import SelectProps from 'react-select'
+
+interface OptionData {
+  imageUrl?: string;
+  label: string;
+  dark?: boolean;
+}
+
+interface CustomSelectProps extends SelectProps {
+  valueComponent?: (data: OptionData) => JSX.Element;
+}
+
+const Option = (props: OptionProps<OptionData, boolean, GroupBase<OptionData>> & { selectProps: CustomSelectProps }): JSX.Element => {
   const {
     imageUrl,
   } = props.data
@@ -16,7 +29,7 @@ const Option = (props: any) => {
           <User
               align="left"
               avatarUrl={imageUrl}
-              dark={props.selectProps.dark}
+              dark={props.data.dark}
               name={props.label}
               orientation="horizontal"
           />

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
@@ -4,7 +4,14 @@ import { components } from 'react-select'
 import Flex from '../../pb_flex/_flex'
 import Icon from '../../pb_icon/_icon'
 
-const Placeholder = (props: any): JSX.Element => (
+type PlaceholderProps = {
+  children: React.ReactNode,
+  selectProps: {
+    plusIcon?: boolean,
+  },
+}
+
+const Placeholder = (props: PlaceholderProps): React.ReactElement => (
   <>
     <Flex
         align="center"

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
@@ -1,18 +1,10 @@
 import React from 'react'
-import { components, PlaceholderProps as ReactSelectPlaceholderProps } from 'react-select'
+import { components } from 'react-select'
 
 import Flex from '../../pb_flex/_flex'
 import Icon from '../../pb_icon/_icon'
 
-interface CustomSelectProps {
-  plusIcon?: boolean;
-}
-
-type PlaceholderProps = ReactSelectPlaceholderProps & {
-  selectProps: ReactSelectPlaceholderProps['selectProps'] & CustomSelectProps;
-};
-
-const Placeholder = (props: PlaceholderProps): JSX.Element => (
+const Placeholder = (props: any): JSX.Element => (
   <>
     <Flex
         align="center"
@@ -21,12 +13,12 @@ const Placeholder = (props: PlaceholderProps): JSX.Element => (
       <components.IndicatorsContainer
           {...props}
       />
-      {props.selectProps.plusIcon && (
+      {props.selectProps.plusIcon &&
         <Icon
             className="typeahead-plus-icon"
             icon="plus"
         />
-      )}
+      }
     </Flex>
   </>
 )

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
@@ -1,10 +1,18 @@
 import React from 'react'
-import { components } from 'react-select'
+import { components, PlaceholderProps as ReactSelectPlaceholderProps } from 'react-select'
 
 import Flex from '../../pb_flex/_flex'
 import Icon from '../../pb_icon/_icon'
 
-const Placeholder = (props: any) => (
+interface CustomSelectProps {
+  plusIcon?: boolean;
+}
+
+type PlaceholderProps = ReactSelectPlaceholderProps & {
+  selectProps: ReactSelectPlaceholderProps['selectProps'] & CustomSelectProps;
+};
+
+const Placeholder = (props: PlaceholderProps): JSX.Element => (
   <>
     <Flex
         align="center"
@@ -13,12 +21,12 @@ const Placeholder = (props: any) => (
       <components.IndicatorsContainer
           {...props}
       />
-      {props.selectProps.plusIcon &&
+      {props.selectProps.plusIcon && (
         <Icon
             className="typeahead-plus-icon"
             icon="plus"
         />
-      }
+      )}
     </Flex>
   </>
 )

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/Placeholder.tsx
@@ -7,16 +7,16 @@ import Icon from '../../pb_icon/_icon'
 const Placeholder = (props: any) => (
   <>
     <Flex
-      align="center"
-      className="placeholder"
+        align="center"
+        className="placeholder"
     >
       <components.IndicatorsContainer
-        {...props}
+          {...props}
       />
       {props.selectProps.plusIcon &&
         <Icon
-          className="typeahead-plus-icon"
-          icon="plus"
+            className="typeahead-plus-icon"
+            icon="plus"
         />
       }
     </Flex>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { components } from 'react-select'
 
-import { ValueContainerProps } from 'react-select'
-
-const ValueContainer = (props: ValueContainerProps): JSX.Element => (
+const ValueContainer = (props: any): JSX.Element => (
   <components.ValueContainer
       className="text_input_value_container"
       {...props}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { components } from 'react-select'
 
-const ValueContainer = (props: any): JSX.Element => (
+type ValueContainerProps = {
+  children: React.ReactNode,
+}
+
+const ValueContainer = (props: ValueContainerProps): React.ReactElement => (
   <components.ValueContainer
       className="text_input_value_container"
       {...props}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { components } from 'react-select'
 
-const ValueContainer = (props: any) => (
+import { ValueContainerProps } from 'react-select'
+
+const ValueContainer = (props: ValueContainerProps): JSX.Element => (
   <components.ValueContainer
       className="text_input_value_container"
       {...props}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/ValueContainer.tsx
@@ -3,8 +3,8 @@ import { components } from 'react-select'
 
 const ValueContainer = (props: any) => (
   <components.ValueContainer
-    className="text_input_value_container"
-    {...props}
+      className="text_input_value_container"
+      {...props}
   />
 )
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_custom_menu_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_custom_menu_list.jsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 
 import {
   Button,
-} from '../..'
+} from 'playbook-ui'
 
 import Typeahead from '../_typeahead'
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_custom_menu_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_custom_menu_list.jsx
@@ -1,8 +1,10 @@
+/* eslint-disable react/no-multi-comp */
+
 import React, { useState } from 'react'
 
 import {
   Button,
-} from 'playbook-ui'
+} from '../..'
 
 import Typeahead from '../_typeahead'
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_highlight.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_highlight.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/no-danger */
 /* eslint-disable react/no-multi-comp */
+/* @flow */
 
 import React, { useState } from 'react'
-import { components } from 'react-select'
+import { components, OptionProps } from 'react-select'
 
 import {
   Avatar,
@@ -11,7 +12,13 @@ import {
   FlexItem,
   Title,
   Typeahead,
-} from 'playbook-ui'
+} from '../..'
+
+type TypeAheadWithHighlightProps = {
+  data: {
+    name: String,
+  },
+};
 
 const USERS = [
   {
@@ -36,12 +43,12 @@ const USERS = [
   },
 ];
 
-const TypeaheadWithHighlight = (props) => {
+const TypeaheadWithHighlight = (props: TypeAheadWithHighlightProps) => {
   const [selectedUser, setSelectedUser] = useState()
 
   const formatOptionLabel = ({name, territory, title}, {inputValue}) => {
 
-    const highlighted = (text) => {
+    const highlighted = (text: string) => {
       if (!inputValue.length) return text
       return text.replace(
         new RegExp(inputValue, 'gi'),
@@ -55,18 +62,11 @@ const TypeaheadWithHighlight = (props) => {
               marginRight="sm"
               name={name}
               size="sm"
-              {...props}
           />
         </FlexItem>
         <FlexItem>
-          <Title
-              size={4}
-              {...props}
-          >
-            <span dangerouslySetInnerHTML={{ __html: highlighted(name) }} /></Title>
-          <Body color="light"
-              {...props}
-          >
+          <Title size={4}><span dangerouslySetInnerHTML={{ __html: highlighted(name) }} /></Title>
+          <Body color="light">
             <span dangerouslySetInnerHTML={{ __html: highlighted(title) }} />{" • "}
             {territory}
           </Body>
@@ -76,7 +76,7 @@ const TypeaheadWithHighlight = (props) => {
   }
 
   const customComponents = {
-    Option: (highlightProps) => (
+    Option: (highlightProps: OptionProps) => (
       <components.Option {...highlightProps}/>
     ),
     SingleValue: ({ ...props }) => (

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_highlight.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_highlight.jsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/no-danger */
 /* eslint-disable react/no-multi-comp */
-/* @flow */
 
 import React, { useState } from 'react'
-import { components, OptionProps } from 'react-select'
+import { components } from 'react-select'
 
 import {
   Avatar,
@@ -12,13 +11,7 @@ import {
   FlexItem,
   Title,
   Typeahead,
-} from '../..'
-
-type TypeAheadWithHighlightProps = {
-  data: {
-    name: String,
-  },
-};
+} from 'playbook-ui'
 
 const USERS = [
   {
@@ -43,12 +36,12 @@ const USERS = [
   },
 ];
 
-const TypeaheadWithHighlight = (props: TypeAheadWithHighlightProps) => {
+const TypeaheadWithHighlight = (props) => {
   const [selectedUser, setSelectedUser] = useState()
 
   const formatOptionLabel = ({name, territory, title}, {inputValue}) => {
 
-    const highlighted = (text: string) => {
+    const highlighted = (text) => {
       if (!inputValue.length) return text
       return text.replace(
         new RegExp(inputValue, 'gi'),
@@ -62,11 +55,18 @@ const TypeaheadWithHighlight = (props: TypeAheadWithHighlightProps) => {
               marginRight="sm"
               name={name}
               size="sm"
+              {...props}
           />
         </FlexItem>
         <FlexItem>
-          <Title size={4}><span dangerouslySetInnerHTML={{ __html: highlighted(name) }} /></Title>
-          <Body color="light">
+          <Title
+              size={4}
+              {...props}
+          >
+            <span dangerouslySetInnerHTML={{ __html: highlighted(name) }} /></Title>
+          <Body color="light"
+              {...props}
+          >
             <span dangerouslySetInnerHTML={{ __html: highlighted(title) }} />{" • "}
             {territory}
           </Body>
@@ -76,7 +76,7 @@ const TypeaheadWithHighlight = (props: TypeAheadWithHighlightProps) => {
   }
 
   const customComponents = {
-    Option: (highlightProps: OptionProps) => (
+    Option: (highlightProps) => (
       <components.Option {...highlightProps}/>
     ),
     SingleValue: ({ ...props }) => (

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async.jsx
@@ -45,8 +45,6 @@ const promiseOptions = (inputValue) =>
 
 const TypeaheadWithPillsAsync = (props) => {
   const [users, setUsers] = useState([])
-  const handleOnChange = (value) => setUsers(formatUsers(value))
-  const formatValue = (users) => formatUsers(users)
   const formatUsers = (users) => {
     const results = () => (users.map((user) => {
       if (Object.keys(user)[0] === 'name' || Object.keys(user)[1] === 'id'){
@@ -57,6 +55,8 @@ const TypeaheadWithPillsAsync = (props) => {
     }))
     return results()
   }
+  const handleOnChange = (value) => setUsers(formatUsers(value))
+  const formatValue = (users) => formatUsers(users)
 
   return (
     <>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async_custom_options.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_async_custom_options.jsx
@@ -83,13 +83,13 @@ const TypeaheadWithPillsAsyncCustomOptions = (props) => {
           onChange={handleOnChange}
           onMultiValueClick={handleOnMultiValueClick}
           placeholder="type the name of a Github user"
-          valueComponent={(props) => (
+          valueComponent={({ imageUrl, label, territory, type }) => (
             <User
                 avatar
-                avatarUrl={props.imageUrl}
-                name={props.label}
-                territory={props.territory}
-                title={props.type}
+                avatarUrl={imageUrl}
+                name={label}
+                territory={territory}
+                title={type}
             />
           )}
           {...props}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This story fixes the typeahead kit linting errors. 

Ran yarn eslint --fix for each file other than the index file and none of the warnings were corrected. I believe them to be unsafe changes and will require manual intervention. 

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to 'Typeahead kit page
2. Should still work as expected


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.