### PR TITLE
[PBNTR-682] Table kit: Clickable Table Rows Doc Example

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_clickable_rows.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_clickable_rows.html.erb
@@ -1,0 +1,55 @@
+<%= pb_rails("table", props: { size: "sm" }) do %>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+      <%= pb_rails("table/table_header", props: { text: "" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row", props: { cursor: "pointer", id: "row-1", data: { clickable: true } }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("icon", props: { color: "primary_action", fixed_width: true, icon: "chevron-right", size: "xs" }) %>
+      <% end %>
+    <% end %>
+
+    <%= pb_rails("table/table_row", props: { cursor: "pointer", id: "row-2", data: { clickable: true } }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("icon", props: { color: "primary_action", fixed_width: true, icon: "chevron-right", size: "xs" }) %>
+      <% end %>
+    <% end %>
+
+    <%= pb_rails("table/table_row", props: { cursor: "pointer", id: "row-3", data: { clickable: true } }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("icon", props: { color: "primary_action", fixed_width: true, icon: "chevron-right", size: "xs" }) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<script>
+  document.querySelectorAll('[data-clickable]').forEach(row => {
+    row.addEventListener('click', () => {
+      alert(`Row ${row.id.split('-')[1]} clicked`)
+    })
+  })
+</script>
+  

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_clickable_rows.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_clickable_rows.jsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { Table, Icon } from 'playbook-ui'
+
+const TableWithClickableRows = (props) => {
+
+
+  return (
+      <Table 
+          size="sm" 
+          {...props}
+      >
+          <Table.Head>
+              <Table.Row>
+                  <Table.Header>{"Column 1"}</Table.Header>
+                  <Table.Header>{"Column 2"}</Table.Header>
+                  <Table.Header>{"Column 3"}</Table.Header>
+                  <Table.Header>{"Column 4"}</Table.Header>
+                  <Table.Header>{"Column 5"}</Table.Header>
+                  <Table.Header>{""}</Table.Header>
+              </Table.Row>
+          </Table.Head>
+          <Table.Body>
+              <Table.Row
+                  cursor="pointer"
+                  htmlOptions={{ onClick: () => alert("Row 1 clicked") }}
+                  {...props}
+              >
+                <Table.Cell>{"Value 1"}</Table.Cell>
+                <Table.Cell>{"Value 2"}</Table.Cell>
+                <Table.Cell>{"Value 3"}</Table.Cell>
+                <Table.Cell>{"Value 4"}</Table.Cell>
+                <Table.Cell>{"Value 5"}</Table.Cell>
+                <Table.Cell textAlign="right">
+                    <Icon 
+                        color="primary_action"
+                        fixedWidth
+                        icon="chevron-right" 
+                        size="xs"
+                        {...props}
+                    />
+                </Table.Cell>
+              </Table.Row>
+              <Table.Row
+                  cursor="pointer"
+                  htmlOptions={{ onClick: () => alert("Row 2 clicked") }}
+                  {...props}
+              >
+                  <Table.Cell>{"Value 1"}</Table.Cell>
+                  <Table.Cell>{"Value 2"}</Table.Cell>
+                  <Table.Cell>{"Value 3"}</Table.Cell>
+                  <Table.Cell>{"Value 4"}</Table.Cell>
+                  <Table.Cell>{"Value 5"}</Table.Cell>
+                  <Table.Cell textAlign="right">
+                      <Icon 
+                          color="primary_action"
+                          fixedWidth
+                          icon="chevron-right" 
+                          size="xs"
+                          {...props}
+                      />                
+                  </Table.Cell>
+              </Table.Row>
+              <Table.Row
+                  cursor="pointer"
+                  htmlOptions={{ onClick: () => alert("Row 3 clicked") }}
+                  {...props}
+              >
+                  <Table.Cell>{"Value 1"}</Table.Cell>
+                  <Table.Cell>{"Value 2"}</Table.Cell>
+                  <Table.Cell>{"Value 3"}</Table.Cell>
+                  <Table.Cell>{"Value 4"}</Table.Cell>
+                  <Table.Cell>{"Value 5"}</Table.Cell>
+                  <Table.Cell textAlign="right">
+                      <Icon 
+                          color="primary_action"
+                          fixedWidth
+                          icon="chevron-right" 
+                          size="xs"
+                          {...props}
+                      />
+                  </Table.Cell>
+              </Table.Row>
+          </Table.Body>
+      </Table>
+  )
+}
+
+export default TableWithClickableRows

--- a/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
@@ -34,6 +34,7 @@ examples:
     - table_with_collapsible_with_custom_content_rails: Table with Collapsible with Custom Content
     - table_with_collapsible_with_nested_rows_rails: Table with Collapsible with Nested Rows
     - table_with_collapsible_with_nested_table_rails: Table with Collapsible with Nested Table
+    - table_with_clickable_rows: Table with Clickable Rows
 
   react:
     - table_sm: Small
@@ -70,3 +71,4 @@ examples:
     - table_with_collapsible_with_custom_content: Table with Collapsible with Custom Content
     - table_with_collapsible_with_nested_rows: Table with Collapsible with Nested Rows
     - table_with_collapsible_with_nested_table: Table with Collapsible with Nested Table
+    - table_with_clickable_rows: Table with Clickable Rows

--- a/playbook/app/pb_kits/playbook/pb_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/index.js
@@ -33,3 +33,4 @@ export { default as TableWithCollapsibleWithCustomContent } from './_table_with_
 export { default as TableWithCollapsibleWithNestedTable } from './_table_with_collapsible_with_nested_table.jsx'
 export { default as TableWithCollapsibleWithNestedRows } from './_table_with_collapsible_with_nested_rows.jsx'
 export { default as TableWithCollapsibleWithCustomClick } from './_table_with_collapsible_with_custom_click.jsx'
+export { default as TableWithClickableRows } from './_table_with_clickable_rows.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-682](https://runway.powerhrg.com/backlog_items/PBNTR-682) creates Rails and React doc examples showcasing clickable table rows functionality.

**Screenshots:** Screenshots to visualize your addition/change
Screenshots to come


**How to test?** Steps to confirm the desired behavior:
1. Go to "Table with Clickable Rows" doc example in milano env (rails | react links to come)
2. Table in doc example appears stylistically similar to the group of "Table with Collapsible" doc examples above it. Click on a row in the table - a console log saying "Row X Clicked" will appear.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~