### PR TITLE
[PLAY-1501] Enable Lightweight User Names in User Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_user/_user.tsx
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.tsx
@@ -79,7 +79,7 @@ const User = (props: UserProps): React.ReactElement => {
       }
       <div className="content_wrapper">
         <Title
-            {...props}
+            bold={bold}
             dark={dark}
             size={size == 'lg' ? 3 : 4}
             text={name}

--- a/playbook/app/pb_kits/playbook/pb_user/_user.tsx
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.tsx
@@ -13,6 +13,7 @@ type UserProps = {
   aria?: {[key: string]: string},
   avatar?: boolean,
   avatarUrl?: string,
+  bold?: boolean,
   className?: string,
   dark?: boolean,
   data?: {[key: string]: string},
@@ -32,6 +33,7 @@ const User = (props: UserProps): React.ReactElement => {
     aria = {},
     avatar = false,
     avatarUrl,
+    bold = true,
     className,
     dark = false,
     data = {},
@@ -48,9 +50,11 @@ const User = (props: UserProps): React.ReactElement => {
   const dataProps: {[key: string]: string} = buildDataProps(data)
   const ariaProps: {[key: string]: string} = buildAriaProps(aria)
   const htmlProps = buildHtmlProps(htmlOptions)
+  const getBold = bold ? '' : 'thin'
+
 
   const classes = classnames(
-    buildCss('pb_user_kit', align, orientation, size),
+    buildCss('pb_user_kit', align, orientation, size, getBold),
     globalProps(props),
     className
   )
@@ -75,6 +79,7 @@ const User = (props: UserProps): React.ReactElement => {
       }
       <div className="content_wrapper">
         <Title
+            {...props}
             dark={dark}
             size={size == 'lg' ? 3 : 4}
             text={name}

--- a/playbook/app/pb_kits/playbook/pb_user/_user.tsx
+++ b/playbook/app/pb_kits/playbook/pb_user/_user.tsx
@@ -50,11 +50,9 @@ const User = (props: UserProps): React.ReactElement => {
   const dataProps: {[key: string]: string} = buildDataProps(data)
   const ariaProps: {[key: string]: string} = buildAriaProps(aria)
   const htmlProps = buildHtmlProps(htmlOptions)
-  const getBold = bold ? '' : 'thin'
-
 
   const classes = classnames(
-    buildCss('pb_user_kit', align, orientation, size, getBold),
+    buildCss('pb_user_kit', align, orientation, size),
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.html.erb
@@ -1,0 +1,42 @@
+<div class="pb--doc-demo-row">
+  <div>
+    <%= pb_rails("user", props: {
+      name: "Anna Black",
+      title: "Remodeling Consultant",
+      orientation: "vertical",
+      align: "center",
+      size: "lg",
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg",
+      bold: false
+      }) %>
+  </div>
+  <div>
+    <%= pb_rails("user", props: {
+      name: "Anna Black",
+      title: "Remodeling Consultant",
+      orientation: "horizontal",
+      align: "left",
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg",
+      bold: false
+      }) %>
+  </div>
+  <div>
+    <%= pb_rails("user", props: {
+      name: "Anna Black",
+      orientation: "horizontal",
+      align: "left",
+      avatar_url: "https://randomuser.me/api/portraits/women/44.jpg",
+      bold: false
+      }) %>
+
+     <br>
+
+     <%= pb_rails("user", props: {
+       name: "Anna Black",
+       orientation: "horizontal",
+       align: "left",
+       avatar: true,
+       bold: false
+     }) %>
+  </div>
+</div>

--- a/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.jsx
+++ b/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { User } from 'playbook-ui'
+
+const UserLightWeight = (props) => {
+  return (
+    <div className="pb--doc-demo-row">
+
+      <div>
+        <User
+            align="center"
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            bold={false}
+            name="Anna Black"
+            orientation="vertical"
+            size="lg"
+            title="Remodeling Consultant"
+            {...props}
+        />
+      </div>
+
+      <div>
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            bold={false}
+            name="Anna Black"
+            orientation="horizontal"
+            title="Remodeling Consultant"
+            {...props}
+        />
+      </div>
+
+      <div>
+        <User
+            align="left"
+            avatarUrl="https://randomuser.me/api/portraits/women/44.jpg"
+            bold={false}
+            name="Anna Black"
+            orientation="horizontal"
+            {...props}
+        />
+
+        <br />
+
+        <User
+            align="left"
+            avatar
+            bold={false}
+            name="Anna Black"
+            orientation="horizontal"
+            {...props}
+        />
+      </div>
+
+    </div>
+  )
+}
+
+export default UserLightWeight

--- a/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.md
+++ b/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.md
@@ -1,0 +1,2 @@
+##### Prop
+Name will use `font-weight: 700` by default, if you want a lighter font weight, use the `bold` prop set to `false`.

--- a/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.md
+++ b/playbook/app/pb_kits/playbook/pb_user/docs/_user_light_weight.md
@@ -1,2 +1,2 @@
 ##### Prop
-Name will use `font-weight: 700` by default, if you want a lighter font weight, use the `bold` prop set to `false`.
+Name will use `font-weight: 700` by default, if you want a lighter font weight, use the `bold` prop set to `false`. Name will then use `font-weight: 300`.

--- a/playbook/app/pb_kits/playbook/pb_user/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_user/docs/example.yml
@@ -2,6 +2,7 @@ examples:
 
   rails:
   - user_default: Default
+  - user_light_weight: Light Weight
   - user_with_territory: With Territory
   - user_text_only: Text Only
   - user_size: Horizontal Size
@@ -11,6 +12,7 @@ examples:
 
   react:
   - user_default: Default
+  - user_light_weight: Light Weight
   - user_with_territory: With Territory
   - user_text_only: Text Only
   - user_size: Horizontal Size

--- a/playbook/app/pb_kits/playbook/pb_user/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_user/docs/index.js
@@ -1,4 +1,5 @@
 export { default as UserDefault } from './_user_default.jsx'
+export { default as UserLightWeight } from './_user_light_weight.jsx'
 export { default as UserWithTerritory } from './_user_with_territory.jsx'
 export { default as UserTextOnly } from './_user_text_only.jsx'
 export { default as UserSize } from './_user_size.jsx'

--- a/playbook/app/pb_kits/playbook/pb_user/user.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_user/user.html.erb
@@ -12,7 +12,7 @@
     }) %>
   <% end %>
   <%= content_tag(:div, class: "content_wrapper") do %>
-    <%= pb_rails("title", props: { text: object.name, size: object.title_size, dark: object.dark }) %>
+    <%= pb_rails("title", props: { text: object.name, size: object.title_size, dark: object.dark, bold: object.bold }) %>
     <%= pb_rails("body", props: {
       text: "#{object.details}",
       dark: object.dark,

--- a/playbook/app/pb_kits/playbook/pb_user/user.rb
+++ b/playbook/app/pb_kits/playbook/pb_user/user.rb
@@ -9,6 +9,7 @@ module Playbook
       prop :avatar, type: Playbook::Props::Boolean,
                     default: false
       prop :avatar_url
+      prop :bold, type: Playbook::Props::Boolean, default: true
       prop :name
       prop :orientation, type: Playbook::Props::Enum,
                          values: %w[vertical horizontal],
@@ -21,7 +22,11 @@ module Playbook
       prop :territory
 
       def classname
-        generate_classname("pb_user_kit", align, orientation, size)
+        generate_classname("pb_user_kit", align, orientation, size, is_bold)
+      end
+
+      def is_bold
+        bold ? nil : "thin"
       end
 
       def avatar_size

--- a/playbook/app/pb_kits/playbook/pb_user/user.rb
+++ b/playbook/app/pb_kits/playbook/pb_user/user.rb
@@ -22,11 +22,7 @@ module Playbook
       prop :territory
 
       def classname
-        generate_classname("pb_user_kit", align, orientation, size, is_bold)
-      end
-
-      def is_bold
-        bold ? nil : "thin"
+        generate_classname("pb_user_kit", align, orientation, size)
       end
 
       def avatar_size

--- a/playbook/app/pb_kits/playbook/pb_user/user.test.js
+++ b/playbook/app/pb_kits/playbook/pb_user/user.test.js
@@ -26,3 +26,17 @@ test('subtitle prop accepts a node', () => {
 
   expect(screen.getByTestId('test-subtitle-block')).toHaveTextContent('test caption')
 })
+
+test('bold prop applies correct styling when false', () => {
+  render(
+    <User
+        bold={false}
+        data={{ testid: 'test-bold-false' }}
+        name="Anna Black"
+    />
+  )
+  const titleElement = screen.getByText("Anna Black")
+  expect(titleElement).toBeInTheDocument()
+
+  expect(titleElement).toHaveClass('pb_title_kit_size_4_thin')
+})


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Allows user to set user names in `User` kit to lightweight.

[Story 1501](https://runway.powerhrg.com/backlog_items/PLAY-1501)
**Screenshots:** Screenshots to visualize your addition/change
**Rails:**
<img width="1050" alt="Screenshot 2025-01-29 at 3 33 00 PM" src="https://github.com/user-attachments/assets/a4beb309-254e-4bcf-8a23-1958e0eb108a" />

**React:**
<img width="709" alt="Screenshot 2025-01-29 at 3 33 53 PM" src="https://github.com/user-attachments/assets/3599805d-774f-4653-8c0c-12cdca10a413" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.