### PR TITLE
[PBNTR-720] Draggable Kit: Simplified API for Card kit for Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.html.erb
@@ -1,5 +1,22 @@
-<%= pb_content_tag(object.tag) do %>
-    <%= content.presence %>
+<% if object.draggable_item %>
+    <%= pb_rails("draggable/draggable_item", props:{drag_id: object.drag_id}) do %>
+        <%= pb_content_tag(object.tag) do %>
+            <% if object.draggable_item && object.drag_handle %>
+                <%= pb_rails("flex", props: { align: "center", width: "100%" }) do %>
+                    <span classname="card_draggable_handle">
+                        <%= pb_rails("icon", props: { icon: "grip-dots-vertical", vertical_align: "middle", padding_right: "xs" }) %>
+                    </span>
+                    <div style="width: '100%'">
+                        <%= content.presence %>
+                    </div>
+                <% end %>
+            <% end %>
+        <% end %>
+    <% end %>
+<% else %>
+    <%= pb_content_tag(object.tag) do %>
+        <%= content.presence %>
+    <% end %>
 <% end %>
 
 

--- a/playbook/app/pb_kits/playbook/pb_card/card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.html.erb
@@ -2,7 +2,7 @@
     <%= pb_rails("draggable/draggable_item", props:{drag_id: object.drag_id}) do %>
         <%= pb_content_tag(object.tag) do %>
             <% if object.draggable_item && object.drag_handle %>
-                <%= pb_rails("flex", props: { align: "center", width: "100%" }) do %>
+                <%= pb_rails("flex", props: { align: "center" }) do %>
                     <span classname="card_draggable_handle">
                         <%= pb_rails("icon", props: { icon: "grip-dots-vertical", padding_right: "xs" }) %>
                     </span>

--- a/playbook/app/pb_kits/playbook/pb_card/card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.html.erb
@@ -1,11 +1,13 @@
 <% if object.draggable_item %>
     <%= pb_rails("draggable/draggable_item", props:{drag_id: object.drag_id}) do %>
         <%= pb_content_tag(object.tag) do %>
-            <% if object.draggable_item && object.drag_handle %>
+            <% if object.draggable_item %>
                 <%= pb_rails("flex", props: { align: "center" }) do %>
-                    <span classname="card_draggable_handle">
-                        <%= pb_rails("icon", props: { icon: "grip-dots-vertical", padding_right: "xs" }) %>
-                    </span>
+                    <% if object.drag_handle %>
+                        <span classname="card_draggable_handle">
+                            <%= pb_rails("icon", props: { icon: "grip-dots-vertical", padding_right: "xs" }) %>
+                        </span>
+                    <% end %>
                     <div style="width: 100%">
                         <%= content.presence %>
                     </div>

--- a/playbook/app/pb_kits/playbook/pb_card/card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.html.erb
@@ -4,9 +4,9 @@
             <% if object.draggable_item && object.drag_handle %>
                 <%= pb_rails("flex", props: { align: "center", width: "100%" }) do %>
                     <span classname="card_draggable_handle">
-                        <%= pb_rails("icon", props: { icon: "grip-dots-vertical", vertical_align: "middle", padding_right: "xs" }) %>
+                        <%= pb_rails("icon", props: { icon: "grip-dots-vertical", padding_right: "xs" }) %>
                     </span>
-                    <div style="width: '100%'">
+                    <div style="width: 100%">
                         <%= content.presence %>
                     </div>
                 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_card/card.rb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.rb
@@ -17,6 +17,13 @@ module Playbook
       prop :background, type: Playbook::Props::Enum,
                         values: %w[white light dark product_1_background product_1_highlight product_2_background product_2_highlight product_3_background product_3_highlight product_4_background product_4_highlight product_5_background product_5_highlight product_6_background product_6_highlight product_7_background product_7_highlight product_8_background product_8_highlight product_9_background product_9_highlight product_10_background product_10_highlight windows siding doors solar roofing gutters insulation none success_subtle warning_subtle error_subtle info_subtle neutral_subtle],
                         default: "none"
+      prop :drag_id, type: Playbook::Props::String
+      prop :draggable_item, type: Playbook::Props::Boolean,
+                            default: false
+      prop :drag_handle, type: Playbook::Props::Boolean,
+                         default: true
+      prop :items, type: Playbook::Props::Array,
+                   default: []
 
       def classname
         generate_classname("pb_card_kit",

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards_rails.html.erb
@@ -7,7 +7,7 @@
 <%= pb_rails("draggable", props: {initial_items: initial_items}) do %>
   <%= pb_rails("draggable/draggable_container") do %>
     <% initial_items.each do |item| %>
-        <%= pb_rails("card", props: {highlight: {position: "side", color:"primary"}, margin_bottom: "xs", padding: "xs", drag_id: item[:id], draggable_item: true}) do %>
+        <%= pb_rails("card", props: {highlight: {position: "side", color:"primary"}, margin_bottom: "xs", padding: "xs", drag_id: item[:id], draggable_item: true }) do %>
           <%= pb_rails("flex", props:{align_items: "stretch", flex_direction:"column"}) do %>
             <%= pb_rails("flex", props:{gap: "xs"}) do %>
               <%= pb_rails("title", props: { text: item[:name], tag: "h4", size: 4 }) %>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards_rails.html.erb
@@ -7,8 +7,7 @@
 <%= pb_rails("draggable", props: {initial_items: initial_items}) do %>
   <%= pb_rails("draggable/draggable_container") do %>
     <% initial_items.each do |item| %>
-      <%= pb_rails("draggable/draggable_item", props:{drag_id: item[:id]}) do %>
-        <%= pb_rails("card", props: {highlight: {position: "side", color:"primary"}, margin_bottom: "xs", padding: "xs"}) do %>
+        <%= pb_rails("card", props: {highlight: {position: "side", color:"primary"}, margin_bottom: "xs", padding: "xs", drag_id: item[:id], draggable_item: true}) do %>
           <%= pb_rails("flex", props:{align_items: "stretch", flex_direction:"column"}) do %>
             <%= pb_rails("flex", props:{gap: "xs"}) do %>
               <%= pb_rails("title", props: { text: item[:name], tag: "h4", size: 4 }) %>
@@ -32,7 +31,6 @@
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_with_cards_rails.md
@@ -1,0 +1,7 @@
+For a simplified version of the Draggable API for the Card kit, you can do the following:
+
+Use the `draggable` kit and manage state as shown.
+
+`draggable/draggable_container` kit creates the container within which the cards can be dragged and dropped.
+
+The Card kit is optimized to work with the draggable kit. To enable drag, use the `draggable_item` and `drag_id` props on the Card kit as shown. An additional optional boolean prop (set to true by default) of `drag_handle` is also available to show the drag handle icon.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
As a Playbook dev,
I want a create a simplified version of the Draggable kit for the Card kit,
So that we can ensure parity between our Rails and React Draggable kits. 

**Screenshots:** Screenshots to visualize your addition/change
<img width="1222" alt="Screenshot 2025-01-23 at 8 59 58 AM" src="https://github.com/user-attachments/assets/b4f822a9-2ae0-43eb-acfc-ff6431654947" />



**How to test?** Steps to confirm the desired behavior:
1. Go to [Rails Draggable kit](https://pr4161.playbook.beta.px.powerapp.cloud/kits/draggable/rails)
2. Scroll down to the 'Draggable with Cards' example


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
