### PR TITLE
[PLAY-1751] Convert Kits to Use pb_content_tag (File Upload, Filter, Form Group, and Form Pill)

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag("div",
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag(:div) do %>
       <%= pb_rails("form_group", props: {cursor: "pointer", full_width: object.full_width}) do %>
         <label
           for="upload-<%= object.id %>"

--- a/playbook/app/pb_kits/playbook/pb_filter/filter.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/filter.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag(:div) do %>
     <%= object.wrapper do %>
       <%= pb_rails("flex", props: { orientation: "row", padding_right: "lg", vertical: "center" }) do %>
         <% if (object.template != "sort_only") %>

--- a/playbook/app/pb_kits/playbook/pb_form_group/form_group.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_group/form_group.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag(:div) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/form_pill.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag(:div, id: object.id, data: object.data, class: object.classname + object.size_class, tabindex: object.tabindex, **combined_html_options) do %>
+<%= pb_content_tag(:div, class: object.classname + object.size_class, tabindex: object.tabindex) do %>
   <% if object.name.present? %>
     <%= pb_rails("avatar", props: { name: object.name, image_url: object.avatar_url, size: "xxs" }) %>
     <% if object.truncate %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Update File Upload, Filter, Form Group, and Form Pill kits to no longer use "content_tag" and use our new "pb_content_tag". 

**How to test?** Steps to confirm the desired behavior:
1. Test Rails File Upload, Filter, Form Group, and Form Pill kits on Playbook website.
2. Test uses on Nitro.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.