### PR TITLE
[PLAY-1478] PB Website - Search Global Props

### DIFF
--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Typeahead } from 'playbook-ui'
 import { matchSorter } from 'match-sorter'
+import { VisualGuidelinesItems } from './MainSidebar/MenuData/GuidelinesNavItems'
 
 type Kit = {
   label: string,
@@ -8,12 +9,16 @@ type Kit = {
 }
 
 type KitSearchProps = {
-  classname: String,
+  classname: string,
   kits: Kit[],
-  id: String,
+  id: string,
 }
+
 const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
-  const [filteredKits, setFilteredKits] = useState(kits)
+  const kitsAndGuidelines = [...kits, ...VisualGuidelinesItems]
+  const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)
+
+  console.log(filteredKits)
 
   useEffect(() => {
     if (id === 'desktop-kit-search') {
@@ -34,10 +39,10 @@ const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
 
   const handleFilteredKits = (query: string) => {
     if (query) {
-      const results = matchSorter(kits, query, { keys: ['label'] })
+      const results = matchSorter(kitsAndGuidelines, query, { keys: ['label', 'name'] })
       setFilteredKits(results)
     } else {
-      setFilteredKits(kits)
+      setFilteredKits(kitsAndGuidelines)
     }
   }
 

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Typeahead } from 'playbook-ui'
+import { Typeahead, Badge } from 'playbook-ui'
 import { matchSorter } from 'match-sorter'
 import { VisualGuidelinesItems } from './MainSidebar/MenuData/GuidelinesNavItems'
 
@@ -57,15 +57,22 @@ const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
     }
   }
 
+
+
+  const formattedKits = filteredKits.map(option => ({
+    ...option,
+    label: option.value.includes("guidelines") ? `${option.label} (Global Prop)` : option.label
+  }));
+
   return (
     <div>
       <Typeahead
           className={classname}
-          dark={document.cookie.split('; ').includes('dark_mode=true')}
+          dark={document.cookie.split("; ").includes("dark_mode=true")}
           id={id}
           onChange={handleChange}
           onInputChange={handleFilteredKits}
-          options={filteredKits}
+          options={formattedKits}
           placeholder="Search..."
       />
     </div>

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react'
-import { Typeahead, Badge } from 'playbook-ui'
+import { useEffect, useState } from 'react'
+import { Typeahead, Badge, Flex } from 'playbook-ui'
 import { matchSorter } from 'match-sorter'
 import { VisualGuidelinesItems } from './MainSidebar/MenuData/GuidelinesNavItems'
 
@@ -57,23 +57,32 @@ const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
     }
   }
 
-
-
-  const formattedKits = filteredKits.map(option => ({
-    ...option,
-    label: option.value.includes("guidelines") ? `${option.label} (Global Prop)` : option.label
-  }));
+  const Item = ({ labelLeft }: { labelLeft: string }) => (
+    <Flex alignItems="center">
+      {labelLeft}
+      <Badge
+        justifyContent="end"
+        text="Global Prop"
+        margin="xs"
+        variant="primary"
+        className="global-prop"
+      />
+    </Flex>
+  )
 
   return (
     <div>
       <Typeahead
-          className={classname}
-          dark={document.cookie.split("; ").includes("dark_mode=true")}
-          id={id}
-          onChange={handleChange}
-          onInputChange={handleFilteredKits}
-          options={formattedKits}
-          placeholder="Search..."
+        className={classname}
+        dark={document.cookie.split("; ").includes("dark_mode=true")}
+        id={id}
+        onChange={handleChange}
+        onInputChange={handleFilteredKits}
+        options={filteredKits}
+        placeholder="Search..."
+        valueComponent={({ label, value }: { label: string, value: string }) => (
+          value.includes("guidelines") ? <Item labelLeft={label} /> : <>{label}</>
+        )}
       />
     </div>
   )

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -58,15 +58,14 @@ const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
   }
 
   const Item = ({ labelLeft }: { labelLeft: string }) => (
-    <Flex alignItems="center">
-      {labelLeft}
-      <Badge
-        justifyContent="end"
-        text="Global Prop"
-        margin="xs"
-        variant="primary"
-        className="global-prop"
-      />
+    <Flex alignItems="center" justify="between">
+        {labelLeft}
+        <Badge
+          text="Global Prop"
+          margin="xs"
+          variant="primary"
+          className="global-prop"
+        />
     </Flex>
   )
 

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -61,10 +61,11 @@ const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
     <Flex alignItems="center" justify="between">
         {labelLeft}
         <Badge
-          text="Global Prop"
-          margin="xs"
-          variant="primary"
           className="global-prop"
+          dark
+          margin="xs"
+          text="Global Prop"
+          variant="primary"
         />
     </Flex>
   )

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -39,7 +39,7 @@ const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
 
   const handleFilteredKits = (query: string) => {
     if (query) {
-      const results = matchSorter(kitsAndGuidelines, query, { keys: ['label', 'name'] })
+      const results = matchSorter(kitsAndGuidelines, query, { keys: ['label'] })
       setFilteredKits(results)
     } else {
       setFilteredKits(kitsAndGuidelines)

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -14,11 +14,22 @@ type KitSearchProps = {
   id: string,
 }
 
-const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
-  const kitsAndGuidelines = [...kits, ...VisualGuidelinesItems]
-  const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)
+interface VisualGuidelineItem {
+  label: string,
+  value: string,
+}
 
-  console.log(filteredKits)
+const combineKitsandVisualGuidelines = (
+  kits: Kit[],
+  VisualGuidelineItems: VisualGuidelineItem[]):
+  (Kit | VisualGuidelineItem)[] => {
+  return [...kits, ...VisualGuidelineItems].sort((a, b) => a.label.localeCompare(b.label))
+}
+
+const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
+  const kitsAndGuidelines = combineKitsandVisualGuidelines(kits, VisualGuidelinesItems)
+
+  const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)
 
   useEffect(() => {
     if (id === 'desktop-kit-search') {

--- a/playbook-website/app/javascript/components/MainSidebar/MenuData/GuidelinesNavItems.ts
+++ b/playbook-website/app/javascript/components/MainSidebar/MenuData/GuidelinesNavItems.ts
@@ -1,98 +1,98 @@
 export const VisualGuidelinesItems = [
     {
-        name: "Colors",
+        label: "Colors",
         link: "/visual_guidelines/colors"
     },
     {
-        name: "Width",
+        label: "Width",
         link: "/visual_guidelines/width"
     },
     {
-        name: "Min Width",
+        label: "Min Width",
         link: "/visual_guidelines/min_width"
     },
     {
-        name: "Max Width",
+        label: "Max Width",
         link: "/visual_guidelines/max_width"
     },
     {
-        name: "Height",
+        label: "Height",
         link: "/visual_guidelines/height"
     },
     {
-        name: "Min Height",
+        label: "Min Height",
         link: "/visual_guidelines/min_height"
     },
     {
-        name : "Max Height",
+        label : "Max Height",
         link: "/visual_guidelines/max_height"
     },
     {
-        name: "Position",
+        label: "Position",
         link: "/visual_guidelines/position"
     },
     {
-        name: "Vertical Align",
+        label: "Vertical Align",
         link: "/visual_guidelines/vertical_align"
     },
     {
-        name: "Z-Index",
+        label: "Z-Index",
         link: "/visual_guidelines/z_index"
     },
     {
-        name: "Line Height",
+        label: "Line Height",
         link: "/visual_guidelines/line_height"
     },
     {
-        name: "Number Spacing",
+        label: "Number Spacing",
         link: "/visual_guidelines/number_spacing"
     },
     {
-        name: "Shadows",
+        label: "Shadows",
         link: "/visual_guidelines/shadows"
     },
     {
-        name: "Spacing",
+        label: "Spacing",
         link: "/visual_guidelines/spacing"
     },
     {
-        name: "Border Radius",
+        label: "Border Radius",
         link: "/visual_guidelines/border_radius"
     },
     {
-        name: "Typography",
+        label: "Typography",
         link: "/visual_guidelines/typography"
     },
     {
-        name: "Display",
+        label: "Display",
         link: "/visual_guidelines/display"
     },
     {
-        name: "Cursor",
+        label: "Cursor",
         link: "/visual_guidelines/cursor"
     },
     {
-        name: "Flex Box",
+        label: "Flex Box",
         link: "/visual_guidelines/flex_box"
     },
     {
-        name: "Hover",
+        label: "Hover",
         link: "/visual_guidelines/hover"
     },
     {
-        name: "Group Hover",
+        label: "Group Hover",
         link: "/visual_guidelines/group_hover"
     },
     {
-        name: "Text Align",
+        label: "Text Align",
         link: "/visual_guidelines/text_align"
     },
     {
-        name: "Overflow",
+        label: "Overflow",
         link: "/visual_guidelines/overflow"
     },
     {
-        name: "Truncate",
+        label: "Truncate",
         link: "/visual_guidelines/truncate"
     },
   ];

--- a/playbook-website/app/javascript/components/MainSidebar/MenuData/GuidelinesNavItems.ts
+++ b/playbook-website/app/javascript/components/MainSidebar/MenuData/GuidelinesNavItems.ts
@@ -1,98 +1,98 @@
 export const VisualGuidelinesItems = [
     {
         label: "Colors",
-        link: "/visual_guidelines/colors"
+        value: "/visual_guidelines/colors"
     },
     {
         label: "Width",
-        link: "/visual_guidelines/width"
+        value: "/visual_guidelines/width"
     },
     {
         label: "Min Width",
-        link: "/visual_guidelines/min_width"
+        value: "/visual_guidelines/min_width"
     },
     {
         label: "Max Width",
-        link: "/visual_guidelines/max_width"
+        value: "/visual_guidelines/max_width"
     },
     {
         label: "Height",
-        link: "/visual_guidelines/height"
+        value: "/visual_guidelines/height"
     },
     {
         label: "Min Height",
-        link: "/visual_guidelines/min_height"
+        value: "/visual_guidelines/min_height"
     },
     {
         label : "Max Height",
-        link: "/visual_guidelines/max_height"
+        value: "/visual_guidelines/max_height"
     },
     {
         label: "Position",
-        link: "/visual_guidelines/position"
+        value: "/visual_guidelines/position"
     },
     {
         label: "Vertical Align",
-        link: "/visual_guidelines/vertical_align"
+        value: "/visual_guidelines/vertical_align"
     },
     {
         label: "Z-Index",
-        link: "/visual_guidelines/z_index"
+        value: "/visual_guidelines/z_index"
     },
     {
         label: "Line Height",
-        link: "/visual_guidelines/line_height"
+        value: "/visual_guidelines/line_height"
     },
     {
         label: "Number Spacing",
-        link: "/visual_guidelines/number_spacing"
+        value: "/visual_guidelines/number_spacing"
     },
     {
         label: "Shadows",
-        link: "/visual_guidelines/shadows"
+        value: "/visual_guidelines/shadows"
     },
     {
         label: "Spacing",
-        link: "/visual_guidelines/spacing"
+        value: "/visual_guidelines/spacing"
     },
     {
         label: "Border Radius",
-        link: "/visual_guidelines/border_radius"
+        value: "/visual_guidelines/border_radius"
     },
     {
         label: "Typography",
-        link: "/visual_guidelines/typography"
+        value: "/visual_guidelines/typography"
     },
     {
         label: "Display",
-        link: "/visual_guidelines/display"
+        value: "/visual_guidelines/display"
     },
     {
         label: "Cursor",
-        link: "/visual_guidelines/cursor"
+        value: "/visual_guidelines/cursor"
     },
     {
         label: "Flex Box",
-        link: "/visual_guidelines/flex_box"
+        value: "/visual_guidelines/flex_box"
     },
     {
         label: "Hover",
-        link: "/visual_guidelines/hover"
+        value: "/visual_guidelines/hover"
     },
     {
         label: "Group Hover",
-        link: "/visual_guidelines/group_hover"
+        value: "/visual_guidelines/group_hover"
     },
     {
         label: "Text Align",
-        link: "/visual_guidelines/text_align"
+        value: "/visual_guidelines/text_align"
     },
     {
         label: "Overflow",
-        link: "/visual_guidelines/overflow"
+        value: "/visual_guidelines/overflow"
     },
     {
         label: "Truncate",
-        link: "/visual_guidelines/truncate"
+        value: "/visual_guidelines/truncate"
     },
   ];

--- a/playbook-website/app/javascript/components/MainSidebar/NavComponents/OtherNavComponent.tsx
+++ b/playbook-website/app/javascript/components/MainSidebar/NavComponents/OtherNavComponent.tsx
@@ -36,7 +36,7 @@ export const OtherNavItems = ({
     }
   }
   let menuItems: { [key: string]: string }[] | string[] = []
-  
+
   const guidesNavItems = getting_started["pages"].map(guide => ({
     name: guide.title,
     link: `/${guide.url}`
@@ -52,9 +52,14 @@ export const OtherNavItems = ({
     link: `/${guide.url}`
   }))
 
+  const tokensAndGuidelinesMenu = VisualGuidelinesItems.map(guide => ({
+    name: guide.label,
+    link: `${guide.value}`
+  }))
+
   //conditionally render navitems depending on name
   if (name === "Tokens & Guidelines") {
-    menuItems = VisualGuidelinesItems
+    menuItems = tokensAndGuidelinesMenu
   } else if (name === "UI Samples" && samples) {
     menuItems = samplesMenu
   } else if (name === "Getting Started") {

--- a/playbook-website/app/javascript/components/MainSidebar/NavComponents/OtherNavComponent.tsx
+++ b/playbook-website/app/javascript/components/MainSidebar/NavComponents/OtherNavComponent.tsx
@@ -54,7 +54,7 @@ export const OtherNavItems = ({
 
   const tokensAndGuidelinesMenu = VisualGuidelinesItems.map(guide => ({
     name: guide.label,
-    link: `${guide.value}`
+    link: guide.value
   }))
 
   //conditionally render navitems depending on name


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1478](https://runway.powerhrg.com/backlog_items/PLAY-1478)

Everything listed on our "Tokens and Guidelines" page now appears in the Playbook website search bar and brings a user to the respective Playbook page.
Each item in the "Tokens and Guidelines" search has an identifying "Global Props" badge.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-02-04 at 9 02 05 AM](https://github.com/user-attachments/assets/49fb2902-cec0-4a9b-b61d-532cd2374175)


**How to test?** Steps to confirm the desired behavior:
1. Go to playbook.powerapp.cloud
2. Search for items listed in the Tokens and Guidelines section
3. Select a Token/Guideline
4. See results in search bar, associated badge -- when clicked, you should be taken to the corresponding tokens page


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.