### PR TITLE
[PLAY]-1715 Fix Website Markdown Code Indention

### DIFF
--- a/playbook-website/app/javascript/site_styles/docs/_markdown.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_markdown.scss
@@ -23,7 +23,7 @@
   blockquote,
   p {
     margin: 1rem 0 0 0;
-  }                    
+  }
   h1 {
     font-size: $text_larger;
     line-height: $text_larger;
@@ -91,7 +91,7 @@
     font-family: monospace;
     background: $bg_light;
     padding: 0.1rem 0.3rem;
-    margin: 0 5px;
+    margin: 0;
     border: 1px solid $border_light;
     border-radius: 0.25rem;
     overflow: hidden;

--- a/playbook-website/app/javascript/site_styles/docs/_markdown.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_markdown.scss
@@ -90,7 +90,7 @@
   code {
     font-family: monospace;
     background: $bg_light;
-    padding: 0rem 0rem;
+    padding: 0rem;
     margin: 0;
     border: 1px solid $border_light;
     border-radius: 0.25rem;

--- a/playbook-website/app/javascript/site_styles/docs/_markdown.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_markdown.scss
@@ -90,7 +90,7 @@
   code {
     font-family: monospace;
     background: $bg_light;
-    padding: 0.1rem 0.3rem;
+    padding: 0rem 0rem;
     margin: 0;
     border: 1px solid $border_light;
     border-radius: 0.25rem;

--- a/playbook-website/app/views/guides/getting_started/react_setup.md
+++ b/playbook-website/app/views/guides/getting_started/react_setup.md
@@ -12,17 +12,17 @@ yarn add playbook-ui
 
 ```json
 "react": "17.0.2",
- "react-dom": "17.0.2",
- "react-is": "^17.0.2",
- "react-trix": "0.10.1",
+"react-dom": "17.0.2",
+"react-is": "^17.0.2",
+"react-trix": "0.10.1",
 ```
 #### Import fonts and CSS styles
 Can be imported in your Index.js file or top level app Component
 
 ```js
 import 'playbook-ui/dist/fonts/fontawesome-min';
- import 'playbook-ui/dist/fonts/regular-min';
- import 'playbook-ui/dist/playbook.css';
+import 'playbook-ui/dist/fonts/regular-min';
+import 'playbook-ui/dist/playbook.css';
 ```
 #### Import Playbook React components
 
@@ -32,5 +32,5 @@ import { Avatar, Button } from 'playbook-ui';
 #### CodeSandbox React Setup Example
 [Link to CodeSandbox Example](https://codesandbox.io/s/playbook-empty-6ixcw)
 
-### Dependencies 
+### Dependencies
 [More details about Playbook dependencies](/guides/getting_started/dependencies)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Removes margin from markdown code blocks to match documentation.

[Story 1715](https://runway.powerhrg.com/backlog_items/PLAY-1715)
**Screenshots:** Screenshots to visualize your addition/change

<img width="857" alt="Screenshot 2025-01-22 at 9 05 41 AM" src="https://github.com/user-attachments/assets/ec729c56-9623-45e0-a942-74b3b84a8e40" />



**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.