### PR TITLE
[PLAY-1797 ] DARK MODE AUDIT - Radio

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_radio/_radio.scss
+++ b/playbook/app/pb_kits/playbook/pb_radio/_radio.scss
@@ -4,7 +4,7 @@
 @import "../pb_body/body";
 @import "../tokens/transition";
 
-[class^=pb_radio_kit] {
+[class^="pb_radio_kit"] {
   display: inline-flex;
   cursor: pointer;
 
@@ -16,10 +16,11 @@
     border-radius: 1000px;
     border: 2px solid $border_light;
     margin-right: $space_xs;
-    transition: background $transition_default ease, box-shadow $transition_default ease, border-color $transition_default ease;
+    transition: background $transition_default ease,
+      box-shadow $transition_default ease, border-color $transition_default ease;
   }
 
-  @media (hover:hover) {
+  @media (hover: hover) {
     &:hover .pb_radio_button {
       background-color: $bg_light;
       border-color: $border_light;
@@ -52,14 +53,14 @@
       }
     }
 
-    &:disabled:checked + .pb_radio_button{
+    &:disabled:checked + .pb_radio_button {
       cursor: not-allowed;
       background-color: $white;
       border: 6px solid $neutral;
     }
   }
 
-  &[class*=vertical] {
+  &[class*="vertical"] {
     flex-direction: column;
     align-items: center;
     .pb_radio_button {
@@ -103,10 +104,10 @@
       }
     }
 
-    @media (hover:hover) {
+    @media (hover: hover) {
       &:hover {
         .pb_radio_button {
-          background-color: rgba($white,.10);
+          background-color: rgba($white, 0.1);
           border-color: $border_dark;
         }
       }
@@ -114,6 +115,9 @@
     &.error {
       > .pb_radio_button {
         border-color: $error_dark;
+      }
+      > .pb_body_kit_negative {
+        color: $error_dark;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_radio/_radio.scss
+++ b/playbook/app/pb_kits/playbook/pb_radio/_radio.scss
@@ -81,7 +81,7 @@
       }
       &:checked {
         & ~ .pb_radio_button {
-          border: 6px solid $primary;
+          border: 6px solid $active_dark;
         }
       }
 

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
@@ -40,7 +40,7 @@ const RadioChildren = (props) => {
           value="Typeahead"
           {...props}
       >
-        <Typeahead 
+        <Typeahead
             marginBottom="none"
             minWidth="xs"
             options={options}
@@ -54,7 +54,10 @@ const RadioChildren = (props) => {
           value="Typography"
           {...props}
       >
-        <Title text="Custom Typography" />
+        <Title
+            dark
+            text="Custom Typography"
+        />
       </Radio>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
@@ -55,8 +55,8 @@ const RadioChildren = (props) => {
           {...props}
       >
         <Title
-            dark
             text="Custom Typography"
+            {...props}
         />
       </Radio>
     </div>

--- a/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
+++ b/playbook/app/pb_kits/playbook/pb_radio/docs/_radio_custom_children.jsx
@@ -29,6 +29,7 @@ const RadioChildren = (props) => {
             marginBottom="none"
             minWidth="xs"
             options={options}
+            {...props}
         />
       </Radio>
       <Radio
@@ -44,6 +45,7 @@ const RadioChildren = (props) => {
             marginBottom="none"
             minWidth="xs"
             options={options}
+            {...props}
         />
       </Radio>
       <Radio


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Story 1797](https://runway.powerhrg.com/backlog_items/PLAY-1797)
**Rails-**
With Error doc example - error label now using `$error_Dark`
All selected/checked radio borders now using `$active_dark` instead of `$primary`

**React-**
Custom Children - Typography example now easily visible with a dark background

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-01-17 at 8 44 51 AM](https://github.com/user-attachments/assets/72c2654c-b46d-4714-8e2d-512e503db550)

![Screenshot 2025-01-17 at 8 45 06 AM](https://github.com/user-attachments/assets/e8f6fb5e-b3c6-4538-a9a6-1a4b8a962acf)


![Screenshot 2025-01-16 at 3 15 41 PM](https://github.com/user-attachments/assets/6bd986e8-ce7f-440a-9b7f-c85b4a99f4ff)

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.