### PR TITLE
[PLAY-1787] Selectable Icon - Dark Mode Audit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/_selectable_icon.tsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/_selectable_icon.tsx
@@ -16,6 +16,7 @@ type SelectableIconProps = {
   checked?: boolean,
   className?: string,
   customIcon?: {[key: string] :SVGElement},
+  dark?: boolean,
   disabled?: boolean,
   data?: GenericObject,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
@@ -33,6 +34,7 @@ const SelectableIcon = ({
   className,
   checked = false,
   customIcon,
+  dark = false,
   data = {},
   disabled = false,
   htmlOptions = {},
@@ -52,10 +54,12 @@ const SelectableIcon = ({
   const classes = classnames(
     buildCss('pb_selectable_icon_kit', {
       checked: checked,
+      dark: dark,
       disabled: disabled,
       enabled: !disabled,
     }),
     globalProps(props),
+    dark ? 'dark' : '',
     className
   )
 
@@ -73,17 +77,19 @@ const SelectableIcon = ({
         <>
           <Icon
               customIcon={customIcon}
+              dark={dark}
               icon={icon}
               size="2x"
           />
           <Title
+              dark={dark}
               size={4}
               tag="h4"
               text={text}
           />
         </>
       )}
-          
+
       {inputs === 'enabled' && (
         <>
           <input
@@ -98,10 +104,12 @@ const SelectableIcon = ({
           <label htmlFor={inputIdPresent}>
             <Icon
                 customIcon={customIcon}
+                dark={dark}
                 icon={icon}
                 size="2x"
             />
             <Title
+                dark={dark}
                 size={4}
                 tag="h4"
                 text={text}

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_default.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import SelectableIcon from '../_selectable_icon'
 
-const SelectableIconDefault = ({ dark } ) => {
+const SelectableIconDefault = (props) => {
   const [ checkSelected, toggleSelected ] = useState(true)
   const [ checkUnselected, toggleUnselected ] = useState(false)
   const [ checkDisabled, toggleDisabled ] = useState(false)
@@ -11,30 +11,30 @@ const SelectableIconDefault = ({ dark } ) => {
     <div className="pb--doc-demo-row">
       <SelectableIcon
           checked={checkSelected}
-          dark={dark}
           icon="dollar-sign"
           inputId={10}
           onChange={() => toggleSelected(!checkSelected)}
           text="US Dollar"
+          {...props}
       />
 
       <SelectableIcon
           checked={checkUnselected}
-          dark={dark}
           icon="euro-sign"
           inputId={11}
           onChange={() => toggleUnselected(!checkUnselected)}
           text="Euro"
+          {...props}
       />
 
       <SelectableIcon
           checked={checkDisabled}
-          dark={dark}
           disabled
           icon="yen-sign"
           inputId={12}
           onChange={() => toggleDisabled(!checkDisabled)}
           text="Yen"
+          {...props}
       />
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_default.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import SelectableIcon from '../_selectable_icon'
 
-const SelectableIconDefault = () => {
+const SelectableIconDefault = ({ dark } ) => {
   const [ checkSelected, toggleSelected ] = useState(true)
   const [ checkUnselected, toggleUnselected ] = useState(false)
   const [ checkDisabled, toggleDisabled ] = useState(false)
@@ -11,6 +11,7 @@ const SelectableIconDefault = () => {
     <div className="pb--doc-demo-row">
       <SelectableIcon
           checked={checkSelected}
+          dark={dark}
           icon="dollar-sign"
           inputId={10}
           onChange={() => toggleSelected(!checkSelected)}
@@ -19,6 +20,7 @@ const SelectableIconDefault = () => {
 
       <SelectableIcon
           checked={checkUnselected}
+          dark={dark}
           icon="euro-sign"
           inputId={11}
           onChange={() => toggleUnselected(!checkUnselected)}
@@ -27,6 +29,7 @@ const SelectableIconDefault = () => {
 
       <SelectableIcon
           checked={checkDisabled}
+          dark={dark}
           disabled
           icon="yen-sign"
           inputId={12}

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_single_select.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_single_select.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import SelectableIcon from '../_selectable_icon'
 
-const SelectableIconSingleSelect = ({ dark }) => {
+const SelectableIconSingleSelect = (props) => {
   const [ selectedFormat, toggleFormat ] = useState(null)
 
   return (
@@ -10,7 +10,6 @@ const SelectableIconSingleSelect = ({ dark }) => {
     <div className="pb--doc-demo-row">
       <SelectableIcon
           checked={selectedFormat === 'Cassette'}
-          dark={dark}
           icon="cassette-tape"
           inputId={13}
           multi={false}
@@ -18,11 +17,11 @@ const SelectableIconSingleSelect = ({ dark }) => {
           onChange={() => toggleFormat('Cassette')}
           text="Cassette"
           value="Cassette"
+          {...props}
       />
 
       <SelectableIcon
           checked={selectedFormat === 'CD'}
-          dark={dark}
           icon="compact-disc"
           inputId={14}
           multi={false}
@@ -30,11 +29,11 @@ const SelectableIconSingleSelect = ({ dark }) => {
           onChange={() => toggleFormat('CD')}
           text="CD"
           value="CD"
+          {...props}
       />
 
       <SelectableIcon
           checked={selectedFormat === 'Vinyl'}
-          dark={dark}
           icon="album-collection"
           inputId={15}
           multi={false}
@@ -42,6 +41,7 @@ const SelectableIconSingleSelect = ({ dark }) => {
           onChange={() => toggleFormat('Vinyl')}
           text="Vinyl"
           value="Vinyl"
+          {...props}
       />
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_single_select.jsx
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/docs/_selectable_icon_single_select.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import SelectableIcon from '../_selectable_icon'
 
-const SelectableIconSingleSelect = () => {
+const SelectableIconSingleSelect = ({ dark }) => {
   const [ selectedFormat, toggleFormat ] = useState(null)
 
   return (
@@ -10,6 +10,7 @@ const SelectableIconSingleSelect = () => {
     <div className="pb--doc-demo-row">
       <SelectableIcon
           checked={selectedFormat === 'Cassette'}
+          dark={dark}
           icon="cassette-tape"
           inputId={13}
           multi={false}
@@ -21,6 +22,7 @@ const SelectableIconSingleSelect = () => {
 
       <SelectableIcon
           checked={selectedFormat === 'CD'}
+          dark={dark}
           icon="compact-disc"
           inputId={14}
           multi={false}
@@ -32,6 +34,7 @@ const SelectableIconSingleSelect = () => {
 
       <SelectableIcon
           checked={selectedFormat === 'Vinyl'}
+          dark={dark}
           icon="album-collection"
           inputId={15}
           multi={false}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR enables proper use of dark mode to the selectable icon kit in React.

**Screenshots:** Screenshots to visualize your addition/change
Before(left) and After(right)
![Screenshot 2025-01-20 at 3 39 32 PM](https://github.com/user-attachments/assets/44593a0e-380a-4537-a34e-15c80445ef69)


**How to test?** Steps to confirm the desired behavior:
1. Go to the selectable icon kit : /kits/selectable_icon/react
2. Toggle Dark Mode
3. Switch to React
4. See change on each selectable icon kit


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.