### PR TITLE
[PLAY-1865] React Date Picker Reinitialization with Other Inputs Bug 

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -134,7 +134,7 @@ useEffect(() => {
     yearRange,
     required: false,
   }, scrollContainer)
-})
+}, [])
   const filteredProps = {...props}
   if (filteredProps.marginBottom === undefined) {
     filteredProps.marginBottom = "sm"


### PR DESCRIPTION
**What does this PR do?**
- Add empty dependency array to React Date Picker kit so flatpickr init runs only on first render.
- If a form had other inputs and date picker(s), any update to the parent form's state would trigger a reinitialization to the date picker(s). Now date pickers should initialize only once.

**How to test?** Steps to confirm the desired behavior:
1. Go to a page with a React form that has the date picker and other inputs in Safari
2. Type and make sure the React Date Picker does not "restart" on every event / slows down other inputs.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.