### PR TITLE
[PLAY-1750] Convert Kits to Use Pb_content_tag

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/button.html.erb
@@ -1,6 +1,5 @@
-<%= content_tag(object.tag,
-                object.tag == "button" ? object.options : object.link_options,
-                **combined_html_options) do %>
+<%= pb_content_tag(object.tag,
+                object.tag == "button" ? object.options : object.link_options) do %>
     <% if object.variant === "reaction" %>
         <% if icon && object.valid_emoji(object.icon) %>
             <%= pb_rails("flex", props:{ align: "center" }) do %>

--- a/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:label, aria: object.aria,
-                        id: object.id,
-                        data: object.data,
-                        class: object.classname,
-                        **combined_html_options
-                ) do %>
+<%= pb_content_tag(:label) do %>
   <%= content.presence || object.input %>
   <% if object.indeterminate %>
     <span data-pb-checkbox-icon-span="true" class="pb_checkbox_indeterminate">

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -1,4 +1,5 @@
-<%= pb_content_tag do %>
+<%= pb_content_tag(:div,
+    class: object.classname + object.error_class) do %>
   <div class="input_wrapper">
     <% if content.present? %>
       <%= content %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname + object.error_class,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <div class="input_wrapper">
     <% if content.present? %>
       <%= content %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
@@ -1,19 +1,14 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
     <% if object.label.present? %>
         <%= pb_rails("caption", props: {text: object.label, margin_bottom:"xs"}) %>
     <% end %>
     <div class="dropdown_wrapper<%= error_class %>" style="position: relative">
-        <input 
-            data-default-value="<%= input_default_value %>" 
-            id="dropdown-selected-option" 
-            name="<%= object.name %>" 
-            style="display: none" 
-            <%= object.required ? "required" : ""%> 
+        <input
+            data-default-value="<%= input_default_value %>"
+            id="dropdown-selected-option"
+            name="<%= object.name %>"
+            style="display: none"
+            <%= object.required ? "required" : ""%>
         />
         <% if content.present? %>
             <%= content.presence %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.html.erb
@@ -1,20 +1,15 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
     <%= pb_rails("list", props: {ordered: false, borderless: false}) do %>
-            <% if content.present? %> 
+            <% if content.present? %>
                 <%= content.presence %>
-            <% else %> 
+            <% else %>
                 <%= pb_rails("list/item", props: {
-                    display: "flex", 
-                    justify_content: "center", 
-                    padding:"xs", 
-                    }) do %> 
+                    display: "flex",
+                    justify_content: "center",
+                    padding:"xs",
+                    }) do %>
                         <%= pb_rails("body", props: {text: "No option"}) %>
                 <% end %>
             <% end %>
-    <% end %>        
+    <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_option.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_option.html.erb
@@ -1,4 +1,4 @@
-<%= pb_content_tag do %>
+<%= pb_content_tag(:div, id: object.option[:id]) do %>
     <%= pb_rails("list/item", props: {
         display: "flex",
         justify_content: "center",

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_option.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_option.html.erb
@@ -1,15 +1,10 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.option[:id],
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
     <%= pb_rails("list/item", props: {
-        display: "flex", 
-        justify_content: "center", 
-        padding:"none", 
+        display: "flex",
+        justify_content: "center",
+        padding:"none",
         cursor: "pointer"
-        }) do %> 
+        }) do %>
             <div class="dropdown_option_wrapper">
                 <% if content.present? %>
                     <%= content.presence %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.html.erb
@@ -1,21 +1,16 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
     <% if content.present? %>
         <div style="display: inline-block" tabindex="0" data-dropdown-custom-trigger>
           <%= content.presence %>
         </div>
     <% else %>
     <%= pb_rails("flex", props: {
-        align: "center", 
-        border_radius:"lg", 
-        classname: object.trigger_wrapper_classes, 
-        cursor: "pointer", 
-        justify: "between", 
-        padding_x:"sm", 
+        align: "center",
+        border_radius:"lg",
+        classname: object.trigger_wrapper_classes,
+        cursor: "pointer",
+        justify: "between",
+        padding_x:"sm",
         padding_y:"xs",
         html_options: {tabindex:"0"}
         }) do %>
@@ -23,7 +18,7 @@
             <%= pb_rails("flex", props: {align: "center"}) do %>
                 <% if object.custom_display.present?  %>
                     <%= pb_rails("flex", props: {align: "center"}) do %>
-                        <div id="dropdown_trigger_custom_display" style="display: none;"> 
+                        <div id="dropdown_trigger_custom_display" style="display: none;">
                             <%= object.custom_display %>
                         </div>
                         <%= pb_rails("body", props: {text: object.default_display_placeholder, id: "dropdown_trigger_display"}) %>
@@ -40,4 +35,3 @@
     <% end %>
     <% end %>
 <% end %>
-      

--- a/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_dropdown/dropdown"
+
+RSpec.describe Playbook::PbDropdown::Dropdown do
+  subject { Playbook::PbDropdown::Dropdown }
+
+  it { is_expected.to define_array_prop(:options).with_default([]) }
+  it { is_expected.to define_string_prop(:label) }
+  it { is_expected.to define_string_prop(:name) }
+  it { is_expected.to define_boolean_prop(:required).with_default(false) }
+  it { is_expected.to define_string_prop(:blank_selection).with_default("") }
+  it { is_expected.to define_enum_prop(:variant).with_values("default", "subtle").with_default("default") }
+  it { is_expected.to define_boolean_prop(:separators).with_default(true) }
+  it { is_expected.to define_string_prop(:default_value) }
+
+  describe "#classname" do
+    it "returns namespaced class name", :aggregate_failures do
+      expect(subject.new({}).classname).to eq "pb_dropdown_default"
+      expect(subject.new(dark: true).classname).to eq "pb_dropdown_default dark"
+      expect(subject.new(margin: "lg").classname).to eq "pb_dropdown_default m_lg"
+      expect(subject.new(classname: "additional_class").classname).to eq "pb_dropdown_default additional_class"
+    end
+  end
+
+  describe "#options_with_blank" do
+    it "includes blank selection option if blank_selection is present" do
+      dropdown = subject.new(blank_selection: "Select an option", options: [{ id: 1, label: "Option 1", value: "1" }])
+      expect(dropdown.send(:options_with_blank)).to include({ id: "", value: "", label: "Select an option" })
+    end
+
+    it "does not include blank selection option if blank_selection is not present" do
+      dropdown = subject.new(options: [{ id: 1, label: "Option 1", value: "1" }])
+      expect(dropdown.send(:options_with_blank)).not_to include({ id: "", value: "", label: "" })
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Updated Button, Checkbox, DatePicker, and Dropdown kits to no longer use "content_tag" and use our new "pb_content_tag". Also added test for Dropdown kit.

[Story 1750](https://runway.powerhrg.com/backlog_items/PLAY-1750)

**Screenshots:** Screenshots to visualize your addition/change


there should be no functional changes to any of these kits. Add Alpha testing locations to story notes


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.