### PR TITLE
Fix disabled state for link

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/button.rb
+++ b/playbook/app/pb_kits/playbook/pb_button/button.rb
@@ -65,7 +65,7 @@ module Playbook
       end
 
       def tag
-        link ? "a" : "button"
+        link && !disabled ? "a" : "button"
       end
 
       def valid_emoji(icon)

--- a/playbook/spec/pb_kits/playbook/kits/button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/button_spec.rb
@@ -32,6 +32,9 @@ RSpec.describe Playbook::PbButton::Button do
     it "returns 'a' when link is provided" do
       expect(subject.new(link: true).tag).to eq "a"
     end
+    it "returns 'button' when link and disabled" do
+      expect(subject.new(link: true, disabled: true).tag).to eq "button"
+    end
   end
 
   describe "#link_options" do


### PR DESCRIPTION
Ruwnay https://runway.powerhrg.com/backlog_items/PLAY-1862

When using the link variant for our button kit, it is not properly applying the disabled prop.

When disabled it is forced to use the button tag

Maddie had the issue and reported it in the playbook room