### PR TITLE
[PLAY-1832] Fix Doc Typos

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_control.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_control.md
@@ -1,3 +1,3 @@
-`sortControl` is an optional prop that can be used to gain greater control over the sort state of the Advanced Table. Tanstack handles sort itself, however it does provide for a way to handle the state manually if needed. Usecases for this include needing to store the sort state so it persists on page reload, set an initial sort state, etc. 
+`sortControl` is an optional prop that can be used to gain greater control over the sort state of the Advanced Table. Tanstack handles sort itself, however it does provide for a way to handle the state manually if needed. Usecases for this include needing to store the sort state so it persists on page reload, set an initial sort state, etc.
 
-The sort state must be an object with a single key/value pair, with the key being "desc" and the value being a boolean. The default for sort directino is `desc: true`.
+The sort state must be an object with a single key/value pair, with the key being "desc" and the value being a boolean. The default for sort direction is `desc: true`.

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_subtle_variant.md
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_subtle_variant.md
@@ -1,1 +1,1 @@
-For the `subtle` variant, it is recommended that you set the `Separators` prop to `false` to remove the separator lines between the options for a more cleaner look.
+For the `subtle` variant, it is recommended that you set the `Separators` prop to `false` to remove the separator lines between the options for a cleaner look.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR fixes typos for the Dropdown & Advanced Table docs.
[Story](https://runway.powerhrg.com/backlog_items/PLAY-1832)

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-01-20 at 1 45 16 PM](https://github.com/user-attachments/assets/eeffb872-11b6-4126-938a-7da3677e3711)
![Screenshot 2025-01-20 at 1 45 46 PM](https://github.com/user-attachments/assets/77064bae-7a25-4d11-83d6-13ab48a118bb)

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.