### PR TITLE
[PLAY]-1741 Advanced Table Highlight In Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -94,6 +94,10 @@
     color: $primary !important;
   }
 
+  .expanded-row {
+    background-color: lighten($silver, $opacity_7);
+  }
+
   // Icons
   .button-icon {
     display: flex;
@@ -179,7 +183,7 @@
   }
 
   // Responsive Styles
-  @media only screen and (max-width: $screen-xl-min) {  
+  @media only screen and (max-width: $screen-xl-min) {
     &[class*="advanced-table-responsive-scroll"] {
       border-radius: 4px;
       box-shadow: 1px 0 0 0px $border_light,
@@ -215,7 +219,7 @@
       .bg-white td:first-child {
           background-color: $white;
       }
-      
+
     }
   }
   @media only screen and (min-width: $screen-xl-min) {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -94,7 +94,7 @@
     color: $primary !important;
   }
 
-  .expanded-row {
+  .bg-silver {
     background-color: lighten($silver, $opacity_7);
   }
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -89,13 +89,8 @@
     }
   }
 
-
   .table-header-cells-active:first-child {
     color: $primary !important;
-  }
-
-  .bg-silver {
-    background-color: lighten($silver, $opacity_7);
   }
 
   // Icons

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
@@ -29,6 +29,7 @@ export default class PbAdvancedTable extends PbEnhancedElement {
           PbAdvancedTable.expandedRows.delete(this.element.id);
         }
         this.toggleElement(this.target);
+        toggleRowHighlight(this.element);
       }
     });
 
@@ -45,6 +46,7 @@ export default class PbAdvancedTable extends PbEnhancedElement {
         } else {
           PbAdvancedTable.expandedRows.delete(button.id);
         }
+        toggleRowHighlight(button);
       });
     });
   }
@@ -222,9 +224,18 @@ export default class PbAdvancedTable extends PbEnhancedElement {
   }
 }
 
-window.expandAllRows = (element) => {
-  PbAdvancedTable.handleToggleAllHeaders(element);
-};
+const toggleRowHighlight = (button) => {
+  const row = button.closest("tr");
+  const isExpanded = button.querySelector(UP_ARROW_SELECTOR).style.display === "inline-block";
+
+  if (isExpanded) {
+    row.classList.add("expanded-row");
+  } else {
+    row.classList.remove("expanded-row");
+  }
+}
+
+window.toggleRowHighlight = toggleRowHighlight;
 
 window.expandAllSubRows = (element, rowDepth) => {
   PbAdvancedTable.handleToggleAllSubRows(element, rowDepth);

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
@@ -235,8 +235,8 @@ const toggleRowHighlight = (button) => {
   }
 }
 
-window.toggleRowHighlight = toggleRowHighlight;
-
 window.expandAllSubRows = (element, rowDepth) => {
   PbAdvancedTable.handleToggleAllSubRows(element, rowDepth);
 };
+
+window.toggleRowHighlight = toggleRowHighlight;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
@@ -29,7 +29,6 @@ export default class PbAdvancedTable extends PbEnhancedElement {
           PbAdvancedTable.expandedRows.delete(this.element.id);
         }
         this.toggleElement(this.target);
-        toggleRowHighlight(this.element);
       }
     });
 
@@ -46,7 +45,6 @@ export default class PbAdvancedTable extends PbEnhancedElement {
         } else {
           PbAdvancedTable.expandedRows.delete(button.id);
         }
-        toggleRowHighlight(button);
       });
     });
   }
@@ -135,14 +133,17 @@ export default class PbAdvancedTable extends PbEnhancedElement {
     if (!elements.length) return;
 
     const isVisible = elements[0].classList.contains("is-visible");
-    if (isVisible) {
-      this.hideElement(elements);
-      this.displayDownArrow();
-    } else {
-      this.showElement(elements);
-      this.displayUpArrow();
+
+    isVisible ? this.hideElement(elements) : this.showElement(elements);
+    isVisible ? this.displayDownArrow() : this.displayUpArrow();
+
+    const row = this.element.closest("tr");
+    if (row) {
+      row.classList.toggle("bg-silver", !isVisible);
+      row.classList.toggle("bg-white", isVisible);
     }
   }
+
 
   displayDownArrow() {
     this.element.querySelector(DOWN_ARROW_SELECTOR).style.display =
@@ -224,19 +225,10 @@ export default class PbAdvancedTable extends PbEnhancedElement {
   }
 }
 
-const toggleRowHighlight = (button) => {
-  const row = button.closest("tr");
-  const isExpanded = button.querySelector(UP_ARROW_SELECTOR).style.display === "inline-block";
-
-  if (isExpanded) {
-    row.classList.add("bg-silver");
-  } else {
-    row.classList.remove("bg-silver");
-  }
-}
+window.expandAllRows = (element) => {
+  PbAdvancedTable.handleToggleAllHeaders(element);
+};
 
 window.expandAllSubRows = (element, rowDepth) => {
   PbAdvancedTable.handleToggleAllSubRows(element, rowDepth);
 };
-
-window.toggleRowHighlight = toggleRowHighlight;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
@@ -229,9 +229,9 @@ const toggleRowHighlight = (button) => {
   const isExpanded = button.querySelector(UP_ARROW_SELECTOR).style.display === "inline-block";
 
   if (isExpanded) {
-    row.classList.add("expanded-row");
+    row.classList.add("bg-silver");
   } else {
-    row.classList.remove("expanded-row");
+    row.classList.remove("bg-silver");
   }
 }
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
@@ -14,11 +14,13 @@
                     <div style="padding-left: <%= depth * 1.25 %>em">
                         <%= pb_rails("flex", props:{align: "center", column_gap: "xs"}) do %>
                             <% if index.zero? && object.row[:children].present? %>
-                                <button onclick="toggleRowHighlight(this);"
-                                    id="<%= "#{object.id}_#{object.row.object_id}" %>" class="gray-icon expand-toggle-icon" data-advanced-table="true" >
-                                    <%= pb_rails("icon", props: { id: "advanced-table_open_icon", icon: "circle-play", cursor: "pointer" }) %>
-                                    <%= pb_rails("icon", props: { id: "advanced-table_close_icon", display: "none", icon: "circle-play", cursor: "pointer", rotation: 90 }) %>
-                                </button>
+                              <button
+                                id="<%= "#{object.id}_#{object.row.object_id}" %>"
+                                class="gray-icon expand-toggle-icon"
+                                data-advanced-table="true">
+                                <%= pb_rails("icon", props: { id: "advanced-table_open_icon", icon: "circle-play", cursor: "pointer" }) %>
+                                <%= pb_rails("icon", props: { id: "advanced-table_close_icon", display: "none", icon: "circle-play", cursor: "pointer", rotation: 90 }) %>
+                              </button>
                             <% end %>
                             <%= pb_rails("flex/flex_item", props:{padding_left: index.zero? && object.row[:children].present? ? "none" : "xs"}) do %>
                                 <% if column[:custom_renderer].present? %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
@@ -15,7 +15,7 @@
                         <%= pb_rails("flex", props:{align: "center", column_gap: "xs"}) do %>
                             <% if index.zero? && object.row[:children].present? %>
                                 <button onclick="toggleRowHighlight(this);"
-id="<%= "#{object.id}_#{object.row.object_id}" %>" class="gray-icon expand-toggle-icon" data-advanced-table="true" >
+                                    id="<%= "#{object.id}_#{object.row.object_id}" %>" class="gray-icon expand-toggle-icon" data-advanced-table="true" >
                                     <%= pb_rails("icon", props: { id: "advanced-table_open_icon", icon: "circle-play", cursor: "pointer" }) %>
                                     <%= pb_rails("icon", props: { id: "advanced-table_close_icon", display: "none", icon: "circle-play", cursor: "pointer", rotation: 90 }) %>
                                 </button>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
@@ -14,8 +14,9 @@
                     <div style="padding-left: <%= depth * 1.25 %>em">
                         <%= pb_rails("flex", props:{align: "center", column_gap: "xs"}) do %>
                             <% if index.zero? && object.row[:children].present? %>
-                                <button id="<%= "#{object.id}_#{object.row.object_id}" %>" class="gray-icon expand-toggle-icon" data-advanced-table="true" >
-                                    <%= pb_rails("icon", props: { id: "advanced-table_open_icon", icon: "circle-play", cursor: "pointer" }) %> 
+                                <button onclick="toggleRowHighlight(this);"
+id="<%= "#{object.id}_#{object.row.object_id}" %>" class="gray-icon expand-toggle-icon" data-advanced-table="true" >
+                                    <%= pb_rails("icon", props: { id: "advanced-table_open_icon", icon: "circle-play", cursor: "pointer" }) %>
                                     <%= pb_rails("icon", props: { id: "advanced-table_close_icon", display: "none", icon: "circle-play", cursor: "pointer", rotation: 90 }) %>
                                 </button>
                             <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Allows the expanded rows on the Rails Advanced Table to be highlighted, so that the user can visibly tell which rows are expanded and which are not.

[[PLAY]-1741](https://runway.powerhrg.com/backlog_items/PLAY-1741)
**Screenshots:** Screenshots to visualize your addition/change

<img width="1016" alt="Screenshot 2025-01-28 at 8 26 26 AM" src="https://github.com/user-attachments/assets/c2fa742c-1757-4ea4-9e8d-fca53de4a389" />
<img width="1017" alt="Screenshot 2025-01-28 at 8 26 59 AM" src="https://github.com/user-attachments/assets/05f18e91-ff39-4c9c-99e8-234027309c2d" />

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.