### PR TITLE
[PBNTR-782] Fixes for Timestamp Spec Failing on Year Change

### DIFF
--- a/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
   subject { Playbook::PbTimestamp::Timestamp }
   let(:timestamp) { DateTime.new(2020, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
   let(:future_timestamp) { (DateTime.current + 4.years).in_time_zone("America/New_York").freeze }
+  let(:dynamic_future_timestamp) do
+    future_year = DateTime.current.year + 4
+    DateTime.new(future_year, 10, 10, 20, 30, 0, "America/New_York").in_time_zone("America/New_York").freeze
+  end
 
   it {
     is_expected.to define_enum_prop(:align)
@@ -103,20 +107,22 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
       context "if show_user is true" do
         let(:show_user) { true }
         it "returns last updated with year including user's name" do
-          date = "Oct 10, #{future_timestamp.year}"
-          time = " 4:30p"
+          timestamp = dynamic_future_timestamp
+          date = timestamp.strftime("%b %-d, %Y")
+          time = timestamp.strftime(" %l:%M%P").strip
 
-          expect(subject.new(timestamp: future_timestamp, variant: variant, show_user: show_user, text: name).send(:format_updated_string)).to eq("Last updated by #{name} on #{date} at#{time}")
+          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user, text: name).send(:format_updated_string)).to eq("Last updated by #{name} on #{date} at#{time}")
         end
       end
 
       context "if show_user is false" do
         let(:show_user) { false }
         it "returns last updated with year without user's name" do
-          date = "Oct 10, #{future_timestamp.year}"
-          time = " 4:30p"
+          timestamp = dynamic_future_timestamp
+          date = timestamp.strftime("%b %-d, %Y")
+          time = timestamp.strftime(" %l:%M%P").strip
 
-          expect(subject.new(timestamp: future_timestamp, variant: variant, show_user: show_user).send(:format_updated_string)).to eq("Last updated on #{date} at#{time}")
+          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user).send(:format_updated_string)).to eq("Last updated on #{date} at#{time}")
         end
       end
     end

--- a/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
 
   subject { Playbook::PbTimestamp::Timestamp }
   let(:timestamp) { DateTime.new(2020, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
-  let(:future_timestamp) { DateTime.new(2029, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
+  let(:future_timestamp) { (DateTime.current + 4.years).in_time_zone("America/New_York").freeze }
 
   it {
     is_expected.to define_enum_prop(:align)
@@ -82,13 +82,15 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
 
   describe "#format_date_string" do
     it "returns date in specific format with year" do
-      expect(subject.new(timestamp: future_timestamp).send(:format_date_string)).to eq(future_timestamp.strftime("%b %-d, %Y").to_s)
+      formatted_date = future_timestamp.strftime("%b %-d, %Y")
+      expect(subject.new(timestamp: future_timestamp).send(:format_date_string)).to eq(formatted_date.to_s)
     end
   end
 
   describe "#format_datetime_string" do
     it "returns full date and time separated by middot" do
-      expect(subject.new(timestamp: future_timestamp).send(:format_datetime_string)).to eq("Oct 10, 2029 &middot; 4:30p")
+      formatted_datetime = "#{future_timestamp.strftime('%b %-d, %Y')} &middot; #{subject.new(timestamp: future_timestamp).send(:format_time_string)}"
+      expect(subject.new(timestamp: future_timestamp).send(:format_datetime_string)).to eq(formatted_datetime)
     end
   end
 
@@ -101,22 +103,20 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
       context "if show_user is true" do
         let(:show_user) { true }
         it "returns last updated with year including user's name" do
-          timestamp = DateTime.new(2029, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
-          date = "Oct 10, 2029"
+          date = "Oct 10, #{future_timestamp.year}"
           time = " 4:30p"
 
-          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user, text: name).send(:format_updated_string)).to eq("Last updated by #{name} on #{date} at#{time}")
+          expect(subject.new(timestamp: future_timestamp, variant: variant, show_user: show_user, text: name).send(:format_updated_string)).to eq("Last updated by #{name} on #{date} at#{time}")
         end
       end
 
       context "if show_user is false" do
         let(:show_user) { false }
         it "returns last updated with year without user's name" do
-          timestamp = DateTime.new(2029, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
-          date = "Oct 10, 2029"
+          date = "Oct 10, #{future_timestamp.year}"
           time = " 4:30p"
 
-          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user).send(:format_updated_string)).to eq("Last updated on #{date} at#{time}")
+          expect(subject.new(timestamp: future_timestamp, variant: variant, show_user: show_user).send(:format_updated_string)).to eq("Last updated on #{date} at#{time}")
         end
       end
     end

--- a/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
 
   subject { Playbook::PbTimestamp::Timestamp }
   let(:timestamp) { DateTime.new(2020, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
-  let(:future_timestamp) { DateTime.new(2025, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
+  let(:future_timestamp) { DateTime.new(2029, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
 
   it {
     is_expected.to define_enum_prop(:align)
@@ -82,13 +82,13 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
 
   describe "#format_date_string" do
     it "returns date in specific format with year" do
-      expect(subject.new(timestamp: future_timestamp).send(:format_date_string)).to eq(future_timestamp.strftime("%b %-d").to_s)
+      expect(subject.new(timestamp: future_timestamp).send(:format_date_string)).to eq(future_timestamp.strftime("%b %-d, %Y").to_s)
     end
   end
 
   describe "#format_datetime_string" do
     it "returns full date and time separated by middot" do
-      expect(subject.new(timestamp: future_timestamp).send(:format_datetime_string)).to eq("Oct 10 &middot; 4:30p")
+      expect(subject.new(timestamp: future_timestamp).send(:format_datetime_string)).to eq("Oct 10, 2029 &middot; 4:30p")
     end
   end
 
@@ -101,8 +101,8 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
       context "if show_user is true" do
         let(:show_user) { true }
         it "returns last updated with year including user's name" do
-          timestamp = DateTime.new(2025, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
-          date = "Oct 10"
+          timestamp = DateTime.new(2029, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
+          date = "Oct 10, 2029"
           time = " 4:30p"
 
           expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user, text: name).send(:format_updated_string)).to eq("Last updated by #{name} on #{date} at#{time}")
@@ -112,8 +112,8 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
       context "if show_user is false" do
         let(:show_user) { false }
         it "returns last updated with year without user's name" do
-          timestamp = DateTime.new(2025, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
-          date = "Oct 10"
+          timestamp = DateTime.new(2029, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
+          date = "Oct 10, 2029"
           time = " 4:30p"
 
           expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user).send(:format_updated_string)).to eq("Last updated on #{date} at#{time}")

--- a/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
@@ -109,9 +109,9 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
         it "returns last updated with year including user's name" do
           timestamp = dynamic_future_timestamp
           date = timestamp.strftime("%b %-d, %Y")
-          time = timestamp.strftime(" %l:%M%P").strip
+          time = timestamp.strftime(" %l:%M%P").strip.gsub(/m$/, "")
 
-          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user, text: name).send(:format_updated_string)).to eq("Last updated by #{name} on #{date} at#{time}")
+          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user, text: name).send(:format_updated_string)).to eq("Last updated by #{name} on #{date} at #{time}")
         end
       end
 
@@ -120,9 +120,9 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
         it "returns last updated with year without user's name" do
           timestamp = dynamic_future_timestamp
           date = timestamp.strftime("%b %-d, %Y")
-          time = timestamp.strftime(" %l:%M%P").strip
+          time = timestamp.strftime(" %l:%M%P").strip.gsub(/m$/, "")
 
-          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user).send(:format_updated_string)).to eq("Last updated on #{date} at#{time}")
+          expect(subject.new(timestamp: timestamp, variant: variant, show_user: show_user).send(:format_updated_string)).to eq("Last updated on #{date} at #{time}")
         end
       end
     end

--- a/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/timestamp_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
 
   subject { Playbook::PbTimestamp::Timestamp }
   let(:timestamp) { DateTime.new(2020, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
-  let(:future_timestamp) { DateTime.new(2024, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
+  let(:future_timestamp) { DateTime.new(2025, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze }
 
   it {
     is_expected.to define_enum_prop(:align)
@@ -101,7 +101,7 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
       context "if show_user is true" do
         let(:show_user) { true }
         it "returns last updated with year including user's name" do
-          timestamp = DateTime.new(2024, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
+          timestamp = DateTime.new(2025, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
           date = "Oct 10"
           time = " 4:30p"
 
@@ -112,7 +112,7 @@ RSpec.describe Playbook::PbTimestamp::Timestamp do
       context "if show_user is false" do
         let(:show_user) { false }
         it "returns last updated with year without user's name" do
-          timestamp = DateTime.new(2024, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
+          timestamp = DateTime.new(2025, 10, 10, 20, 30, 0o0).in_time_zone("America/New_York").freeze
           date = "Oct 10"
           time = " 4:30p"
 


### PR DESCRIPTION
[Runway Story](https://runway.powerhrg.com/backlog_items/PBNTR-782)

Any commit pushed up today is getting this failing spec:

![Screenshot 2025-01-02 at 9 46 34 AM](https://github.com/user-attachments/assets/79bea884-6df7-435f-b718-24dbc86f8a7a)


- No issue in kit, issue only in spec test
- The issue was the hard coded value for future_year being 2024 + changes made on [this PR](https://github.com/powerhome/playbook/pull/2977/files#diff-600f6c819a48f07dd029c8b79fc0798daddecaae4e7570da12a5d2a2e43d8348L82) that was removing check for year

# Fixes Made
- Made future date calculation dynamic to avoid this issue in the future
- Fixes test to expect the correct value

