### PR TITLE
[PLAY-1789] Dark Mode Select

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
@@ -29,6 +29,7 @@ const RadioChildren = (props) => {
             marginBottom="none"
             minWidth="xs"
             options={options}
+            {...props}
         />
       </Radio>
       <Radio

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -214,8 +214,11 @@
   }
   .pb_select_kit_wrapper {
     &.error {
-      > select:first-child {
+      > select {
         border-color: $error_dark;
+      }
+      > div {
+        color: $error_dark;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -234,7 +234,7 @@
     &:hover {
       select {
         color: $white !important;
-        background: rgba(0,130,255,0.1);
+        background: rgba(196, 221, 245, 0.1);
       }
       svg {
         color: $primary !important;

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -201,6 +201,12 @@
       background-color: $hover_dark;
     }
   }
+  label {
+    color: $text_dk_light;
+    * {
+      color: inherit;
+    }
+  }
   option {
     color: $text_dk_default;
   }

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -212,9 +212,6 @@
       > select {
         border-color: $error_dark;
       }
-      > div {
-        color: $error_dark;
-      }
     }
   }
   &.inline {

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -214,10 +214,8 @@
   }
   .pb_select_kit_wrapper {
     &.error {
-      .pb_select_kit_wrapper {
-        > select:first-child {
-          border-color: $error_dark;
-        }
+      > select:first-child {
+        border-color: $error_dark;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -201,10 +201,9 @@
       background-color: $hover_dark;
     }
   }
-  label {
-    color: $text_dk_light;
-    * {
-      color: inherit;
+  .pb_select_kit_label {
+    > div:first-child{
+      color: $text_dk_light;
     }
   }
   option {

--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -201,11 +201,6 @@
       background-color: $hover_dark;
     }
   }
-  .pb_select_kit_label {
-    > div:first-child{
-      color: $text_dk_light;
-    }
-  }
   option {
     color: $text_dk_default;
   }
@@ -234,7 +229,7 @@
     &:hover {
       select {
         color: $white !important;
-        background: rgba(196, 221, 245, 0.1);
+        background: $focus_input_dark;
       }
       svg {
         color: $primary !important;

--- a/playbook/app/pb_kits/playbook/pb_select/_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.tsx
@@ -94,6 +94,7 @@ const Select = ({
   const angleDown = getAllIcons()["angleDown"].icon as unknown as { [key: string]: SVGElement }
 
   const selectWrapperClass = classnames(buildCss('pb_select_kit_wrapper'), { error }, className)
+
   const selectBody =(() =>{
     if (children) return children
     return (
@@ -128,7 +129,7 @@ const Select = ({
             htmlFor={name}
         >
           <Caption 
-              dark
+              dark={props.dark}
               text={label} 
           />
         </label>
@@ -149,6 +150,7 @@ const Select = ({
         }
         {error &&
           <Body
+              dark={props.dark}
               status="negative"
               text={error}
           />

--- a/playbook/app/pb_kits/playbook/pb_select/_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.tsx
@@ -94,7 +94,6 @@ const Select = ({
   const angleDown = getAllIcons()["angleDown"].icon as unknown as { [key: string]: SVGElement }
 
   const selectWrapperClass = classnames(buildCss('pb_select_kit_wrapper'), { error }, className)
-
   const selectBody =(() =>{
     if (children) return children
     return (

--- a/playbook/app/pb_kits/playbook/pb_select/_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.tsx
@@ -127,7 +127,10 @@ const Select = ({
             className="pb_select_kit_label"
             htmlFor={name}
         >
-          <Caption text={label} />
+          <Caption 
+              dark
+              text={label} 
+          />
         </label>
       }
       <label

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -5,7 +5,7 @@
   **combined_html_options) do %>
   <% if object.label %>
     <label class="pb_select_kit_label" for="<%= object.name %>">
-      <%= pb_rails("caption", props: { text: object.label }) %>
+      <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>
     </label>
   <% end %>
   <label class="<%= object.select_wrapper_class %>" for="<%= object.name %>">

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -23,7 +23,7 @@
         object.all_attributes
       )
       %>
-      <%= pb_rails("body", props: { status: "negative", text: object.error }) %>
+      <%= pb_rails("body", props: { status: "negative", text: object.error, dark: object.dark }) %>
     <% end %>
     <% if object.multiple != true %>
       <%= pb_rails("icon", props: { custom_icon: Playbook::Engine::root.join(angle_down_path), fixed_width: true, classname: "pb_select_kit_caret"}) %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This PR audits the Select component for proper use of dark mode colors.
1. Change all lables to use $text_dk_light
2. Select Inline us updated to have a more visible hover color
3. Error state is using $error_dark for border-color

[Story](https://runway.powerhrg.com/backlog_items/PLAY-1789)

**Screenshots:** Screenshots to visualize your addition/change

<img width="588" alt="Screenshot 2025-01-15 at 8 33 22 AM" src="https://github.com/user-attachments/assets/a4dcc56d-b7c3-4bba-a9b9-8fb6f22b85d2" />
<img width="758" alt="Screenshot 2025-01-15 at 8 39 14 AM" src="https://github.com/user-attachments/assets/2419831c-72ea-4bc9-83ad-243390f92ea5" />



**How to test?** Steps to confirm the desired behavior:
1. Go to [https://pr4128.playbook.beta.gm.powerapp.cloud/kits/select/rails](https://pr4128.playbook.beta.gm.powerapp.cloud/kits/select/rails)
4. Turn on "Dark Mode" and go to the Select Kit
5. Scroll down to 'Select Default'
6. Compare caption text color to prod
7. Scroll down to 'Select w/Error'
8. Observe color of border and error message. Not that different from prod.
9. Scroll down to 'Select Inline'
10. Hover over to see color change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.