### PR TITLE
[PLAY-1772] Build Input Masking for Text Input Kit [1 of 2] Rails Only

### DIFF
--- a/playbook/app/entrypoints/playbook-rails.js
+++ b/playbook/app/entrypoints/playbook-rails.js
@@ -1,3 +1,7 @@
+// Text Input
+import PbTextInput from 'kits/pb_text_input'
+PbTextInput.start()
+
 // Forms
 import 'kits/pb_form/pb_form_validation'
 import formHelper from 'kits/pb_form/formHelper'
@@ -52,9 +56,6 @@ PbRadio.start()
 
 import PbDraggable from 'kits/pb_draggable'
 PbDraggable.start()
-
-import PbTextInput from 'kits/pb_text_input'
-PbTextInput.start()
 
 import 'flatpickr'
 

--- a/playbook/app/entrypoints/playbook-rails.js
+++ b/playbook/app/entrypoints/playbook-rails.js
@@ -53,6 +53,9 @@ PbRadio.start()
 import PbDraggable from 'kits/pb_draggable'
 PbDraggable.start()
 
+import PbTextInput from 'kits/pb_text_input'
+PbTextInput.start()
+
 import 'flatpickr'
 
 // React-Rendered Rails Kits =====

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
@@ -1,31 +1,28 @@
 <%= pb_rails("text_input", props: {
-  label: "First Name",
-  placeholder: "Enter first name",
-  value: "Timothy Wenhold",
-  data: { say: "hi", yell: "go" },
-  aria: { something: "hello"},
-  id: "unique_id"
+  label: "SSN",
+  placeholder: "123-45-6789",
+  mask: "ssn",
+  id: "ssn",
+  name: "ssn"
 }) %>
-
 <%= pb_rails("text_input", props: {
-  label: "Last Name",
-  placeholder: "Enter last name"
+  label: "Currency",
+  placeholder: "$0.00",
+  mask: "currency",
+  id: "currency",
+  name: "currency"
 }) %>
-
 <%= pb_rails("text_input", props: {
-    label: "Phone Number",
-    type: "phone",
-    placeholder: "Enter phone number"
+  label: "Postal Code",
+  placeholder: 12345-1234,
+  mask: "postal_code",
+  id: "postal_code",
+  name: "postal_code"
 }) %>
-
 <%= pb_rails("text_input", props: {
-    label: "Email Address",
-    type: "email",
-    placeholder: "Enter email address"
-}) %>
-
-<%= pb_rails("text_input", props: {
-    label: "Zip Code",
-    type: "number",
-    placeholder: "Enter zip code"
+  label: "Zip Code",
+  placeholder: 12345,
+  mask: "zip_code",
+  id: "zip_code",
+  name: "zip_code"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
@@ -1,28 +1,31 @@
 <%= pb_rails("text_input", props: {
-  label: "SSN",
-  placeholder: "123-45-6789",
-  mask: "ssn",
-  id: "ssn",
-  name: "ssn"
+  label: "First Name",
+  placeholder: "Enter first name",
+  value: "Timothy Wenhold",
+  data: { say: "hi", yell: "go" },
+  aria: { something: "hello"},
+  id: "unique_id"
 }) %>
+
 <%= pb_rails("text_input", props: {
-  label: "Currency",
-  placeholder: "$0.00",
-  mask: "currency",
-  id: "currency",
-  name: "currency"
+  label: "Last Name",
+  placeholder: "Enter last name"
 }) %>
+
 <%= pb_rails("text_input", props: {
-  label: "Postal Code",
-  placeholder: 12345-1234,
-  mask: "postal_code",
-  id: "postal_code",
-  name: "postal_code"
+    label: "Phone Number",
+    type: "phone",
+    placeholder: "Enter phone number"
 }) %>
+
 <%= pb_rails("text_input", props: {
-  label: "Zip Code",
-  placeholder: 12345,
-  mask: "zip_code",
-  id: "zip_code",
-  name: "zip_code"
+    label: "Email Address",
+    type: "email",
+    placeholder: "Enter email address"
+}) %>
+
+<%= pb_rails("text_input", props: {
+    label: "Zip Code",
+    type: "number",
+    placeholder: "Enter zip code"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask.html.erb
@@ -1,0 +1,35 @@
+
+
+
+<%= pb_rails("title", props: { text: "Input Masks", size: 4, margin_bottom: "md" }) %>
+
+<div class="pb--doc-demo-elements">
+  <%= pb_rails("text_input", props: {
+    label: "Currency",
+    mask: "currency",
+    margin_bottom: "md",
+    id: "currency"
+  }) %>
+
+  <%= pb_rails("text_input", props: {
+    label: "ZIP Code",
+    mask: "zip_code",
+    margin_bottom: "md",
+    id: "zip_code"
+  }) %>
+
+  <%= pb_rails("text_input", props: {
+    label: "Postal Code",
+    mask: "postal_code",
+    placeholder: "12345-6789",
+    margin_bottom: "md",
+    id: "postal_code"
+  }) %>
+
+  <%= pb_rails("text_input", props: {
+    label: "Social Security Number",
+    mask: "ssn",
+    margin_bottom: "md",
+    id: "ssn"
+  }) %>
+</div>

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask.html.erb
@@ -8,14 +8,13 @@
     label: "Currency",
     mask: "currency",
     margin_bottom: "md",
-    id: "currency"
+    name: "currency_name"
   }) %>
 
   <%= pb_rails("text_input", props: {
     label: "ZIP Code",
     mask: "zip_code",
     margin_bottom: "md",
-    id: "zip_code"
   }) %>
 
   <%= pb_rails("text_input", props: {
@@ -23,13 +22,29 @@
     mask: "postal_code",
     placeholder: "12345-6789",
     margin_bottom: "md",
-    id: "postal_code"
   }) %>
 
   <%= pb_rails("text_input", props: {
     label: "Social Security Number",
     mask: "ssn",
     margin_bottom: "md",
-    id: "ssn"
   }) %>
+
+  <%= pb_rails("title" , props: {
+    text: "Hidden Input Under The Hood",
+    padding_bottom: "sm"
+  })%>
+
+  <%= pb_rails("text_input", props: {
+    label: "Currency",
+    mask: "currency",
+    margin_bottom: "md",
+    name: "currency_name",
+    id: "example-currency"
+  }) %>
+
+<style>
+#example-currency-sanitized {display: flex !important;}
+</style>
+
 </div>

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask_rails.md
@@ -1,3 +1,3 @@
 The mask prop lets you style your inputs while maintaining the value that the user typed in.
 
-There's a hidden input file that stores the raw value, and has the `name` feild. It will also copy the id field with a "#{your-id-sanitized}"
+It uses a hidden input field to submit the unformatted value as it will have the proper `name` attribute. It will also copy the id field with a `"#{your-id-sanitized}"`

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask_rails.md
@@ -1,3 +1,3 @@
-This mask feature lets you style your inputs while maintaining the value that the user typed in.
+The mask prop lets you style your inputs while maintaining the value that the user typed in.
 
 There's a hidden input file that stores the raw value, and has the `name` feild. It will also copy the id field with a "#{your-id-sanitized}"

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_mask_rails.md
@@ -1,0 +1,3 @@
+This mask feature lets you style your inputs while maintaining the value that the user typed in.
+
+There's a hidden input file that stores the raw value, and has the `name` feild. It will also copy the id field with a "#{your-id-sanitized}"

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/example.yml
@@ -8,6 +8,7 @@ examples:
   - text_input_inline: Inline
   - text_input_no_label: No Label
   - text_input_options: Input Options
+  - text_input_mask: Mask
   react:
   - text_input_default: Default
   - text_input_error: With Error

--- a/playbook/app/pb_kits/playbook/pb_text_input/index.js
+++ b/playbook/app/pb_kits/playbook/pb_text_input/index.js
@@ -1,0 +1,18 @@
+import PbEnhancedElement from '../pb_enhanced_element'
+
+
+
+export default class PbTextInput extends PbEnhancedElement {
+  static get selector() {
+    return '[data-pb-text-input-kit]'
+  }
+
+  connect() {
+    console.log('PbTextInput connected')
+  }
+
+
+
+
+
+}

--- a/playbook/app/pb_kits/playbook/pb_text_input/index.js
+++ b/playbook/app/pb_kits/playbook/pb_text_input/index.js
@@ -1,18 +1,103 @@
-import PbEnhancedElement from '../pb_enhanced_element'
+export default class PbTextInput {
+  static start() {
+    const inputElements = document.querySelectorAll('[data-pb-input-mask="true"]');
 
+    inputElements.forEach((inputElement) => {
+      inputElement.addEventListener("input", (event) => {
+        const maskType = inputElement.getAttribute("mask");
+        const cursorPosition = inputElement.selectionStart;
 
+        let rawValue = event.target.value;
+        let formattedValue = rawValue;
 
-export default class PbTextInput extends PbEnhancedElement {
-  static get selector() {
-    return '[data-pb-text-input-kit]'
+        // Apply formatting based on the mask type
+        switch (maskType) {
+          case "currency":
+            formattedValue = formatCurrency(rawValue);
+            break;
+          case "ssn":
+            formattedValue = formatSSN(rawValue);
+            break;
+          case "postal_code":
+            formattedValue = formatPostalCode(rawValue);
+            break;
+          case "zip_code":
+            formattedValue = formatZipCode(rawValue);
+            break;
+        }
+
+        // Update the sanitized input field in the same wrapper
+        const sanitizedInput = inputElement
+          .closest(".text_input_wrapper")
+          ?.querySelector('[data="sanitized-pb-input"]');
+
+        if (sanitizedInput) {
+          switch (maskType) {
+            case "ssn":
+              sanitizedInput.value = sanitizeSSN(formattedValue);
+              break;
+            case "currency":
+              sanitizedInput.value = sanitizeCurrency(formattedValue);
+              break;
+            default:
+              sanitizedInput.value = formattedValue; 
+          }
+        }
+
+        inputElement.value = formattedValue;
+        setCursorPosition(inputElement, cursorPosition, rawValue, formattedValue);
+      });
+    });
+
   }
+}
 
-  connect() {
-    console.log('PbTextInput connected')
-  }
+function formatCurrency(value) {
+  const numericValue = value.replace(/[^0-9]/g, "").slice(0, 15);
 
+  if (!numericValue) return "";
 
+  const dollars = parseFloat((parseInt(numericValue) / 100).toFixed(2));
+  if (dollars === 0) return "";
 
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(dollars);
+}
 
+function formatSSN(value) {
+  const cleaned = value.replace(/\D/g, "").slice(0, 9);
+  return cleaned
+    .replace(/(\d{5})(?=\d)/, "$1-")
+    .replace(/(\d{3})(?=\d)/, "$1-");
+}
 
+function formatZipCode(value) {
+  return value.replace(/\D/g, "").slice(0, 5);
+}
+
+function formatPostalCode(value) {
+  const cleaned = value.replace(/\D/g, "").slice(0, 9);
+  return cleaned.replace(/(\d{5})(?=\d)/, "$1-");
+}
+
+function sanitizeSSN(input) {
+  return input.replace(/\D/g, ""); 
+}
+
+function sanitizeCurrency(input) {
+  return input.replace(/[$,]/g, ""); 
+}
+
+// function to set cursor position
+function setCursorPosition(inputElement, cursorPosition, rawValue, formattedValue) {
+  const difference = formattedValue.length - rawValue.length;
+
+  const newPosition = Math.max(0, cursorPosition + difference);
+
+  requestAnimationFrame(() => {
+    inputElement.setSelectionRange(newPosition, newPosition);
+  });
 }

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     <% elsif mask.present? %>
       <%= input_tag %>
-      <%= tag(:input, placeholder: object.id, id: "#{object.id}-sanitized", name: object.name) %>
+      <%= tag(:input, data: "sanitized-pb-input", id: sanitized_id, name: object.name, style: "display: none;") %>
     <% else %>
       <%= input_tag %>
     <% end %>
@@ -23,71 +23,3 @@
   <% end %>
 <% end %>
 
-<script>
-
-
-function formatSSN(value){
-    var cleaned = value.replace(/\D/g, '').slice(0, 9);
-    return cleaned
-        .replace(/(\d{5})(?=\d)/, '$1-')
-        .replace(/(\d{3})(?=\d)/, '$1-');
-}
-
-function formatCurrency(value){
-    const numericValue = value.replace(/[^0-9]/g, '').slice(0, 15)
-
-    if (!numericValue) return ''
-
-    const dollars = parseFloat((parseInt(numericValue) / 100).toFixed(2))
-    if (dollars === 0) return ''
-
-    return new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        maximumFractionDigits: 2,
-    }).format(dollars)
-}
-
-function formatZipCode(value){
-    return value.replace(/\D/g, '').slice(0, 5)
-}
-
-function formatPostalCode(value){
-    var cleaned = value.replace(/\D/g, '').slice(0, 9);
-    return cleaned
-        .replace(/(\d{5})(?=\d)/, '$1-')
-}
-
-function sanitizeSSN(input){
-    return input.replace(/\D/g, '');
-}
-
-function sanitizeCurrency(input){
-    return input.replace(/[$,]/g, '');
-}
-
-  document.addEventListener("DOMContentLoaded", function() {
-    var input = document.getElementById("<%= object.id %>");
-    var sanitized = document.getElementById("<%= object.id %>-sanitized");
-
-    if (input && sanitized) {
-      input.addEventListener("input", function() {
-        if (input.getAttribute("mask") === "ssn") {
-          input.value = formatSSN(input.value);
-          sanitized.value = sanitizeSSN(input.value);
-        } else if (input.getAttribute("mask") === "zip_code") {
-          input.value = formatZipCode(input.value);
-          sanitized.value = formatZipCode(input.value)
-        } else if (input.getAttribute("mask") === "currency") {
-          input.value = formatCurrency(input.value);
-          sanitized.value=sanitizeCurrency(input.value)
-        } else if (input.getAttribute("mask") === "postal_code") {
-          input.value = formatPostalCode(input.value);
-          sanitized.value = sanitizeSSN(input.value)
-        }
-      });
-    }
-});
-
-
-  </script>

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
@@ -13,9 +13,81 @@
       <%= pb_rails("text_input/add_on", props: object.add_on_props) do %>
         <%= input_tag %>
       <% end %>
+    <% elsif mask.present? %>
+      <%= input_tag %>
+      <%= tag(:input, placeholder: object.id, id: "#{object.id}-sanitized", name: object.name) %>
     <% else %>
       <%= input_tag %>
     <% end %>
     <%= pb_rails("body", props: {dark: object.dark, status: "negative", text: object.error}) if object.error %>
   <% end %>
 <% end %>
+
+<script>
+
+
+function formatSSN(value){
+    var cleaned = value.replace(/\D/g, '').slice(0, 9);
+    return cleaned
+        .replace(/(\d{5})(?=\d)/, '$1-')
+        .replace(/(\d{3})(?=\d)/, '$1-');
+}
+
+function formatCurrency(value){
+    const numericValue = value.replace(/[^0-9]/g, '').slice(0, 15)
+
+    if (!numericValue) return ''
+
+    const dollars = parseFloat((parseInt(numericValue) / 100).toFixed(2))
+    if (dollars === 0) return ''
+
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 2,
+    }).format(dollars)
+}
+
+function formatZipCode(value){
+    return value.replace(/\D/g, '').slice(0, 5)
+}
+
+function formatPostalCode(value){
+    var cleaned = value.replace(/\D/g, '').slice(0, 9);
+    return cleaned
+        .replace(/(\d{5})(?=\d)/, '$1-')
+}
+
+function sanitizeSSN(input){
+    return input.replace(/\D/g, '');
+}
+
+function sanitizeCurrency(input){
+    return input.replace(/[$,]/g, '');
+}
+
+  document.addEventListener("DOMContentLoaded", function() {
+    var input = document.getElementById("<%= object.id %>");
+    var sanitized = document.getElementById("<%= object.id %>-sanitized");
+
+    if (input && sanitized) {
+      input.addEventListener("input", function() {
+        if (input.getAttribute("mask") === "ssn") {
+          input.value = formatSSN(input.value);
+          sanitized.value = sanitizeSSN(input.value);
+        } else if (input.getAttribute("mask") === "zip_code") {
+          input.value = formatZipCode(input.value);
+          sanitized.value = formatZipCode(input.value)
+        } else if (input.getAttribute("mask") === "currency") {
+          input.value = formatCurrency(input.value);
+          sanitized.value=sanitizeCurrency(input.value)
+        } else if (input.getAttribute("mask") === "postal_code") {
+          input.value = formatPostalCode(input.value);
+          sanitized.value = sanitizeSSN(input.value)
+        }
+      });
+    }
+});
+
+
+  </script>

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -65,6 +65,10 @@ module Playbook
         { dark: dark }.merge(add_on || {})
       end
 
+      def sanitized_id
+        "#{object.id}-sanitized" if id.present?
+      end
+
     private
 
       def all_input_options
@@ -95,7 +99,7 @@ module Playbook
       def validation_data
         fields = input_options.dig(:data) || {}
         fields[:message] = validation_message unless validation_message.blank?
-        fields
+        mask ? fields.merge(pb_input_mask: true) : fields
       end
 
       def error_class

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -25,6 +25,8 @@ module Playbook
       prop :add_on, type: Playbook::Props::NestedProps,
                     nested_kit: Playbook::PbTextInput::AddOn
 
+      prop :mask
+
       def classname
         default_margin_bottom = margin_bottom.present? ? "" : " mb_sm"
         generate_classname("pb_text_input_kit") + default_margin_bottom + error_class + inline_class
@@ -55,12 +57,13 @@ module Playbook
           data: validation_data,
           disabled: disabled,
           id: input_options.dig(:id) || id,
-          name: name,
+          name: mask.present? ? "" : name,
           pattern: validation_pattern,
           placeholder: placeholder,
           required: required,
           type: type,
           value: value,
+          mask: mask,
         }.merge(input_options)
       end
 
@@ -68,13 +71,9 @@ module Playbook
         validation[:message] || ""
       end
 
-      def validation_pattern
-        validation[:pattern] || nil
-      end
-
       def validation_data
         fields = input_options.dig(:data) || {}
-        fields[:message] = validation_message unless validation_message.blank?
+        fields[:message] = wvalidation_message unless validation_message.blank?
         fields
       end
 

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -4,6 +4,22 @@
 module Playbook
   module PbTextInput
     class TextInput < Playbook::KitBase
+      VALID_MASKS = %w[currency zipCode postalCode ssn].freeze
+
+      MASK_PATTERNS = {
+        "currency" => '^\$\d{1,3}(?:,\d{3})*(?:\.\d{2})?$',
+        "zip_code" => '\d{5}',
+        "postal_code" => '\d{5}-\d{4}',
+        "ssn" => '\d{3}-\d{2}-\d{4}',
+      }.freeze
+
+      MASK_PLACEHOLDERS = {
+        "currency" => "$0.00",
+        "zip_code" => "12345",
+        "postal_code" => "12345-6789",
+        "ssn" => "123-45-6789",
+      }.freeze
+
       prop :autocomplete, type: Playbook::Props::Boolean,
                           default: true
       prop :disabled, type: Playbook::Props::Boolean,
@@ -25,7 +41,8 @@ module Playbook
       prop :add_on, type: Playbook::Props::NestedProps,
                     nested_kit: Playbook::PbTextInput::AddOn
 
-      prop :mask
+      prop :mask, type: Playbook::Props::String,
+                  default: nil
 
       def classname
         default_margin_bottom = margin_bottom.present? ? "" : " mb_sm"
@@ -58,8 +75,8 @@ module Playbook
           disabled: disabled,
           id: input_options.dig(:id) || id,
           name: mask.present? ? "" : name,
-          pattern: validation_pattern,
-          placeholder: placeholder,
+          pattern: validation_pattern || mask_pattern,
+          placeholder: placeholder || mask_placeholder,
           required: required,
           type: type,
           value: value,
@@ -71,9 +88,13 @@ module Playbook
         validation[:message] || ""
       end
 
+      def validation_pattern
+        validation[:pattern] || nil
+      end
+
       def validation_data
         fields = input_options.dig(:data) || {}
-        fields[:message] = wvalidation_message unless validation_message.blank?
+        fields[:message] = validation_message unless validation_message.blank?
         fields
       end
 
@@ -83,6 +104,25 @@ module Playbook
 
       def inline_class
         inline ? " inline" : ""
+      end
+
+      def mask_data
+        return {} unless mask
+        raise ArgumentError, "mask must be one of: #{VALID_MASKS.join(', ')}" unless VALID_MASKS.include?(mask)
+
+        { mask: mask }
+      end
+
+      def mask_pattern
+        return nil unless mask
+
+        MASK_PATTERNS[mask]
+      end
+
+      def mask_placeholder
+        return nil unless mask
+
+        MASK_PLACEHOLDERS[mask]
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Create mask prop for text input kit. (rails side)

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.