### PR TITLE
[PBNTR-781] Date Picker default date prop description update

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_default_date.md
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_default_date.md
@@ -2,4 +2,4 @@ The `defaultDate`/`default_date` prop has a null or empty string value by defaul
 
 If you use a Date object without UTC time standardization the Date Picker kit may misinterpret that date as yesterdays date (consequence of timezone differentials and the Javascript Date Object constructor).  See [this GitHub issue for more information](https://github.com/powerhome/playbook/issues/1167) and the anti-pattern examples below.
 
-
+You can leverage the `defaultDate`/`default_date` prop with custom logic in your filter or controller files where the determination of the default value changes based on user interaction. The page can load with an initial default date picker value or placeholder text, then after filter submission save the submitted values as the "new default" (via state or params).


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-781](https://runway.powerhrg.com/backlog_items/PBNTR-781) is the culmination into an investigation into mastering Date Picker default behavior. This doc example description update should help guide devs into utilizing the default date prop more dynamically in rails and react when they want to have intermediate or dynamic defaults set. 

This description update will go hand in hand with [this huddle doc](https://huddle.powerapp.cloud/projects/647/artifacts/7619) which will serve as a reference for UXEs guiding Nitro devs for Nitro specific use (Rails and React).


**Screenshots:** Screenshots to visualize your addition/change
<img width="1391" alt="for PR doc ex updated" src="https://github.com/user-attachments/assets/93b99a5e-7bc9-4483-bf38-37b3fe720502" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the default date Date Picker doc example rails or react (link to come)
2. See updated description with new paragraph about leveraging the prop.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~