### PR TITLE
Add brakeman as a development dependency in playbook

### DIFF
--- a/playbook/Gemfile.lock
+++ b/playbook/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    brakeman (7.0.0)
+      racc
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.2.3)
@@ -296,6 +298,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brakeman (= 7.0.0)
   byebug (>= 11.0.0)
   github_changelog_generator (= 1.15.2)
   playbook_ui!

--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "view_component", "2.83.0"
   s.add_dependency "webpacker-react", "~> 0.3.2"
 
+  s.add_development_dependency "brakeman", "7.0.0"
   s.add_development_dependency "byebug", ">= 11.0.0"
   s.add_development_dependency "github_changelog_generator", "1.15.2"
   s.add_development_dependency "rails", ">= 5.2.4.5"


### PR DESCRIPTION
**What does this PR do?**

Adds brakeman as a development dependency. This allows the scanner to work correctly, and developers to scan locally. It does not affect production code. 


**How to test?** Steps to confirm the desired behavior:

This does not contain any functional changes. If you want to run brakeman locally, make sure you're inside of playbook/playbook and have bundled. Then run `brakeman scan .` 


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.