### PR TITLE
[PLAY-1801] 'Inactive RC' Label: Skip Later Steps

### DIFF
--- a/.github/workflows/github-actions-release-candidate.yml
+++ b/.github/workflows/github-actions-release-candidate.yml
@@ -62,6 +62,7 @@ jobs:
 
           if echo "$LABELS" | grep -iq "Inactive RC"; then
             echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            echo "SKIP_REMAINING_STEPS=true" >> $GITHUB_ENV  # Set flag to skip steps
             exit 0  # Exit the job early, skipping the rest of the workflow
           fi
 
@@ -93,6 +94,10 @@ jobs:
       - name: Grab Current Version and Set New RC Version
         id: set-version
         run: |
+          if [ "${{ env.SKIP_REMAINING_STEPS }}" == "true" ]; then
+            echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0
+          fi
           current_npm_version=$(node -pe "require('./package.json').version")
 
           case ${{ env.SEMVER_LABEL }} in
@@ -119,6 +124,10 @@ jobs:
 
       - name: Check if version exists and increment if necessary
         run: |
+          if [ "${{ env.SKIP_REMAINING_STEPS }}" == "true" ]; then
+            echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0
+          fi
           max_attempts=100
           attempt=0
           current_version="${{ env.new_npm_version }}"
@@ -142,11 +151,19 @@ jobs:
           echo "new_ruby_version=${new_ruby_version}" >> $GITHUB_ENV
       - name: Update Version.rb
         run: |
+          if [ "${{ env.SKIP_REMAINING_STEPS }}" == "true" ]; then
+            echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0
+          fi
           gem install bundler
           bundle
           bin/rails pb_release:action[${{env.new_ruby_version}}]
       - name: Distribute and Publish (NPM)
         run: |
+          if [ "${{ env.SKIP_REMAINING_STEPS }}" == "true" ]; then
+            echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0
+          fi
           yarn install
           bundle
           yarn release
@@ -154,6 +171,10 @@ jobs:
           npm publish --registry https://registry.npmjs.org playbook-ui-${{ env.new_npm_version }}.tgz --tag rc
       - name: Distribute and Publish (RubyGems)
         run: |
+          if [ "${{ env.SKIP_REMAINING_STEPS }}" == "true" ]; then
+            echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0
+          fi
           bin/build_gem
           gem build lib/playbook_ui_docs.gemspec
           rm -rf dist/playbook-doc.js dist/playbook-rails.js dist/app  dist/pb_doc_helper.rb dist/menu.yml
@@ -163,6 +184,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [ "${{ env.SKIP_REMAINING_STEPS }}" == "true" ]; then
+            echo "⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process."
+            exit 0
+          fi
           gh release create v${{ env.new_npm_version }} \
             --title "Release Candidate v${{ env.new_npm_version }}" \
             --notes "This is a release candidate version. Please test thoroughly before promoting to a stable release." \
@@ -179,6 +204,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            if (process.env.SKIP_REMAINING_STEPS === 'true') {
+              console.log("⏭️ PR has the 'Inactive RC' label. Skipping the release candidate process.");
+              return;
+            }
+
             const commitSha = context.payload.head_commit.id;
             const commitMessage = context.payload.head_commit.message;
             const commitAuthor = context.payload.head_commit.author.name;


### PR DESCRIPTION
**What does this PR do?**

- Fix "Inactive RC" label bug that would show a failed run. Make it so there is a successful run, but an RC is still not made. 
- The RC GitHub action showed an error on the [next "Grab Current Version and Set New RC Version" step](https://github.com/powerhome/playbook/actions/runs/12547084762/job/34983953428) because `exit 0` on the "Get Semver Label" step indicates there is no bug and should still run subsequent steps. But, since the label was never set, this following step fails. 
- Set SKIP_REMAINING_STEPS to true and add a conditional to exit 0 or return for all later steps.

**How to test?** Steps to confirm the desired behavior:
1. Merge this PR
2. The GitHub action should not create an RC
3. It should also run successfully


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.