### PR TITLE
Scss fixes for Responsive Scroll for Table

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/styles/_scroll.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_scroll.scss
@@ -1,4 +1,5 @@
 @import "../../tokens/screen_sizes";
+@import "../../tokens/border_radius";
 
 .table-responsive-scroll {
     overflow-x: scroll;
@@ -27,7 +28,7 @@
     @media (max-width: 1600px) {
         &[class*="table-responsive-scroll"] {
                 &:has(> table.table-card) {
-                    border-radius: 4px;
+                    border-radius: $border_rad_light;
                     box-shadow: 1px 0 0 0px $border_light,
                         -1px 0 0 0px $border_light
                 }

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_scroll.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_scroll.scss
@@ -26,11 +26,12 @@
     // Responsive Styles
     @media (max-width: 1600px) {
         &[class*="table-responsive-scroll"] {
-            border-radius: 4px;
-            box-shadow: 1px 0 0 0px $border_light,
+                &:has(> table.table-card) {
+                    border-radius: 4px;
+                    box-shadow: 1px 0 0 0px $border_light,
                         -1px 0 0 0px $border_light
-        }
-
+                }
+            }
         &[class^=pb_table].table-sm.table-card thead tr th:first-child,
         &[class^=pb_table].table-sm:not(.no-hover).table-card tbody tr td:first-child {
             border-left-width: 0px;

--- a/playbook/app/pb_kits/playbook/pb_table/styles/_scroll.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_scroll.scss
@@ -1,7 +1,6 @@
 @import "../../tokens/screen_sizes";
 
 .table-responsive-scroll {
-    display: block;
     overflow-x: scroll;
 
     // hides duplicate scroll bar for those that see two (byproduct of repeated table-responsive-scroll class


### PR DESCRIPTION
Testing a fix for for the templates for [PBNTR-778](https://runway.powerhrg.com/backlog_items/PBNTR-778)

This PR:
- Removes display block from responsive scroll class as it was breaking the table when it did not have enough columns to take up full width
- Makes fixes so that box-shadow on table-responsive-scroll does not appear if the container=false prop is used