### PR TITLE
[PLAY-1724] DARK MODE AUDIT - Map

### DIFF
--- a/playbook-website/app/javascript/site_styles/map_styles/_map_default.scss
+++ b/playbook-website/app/javascript/site_styles/map_styles/_map_default.scss
@@ -7,4 +7,13 @@
 .pb_map {
   height: 600px;
   position: relative;
+  [class^="pb_title_kit"][class*="_4"] {
+    color: $text_lt_default
+  }
+
+  .dark & {
+    [class^="pb_title_kit"][class*="_4"] {
+      color: $text_dk_default;
+    }
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_map/_map.scss
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.scss
@@ -160,6 +160,7 @@
   }
 
   .maplibregl-popup-content {
+    @include pb_title_4;
     padding: $space_sm;
     background-color: $card_light;
     box-shadow: $shadow_deeper;

--- a/playbook/app/pb_kits/playbook/pb_map/_map.scss
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.scss
@@ -3,7 +3,7 @@
 @import "../tokens/shadows";
 @import "../tokens/border_radius";
 @import "./_pb_map_button_mixin.scss";
-@import "../tokens/titles.scss";
+@import "../tokens/titles";
 
 [class*="pb_map"] {
   .pb_map-custom-button {

--- a/playbook/app/pb_kits/playbook/pb_map/_map.scss
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.scss
@@ -194,13 +194,13 @@
     }
 
     .maplibregl-popup-content {
-      background-color: $bg_dark;
+      background-color: $white;
       color: $text_dk_default;
     }
 
     .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
     .maplibregl-popup-anchor-bottom .maplibregl-popup-tip {
-      border-top-color: $bg_dark;
+      border-top-color: $white;
     }
     .map-zoom-in-button,
     .map-zoom-out-button,

--- a/playbook/app/pb_kits/playbook/pb_map/_map.scss
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.scss
@@ -3,7 +3,6 @@
 @import "../tokens/shadows";
 @import "../tokens/border_radius";
 @import "./_pb_map_button_mixin.scss";
-@import "../tokens/titles";
 
 [class*="pb_map"] {
   .pb_map-custom-button {
@@ -160,7 +159,6 @@
   }
 
   .maplibregl-popup-content {
-    @include pb_title_4;
     padding: $space_sm;
     background-color: $card_light;
     box-shadow: $shadow_deeper;
@@ -196,7 +194,6 @@
     }
 
     .maplibregl-popup-content {
-      @include pb_title_4;
       background-color: $bg_dark;
       color: $text_dk_default;
     }

--- a/playbook/app/pb_kits/playbook/pb_map/_map.scss
+++ b/playbook/app/pb_kits/playbook/pb_map/_map.scss
@@ -3,6 +3,7 @@
 @import "../tokens/shadows";
 @import "../tokens/border_radius";
 @import "./_pb_map_button_mixin.scss";
+@import "../tokens/titles.scss";
 
 [class*="pb_map"] {
   .pb_map-custom-button {
@@ -194,13 +195,14 @@
     }
 
     .maplibregl-popup-content {
-      background-color: $white;
+      @include pb_title_4;
+      background-color: $bg_dark;
       color: $text_dk_default;
     }
 
     .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
     .maplibregl-popup-anchor-bottom .maplibregl-popup-tip {
-      border-top-color: $white;
+      border-top-color: $bg_dark;
     }
     .map-zoom-in-button,
     .map-zoom-out-button,

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_default.jsx
@@ -25,12 +25,12 @@ const MapDefault = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4 class="pb_title_kit_size_4">Hello World!</h4>`)) // add popup
+        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4>Hello World!</h4>`)) // add popup
         .addTo(map);
 
         // disable map zoom when using scroll
         map.scrollZoom.disable();
-        
+
         //add attributioncontrols
         map.addControl(new maplibregl.AttributionControl({
           compact: true
@@ -49,7 +49,7 @@ const MapDefault = (props) => {
 
     }, [])
 
-return ( 
+return (
   <Map flyTo
       flyToClick={()=> {handleFlyTo(mapInstance)}}
       zoomBtns
@@ -63,7 +63,7 @@ return (
               position: 'absolute',
               left: 0,
               right: 0,
-              top: 0, 
+              top: 0,
               bottom: 0,
            }}
        />

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_default.jsx
@@ -25,12 +25,11 @@ const MapDefault = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML('Hello World!')) // add popup
+        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4 class="pb_title_kit_size_4">Hello World!</h4>`)) // add popup
         .addTo(map);
 
         // disable map zoom when using scroll
         map.scrollZoom.disable();
-
         //add attributioncontrols
         map.addControl(new maplibregl.AttributionControl({
           compact: true

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_default.jsx
@@ -25,7 +25,7 @@ const MapDefault = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4>Hello World!</h4>`)) // add popup
+        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML('Hello World!')) // add popup
         .addTo(map);
 
         // disable map zoom when using scroll

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_custom_button.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_custom_button.jsx
@@ -25,7 +25,7 @@ const MapWithCustomButton = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4>Hello World!</h4>`)) // add popup
+        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML('Hello World!')) // add popup
         .addTo(map);
 
         // disable map zoom when using scroll

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_custom_button.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_custom_button.jsx
@@ -25,12 +25,11 @@ const MapWithCustomButton = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML('Hello World!')) // add popup
+        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4 class="pb_title_kit_size_4">Hello World!</h4>`)) // add popup
         .addTo(map);
 
         // disable map zoom when using scroll
         map.scrollZoom.disable();
-
         //add attributioncontrols
         map.addControl(new maplibregl.AttributionControl({
           compact: true

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_custom_button.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_custom_button.jsx
@@ -25,12 +25,12 @@ const MapWithCustomButton = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4 class="pb_title_kit_size_4">Hello World!</h4>`)) // add popup
+        .setPopup(new maplibregl.Popup({closeButton: false}).setHTML(`<h4>Hello World!</h4>`)) // add popup
         .addTo(map);
 
         // disable map zoom when using scroll
         map.scrollZoom.disable();
-        
+
         //add attributioncontrols
         map.addControl(new maplibregl.AttributionControl({
           compact: true
@@ -49,8 +49,8 @@ const MapWithCustomButton = (props) => {
 
     }, [])
 
-return ( 
-  <Map 
+return (
+  <Map
       {...props}
   >
     <Map.Controls flyTo
@@ -59,10 +59,10 @@ return (
         zoomInClick={() => {handleZoomIn(mapInstance)}}
         zoomOutClick={()=> {handleZoomOut(mapInstance)}}
     >
-      <MapCustomButton icon="home" 
+      <MapCustomButton icon="home"
           onClick={() => alert("button clicked!")}
       />
-      <MapCustomButton icon="search" 
+      <MapCustomButton icon="search"
           onClick={() => alert("button clicked!")}
       />
     </Map.Controls>
@@ -72,7 +72,7 @@ return (
               position: 'absolute',
               left: 0,
               right: 0,
-              top: 0, 
+              top: 0,
               bottom: 0,
            }}
        />

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_plugin.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_plugin.jsx
@@ -25,7 +25,7 @@ const MapWithPlugin = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({className: 'map_popup', closeButton: false}).setHTML(`<h4>Hello World!</h4>`)) // add popup
+        .setPopup(new maplibregl.Popup({className: 'map_popup', closeButton: false}).setHTML('Hello World!')) // add popup
         .addTo(map);
 
         //add maplibre default zoom controls

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_plugin.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_plugin.jsx
@@ -25,7 +25,7 @@ const MapWithPlugin = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({className: 'map_popup', closeButton: false}).setHTML('Hello World!')) // add popup
+        .setPopup(new maplibregl.Popup({className: 'map_popup', closeButton: false}).setHTML(`<h4 class="pb_title_kit_size_4">Hello World!</h4>`)) // add popup
         .addTo(map);
 
         //add maplibre default zoom controls
@@ -33,7 +33,6 @@ const MapWithPlugin = (props) => {
 
         // disable map zoom when using scroll
         map.scrollZoom.disable();
-
         //Add polygon draw button using map-box-gl-draw plugin
         var draw = new MapboxDraw({
             displayControlsDefault: false,
@@ -60,7 +59,6 @@ const MapWithPlugin = (props) => {
             ...mapTheme.mapConfig
         }).on('load', loadMap)
     }, [])
-
 
 
 return (

--- a/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_plugin.jsx
+++ b/playbook/app/pb_kits/playbook/pb_map/docs/_map_with_plugin.jsx
@@ -25,7 +25,7 @@ const MapWithPlugin = (props) => {
         new maplibregl.Marker({
           color: mapTheme.marker,
         }).setLngLat(defaultPosition)
-        .setPopup(new maplibregl.Popup({className: 'map_popup', closeButton: false}).setHTML(`<h4 class="pb_title_kit_size_4">Hello World!</h4>`)) // add popup
+        .setPopup(new maplibregl.Popup({className: 'map_popup', closeButton: false}).setHTML(`<h4>Hello World!</h4>`)) // add popup
         .addTo(map);
 
         //add maplibre default zoom controls
@@ -48,7 +48,7 @@ const MapWithPlugin = (props) => {
         map.addControl(new maplibregl.AttributionControl({
             compact: true
         }));
-          
+
         //set map instance
         setMapInstance(map)
     }
@@ -62,8 +62,8 @@ const MapWithPlugin = (props) => {
     }, [])
 
 
-    
-return ( 
+
+return (
   <Map flyTo
       flyToClick={()=> {handleFlyTo(mapInstance)}}
       zoomBtns
@@ -77,7 +77,7 @@ return (
               position: 'absolute',
               left: 0,
               right: 0,
-              top: 0, 
+              top: 0,
               bottom: 0,
            }}
        />


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1724](https://runway.powerhrg.com/backlog_items/PLAY-1724)

This PR is a part of the Dark Mode Audit on 'Map'.
We've updated the pop up content, it should display a dark background and white text.
Light mode was also impacted to create this change, the functionality remains the same. 

**Screenshots:** Screenshots to visualize your addition/change
Before (left) and After (right)
<img width="1708" alt="Screenshot 2025-01-15 at 3 20 13 PM" src="https://github.com/user-attachments/assets/e4954b35-59f1-43cb-814d-117a952b1a0b" />

**How to test?** Steps to confirm the desired behavior:
1. Go to playbook.powerapp.cloud/kits/map/react
2. Enable 'dark mode'
3. Check each map
4. Click on the location icon on the map --> all pop up content should have a dark background and white text
5. Enable 'light mode', make sure the pop up content behaves the same way as production


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.