### PR TITLE
PBNTR-779 | Draggable kit: Add the "cross-container" functionality to RAILS kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
@@ -131,50 +131,54 @@
         case 'In Progress':
           return { text: 'progress', variant: 'primary' };
         case 'Done':
-          return { text: 'done', variant: 'success_sm' };
+          return { text: 'done', variant: 'success' };
         default:
-          console.log('Unknown container:', container);
           return { text: 'queue', variant: 'warning' };
       }
     };
 
     let draggedElement = null;
+    let startContainer = null;
 
     document.querySelectorAll('.pb_draggable_item').forEach(function(item) {
       item.addEventListener('dragstart', function(event) {
         draggedElement = event.target;
+        startContainer = draggedElement.closest('.pb_draggable_container');
       });
     });
 
     document.querySelectorAll('.pb_draggable_container').forEach(function(container) {
       container.addEventListener('drop', function(event) {
         event.preventDefault();
+
         if (draggedElement) {
           setTimeout(function() {
-            // Get container data from the container element
-            const containerData = container.getAttribute('data-container');
+            const currentContainer = container;
 
-            const badge = draggedElement.querySelector('[data-pb-status-badge]');
+            if (currentContainer && startContainer && currentContainer !== startContainer) {
+              const containerData = currentContainer.getAttribute('data-container');
+              const badge = draggedElement.querySelector('[data-pb-status-badge]');
 
-            if (badge && containerData) {
-              const newProperties = updateBadge(containerData);
+              if (badge && containerData) {
+                const newProperties = updateBadge(containerData);
+                const span = badge.querySelector('span');
 
-              // Update the span text
-              const span = badge.querySelector('span');
-              if (span) {
-                span.textContent = newProperties.text;
-              }
-
-              // Remove old classes
-              badge.classList.forEach(function(className) {
-                if (className.includes('pb_badge_kit_') || className === 'ml_sm') {
-                  badge.classList.remove(className);
+                if (span) {
+                  span.textContent = newProperties.text;
                 }
-              });
 
-              // Set new classes in correct order
-              badge.className = `pb_badge_kit_${newProperties.variant}_rounded ml_sm`;
+                badge.classList.forEach(function(className) {
+                  if (className.includes('pb_badge_kit_') || className === 'ml_sm') {
+                    badge.classList.remove(className);
+                  }
+                });
+
+                badge.className = `pb_badge_kit_${newProperties.variant}_rounded ml_sm`;
+              }
             }
+
+            draggedElement = null;
+            startContainer = null;
           }, 50);
         }
       });

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
@@ -1,16 +1,3 @@
-<% content_for :helper_methods do %>
-  <% def badge_properties(container)
-    case container
-    when "To Do"
-      { text: "queue", variant: "warning" }
-    when "In Progress"
-      { text: "progress", variant: "primary" }
-    else
-      { text: "done", variant: "success" }
-    end
-  end %>
-<% end %>
-
 <% containers = [
   "To Do",
   "In Progress",
@@ -71,123 +58,43 @@
 <%= pb_rails("draggable", props: { initial_items: items_data }) do %>
   <%= pb_rails("flex", props: { justify_content: "center" }) do %>
     <% containers.each do |container| %>
-        <%= pb_rails("draggable/draggable_container", props: {
-            container: container,
-            width: "xs",
-            height: "xs",
-            padding: "sm",
-            data: { container: container }
-        }) do %>
-            <%= pb_rails("caption", props: { text_align: "center" }) do %><%= container %><% end %>
-            <%= pb_rails("flex", props: {align_items: "stretch", orientation: "column"}) do %>
-                <% items_data.select { |item| item[:container] == container }.each do |item| %>
-                    <%= pb_rails("draggable/draggable_item", props: {
-                        container: container,
-                        drag_id: item[:id]
-                    }) do %>
-                        <%= pb_rails("card", props: { margin_bottom: "sm", padding: "sm"}) do %>
-                            <%= pb_rails("flex", props: { justify: "between" }) do %>
-                                <%= pb_rails("flex/flex_item") do %>
-                                    <%= pb_rails("flex") do %>
-                                        <%= pb_rails("avatar", props: {
-                                            image_url: item[:assignee_img],
-                                            name: item[:assignee_name],
-                                            size: "xxs"
-                                        }) %>
-                                        <%= pb_rails("title", props: {
-                                            padding_left: "xs",
-                                            size: 4,
-                                            text: item[:title]
-                                        }) %>
-                                    <% end %>
-                                <% end %>
-                                <%= pb_rails("badge", props: {
-                                    margin_left: "sm",
-                                    rounded: true,
-                                    text: badge_properties(container)[:text],
-                                    variant: badge_properties(container)[:variant],
-                                      data: {
-                                        pb_status_badge: true,
-                                        pb_tag_type: "badge"
-                                      }
-                                }) %>
-                            <% end %>
-                            <%= pb_rails("body", props: { padding_top: "xs", text: item[:description] }) %>
-                        <% end %>
+      <%= pb_rails("draggable/draggable_container", props: {
+          container: container,
+          width: "xs",
+          height: "xs",
+          padding: "sm",
+          data: { container: container }
+      }) do %>
+        <%= pb_rails("caption", props: { text_align: "center" }) do %><%= container %><% end %>
+        <%= pb_rails("flex", props: {align_items: "stretch", orientation: "column"}) do %>
+          <% items_data.select { |item| item[:container] == container }.each do |item| %>
+            <%= pb_rails("draggable/draggable_item", props: {
+                container: container,
+                drag_id: item[:id]
+            }) do %>
+              <%= pb_rails("card", props: { margin_bottom: "sm", padding: "sm"}) do %>
+                <%= pb_rails("flex", props: { justify: "between" }) do %>
+                  <%= pb_rails("flex/flex_item") do %>
+                    <%= pb_rails("flex") do %>
+                      <%= pb_rails("avatar", props: {
+                          image_url: item[:assignee_img],
+                          name: item[:assignee_name],
+                          size: "xxs"
+                      }) %>
+                      <%= pb_rails("title", props: {
+                          padding_left: "xs",
+                          size: 4,
+                          text: item[:title]
+                      }) %>
                     <% end %>
+                  <% end %>
                 <% end %>
+                <%= pb_rails("body", props: { padding_top: "xs", text: item[:description] }) %>
+              <% end %>
             <% end %>
+          <% end %>
         <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>
-
-<script>
-  const initBadgeUpdates = function() {
-    const updateBadge = function(container) {
-      switch (container) {
-        case 'To Do':
-          return { text: 'queue', variant: 'warning' };
-        case 'In Progress':
-          return { text: 'progress', variant: 'primary' };
-        case 'Done':
-          return { text: 'done', variant: 'success' };
-        default:
-          return { text: 'queue', variant: 'warning' };
-      }
-    };
-
-    let draggedElement = null;
-    let startContainer = null;
-
-    document.querySelectorAll('.pb_draggable_item').forEach(function(item) {
-      item.addEventListener('dragstart', function(event) {
-        draggedElement = event.target;
-        startContainer = draggedElement.closest('.pb_draggable_container');
-      });
-    });
-
-    document.querySelectorAll('.pb_draggable_container').forEach(function(container) {
-      container.addEventListener('drop', function(event) {
-        event.preventDefault();
-
-        if (draggedElement) {
-          setTimeout(function() {
-            const currentContainer = container;
-
-            if (currentContainer && startContainer && currentContainer !== startContainer) {
-              const containerData = currentContainer.getAttribute('data-container');
-              const badge = draggedElement.querySelector('[data-pb-status-badge]');
-
-              if (badge && containerData) {
-                const newProperties = updateBadge(containerData);
-                const span = badge.querySelector('span');
-
-                if (span) {
-                  span.textContent = newProperties.text;
-                }
-
-                badge.classList.forEach(function(className) {
-                  if (className.includes('pb_badge_kit_') || className === 'ml_sm') {
-                    badge.classList.remove(className);
-                  }
-                });
-
-                badge.className = `pb_badge_kit_${newProperties.variant}_rounded ml_sm`;
-              }
-            }
-
-            draggedElement = null;
-            startContainer = null;
-          }, 50);
-        }
-      });
-    });
-  };
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initBadgeUpdates);
-  } else {
-    initBadgeUpdates();
-  }
-</script>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
@@ -1,0 +1,189 @@
+<% content_for :helper_methods do %>
+  <% def badge_properties(container)
+    case container
+    when "To Do"
+      { text: "queue", variant: "warning" }
+    when "In Progress"
+      { text: "progress", variant: "primary" }
+    else
+      { text: "done", variant: "success" }
+    end
+  end %>
+<% end %>
+
+<% containers = [
+  "To Do",
+  "In Progress",
+  "Done"
+] %>
+
+<% items_data = [
+  {
+    id: "11",
+    container: "To Do",
+    title: "Task 1",
+    description: "Bug fixes",
+    assignee_name: "Terry Miles",
+    assignee_img: "https://randomuser.me/api/portraits/men/44.jpg",
+  },
+  {
+    id: "12",
+    container: "To Do",
+    title: "Task 2",
+    description: "Documentation",
+    assignee_name: "Sophia Miles",
+    assignee_img: "https://randomuser.me/api/portraits/women/8.jpg",
+  },
+  {
+    id: "13",
+    container: "In Progress",
+    title: "Task 3",
+    description: "Add a variant",
+    assignee_name: "Alice Jones",
+    assignee_img: "https://randomuser.me/api/portraits/women/10.jpg",
+  },
+  {
+    id: "14",
+    container: "To Do",
+    title: "Task 4",
+    description: "Add jest tests",
+    assignee_name: "Mike James",
+    assignee_img: "https://randomuser.me/api/portraits/men/8.jpg",
+  },
+  {
+    id: "15",
+    container: "Done",
+    title: "Task 5",
+    description: "Alpha testing",
+    assignee_name: "James Guy",
+    assignee_img: "https://randomuser.me/api/portraits/men/18.jpg",
+  },
+  {
+    id: "16",
+    container: "In Progress",
+    title: "Task 6",
+    description: "Release",
+    assignee_name: "Sally Jones",
+    assignee_img: "https://randomuser.me/api/portraits/women/28.jpg",
+  },
+] %>
+
+<%= pb_rails("draggable", props: { initial_items: items_data }) do %>
+  <%= pb_rails("flex", props: { justify_content: "center" }) do %>
+    <% containers.each do |container| %>
+        <%= pb_rails("draggable/draggable_container", props: {
+            container: container,
+            width: "xs",
+            height: "xs",
+            padding: "sm",
+            data: { container: container }
+        }) do %>
+            <%= pb_rails("caption", props: { text_align: "center" }) do %><%= container %><% end %>
+            <%= pb_rails("flex", props: {align_items: "stretch", orientation: "column"}) do %>
+                <% items_data.select { |item| item[:container] == container }.each do |item| %>
+                    <%= pb_rails("draggable/draggable_item", props: {
+                        container: container,
+                        drag_id: item[:id]
+                    }) do %>
+                        <%= pb_rails("card", props: { margin_bottom: "sm", padding: "sm"}) do %>
+                            <%= pb_rails("flex", props: { justify: "between" }) do %>
+                                <%= pb_rails("flex/flex_item") do %>
+                                    <%= pb_rails("flex") do %>
+                                        <%= pb_rails("avatar", props: {
+                                            image_url: item[:assignee_img],
+                                            name: item[:assignee_name],
+                                            size: "xxs"
+                                        }) %>
+                                        <%= pb_rails("title", props: {
+                                            padding_left: "xs",
+                                            size: 4,
+                                            text: item[:title]
+                                        }) %>
+                                    <% end %>
+                                <% end %>
+                                <%= pb_rails("badge", props: {
+                                    margin_left: "sm",
+                                    rounded: true,
+                                    text: badge_properties(container)[:text],
+                                    variant: badge_properties(container)[:variant],
+                                      data: {
+                                        pb_status_badge: true,
+                                        pb_tag_type: "badge"
+                                      }
+                                }) %>
+                            <% end %>
+                            <%= pb_rails("body", props: { padding_top: "xs", text: item[:description] }) %>
+                        <% end %>
+                    <% end %>
+                <% end %>
+            <% end %>
+        <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<script>
+  const initBadgeUpdates = function() {
+    const updateBadge = function(container) {
+      switch (container) {
+        case 'To Do':
+          return { text: 'queue', variant: 'warning' };
+        case 'In Progress':
+          return { text: 'progress', variant: 'primary' };
+        case 'Done':
+          return { text: 'done', variant: 'success_sm' };
+        default:
+          console.log('Unknown container:', container);
+          return { text: 'queue', variant: 'warning' };
+      }
+    };
+
+    let draggedElement = null;
+
+    document.querySelectorAll('.pb_draggable_item').forEach(function(item) {
+      item.addEventListener('dragstart', function(event) {
+        draggedElement = event.target;
+      });
+    });
+
+    document.querySelectorAll('.pb_draggable_container').forEach(function(container) {
+      container.addEventListener('drop', function(event) {
+        event.preventDefault();
+        if (draggedElement) {
+          setTimeout(function() {
+            // Get container data from the container element
+            const containerData = container.getAttribute('data-container');
+
+            const badge = draggedElement.querySelector('[data-pb-status-badge]');
+
+            if (badge && containerData) {
+              const newProperties = updateBadge(containerData);
+
+              // Update the span text
+              const span = badge.querySelector('span');
+              if (span) {
+                span.textContent = newProperties.text;
+              }
+
+              // Remove old classes
+              badge.classList.forEach(function(className) {
+                if (className.includes('pb_badge_kit_') || className === 'ml_sm') {
+                  badge.classList.remove(className);
+                }
+              });
+
+              // Set new classes in correct order
+              badge.className = `pb_badge_kit_${newProperties.variant}_rounded ml_sm`;
+            }
+          }, 50);
+        }
+      });
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initBadgeUpdates);
+  } else {
+    initBadgeUpdates();
+  }
+</script>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.html.erb
@@ -61,7 +61,6 @@
       <%= pb_rails("draggable/draggable_container", props: {
           container: container,
           width: "xs",
-          height: "xs",
           padding: "sm",
           data: { container: container }
       }) do %>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_multiple_containers_rails.md
@@ -1,0 +1,1 @@
+The Draggable kit can also be used to achieve more complex, multiple container functionality as shown here. This complex usage requires the full subcomponent structure.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
@@ -1,18 +1,14 @@
 examples:
-  
-  
   react:
   - draggable_default: Default
   - draggable_with_list: Draggable with List Kit
   - draggable_with_selectable_list: Draggable with SelectableList Kit
   - draggable_with_cards: Draggable with Cards
   - draggable_multiple_containers: Dragging Across Multiple Containers
-  
   rails:
   - draggable_default_rails: Default
   - draggable_with_list_rails: Draggable with List Kit
   - draggable_with_selectable_list_rails: Draggable with SelectableList Kit
   - draggable_with_cards_rails: Draggable with Cards
+  - draggable_multiple_containers_rails: Dragging Across Multiple Containers
 
-
-  

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable_container.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable_container.html.erb
@@ -1,3 +1,3 @@
 <%= pb_content_tag do %>
-    <%= content.presence %>
-  <% end %>
+  <%= content.presence %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable_container.rb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable_container.rb
@@ -3,6 +3,9 @@
 module Playbook
   module PbDraggable
     class DraggableContainer < ::Playbook::KitBase
+      prop :container, type: Playbook::Props::String,
+                       default: ""
+
       def data
         Hash(prop(:data)).merge(pb_draggable_container: true)
       end

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable_item.rb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable_item.rb
@@ -5,6 +5,8 @@ module Playbook
     class DraggableItem < ::Playbook::KitBase
       prop :drag_id, type: Playbook::Props::String,
                      default: ""
+      prop :container, type: Playbook::Props::String,
+                       default: ""
 
       def data
         Hash(prop(:data)).merge(pb_draggable_item: true)

--- a/playbook/app/pb_kits/playbook/pb_draggable/index.js
+++ b/playbook/app/pb_kits/playbook/pb_draggable/index.js
@@ -155,7 +155,19 @@ export default class PbDraggable extends PbEnhancedElement {
       id: item.id,
       container: item.closest(DRAGGABLE_CONTAINER).id
     }));
-  
+
+    // Store reordered items in a data attribute on the container
+    container.setAttribute("data-reordered-items", JSON.stringify(reorderedItems));
+
+    const customEvent = new CustomEvent('pb-draggable-reorder', {
+      detail: {
+        reorderedItems,
+        containerId: container.id,
+      }
+    });
+
+    this.element.dispatchEvent(customEvent);
+
     this.setState({
       items: reorderedItems,  // Changed from reorderedItems to items to match setState
       isDragging: "",


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
As a Playbook dev, 
I want to implement the "cross container" functionality to our Rails Draggable kit,
so that I can ensure parity between my Rails and React Draggable kits.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-01-31 at 2 56 29 PM](https://github.com/user-attachments/assets/d7f5b653-b81f-41c9-a22a-3efe84beb6fc)

**How to test?** Steps to confirm the desired behavior:
1. Go to '[Dragging Across Multiple Containers](https://pr4210.playbook.beta.hq.powerapp.cloud/kits/draggable/rails#dragging-across-multiple-containers)' doc example


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.