### PR TITLE
[PLAY-1884] Responsive Progress Pill

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_progress_pills/_progress_pills.scss
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/_progress_pills.scss
@@ -3,7 +3,8 @@
 @import "../tokens/border_radius";
 
 @mixin pb_progress_pill {
-  width: 45px;
+  width: 100%;
+  max-width: 45px;
   height: 4px;
   border-radius: $border_rad_light;
   margin-right: $space_xs;

--- a/playbook/app/pb_kits/playbook/pb_progress_pills/docs/_progress_pills_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/docs/_progress_pills_default.html.erb
@@ -1,1 +1,2 @@
 <%= pb_rails("progress_pills", props: { aria: { label: "2 out of 3 steps complete" }, steps: 3, active: 2 }) %>
+<%= pb_rails("progress_pills", props: { aria: { label: "9 out of 18 steps complete" }, steps: 18, active: 9, margin_top: "md" }) %>

--- a/playbook/app/pb_kits/playbook/pb_progress_pills/docs/_progress_pills_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/docs/_progress_pills_default.jsx
@@ -10,6 +10,13 @@ const ProgressPillsDefault = (props) => {
                 steps={3}
                 {...props}
             />
+            <ProgressPills
+                active={9}
+                aria={{ label: '9 out of 18 steps complete' }}
+                marginTop="md"
+                steps={18}
+                {...props}
+            />
         </>
     )
 }

--- a/playbook/app/pb_kits/playbook/pb_progress_pills/docs/_progress_pills_default.md
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/docs/_progress_pills_default.md
@@ -1,0 +1,1 @@
+Progress pills start at `45px` wide if the container allows, but will shrink down to `1px` as the container gets smaller. Resize this window to see each pill shrink.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Story](https://runway.powerhrg.com/backlog_items/PLAY-1884)
This PR makes our Progress Pill kit more responsive by setting the width of the pill to 100% of the container and the `max-width: 45px` which is our current fixed width. This will allow the pills to expand and shrink inside their container. 

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-02-11 at 1 40 06 PM](https://github.com/user-attachments/assets/d00f0c5c-bf04-4311-93f4-824917af95f2)
![Screenshot 2025-02-11 at 1 40 32 PM](https://github.com/user-attachments/assets/66f7f8f7-0a50-47fa-98c4-93607e71aaf8)


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.