### PR TITLE
[PLAY-1752] Implement pb_content_tag

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon/icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon/icon.html.erb
@@ -5,12 +5,8 @@
     <%= object.icon.html_safe %>
   </span>
 <% else %>
-  <%= content_tag(:i, nil,
-      id: object.id,
-      data: object.data,
-      class: object.classname,
-      **combined_html_options
-  ) %>
+  <%= pb_content_tag(:i) do %>
+  <% end %>
   <%= content_tag(:span, nil,
       aria: { label: "#{object.icon} icon" }.merge(object.aria),
       hidden: true

--- a/playbook/app/pb_kits/playbook/pb_layout/body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/body.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(object.tag,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/footer.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/footer.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(object.tag,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/header.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(object.tag,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/item.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/layout.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/layout.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_layout/sidebar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_layout/sidebar.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_legend/legend.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_legend/legend.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div, object.text,
-    aria: object.aria,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= pb_rails("body", props: {color: object.body_color}) do %>
     <span style="<%= object.custom_color %>" class=<%= object.custom_color_class %>></span>
     <%= pb_rails("title", props: { dark: object.dark, text: object.prefix_text, tag: "span", size: 4 }) %>

--- a/playbook/app/pb_kits/playbook/pb_message/message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
     <% if object.valid? %>
       <%= pb_rails("avatar", props: {
         name: object.avatar_name,

--- a/playbook/app/pb_kits/playbook/pb_message/message_mention.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_message/message_mention.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    aria: object.aria,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
         <%= content %>
 <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Update Icon, Layout, Legend, Message kits to no longer use `content_tag` and use our new `pb_content_tag`

There should be no visible changes to the kits.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.