### PR TITLE
[PLAY-1774] Fix Timeline Label and Step Spacing

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
@@ -86,6 +86,11 @@ $gap_lg: $height_from_top + $space_lg;
                     }
                 }
             }
+            [class=pb_timeline_item_step] { 
+                > :first-child:not([class^=pb_icon_circle_kit]) { 
+                    margin-top: $space_xs;
+                }
+            }
         }
         &[class*=_with_date] {
             @include flex_wrapper(row);

--- a/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
@@ -50,7 +50,7 @@ $gap_lg: $height_from_top + $space_lg;
         >div {
             &:last-child {
                 flex-basis: auto !important;
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     [class=pb_timeline_item_connector] {
                         opacity: 0;
                     }
@@ -66,7 +66,7 @@ $gap_lg: $height_from_top + $space_lg;
         [class*=pb_timeline_item_kit] {
             &[class*=_solid] {
                 flex-basis: 100%;
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     @include flex_wrapper(row);
                     align-items: center;
                     margin-top: $space_xs;
@@ -78,7 +78,7 @@ $gap_lg: $height_from_top + $space_lg;
             }
             &[class*=_dotted] {
                 flex-basis: 100%;
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     @include flex_wrapper(row);
                     align-items: center;
                     margin-top: $space_xs;
@@ -95,7 +95,7 @@ $gap_lg: $height_from_top + $space_lg;
             >div {
                 &:last-child {
                     flex-basis: auto !important;
-                    [class=pb_timeline_item_step] {
+                    [class^=pb_timeline_item_step] {
                         [class=pb_timeline_item_connector] {
                             opacity: 0;
                         }
@@ -125,7 +125,7 @@ $gap_lg: $height_from_top + $space_lg;
                             }
                         }
                     }
-                    [class=pb_timeline_item_step] {
+                    [class^=pb_timeline_item_step] {
                         @include flex_wrapper(row);
                         margin-top: $space_xs;
                         margin-bottom: $space_xs;
@@ -149,7 +149,7 @@ $gap_lg: $height_from_top + $space_lg;
                             }
                         }
                     }
-                    [class=pb_timeline_item_step] {
+                    [class^=pb_timeline_item_step] {
                         @include flex_wrapper(row);
                         margin-top: $space_xs;
                         margin-bottom: $space_xs;
@@ -166,7 +166,7 @@ $gap_lg: $height_from_top + $space_lg;
         align-items: flex-start;
         align-self: auto;
         >div:last-child {
-            [class=pb_timeline_item_step] {
+            [class^=pb_timeline_item_step] {
                 [class=pb_timeline_item_connector] {
                     opacity: 0;
                 }
@@ -176,7 +176,7 @@ $gap_lg: $height_from_top + $space_lg;
             @include flex_wrapper(row);
             &[class*=_solid] {
                 flex-basis: 100%;
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     @include flex_wrapper(column);
                     align-items: center;
                     align-content: flex-start;
@@ -197,7 +197,7 @@ $gap_lg: $height_from_top + $space_lg;
             }
             &[class*=_dotted] {
                 flex-basis: 100%;
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     @include flex_wrapper(column);
                     align-items: center;
                     margin-right: $space_sm;
@@ -221,7 +221,7 @@ $gap_lg: $height_from_top + $space_lg;
             align-items: flex-start;
             align-self: auto;
             >div:last-child {
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     [class=pb_timeline_item_connector] {
                         opacity: 0;
                     }
@@ -231,7 +231,7 @@ $gap_lg: $height_from_top + $space_lg;
                 @include flex_wrapper(row);
                 &[class*=_solid] {
                     flex-basis: 100%;
-                    [class=pb_timeline_item_step] {
+                    [class^=pb_timeline_item_step] {
                         @include flex_wrapper(column);
                         align-items: center;
                         align-content: flex-start;
@@ -252,7 +252,7 @@ $gap_lg: $height_from_top + $space_lg;
                 }
                 &[class*=_dotted] {
                     flex-basis: 100%;
-                    [class=pb_timeline_item_step] {
+                    [class^=pb_timeline_item_step] {
                         @include flex_wrapper(column);
                         align-items: center;
                         margin-right: $space_sm;
@@ -274,7 +274,7 @@ $gap_lg: $height_from_top + $space_lg;
         }
         &[class*=_gap_xs] {
             [class*=pb_timeline_item_kit] {
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     [class=pb_timeline_item_connector] {
                         height: $gap_xs !important;
                     }
@@ -283,7 +283,7 @@ $gap_lg: $height_from_top + $space_lg;
         }
         &[class*=_gap_sm] {
             [class*=pb_timeline_item_kit] {
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     [class=pb_timeline_item_connector] {
                         height: $gap_sm !important;
                     }
@@ -292,7 +292,7 @@ $gap_lg: $height_from_top + $space_lg;
         }
         &[class*=_gap_md] {
             [class*=pb_timeline_item_kit] {
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     [class=pb_timeline_item_connector] {
                         height: $gap_md !important;
                     }
@@ -301,7 +301,7 @@ $gap_lg: $height_from_top + $space_lg;
         }
         &[class*=_gap_lg] {
             [class*=pb_timeline_item_kit] {
-                [class=pb_timeline_item_step] {
+                [class^=pb_timeline_item_step] {
                     [class=pb_timeline_item_connector] {
                         height: $gap_lg !important;
                     }

--- a/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
@@ -68,10 +68,11 @@ $gap_lg: $height_from_top + $space_lg;
                 flex-basis: 100%;
                 [class=pb_timeline_item_step] {
                     @include flex_wrapper(row);
+                    align-items: center;
                     margin-top: $space_xs;
                     margin-bottom: $space_xs;
                     [class=pb_timeline_item_connector] {
-                        @include pb_timeline_line_solid($connector_width, $connector_width, $height_from_top $icon_margin 0 $icon_margin );
+                        @include pb_timeline_line_solid($connector_width, $connector_width, 0 $icon_margin 0 $icon_margin );
                     }
                 }
             }
@@ -79,16 +80,12 @@ $gap_lg: $height_from_top + $space_lg;
                 flex-basis: 100%;
                 [class=pb_timeline_item_step] {
                     @include flex_wrapper(row);
+                    align-items: center;
                     margin-top: $space_xs;
                     margin-bottom: $space_xs;
                     [class=pb_timeline_item_connector] {
-                        @include pb_timeline_line_dotted_horizontal($connector_width, $connector_width, $height_from_top $icon_margin 0 $icon_margin );
+                        @include pb_timeline_line_dotted_horizontal($connector_width, $connector_width, 0 $icon_margin 0 $icon_margin );
                     }
-                }
-            }
-            [class=pb_timeline_item_step] { 
-                > :first-child:not([class^=pb_icon_circle_kit]) { 
-                    margin-top: $space_xs;
                 }
             }
         }
@@ -133,7 +130,7 @@ $gap_lg: $height_from_top + $space_lg;
                         margin-top: $space_xs;
                         margin-bottom: $space_xs;
                         [class=pb_timeline_item_connector] {
-                            @include pb_timeline_line_solid($connector_width, $connector_width, $height_from_top $icon_margin 0 $icon_margin );
+                            @include pb_timeline_line_solid($connector_width, $connector_width, 0 $icon_margin 0 $icon_margin );
                         }
                     }
                 }
@@ -157,7 +154,7 @@ $gap_lg: $height_from_top + $space_lg;
                         margin-top: $space_xs;
                         margin-bottom: $space_xs;
                         [class=pb_timeline_item_connector] {
-                            @include pb_timeline_line_dotted_horizontal($connector_width, $connector_width, $height_from_top $icon_margin 0 $icon_margin );
+                            @include pb_timeline_line_dotted_horizontal($connector_width, $connector_width, 0 $icon_margin 0 $icon_margin );
                         }
                     }
                 }
@@ -181,11 +178,12 @@ $gap_lg: $height_from_top + $space_lg;
                 flex-basis: 100%;
                 [class=pb_timeline_item_step] {
                     @include flex_wrapper(column);
+                    align-items: center;
                     align-content: flex-start;
                     margin-right: $space_sm;
                     margin-left: $space_sm;
                     [class=pb_timeline_item_connector] {
-                        @include pb_timeline_line_solid($connector_width, $connector_width, $icon_margin 0 $icon_margin $height_from_top);
+                        @include pb_timeline_line_solid($connector_width, $connector_width, $icon_margin 0 $icon_margin 0);
                     }
                 }
                 [class=pb_timeline_item_left_block] {
@@ -201,10 +199,11 @@ $gap_lg: $height_from_top + $space_lg;
                 flex-basis: 100%;
                 [class=pb_timeline_item_step] {
                     @include flex_wrapper(column);
+                    align-items: center;
                     margin-right: $space_sm;
                     margin-left: $space_sm;
                     [class=pb_timeline_item_connector] {
-                        @include pb_timeline_line_dotted_vertical($connector_width, $connector_width, $icon_margin 0 $icon_margin $height_from_top);
+                        @include pb_timeline_line_dotted_vertical($connector_width, $connector_width, $icon_margin 0 $icon_margin 0);
                     }
                 }
                 [class=pb_timeline_item_left_block] {
@@ -234,11 +233,12 @@ $gap_lg: $height_from_top + $space_lg;
                     flex-basis: 100%;
                     [class=pb_timeline_item_step] {
                         @include flex_wrapper(column);
+                        align-items: center;
                         align-content: flex-start;
                         margin-right: $space_sm;
                         margin-left: $space_sm;
                         [class=pb_timeline_item_connector] {
-                            @include pb_timeline_line_solid($connector_width, $connector_width, $icon_margin 0 $icon_margin $height_from_top);
+                            @include pb_timeline_line_solid($connector_width, $connector_width, $icon_margin 0 $icon_margin 0);
                         }
                     }
                     [class=pb_timeline_item_left_block] {
@@ -254,10 +254,11 @@ $gap_lg: $height_from_top + $space_lg;
                     flex-basis: 100%;
                     [class=pb_timeline_item_step] {
                         @include flex_wrapper(column);
+                        align-items: center;
                         margin-right: $space_sm;
                         margin-left: $space_sm;
                         [class=pb_timeline_item_connector] {
-                            @include pb_timeline_line_dotted_vertical($connector_width, $connector_width, $icon_margin 0 $icon_margin $height_from_top);
+                            @include pb_timeline_line_dotted_vertical($connector_width, $connector_width, $icon_margin 0 $icon_margin 0);
                         }
                     }
                     [class=pb_timeline_item_left_block] {

--- a/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
+++ b/playbook/app/pb_kits/playbook/pb_timeline/_timeline.scss
@@ -66,9 +66,6 @@ $gap_lg: $height_from_top + $space_lg;
         [class*=pb_timeline_item_kit] {
             &[class*=_solid] {
                 flex-basis: 100%;
-                [class=pb_timeline_item_left_block] {
-                    height: 0px;
-                }
                 [class=pb_timeline_item_step] {
                     @include flex_wrapper(row);
                     margin-top: $space_xs;
@@ -80,9 +77,6 @@ $gap_lg: $height_from_top + $space_lg;
             }
             &[class*=_dotted] {
                 flex-basis: 100%;
-                [class=pb_timeline_item_left_block] {
-                    height: 0;
-                }
                 [class=pb_timeline_item_step] {
                     @include flex_wrapper(row);
                     margin-top: $space_xs;


### PR DESCRIPTION
**What does this PR do?**
- Remove 0 height which breaks padding and margin for Timeline labels
- Use flex align-items: center to center step children and connectors
- Remove margin that was centering step children/connectors before
- Correct step children CSS (add ^ "starts with" so you can add global props like "pb_timeline_item_step my_xxs")

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-01-09 at 9 25 05 AM](https://github.com/user-attachments/assets/6ade2b70-07c1-4f09-95ea-0ad9c78afa0b)

**How to test?** Steps to confirm the desired behavior:
1. Go to https://runway.powerhrg.com/backlog_items/PLAY-1774
2. View the code sandbox and make sure
3. Padding works as expected on labels
4. The step "children" (online status and icons) are centered with the "connectors"

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.