### PR TITLE
[PLAY-1661] Remove react-animate-height from Playbook

### DIFF
--- a/playbook-website/app/javascript/components/KitDocs/index.tsx
+++ b/playbook-website/app/javascript/components/KitDocs/index.tsx
@@ -6,7 +6,6 @@ import {
   SandpackCodeEditor,
 } from "@codesandbox/sandpack-react"
 
-import AnimateHeight from "react-animate-height"
 import { Button, Caption } from "playbook-ui"
 import entryPoint from "./entryPoint"
 
@@ -121,11 +120,9 @@ const KitDocs = ({ source, exampleTitle }: KitDocsType) => {
               </div>
             )}
 
-            <AnimateHeight duration={500} height={editorHeight}>
-              <SandpackCodeEditor
-                style={{ height: "100%", maxHeight: "300px" }}
-              />
-            </AnimateHeight>
+            <SandpackCodeEditor
+              style={{ height: editorHeight, maxHeight: "300px" }}
+            />
           </div>
         </SandpackLayout>
       </SandpackProvider>

--- a/playbook/package.json
+++ b/playbook/package.json
@@ -78,7 +78,6 @@
     "lazysizes": "^5.3.2",
     "lodash-es": "^4.17.12",
     "react": "^17.0.2",
-    "react-animate-height": "^2.0.23",
     "react-dom": "^17.0.2",
     "react-dropzone": "^10.2.2",
     "react-highlight-words": "^0.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5066,7 +5066,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.2.6:
   version "2.3.2"
   resolved "https://npm.powerapp.cloud/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
@@ -9778,7 +9778,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://npm.powerapp.cloud/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9978,14 +9978,6 @@ quickselect@^2.0.0:
   version "2.0.0"
   resolved "https://npm.powerapp.cloud/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
   integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
-
-react-animate-height@^2.0.23:
-  version "2.1.2"
-  resolved "https://npm.powerapp.cloud/react-animate-height/-/react-animate-height-2.1.2.tgz#9b450fc64d46f10f5e07da8d0d5e2c47b9f15030"
-  integrity sha512-A9jfz/4CTdsIsE7WCQtO9UkOpMBcBRh8LxyHl2eoZz1ki02jpyUL5xt58gabd0CyeLQ8fRyQ+s2lyV2Ufu8Owg==
-  dependencies:
-    classnames "^2.2.5"
-    prop-types "^15.6.1"
 
 react-devtools-inline@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
**What does this PR do?**
It removes `react-animate-height` from Playbook and from the experimental Sandpack kit pages. 
`react-animate-height` is not used in any kits. 

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-01-06 at 11 36 36 AM](https://github.com/user-attachments/assets/d5892045-3e4b-436a-881f-f8474d8bedc8)

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/title/sandpack
2. Click "Show Code"
3. The code should be shown


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.