### PR TITLE
[PBNTR-718] Draggable Kit: Simplified API for SelectableList for Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list_rails.html.erb
@@ -1,0 +1,38 @@
+<%= pb_rails("selectable_list",
+        props: {
+          enable_drag: true,
+          variant: "radio",
+          items: [
+            { drag_id: "41",
+              text: "Task 1",
+              input_options: {
+                value: "1",
+                name: "radio-name",
+              }
+            },
+            { drag_id: "42",
+              text: "Task 2",
+              checked: true,
+              input_options: {
+                value: "2",
+                name: "radio-name",
+              }
+            },
+            { drag_id: "43",
+              text: "Task 3",
+              input_options: {
+                value: "3",
+                name: "radio-name",
+              }
+            },
+            { drag_id: "44",
+              text: "Task 4",
+              input_options: {
+                value: "4",
+                name: "radio-name",
+              }
+            }
+          ]
+        }
+    )
+%>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_selectable_list_rails.md
@@ -1,0 +1,3 @@
+For a simplified version of the Draggable API for the SelectableList kit, you can do the following:
+
+The SelectableList kit is optimized to work with the draggable kit. To enable drag, use the `enable_drag` prop on SelectableList kit AND `drag_id` prop within the SelectableList kit prop. An additional optional boolean prop (set to true by default) of `drag_handle` is also available on SelectableList kit to show the drag handle icon.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
@@ -11,6 +11,7 @@ examples:
   rails:
   - draggable_default_rails: Default
   - draggable_with_list_rails: Draggable with List Kit
+  - draggable_with_selectable_list_rails: Draggable with SelectableList Kit
   - draggable_with_cards_rails: Draggable with Cards
 
 

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
@@ -4,9 +4,23 @@
     data: object.data,
     id: object.id,
     **combined_html_options) do %>
-  <%= pb_rails("list") do %>
-    <% object.items.each do |item| %>
-      <%= pb_rails("selectable_list/selectable_list_item", props: item.merge(variant: object.variant, id: object.get_id(item)) )%>
+  <% if enable_drag %>
+    <%= pb_rails("draggable", props: {initial_items: object.items}) do %>
+      <%= pb_rails("draggable/draggable_container") do %>
+        <%= pb_rails("list", props: {ordered: false}) do %>
+          <% object.items.each do |item| %>
+            <%= pb_rails("draggable/draggable_item", props: {drag_id: item[:drag_id]}) do %>
+              <%= pb_rails("selectable_list/selectable_list_item", props: item.merge(variant: object.variant, id: object.get_id(item), drag_id: item[:drag_id]) )%>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= pb_rails("list") do %>
+      <% object.items.each do |item| %>
+        <%= pb_rails("selectable_list/selectable_list_item", props: item.merge(variant: object.variant, id: object.get_id(item)) )%>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.rb
@@ -14,6 +14,9 @@ module Playbook
       prop :items, type: Playbook::Props::Array,
                    default: []
 
+      prop :enable_drag, type: Playbook::Props::Boolean,
+                         default: false
+
       def classname
         generate_classname("pb_selectable_list_kit")
       end

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.html.erb
@@ -4,6 +4,13 @@
     data: object.data,
     id: object.id,
     **combined_html_options) do %>
+  <% if object.drag_id && object.drag_handle %>
+    <span style="vertical-align: middle;">
+      <%= pb_rails("body") do %>
+        <svg width="auto" height="auto" viewBox="0 0 31 25" fill="none" xmlns="http://www.w3.org/2000/svg" color="currentColor" class="pb_custom_icon svg-inline--fa vertical_align_middle  svg_fw"><path d="M12.904 6.355a1.48 1.48 0 01-1.5-1.5c0-.796.656-1.5 1.5-1.5.797 0 1.5.704 1.5 1.5 0 .844-.703 1.5-1.5 1.5zm0 7.5a1.48 1.48 0 01-1.5-1.5c0-.796.656-1.5 1.5-1.5.797 0 1.5.704 1.5 1.5 0 .844-.703 1.5-1.5 1.5zm1.5 6c0 .844-.703 1.5-1.5 1.5a1.48 1.48 0 01-1.5-1.5c0-.796.656-1.5 1.5-1.5.797 0 1.5.704 1.5 1.5zm4.5-13.5a1.48 1.48 0 01-1.5-1.5c0-.796.657-1.5 1.5-1.5.797 0 1.5.704 1.5 1.5 0 .844-.703 1.5-1.5 1.5zm1.5 6c0 .844-.703 1.5-1.5 1.5a1.48 1.48 0 01-1.5-1.5c0-.796.657-1.5 1.5-1.5.797 0 1.5.704 1.5 1.5zm-1.5 9a1.48 1.48 0 01-1.5-1.5c0-.796.657-1.5 1.5-1.5.797 0 1.5.704 1.5 1.5 0 .844-.703 1.5-1.5 1.5z" fill="#242B42"></path></svg>
+      <% end %>
+    </span>
+  <% end %>
   <% if object.variant == "radio"%>
     <%= pb_rails("radio", props: { text: object.text, checked: object.checked, input_options: object.input_options } ) %>
     <% if content.present? %>
@@ -19,10 +26,10 @@
   <% if object.variant == "checkbox"%>
     <script>
       var checkboxElement = document.querySelector("#<%=object.id%> input[type=checkbox]")
-      
+
       checkboxElement.addEventListener("change", (evt) => {
         var listItemElement = document.querySelector("#<%=object.id%>")
-        
+
         if (evt.target.checked) {
           listItemElement.classList.add("checked_item");
         } else {
@@ -34,9 +41,9 @@
     <script>
       var radioElement = document.querySelector("#<%=object.id%> input[type=radio]")
 
-      radioElement.addEventListener("change", () => {        
+      radioElement.addEventListener("change", () => {
         var radios = radioElement.closest("ul").querySelectorAll("input[type=radio]")
-        
+
         radios.forEach((radio) => {
           if (radio.checked) {
             radio.closest("li").classList.add("checked_item");

--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list_item.rb
@@ -6,6 +6,9 @@ module Playbook
       prop :tabindex
       prop :checked, type: Playbook::Props::Boolean,
                      default: false
+      prop :drag_handle, type: Playbook::Props::Boolean,
+                         default: true
+      prop :drag_id, type: Playbook::Props::String
       prop :name, type: Playbook::Props::String
       prop :text, type: Playbook::Props::String
       prop :value, type: Playbook::Props::String


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-718](https://runway.powerhrg.com/backlog_items/PBNTR-718)
As a Playbook dev,
I want a create a simplified version of the Draggable kit for the SelectableList kit,
So that we can ensure parity between our Rails and React Draggable kits.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-01-14 at 8 13 22 AM](https://github.com/user-attachments/assets/9f021ae8-203f-4c78-9e0e-a8c5a6234ade)


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
