### PR TITLE
[PLAY-1776] Update Kits To Remove Deprecation Warning With Division

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_avatar_action_button/_avatar_action_button.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 [class^=pb_avatar_action_button_kit] {
 
   $icon_size: 0px;
@@ -13,7 +15,7 @@
       color: $value;
     }
   }
-  
+
   @mixin icon-base {
     &.dark{
         background-color: $bg_dark
@@ -31,22 +33,22 @@
   }
 
   @each $name, $size in $avatar-sizes {
-    
+
     &[class*=_#{$name}] {
-      
+
       $avatar_size: map-get($avatar-sizes, $name);
-      $icon_size: $avatar_size / 2;
-      $border_size: $icon_size / 10;
+      $icon_size: math.div($avatar_size, 2);
+      $border_size: math.div($icon_size, 10);
 
       position: relative;
       width: $avatar_size * 1.25;
       height: $avatar_size * 1.1;
       display: flex;
-    
+
       [class^=pb_tooltip_kit] {
         justify-self: center;
       }
-    
+
       &[class*=_bottom] .icon {
         @include icon-base;
         top: $icon_size * 1.27;
@@ -59,7 +61,7 @@
         left: $icon_size * 1.5;
       }
       &[class*=_left] [class^=pb_avatar_kit] {
-        padding-left: $icon_size / 2;
+        padding-left: math.div($icon_size , 2);
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_badge/_badge.scss
+++ b/playbook/app/pb_kits/playbook/pb_badge/_badge.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/border_radius";
 @import "../tokens/colors";
 @import "../tokens/opacity";
@@ -11,7 +13,7 @@
   align-items: center;
   justify-content: center;
   border-radius: $border_rad_light;
-  padding: 0 $space_xs/2;
+  padding: 0 math.div($space_xs, 2);
   border-width: 1px;
   border-style: solid;
   border-color: $card_light;
@@ -34,7 +36,7 @@
     height: $pb_badge_height;
     min-height: $pb_badge_height;
     min-width: $pb_badge_height;
-    border-radius: $pb_badge_height / 2;
+    border-radius: math.div($pb_badge_height, 2);
   }
 
   &[class*=_notification] {

--- a/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.scss
+++ b/playbook/app/pb_kits/playbook/pb_bread_crumbs/_bread_crumbs.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/colors";
 @import "../tokens/opacity";
 @import "../tokens/spacing";
@@ -9,7 +11,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 $space_xs/2;
+  padding: 0 math.div($space_xs, 2);
 
   svg {
    margin-right: 8px;

--- a/playbook/app/pb_kits/playbook/pb_button/_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "./button_mixins";
 @import "../tokens/colors";
 @import "../tokens/border_radius";
@@ -17,7 +19,7 @@ $pb_button_sizes: (
   @each $name, $size in $pb_button_sizes {
     &[class*=size_#{$name}] {
       font-size: $size;
-      padding: $size / 2 $size * 2.42;
+      padding: math.div($size, 2) $size * 2.42;
       @if $name == "sm" {
         min-height: 0;
       }

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../pb_button/button";
 @import "../pb_button/button_mixins";
 
@@ -16,7 +18,7 @@ $pb_button_styles: (
   flex-grow: 0;
   width: $pb_button_size;
   height: $pb_button_size;
-  border-radius: $pb_button_size / 2;
+  border-radius: math.div($pb_button_size, 2);
   line-height: $pb_button_size;
   flex-basis: $pb_button_size;
   min-width: $pb_button_size;

--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_input_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_input_styles.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../../pb_textarea/textarea_mixin";
 
 [class^=pb_date_picker_kit] {
@@ -41,7 +43,7 @@
   &.error {
     .date_picker_input_wrapper {
       [class*=pb_body_kit] {
-        margin-top: $space_xs / 2;
+        margin-top: math.div($space_xs, 2);
       }
 
       input,

--- a/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_overrides.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_overrides.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @media (min-width: 500px) {
   .flatpickr-calendar {
     padding: $space_xs;
@@ -6,8 +8,8 @@
     width: 315.88px
   }
   .flatpickr-months {
-    margin-left: $space_xs / 4;
-    margin-top: $space_xs / 3;
+    margin-left: math.div($space_xs, 4);
+    margin-top: math.div($space_xs, 3);
   }
 }
 @media (max-width: 499px) {
@@ -19,7 +21,7 @@
   }
 }
 // Firefox Header Adjustments
-@supports (-moz-appearance:none) { 
+@supports (-moz-appearance:none) {
   select.flatpickr-monthDropdown-months {
       width: 97px !important;
       margin-left: $space_xs + 3;

--- a/playbook/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_range_inline/_date_range_inline.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 [class^=pb_date_range_inline_kit] {
   &[class*=_center]  {
     & > [class^=pb_caption],
@@ -21,14 +23,14 @@
     display: flex;
     align-items: center;
     [class*=pb_date_range_inline_arrow] {
-      margin-left: $space_xs/2;
-      margin-right: $space_xs/2;
+      margin-left: math.div($space_xs, 2);
+      margin-right: math.div($space_xs, 2);
     }
     [class*=pb_date_range_inline_timezone] {
-      margin-left: $space_xs/2;
+      margin-left: math.div($space_xs, 2);
     }
     [class*=pb_date_range_inline_icon] {
-      margin-right: $space_xs/2;
+      margin-right: math.div($space_xs, 2);
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_date_time_stacked/_date_time_stacked.scss
+++ b/playbook/app/pb_kits/playbook/pb_date_time_stacked/_date_time_stacked.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 [class^=pb_date_time_stacked] {
 
   [class^=padding_month] {
@@ -19,7 +21,7 @@
 
 }
 .date-time-padding {
-  padding-right: $space_xs / 2;
-  padding-left: $space_xs / 2;
+  padding-right: math.div($space_xs, 2);
+  padding-left: math.div($space_xs, 2);
 }
 

--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.scss
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/colors";
 @import "../tokens/spacing";
 @import "../tokens/typography";
@@ -122,7 +124,7 @@
 
     &.error {
       [class*=pb_body_kit] {
-        margin-top: $space_xs / 2;
+        margin-top: math.div($space_xs, 2);
       }
 
       [class*="dropdown_trigger_wrapper"] {
@@ -146,7 +148,7 @@
   &[class*="subtle"] {
     .dropdown_wrapper {
       .pb_dropdown_container {
-        
+
         [class*="pb_dropdown_option"]:first-child {
           margin-top: $space_xs;
         }
@@ -161,7 +163,7 @@
           border-radius: $border_radius_md;
           border-bottom: none;
           position: relative;
-        
+
           &::after {
             content: "";
             position: absolute;
@@ -172,20 +174,20 @@
             background: $border_light;
           }
         }
-        
+
         [class*="pb_dropdown_option"]:last-child::after {
-          display: none; 
+          display: none;
         }
       }
     }
-  
+
     &[class*="separators_hidden"] {
       .dropdown_wrapper {
         .pb_dropdown_container {
           [class*="pb_dropdown_option"]:first-child {
             margin-top: $space_xs;
           }
-  
+
           [class*="pb_dropdown_option"]:last-child {
             margin-bottom: $space_xs;
           }
@@ -193,7 +195,7 @@
           [class*="pb_dropdown_option"] {
             padding: $space_xxs $space_xs;
             margin: $space_xxs $space_xs;
-     
+
             &::after {
               height: 0px;
             }

--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/spacing";
 @import "../tokens/colors";
 @import "../tokens/opacity";
@@ -14,9 +16,9 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  padding: 0 $space-md/2;
+  padding: 0 math.div($space-md, 2);
   height: $pb_form_pill_height;
-  border-radius: $pb_form_pill_height/2;
+  border-radius: math.div($pb_form_pill_height, 2);
   margin-bottom: 2px;
   margin-top: 2px;
   cursor: pointer;
@@ -142,7 +144,7 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
     height: 12px !important;
     width: 12px !important;
     padding-right: $space_xs;
-    + .pb_form_pill_text, + .pb_form_pill_tag, 
+    + .pb_form_pill_text, + .pb_form_pill_tag,
     + .pb_tooltip_kit .pb_form_pill_text, + .pb_tooltip_kit .pb_form_pill_tag,
     + div .pb_form_pill_text, + div .pb_form_pill_tag {
       padding-left: 0;
@@ -171,7 +173,7 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
     }
     .pb_form_pill_icon {
       padding-right: $space_xxs;
-      + .pb_form_pill_text, + .pb_form_pill_tag, 
+      + .pb_form_pill_text, + .pb_form_pill_tag,
       + .pb_tooltip_kit .pb_form_pill_text, + .pb_tooltip_kit .pb_form_pill_tag,
       + div .pb_form_pill_text, + div .pb_form_pill_tag {
         padding-left: 0;

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/_icon_circle.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/border_radius";
 @import "../tokens/colors";
 @import "../tokens/typography";
@@ -44,7 +46,7 @@ $pb_icon_circle_sizes: (
     &[class*=_size_#{$name}] {
       width: $size;
       height: $size;
-      border-radius: $size/2;
+      border-radius: math.div($size, 2);
       background: $silver;
       color: $text_lt_light;
       font-size: if($name == "xxs", $size - 6px, $size * 0.38);

--- a/playbook/app/pb_kits/playbook/pb_label_value/_label_value.scss
+++ b/playbook/app/pb_kits/playbook/pb_label_value/_label_value.scss
@@ -1,7 +1,9 @@
+@use "sass:math";
+
 @import "../tokens/spacing";
 
 [class^=pb_label_value_kit] {
   [class^=pb_caption_kit]  {
-    margin-bottom: $space-xs/1.5;
+    margin-bottom: math.div($space-xs, 1.5);
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
+++ b/playbook/app/pb_kits/playbook/pb_message/_message_mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/spacing";
 
 @mixin pb_message {
@@ -17,7 +19,7 @@
     }
 
     .message_text {
-      margin: 0 0 $space-xs/2;
+      margin: 0 0 math.div($space-xs, 2);
     }
 
     .message_title {

--- a/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users/_multiple_users.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/colors";
 @import "../utilities/colors";
 @import "../tokens/opacity";
@@ -18,7 +20,7 @@ $pb_multiple_users_size_xxs: map-get($avatar-sizes, "xxs");
     justify-content: center;
     width: $pb_multiple_users_size;
     height: $pb_multiple_users_size;
-    border-radius: $pb_multiple_users_size / 2 + 2;
+    border-radius: math.div($pb_multiple_users_size, 2) + 2;
     background: tint($primary, 90%);
     border: $pb_multiple_users_border_size solid $white;
     color: $primary;

--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.scss
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/colors";
 @import "../tokens/spacing";
 @import "../tokens/screen_sizes";
@@ -21,14 +23,14 @@
   }
 
   .passphrase-label {
-    margin-right: $space_xs / 2;
+    margin-right: math.div($space_xs, 2);
   }
 
   .passphrase-text-input-wrapper {
     position: relative;
 
     .pb_text_input_kit_label {
-      margin-bottom: $space_xs / 2;
+      margin-bottom: math.div($space_xs, 2);
     }
 
     .passphrase-text-input input {
@@ -57,7 +59,7 @@
   }
 
   .pb_progress_simple_wrapper, .pb_progress_simple_wrapper_dark {
-    margin-bottom: $space_xs/2;
+    margin-bottom: math.div($space_xs, 2);
 
     &.progress-empty-input {
       visibility: hidden;

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -165,7 +165,7 @@ $flag-min-resolution: 192dpi;
   }
 
   .iti__arrow.iti__arrow--up::before {
-    transform: rotate(-math.div($transform-rotate-deg, 3));
+    transform: rotate(-(math.div($transform-rotate-deg, 3)));
     top: $space_xs + 4px;
     color: $primary_action;
   }

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "./intlTelInput";
 @import "../tokens/colors";
 
@@ -39,7 +41,7 @@ $flag-min-resolution: 192dpi;
     color: $charcoal;
   }
 
-  // iti-spacer-horizontal's default is 8px, or $space_xs 
+  // iti-spacer-horizontal's default is 8px, or $space_xs
   .iti__country-list .iti__flag, .iti__country-name {
     margin-right: $space_xs;
   }
@@ -73,7 +75,7 @@ $flag-min-resolution: 192dpi;
   }
 
   .iti__divider {
-    border-bottom: 1px solid $border_light !important;  
+    border-bottom: 1px solid $border_light !important;
   }
 
   .iti__selected-country-primary {
@@ -93,7 +95,7 @@ $flag-min-resolution: 192dpi;
     justify-content: center;
     align-items: center;
     border-width: 0;
-    border-radius: $space_xxs; 
+    border-radius: $space_xxs;
 
     &[aria-expanded="true"] {
       color: $primary_action;
@@ -163,7 +165,7 @@ $flag-min-resolution: 192dpi;
   }
 
   .iti__arrow.iti__arrow--up::before {
-    transform: rotate(-($transform-rotate-deg/3));
+    transform: rotate(-math.div($transform-rotate-deg, 3));
     top: $space_xs + 4px;
     color: $primary_action;
   }
@@ -196,7 +198,7 @@ $flag-min-resolution: 192dpi;
   }
 
   .iti__dropdown-content {
-    border-radius: $space_xs; 
+    border-radius: $space_xs;
     border: 1px solid $border_light !important;
     position: absolute;
     top: 100%;
@@ -225,12 +227,12 @@ $flag-min-resolution: 192dpi;
     }
 
     .iti__dropdown-content {
-      border-radius: $space_xs; 
+      border-radius: $space_xs;
       border: 1px solid $border_dark !important;
     }
 
     .iti__divider {
-      border-bottom: 1px solid $border_dark !important;  
+      border-bottom: 1px solid $border_dark !important;
     }
 
     .iti__country-list {
@@ -265,7 +267,7 @@ $flag-min-resolution: 192dpi;
       color: $white;
     }
   }
-  
+
   @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: $flag-min-resolution) {
     .iti__flag {
       background-image: url("https://unpkg.com/intl-tel-input@24.6.0/build/img/flags@2x.png");

--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/spacing";
 @import "../tokens/colors";
 @import "../tokens/opacity";
@@ -9,9 +11,9 @@ $pb_pill_height: 22px;
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  padding: 0 $space-sm/1.8;
+  padding: 0 math.div($space-sm, 1.8);
   height: $pb_pill_height;
-  border-radius: $pb_pill_height/2;
+  border-radius: math.div($pb_pill_height, 2);
   white-space: nowrap;
 
   &[class*=lowercase] {

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.scss
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/colors";
 @import "../tokens/opacity";
 @import "../tokens/colors";
@@ -21,7 +23,7 @@ $pb_progress_simple_height: 4px;
 [class^=pb_progress_simple_kit] {
   width: 100%;
   height: $pb_progress_simple_height;
-  border-radius: $pb_progress_simple_height/2;
+  border-radius: math.div($pb_progress_simple_height, 2);
   background: rgba($primary, $opacity-1);
     &[class*=_positive] {
       .progress_simple_value {

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.scss
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/_progress_simple.scss
@@ -44,7 +44,7 @@ $pb_progress_simple_height: 4px;
   [class^=progress_simple_value] {
     width: 0%;
     height: 100%;
-    border-radius: $pb_progress_simple_height/2;
+    border-radius: math.div($pb_progress_simple_height, 2);
     background: $primary;
   }
 

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../pb_textarea/textarea_mixin";
 @import "../pb_button/_button_mixins";
 @import "../tokens/border_radius";
@@ -94,7 +96,7 @@
     .trix-button--icon {
       height: $space_lg;
       width: $space_lg;
-      margin: $space_xs / 2;
+      margin: math.div($space_xs, 2);
       border-radius: $border_rad_heavier;
       &::before {
         background-size: auto;
@@ -104,7 +106,7 @@
       background: $white;
       border: 1px solid #E4E8F0;
       border-bottom: none;
-      padding: $space_xs / 2;
+      padding: math.div($space_xs, 2);
       border-top-left-radius: $border_rad_heavier;
       border-top-right-radius: $border_rad_heavier;
       .trix-button-group {

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../pb_body/body_mixins";
 @import "../pb_textarea/textarea_mixin";
 @import "../tokens/titles";
@@ -81,7 +83,7 @@
     display: block;
     &.error {
       [class*=pb_body_kit] {
-        margin-top: $space_xs / 2;
+        margin-top: math.div($space_xs, 2);
       }
       > select:first-child {
         border-color: $error;
@@ -133,7 +135,7 @@
       box-shadow: none;
       border-color: transparent;
       padding: 4px 8px;
-      padding-right: $space_lg; 
+      padding-right: $space_lg;
       border-radius: 4px;
       option {
         background-color: $white;
@@ -240,7 +242,7 @@
       border-color: transparent;
       background: transparent;
       padding: 4px 8px;
-      padding-right: $space_lg; 
+      padding-right: $space_lg;
       border-radius: 4px;
       option {
         background-color: $white;

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/_selectable_card.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/animation-curves";
 @import "../tokens/colors";
 @import "../tokens/opacity";
@@ -60,7 +62,7 @@ $pb_selectable_paddings: (
       align-items: center;
       height: $pb_selectable_card_indicator_size;
       width: $pb_selectable_card_indicator_size;
-      border-radius: $pb_selectable_card_indicator_size/2 + $pb_selectable_card_border/2;
+      border-radius: (math.div($pb_selectable_card_indicator_size, 2)) + (math.div($pb_selectable_card_border, 2));
       border-width: $pb_selectable_card_border;
       border-style: solid;
       border-color: $white;
@@ -69,8 +71,8 @@ $pb_selectable_paddings: (
       font-size: $font_smaller;
       text-align: center;
       position: absolute;
-      top: -($pb_selectable_card_indicator_size/2);
-      right: -($pb_selectable_card_indicator_size/2);
+      top: -(math.div($pb_selectable_card_indicator_size, 2));
+      right: -(math.div($pb_selectable_card_indicator_size, 2));
       opacity: 0;
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../pb_textarea/textarea_mixin";
 @import "../tokens/titles";
 @import "../tokens/colors";
@@ -100,7 +102,7 @@
   &.error {
     .text_input_wrapper {
       [class*="pb_body_kit"] {
-        margin-top: $space_xs / 2;
+        margin-top: math.div($space_xs, 2);
       }
       input,
       .text_input {

--- a/playbook/app/pb_kits/playbook/pb_textarea/_textarea.scss
+++ b/playbook/app/pb_kits/playbook/pb_textarea/_textarea.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../pb_body/body_mixins";
 @import "./textarea_mixin";
 @import "../tokens/spacing";
@@ -60,7 +62,7 @@
 
   &.error {
     [class*=pb_body_kit] {
-      margin-top: $space_xs / 2;
+      margin-top: math.div($space_xs, 2);
     }
     textarea {
       border-color: $error;

--- a/playbook/app/pb_kits/playbook/pb_time_range_inline/_time_range_inline.scss
+++ b/playbook/app/pb_kits/playbook/pb_time_range_inline/_time_range_inline.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 
 [class^=pb_time_range_inline_kit] {
   &[class*=_center]  {
@@ -22,14 +23,14 @@
     display: flex;
     align-items: center;
     [class*=pb_time_range_inline_arrow] {
-      margin-left: $space_xs/2;
-      margin-right: $space_xs/2;
+      margin-left: math.div($space_xs, 2);
+      margin-right:math.div($space_xs, 2);
     }
     [class*=pb_time_range_inline_timezone] {
-      margin-left: $space_xs/2;
+      margin-left: math.div($space_xs, 2);
     }
     [class*=pb_time_range_inline_icon] {
-      margin-right: $space_xs/2;
+      margin-right: math.div($space_xs, 2);
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
@@ -1,12 +1,14 @@
+@use "sass:math";
+
 @import "../tokens/colors";
 @import "../tokens/spacing";
 @import "../tokens/opacity";
 @import "../tokens/typography";
 
 $connector_width: 2px;
-$icon_margin: $space_xs/2;
+$icon_margin: math.div($space_xs, 2);
 $icon_height: 28px;
-$height_from_top: $icon_height/2 - $connector_width/2;
+$height_from_top: (math.div($icon_height, 2)) - (math.div($connector_width, 2));
 
 // Add gap variables
 $gap_xs: $height_from_top + $space_xs;

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../tokens/colors";
 
 $color_checkbox_success: $data_1;
@@ -8,7 +10,7 @@ $transition: .2s ease-in-out;
 [class^=pb_toggle_kit] {
   position: relative;
   $width: 44px;
-  $height: $width / 2;
+  $height: math.div($width, 2);
   $border_success: 3px solid $color_checkbox_success;
   $border_default: 3px solid $color_checkbox_default;
 
@@ -27,7 +29,7 @@ $transition: .2s ease-in-out;
       &:after {
         transition: $transition;
         content: "";
-        width: $width / 2 - 4px;
+        width: math.div($width, 2) - 4px;
         height: $height - 4px;
         background-color: $color_checkbox_default;
         border-radius: 50%;
@@ -68,7 +70,7 @@ $transition: .2s ease-in-out;
         background-color: $color_checkbox_success;
 
         &:after {
-          left: $width / 2 + 2px;
+          left: math.div($width, 2) + 2px;
           background-color: $white;
         }
       }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Updated kits in playbook to address deprecation warning when starting a playbook website server. Used sass math model and updated all divisional operations to use new division syntax. Following in all kits that have been updated: 

- Avatar Action Button
- Badge Kit
- Bread crumbs kit
- Button
- Circle Icon Button
- Date Picker
- Date Range
- Date Time Stacked
- Dropdown
- Form Pill
- Icon Circle
- Pill
- Label value
- Message
- Multiple User
- Prassphrase
- Phone Number Input
- Progress simple
- Rich Text Editor
- Select
- Selectable Card
- Text Input
- Textarea
- Time Range Inline
- Timeline
- Toggle

[Story 1776](https://runway.powerhrg.com/backlog_items/PLAY-1776)


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '/kits/avatar_action_button/react
2. Click on Avatar and inspect that the icon size is half of avatar size
3. Check on Rails version of kit
4. See addition styling of all the kits listed above as calculations are computed for various different style elements in the scss of those kits


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.