### PR TITLE
[PBNTR-768] Adding sticky right column and refactoring PBTable enhanced element

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_table/_table.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
 import { globalProps, GlobalProps, globalInlineProps } from '../utilities/globalProps'
-import PbTable from '.'
 import {
     TableHead,
     TableHeader,
@@ -10,6 +9,7 @@ import {
     TableRow,
     TableCell,
 } from "./subcomponents";
+import { addDataTitle } from './utilities/addDataTitle'
 
 type TableProps = {
     aria?: { [key: string]: string },
@@ -196,8 +196,7 @@ const Table = (props: TableProps): React.ReactElement => {
     }, [stickyRightColumn]);
 
     useEffect(() => {
-        const instance = new PbTable()
-        instance.connect()
+        addDataTitle()
     }, [])
 
     return (

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.html.erb
@@ -1,0 +1,74 @@
+<%= pb_rails("table", props: { size: "md", responsive: "scroll", sticky_left_column: ["a"], sticky_right_column: ["b"] }) do %>
+  <thead>
+    <tr>
+      <th id="a">Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+      <th>Column 4</th>
+      <th>Column 5</th>
+      <th>Column 6</th>
+      <th>Column 7</th>
+      <th>Column 8</th>
+      <th>Column 9</th>
+      <th>Column 10</th>
+      <th>Column 11</th>
+      <th>Column 12</th>
+      <th>Column 13</th>
+      <th>Column 14</th>
+      <th id="b">Column 15</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td id="a">Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+      <td>Value 6</td>
+      <td>Value 7</td>
+      <td>Value 8</td>
+      <td>Value 9</td>
+      <td>Value 10</td>
+      <td>Value 11</td>
+      <td>Value 12</td>
+      <td>Value 13</td>
+      <td>Value 14</td>
+      <td id="b">Value 15</td>
+    </tr>
+    <tr>
+      <td id="a">Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+      <td>Value 6</td>
+      <td>Value 7</td>
+      <td>Value 8</td>
+      <td>Value 9</td>
+      <td>Value 10</td>
+      <td>Value 11</td>
+      <td>Value 12</td>
+      <td>Value 13</td>
+      <td>Value 14</td>
+      <td id="b">Value 15</td>
+    </tr>
+    <tr>
+      <td id="a">Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+      <td>Value 6</td>
+      <td>Value 7</td>
+      <td>Value 8</td>
+      <td>Value 9</td>
+      <td>Value 10</td>
+      <td>Value 11</td>
+      <td>Value 12</td>
+      <td>Value 13</td>
+      <td>Value 14</td>
+      <td id="b">Value 15</td>
+    </tr>
+  </tbody>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns_rails.md
@@ -1,0 +1,3 @@
+The `sticky_left_column` and `sticky_right_column` props can be used together on the same table as needed.
+
+Please ensure that unique ids are used for all columns across multiple tables. Using the same columns ids on multiple tables can lead to issues when using props.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns_rails.md
@@ -1,3 +1,3 @@
-The `stickyLeftColumn` prop expects an array of the column ids you want to be sticky. Make sure to add the corresponding id to the `<th>` and `<td>`.
+The `sticky_left_column` prop expects an array of the column ids you want to be sticky. Make sure to add the corresponding id to the `<th>` and `<td>`.
 
-Please ensure that unique ids are used for all columns across multiple tables. Using the same columns ids on multiple tables can lead to issues when using the `stickyLeftColumn`.
+Please ensure that unique ids are used for all columns across multiple tables. Using the same columns ids on multiple tables can lead to issues when using the `sticky_left_column`.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.html.erb
@@ -1,0 +1,74 @@
+<%= pb_rails("table", props: { size: "md", responsive: "scroll", sticky_right_column: ["13", "14", "15"] }) do %>
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+      <th>Column 4</th>
+      <th>Column 5</th>
+      <th>Column 6</th>
+      <th>Column 7</th>
+      <th>Column 8</th>
+      <th>Column 9</th>
+      <th>Column 10</th>
+      <th>Column 11</th>
+      <th>Column 12</th>
+      <th id="13">Column 13</th>
+      <th id="14">Column 14</th>
+      <th id="15">Column 15</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+      <td>Value 6</td>
+      <td>Value 7</td>
+      <td>Value 8</td>
+      <td>Value 9</td>
+      <td>Value 10</td>
+      <td>Value 11</td>
+      <td>Value 12</td>
+      <td id="13">Value 13</td>
+      <td id="14">Value 14</td>
+      <td id="15">Value 15</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+      <td>Value 6</td>
+      <td>Value 7</td>
+      <td>Value 8</td>
+      <td>Value 9</td>
+      <td>Value 10</td>
+      <td>Value 11</td>
+      <td>Value 12</td>
+      <td id="13">Value 13</td>
+      <td id="14">Value 14</td>
+      <td id="15">Value 15</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+      <td>Value 6</td>
+      <td>Value 7</td>
+      <td>Value 8</td>
+      <td>Value 9</td>
+      <td>Value 10</td>
+      <td>Value 11</td>
+      <td>Value 12</td>
+      <td id="13">Value 13</td>
+      <td id="14">Value 14</td>
+      <td id="15">Value 15</td>
+    </tr>
+  </tbody>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns_rails.md
@@ -1,0 +1,3 @@
+The `sticky_right_column` prop works in the same way as the above `sticky_left_column` prop. It expects an array of the column ids you want to be sticky. Make sure to add the corresponding id to the `<th>` and `<td>`.
+
+Please ensure that unique ids are used for all columns across multiple tables. Using the same columns ids on multiple tables can lead to issues when using the `sticky_right_column` prop.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
@@ -5,6 +5,8 @@ examples:
     - table_lg: Large
     - table_sticky: Sticky Header
     - table_sticky_left_columns: Sticky Left Column
+    - table_sticky_right_columns: Sticky Right Column
+    - table_sticky_columns: Sticky Left and Right Columns
     - table_header: Table Header
     - table_alignment_row_rails: Row Alignment
     - table_alignment_column_rails: Cell Alignment

--- a/playbook/app/pb_kits/playbook/pb_table/table.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table.html.erb
@@ -4,7 +4,7 @@
   <% responsive_class = nil %>
 <% end %>
 
-<%= content_tag(:div, class: responsive_class) do %>
+<%= content_tag(:div, class: responsive_class, 'data-pb-table-wrapper' => true) do %>
   <% if object.tag == "table" %>
     <%= content_tag(:table,
       aria: object.aria,

--- a/playbook/app/pb_kits/playbook/pb_table/table.rb
+++ b/playbook/app/pb_kits/playbook/pb_table/table.rb
@@ -25,6 +25,8 @@ module Playbook
                     default: false
       prop :sticky_left_column, type: Playbook::Props::Array,
                                 default: []
+      prop :sticky_right_column, type: Playbook::Props::Array,
+                                 default: []
       prop :vertical_border, type: Playbook::Props::Boolean,
                              default: false
       prop :striped, type: Playbook::Props::Boolean,
@@ -40,7 +42,7 @@ module Playbook
         generate_classname(
           "pb_table", "table-#{size}", single_line_class, dark_class,
           disable_hover_class, container_class, data_table_class, sticky_class, sticky_left_column_class,
-          collapse_class, vertical_border_class, striped_class, outer_padding_class,
+          sticky_right_column_class, collapse_class, vertical_border_class, striped_class, outer_padding_class,
           "table-responsive-#{responsive}", separator: " "
         )
       end
@@ -83,8 +85,21 @@ module Playbook
         if sticky_left_column.empty?
           nil
         else
-          sticky_col_classname = "sticky-left-column sticky-columns"
+          sticky_col_classname = "sticky-left-column sticky-left-columns-ids"
           sticky_left_column.each do |id|
+            sticky_col_classname += "-#{id}"
+          end
+
+          sticky_col_classname
+        end
+      end
+
+      def sticky_right_column_class
+        if sticky_right_column.empty?
+          nil
+        else
+          sticky_col_classname = "sticky-right-column sticky-right-columns-ids"
+          sticky_right_column.each do |id|
             sticky_col_classname += "-#{id}"
           end
 

--- a/playbook/app/pb_kits/playbook/pb_table/utilities/addDataTitle.ts
+++ b/playbook/app/pb_kits/playbook/pb_table/utilities/addDataTitle.ts
@@ -1,0 +1,22 @@
+export const addDataTitle = () => {
+    const tables = document.querySelectorAll('.table-responsive-collapse');
+    // Each Table
+    [].forEach.call(tables, (table: HTMLTableElement) => {
+        // Header Titles
+        const headers: string[] = [];
+        [].forEach.call(table.querySelectorAll('th'), (header: HTMLTableCellElement) => {
+            const colSpan = header.colSpan
+            for (let i = 0; i < colSpan; i++) {
+                headers.push(header.textContent.replace(/\r?\n|\r/, ''));
+            }
+        });
+        // for each row in tbody
+        [].forEach.call(table.querySelectorAll('tbody tr'), (row: HTMLTableRowElement) => {
+            // for each cell
+            [].forEach.call(row.cells, (cell: HTMLTableCellElement, headerIndex: number) => {
+                // apply the attribute
+                cell.setAttribute('data-title', headers[headerIndex])
+            })
+        })
+    });
+}

--- a/playbook/spec/pb_kits/playbook/kits/table_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/table_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Playbook::PbTable::Table do
       expect(subject.new(disable_hover: true, dark: true, size: "lg", single_line: true).classname).to eq "pb_table table-lg single-line table-dark no-hover table-card table-collapse-sm table-responsive-collapse dark"
       expect(subject.new(sticky: true).classname).to eq "pb_table table-md table-card sticky-header table-collapse-sm table-responsive-collapse"
       expect(subject.new(outer_padding: "sm").classname).to eq "pb_table table-md table-card table-collapse-sm outer_padding_space_sm table-responsive-collapse"
-      expect(subject.new(sticky_left_column: %w[1 2 3]).classname).to eq "pb_table table-md table-card sticky-left-column sticky-columns-1-2-3 table-collapse-sm table-responsive-collapse"
+      expect(subject.new(sticky_left_column: %w[1 2 3]).classname).to eq "pb_table table-md table-card sticky-left-column sticky-left-columns-ids-1-2-3 table-collapse-sm table-responsive-collapse"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Adding sticky right column and refactoring PBTable enhanced element.

**What was done:**
1. Using the class selector (".table-responsive-collapse"), we weren't running the PBTable Enhanced Element for all the tables. What made this work for the other tables was the "document.querySelectorAll".
2. Using "document.querySelectorAll" caused unexpected behaviors (as mentioned above) and performance issues. For each table, we would run the same logic for ALL the tables on the page. This is an On2 code. If we had 10 tables on the page, we would have run it 100 times.
3. I removed the use of ref functions and binds since using arrow functions, we don't need it.
4. The React version was executing PBTable Enhanced Element causing all the issues mentioned above. This code was added 5 years ago so we could add the data atttribute "data-title" to cells. I removed this connection and I am proposing on "Next steps" we refactor the way we do it.

**How to test?** Steps to confirm the desired behavior:
1. Go to Table doc page for Rails and React


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.