### PR TITLE
[PLAY-1887] Add Nil Check for custom_titleize

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -54,6 +54,8 @@ module Playbook
       end
 
       def custom_titleize(str)
+        return "" if str.nil?
+
         str.split(" ").map(&:capitalize).join(" ")
       end
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR adds a nil check for the `custom_titleize` which will prevent crashes when a street address is not passed to the `home_address_kit`

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.