### PR TITLE
[PLAY-1887] Home Address with fix

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
@@ -18,6 +18,7 @@ type HomeAddressStreetProps = {
   className?: string,
   data?: { [key: string]: string },
   dark?: boolean,
+  preserveCase?: boolean,
   emphasis: "street" | "city" | "none",
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   homeId: string,
@@ -43,6 +44,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
     htmlOptions = {},
     homeId,
     homeUrl,
+    preserveCase = false,
     target,
     newWindow,
     houseStyle,
@@ -77,6 +79,8 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
     return null
   }
 
+  const formatStreetAdr = (address: string): string => preserveCase ? address : titleize(address)
+
   return (
     <div
         className={classes(className, dark)}
@@ -91,7 +95,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
               dark={dark}
               size={4}
           >
-            {joinPresent([titleize(address), houseStyle], ' · ')}
+            {joinPresent([formatStreetAdr(address), houseStyle], ' · ')}
           </Title>
           <Title
               className="pb_home_address_street_address"
@@ -108,7 +112,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
       {emphasis == 'city' &&
         <div>
           <Body color="light">
-            {joinPresent([titleize(address), houseStyle], ' · ')}
+            {joinPresent([formatStreetAdr(address), houseStyle], ' · ')}
           </Body>
           <Body color="light">{titleize(addressCont)}</Body>
           <div>
@@ -132,9 +136,9 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
       {emphasis == 'none' &&
         <div>
           <Body dark={dark}>
-            {joinPresent([titleize(address), houseStyle], ' · ')}
+            {joinPresent([formatStreetAdr(address), houseStyle], ' · ')}
           </Body>
-          <Body dark={dark}>{titleize(addressCont)}</Body>
+          <Body dark={dark}>{formatStreetAdr(addressCont)}</Body>
           <div>
             <Body
                 color="light"

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
@@ -101,7 +101,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
             {titleize(addressCont)}
           </Title>
           <Body color="light">
-            {`${titleize(city)}, ${state} ${zipcode}`}
+            {`${titleize(city)}, ${state.toUpperCase()} ${zipcode}`}
           </Body>
         </div>
       }
@@ -118,7 +118,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
                 size={4}
                 tag="span"
             >
-              {`${titleize(city)}, ${state}`}
+              {`${titleize(city)}, ${state.toUpperCase()}`}
             </Title>
             <Body
                 color="light"
@@ -140,7 +140,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
                 color="light"
                 dark={dark}
               >
-            {`${titleize(city)}, ${state} ${zipcode}`}
+            {`${titleize(city)}, ${state.toUpperCase()} ${zipcode}`}
           </Body>
           </div>
         </div>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.html.erb
@@ -1,0 +1,12 @@
+<%= pb_rails("home_address_street", props: {
+  address: "70 Prospect Ave",
+  address_cont: "Apt M18",
+  city: "West Chester",
+  home_id: 8250263,
+  home_url: "https://powerhrg.com/",
+  house_style: "Colonial",
+  preserve_case: true,
+  state: "pa",
+  zipcode: "19382",
+  territory: "PHL",
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.html.erb
@@ -1,10 +1,9 @@
 <%= pb_rails("home_address_street", props: {
-  address: "70 Prospect Ave",
+  address: "71 pRoSpEcT ave",
   address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,
   home_url: "https://powerhrg.com/",
-  house_style: "Colonial",
   preserve_case: true,
   state: "pa",
   zipcode: "19382",

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("home_address_street", props: {
-  address: "71 pRoSpEcT ave",
+  address: "70 pRoSpEcT ave",
   address_cont: "Apt M18",
   city: "West Chester",
   home_id: 8250263,

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
@@ -10,7 +10,6 @@ const HomeAddressStreetFormatting = (props) => {
         city="West Chester"
         homeId="8250263"
         homeUrl="https://powerhrg.com/"
-        houseStyle="Colonial"
         preserveCase
         state="pa"
         territory="PHL"

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
@@ -5,7 +5,7 @@ import HomeAddressStreet from '../_home_address_street'
 const HomeAddressStreetFormatting = (props) => {
   return (
     <HomeAddressStreet
-        address="70 prospect ave"
+        address="70 pRoSpEcT ave"
         addressCont="Apt M18"
         city="West Chester"
         homeId="8250263"

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
@@ -5,12 +5,13 @@ import HomeAddressStreet from '../_home_address_street'
 const HomeAddressStreetFormatting = (props) => {
   return (
     <HomeAddressStreet
-        address="70 Prospect Ave"
+        address="70 prospect ave"
         addressCont="Apt M18"
         city="West Chester"
         homeId="8250263"
         homeUrl="https://powerhrg.com/"
         houseStyle="Colonial"
+        preserveCase
         state="pa"
         territory="PHL"
         zipcode="19382"

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import HomeAddressStreet from '../_home_address_street'
+
+const HomeAddressStreetFormatting = (props) => {
+  return (
+    <HomeAddressStreet
+        address="70 Prospect Ave"
+        addressCont="Apt M18"
+        city="West Chester"
+        homeId="8250263"
+        homeUrl="https://powerhrg.com/"
+        houseStyle="Colonial"
+        state="pa"
+        territory="PHL"
+        zipcode="19382"
+        {...props}
+    />
+  )
+}
+
+export default HomeAddressStreetFormatting

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.md
@@ -1,1 +1,1 @@
-The `state` prop will always capitalize the state even if the data entered was lower case. See the code example how `state="pa"` becomes PA when rendered.
+The `state` prop will always capitalize the state even if the data entered was lower case. See the code example how `state="pa"` becomes PA when rendered. When you pass `preserveCase` for React or `preserve_case` for Rails, the street address will be rendered as entered with no title capitalization. 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.md
@@ -1,0 +1,1 @@
+The `state` prop will always capitalize the state even if the data entered was lower case. See the code example how `state="pa"` becomes PA when rendered.

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting.md
@@ -1,1 +1,0 @@
-The `state` prop will always capitalize the state even if the data entered was lower case. See the code example how `state="pa"` becomes PA when rendered. When you pass `preserveCase` for React or `preserve_case` for Rails, the street address will be rendered as entered with no title capitalization. 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting_rails.md
@@ -1,0 +1,1 @@
+The `state` prop will always capitalize the state name, even if the data entered is in lowercase. For example, when `state="pa"` is passed, it will be rendered as "PA". When you pass `preserve_case: true`, the street address will be rendered exactly as entered, without automatic title capitalization.

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting_react.md
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_home_address_street_formatting_react.md
@@ -1,0 +1,1 @@
+The `state` prop will always capitalize the state name, even if the data entered is in lowercase. For example, when `state="pa"` is passed, it will be rendered as "PA". When you pass `preserveCase`, the street address will be rendered exactly as entered, without automatic title capitalization.

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
@@ -5,6 +5,7 @@ examples:
   - home_address_street_emphasis: Emphasis
   - home_address_street_modified: Modified
   - home_address_street_link: Link
+  - home_address_street_formatting: Formatting
 
   react:
   - home_address_street_default: Default

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/example.yml
@@ -11,6 +11,7 @@ examples:
   - home_address_street_emphasis: Emphasis
   - home_address_street_modified: Modified
   - home_address_street_link: Link
+  - home_address_street_formatting: Formatting
 
   swift:
   - home_address_street_default_swift: Default

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/index.js
@@ -2,3 +2,4 @@ export { default as HomeAddressStreetDefault } from './_home_address_street_defa
 export { default as HomeAddressStreetEmphasis } from './_home_address_street_emphasis.jsx'
 export { default as HomeAddressStreetModified } from './_home_address_street_modified.jsx'
 export { default as HomeAddressStreetLink } from './_home_address_street_link.jsx'
+export { default as HomeAddressStreetFormatting } from './_home_address_street_formatting.jsx'

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -18,6 +18,7 @@ module Playbook
       prop :state
       prop :zipcode
       prop :territory
+      prop :preserve_case, default: false
       prop :dark, type: Playbook::Props::Boolean, default: false
 
       def classname
@@ -37,7 +38,7 @@ module Playbook
       end
 
       def address_house_style
-        [address&.titleize, house_style].join(separator)
+        [format_street_address, house_style].join(separator)
       end
 
       def address_house_style2
@@ -46,6 +47,10 @@ module Playbook
 
       def separator
         house_style ? " \u00b7 " : ""
+      end
+
+      def format_street_address
+        preserve_case ? address : address.titleize
       end
 
       def city_emphasis_props

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -54,6 +54,8 @@ module Playbook
       end
 
       def custom_titleize(str)
+        return "" if str.nil?
+
         str.split(" ").map(&:capitalize).join(" ")
       end
 

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -50,7 +50,11 @@ module Playbook
       end
 
       def format_street_address
-        preserve_case ? address : address.titleize
+        preserve_case ? address : custom_titleize(address)
+      end
+
+      def custom_titleize(str)
+        str.split(" ").map(&:capitalize).join(" ")
       end
 
       def city_emphasis_props

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/home_address_street.rb
@@ -29,7 +29,7 @@ module Playbook
       end
 
       def city_state
-        [city&.titleize, state].join(", ")
+        [city&.titleize, state&.upcase].join(", ")
       end
 
       def zip


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR includes all the code from [Story](https://runway.powerhrg.com/backlog_items/PLAY-1821) [PR](https://github.com/powerhome/playbook/pull/4176) plus adds a nil check for custom_titleize so the app does not crash when we don't pass a home address prop

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.