### PR TITLE
[PLAY-1724] Dark Mode - Map Audit

### DIFF
--- a/playbook-website/app/javascript/site_styles/map_styles/_map_default.scss
+++ b/playbook-website/app/javascript/site_styles/map_styles/_map_default.scss
@@ -7,4 +7,13 @@
 .pb_map {
   height: 600px;
   position: relative;
+  [class^="pb_title_kit"][class*="_4"] {
+    color: $text_lt_default
+  }
+
+  .dark & {
+    [class^="pb_title_kit"][class*="_4"] {
+      color: $text_dk_default;
+    }
+  }
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1724](https://runway.powerhrg.com/backlog_items/PLAY-1724)

This PR is a part of the Dark Mode Audit on 'Map'.
We've updated the pop up content, it should display a dark background and white text.
Light mode was also impacted to create this change, the functionality remains the same.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1708" alt="403572936-e4954b35-59f1-43cb-814d-117a952b1a0b" src="https://github.com/user-attachments/assets/3dc39783-ce46-421c-814c-c8084ea3376c" />

**How to test?** Steps to confirm the desired behavior:
1.  Go to playbook.powerapp.cloud/kits/map/react
2.  Enable 'dark mode'
3.  Check each map
4.  Click on the location icon on the map --> all pop up content should have a dark background and white text
5.  Enable 'light mode', make sure the pop up content behaves the same way as production

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.