### PR TITLE
[PLAY-1851] Checkbox React Hook Form support

### DIFF
--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -15,7 +15,8 @@
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^2.4.0",
     "match-sorter": "^8.0.0",
-    "playbook-ui": ">= 1"
+    "playbook-ui": ">= 1",
+    "react-hook-form": "^7.28.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.8",

--- a/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.tsx
@@ -6,15 +6,15 @@ import classnames from 'classnames'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 type CheckboxProps = {
-  aria?: { [key: string]: string },
+  aria?: {[key: string]: string},
   checked?: boolean,
   children?: React.ReactChild[] | React.ReactChild,
   className?: string,
   dark?: boolean,
-  data?: { [key: string]: string },
+  data?: {[key: string]: string},
   disabled?: boolean,
   error?: boolean,
-  htmlOptions?: { [key: string]: string | number | boolean | (() => void) },
+  htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
   indeterminate?: boolean,
   name?: string,
@@ -53,13 +53,12 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
       (ref as React.MutableRefObject<HTMLInputElement | null>).current = el
     }
   }
-
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(
-    buildCss('pb_checkbox_kit', checked ? 'checked' : null, error ? 'error' : null, indeterminate ? 'indeterminate' : null),
+    buildCss('pb_checkbox_kit', checked ? 'checked' : null, error ? 'error' : null, indeterminate? 'indeterminate' : null),
     globalProps(props),
     className
   )
@@ -72,19 +71,20 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
   }, [indeterminate, checked])
 
   const checkboxChildren = () => {
-    if (children) return children
+    if (children)
+      return (children)
+    else
     return (
-      <input
-          defaultChecked={checked}
-          disabled={disabled}
-          name={name}
-          onChange={onChange}
-          ref={setRefs}
-          tabIndex={tabIndex}
-          type="checkbox"
-          value={value}
-      />
-    )
+    <input
+        defaultChecked={checked}
+        disabled={disabled}
+        name={name}
+        onChange={onChange}
+        ref={setRefs}
+        tabIndex={tabIndex}
+        type="checkbox"
+        value={value}
+    />)
   }
 
   return (
@@ -95,25 +95,27 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
         className={classes}
         id={id}
     >
-      {checkboxChildren()}
+      <>{checkboxChildren()}</>
 
-      {!indeterminate && (
+      {!indeterminate &&
         <span className="pb_checkbox_checkmark">
-          <Icon className="check_icon" 
-              fixedWidth 
+          <Icon
+              className="check_icon"
+              fixedWidth
               icon="check"
           />
         </span>
-      )}
+      }
 
-      {indeterminate && (
+      {indeterminate &&
         <span className="pb_checkbox_indeterminate">
-          <Icon className="indeterminate_icon"
+          <Icon
+              className="indeterminate_icon"
               fixedWidth
               icon="minus"
           />
         </span>
-      )}
+      }
 
       <Body
           className="pb_checkbox_label"
@@ -128,5 +130,4 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
 })
 
 Checkbox.displayName = "Checkbox"
-
 export default Checkbox

--- a/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.tsx
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/_checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, forwardRef } from 'react'
 import Body from '../pb_body/_body'
 import Icon from '../pb_icon/_icon'
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
@@ -6,15 +6,15 @@ import classnames from 'classnames'
 import { globalProps, GlobalProps } from '../utilities/globalProps'
 
 type CheckboxProps = {
-  aria?: {[key: string]: string},
+  aria?: { [key: string]: string },
   checked?: boolean,
   children?: React.ReactChild[] | React.ReactChild,
   className?: string,
   dark?: boolean,
-  data?: {[key: string]: string},
+  data?: { [key: string]: string },
   disabled?: boolean,
   error?: boolean,
-  htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
+  htmlOptions?: { [key: string]: string | number | boolean | (() => void) },
   id?: string,
   indeterminate?: boolean,
   name?: string,
@@ -24,7 +24,7 @@ type CheckboxProps = {
   value?: string,
 } & GlobalProps
 
-const Checkbox = (props: CheckboxProps): React.ReactElement => {
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {
   const {
     aria = {},
     checked = false,
@@ -44,39 +44,47 @@ const Checkbox = (props: CheckboxProps): React.ReactElement => {
     value = '',
   } = props
 
-  const checkRef = useRef(null)
+  const internalRef = useRef<HTMLInputElement>(null)
+  const setRefs = (el: HTMLInputElement) => {
+    internalRef.current = el
+    if (typeof ref === 'function') {
+      ref(el)
+    } else if (ref) {
+      (ref as React.MutableRefObject<HTMLInputElement | null>).current = el
+    }
+  }
+
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
 
   const classes = classnames(
-    buildCss('pb_checkbox_kit', checked ? 'checked' : null, error ? 'error' : null, indeterminate? 'indeterminate' : null),
+    buildCss('pb_checkbox_kit', checked ? 'checked' : null, error ? 'error' : null, indeterminate ? 'indeterminate' : null),
     globalProps(props),
     className
   )
 
   useEffect(() => {
-    if (checkRef.current) {
-      checkRef.current.checked = checked
-      checkRef.current.indeterminate = indeterminate
+    if (internalRef.current) {
+      internalRef.current.checked = checked
+      internalRef.current.indeterminate = indeterminate
     }
   }, [indeterminate, checked])
 
   const checkboxChildren = () => {
-    if (children)
-      return (children)
-    else
+    if (children) return children
     return (
-    <input
-        defaultChecked={checked}
-        disabled={disabled}
-        name={name}
-        onChange={onChange}
-        ref={checkRef}
-        tabIndex={tabIndex}
-        type="checkbox"
-        value={value}
-    />)
+      <input
+          defaultChecked={checked}
+          disabled={disabled}
+          name={name}
+          onChange={onChange}
+          ref={setRefs}
+          tabIndex={tabIndex}
+          type="checkbox"
+          value={value}
+      />
+    )
   }
 
   return (
@@ -87,27 +95,25 @@ const Checkbox = (props: CheckboxProps): React.ReactElement => {
         className={classes}
         id={id}
     >
-      <>{checkboxChildren()}</>
+      {checkboxChildren()}
 
-      {!indeterminate &&
+      {!indeterminate && (
         <span className="pb_checkbox_checkmark">
-          <Icon
-              className="check_icon"
-              fixedWidth
+          <Icon className="check_icon" 
+              fixedWidth 
               icon="check"
           />
         </span>
-      }
+      )}
 
-      {indeterminate &&
+      {indeterminate && (
         <span className="pb_checkbox_indeterminate">
-          <Icon
-              className="indeterminate_icon"
+          <Icon className="indeterminate_icon"
               fixedWidth
               icon="minus"
           />
         </span>
-      }
+      )}
 
       <Body
           className="pb_checkbox_label"
@@ -119,6 +125,8 @@ const Checkbox = (props: CheckboxProps): React.ReactElement => {
       </Body>
     </label>
   )
-}
+})
+
+Checkbox.displayName = "Checkbox"
 
 export default Checkbox

--- a/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.test.js
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.test.js
@@ -106,3 +106,19 @@ test('has disabled attribute', () => {
   const input = kit.querySelector('input')
   expect(input).toHaveAttribute('disabled')
 }) 
+
+test('has ref in the input element', () => {
+  const ref = React.createRef()
+    render(
+      <Checkbox
+          data={{ testid: testId }}
+          name="checkbox-name"
+          ref={ref}
+          text="Checkbox"
+          value="check-box value"
+      />
+  )
+
+  expect(ref.current).not.toBeNull()
+  expect(ref.current?.tagName).toBe('INPUT')
+})

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_react_hook.jsx
@@ -28,15 +28,18 @@ const CheckboxReactHook = () => {
           paddingRight="lg"
       >
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Checkbox text="Small"
+          <Checkbox padding="xs"
+              text="Small"
               {...register("Small")}
           />
           <br />
-          <Checkbox text="Medium"
+          <Checkbox padding="xs"
+              text="Medium"
               {...register("Medium")}
           />
           <br />
-          <Checkbox text="Large"
+          <Checkbox padding="xs"
+              text="Large"
               {...register("Large")}
           />
           <br />
@@ -49,9 +52,15 @@ const CheckboxReactHook = () => {
       <Flex align="start"
           orientation="column"
       >
-        <Body text={`Small: ${submittedData.Small ? "true" : "false"}`} />
-        <Body text={`Medium: ${submittedData.Medium ? "true" : "false"}`} />
-        <Body text={`Large: ${submittedData.Large ? "true" : "false"}`} />
+        <Body padding="xs"
+            text={`Small: ${submittedData.Small ? "true" : "false"}`}
+        />
+        <Body padding="xs"
+            text={`Medium: ${submittedData.Medium ? "true" : "false"}`}
+        />
+        <Body padding="xs"
+            text={`Large: ${submittedData.Large ? "true" : "false"}`}
+        />
       </Flex>
     </Flex>
   )

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_react_hook.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react"
+import { useForm } from "react-hook-form"
+import { Button, Checkbox, Flex, Body } from "playbook-ui"
+
+const CheckboxReactHook = () => {
+  const { register, handleSubmit } = useForm({
+    defaultValues: {
+      Small: false,
+      Medium: false,
+      Large: false,
+    },
+  })
+
+  const [submittedData, setSubmittedData] = useState({
+    Small: false,
+    Medium: false,
+    Large: false,
+  })
+
+  const onSubmit = (data) => {
+    setSubmittedData(data)
+  }
+
+  return (
+    <Flex orientation="row">
+      <Flex align="start"
+          orientation="column"
+          paddingRight="lg"
+      >
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Checkbox text="Small"
+              {...register("Small")}
+          />
+          <br />
+          <Checkbox text="Medium"
+              {...register("Medium")}
+          />
+          <br />
+          <Checkbox text="Large"
+              {...register("Large")}
+          />
+          <br />
+          <Button htmlType="submit"
+              marginTop="sm"
+              text="submit"
+          />
+        </form>
+      </Flex>
+      <Flex align="start"
+          orientation="column"
+      >
+        <Body text={`Small: ${submittedData.Small ? "true" : "false"}`} />
+        <Body text={`Medium: ${submittedData.Medium ? "true" : "false"}`} />
+        <Body text={`Large: ${submittedData.Large ? "true" : "false"}`} />
+      </Flex>
+    </Flex>
+  )
+}
+
+export default CheckboxReactHook

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_react_hook.md
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_react_hook.md
@@ -1,0 +1,1 @@
+You can pass react hook props to the checkbox kit.

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/example.yml
@@ -11,6 +11,7 @@ examples:
   react:
   - checkbox_default: Default
   - checkbox_checked: Load as checked
+  - checkbox_react_hook: React Hook Form
   - checkbox_custom: Custom Checkbox
   - checkbox_error: Default w/ Error
   - checkbox_indeterminate: Indeterminate Checkbox

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/index.js
@@ -1,5 +1,6 @@
 export { default as CheckboxDefault } from './_checkbox_default.jsx'
 export { default as CheckboxCustom } from './_checkbox_custom.jsx'
+export { default as CheckboxReactHook } from './_checkbox_react_hook.jsx'
 export { default as CheckboxError } from './_checkbox_error.jsx'
 export { default as CheckboxChecked } from './_checkbox_checked.jsx'
 export { default as CheckboxIndeterminate } from './_checkbox_indeterminate.jsx'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10086,6 +10086,11 @@ react-highlight-words@^0.20.0:
     memoize-one "^4.0.0"
     prop-types "^15.5.8"
 
+react-hook-form@^7.28.1:
+  version "7.54.2"
+  resolved "https://npm.powerapp.cloud/react-hook-form/-/react-hook-form-7.54.2.tgz#8c26ed54c71628dff57ccd3c074b1dd377cfb211"
+  integrity sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==
+
 react-innertext@^1.1.5:
   version "1.1.5"
   resolved "https://npm.powerapp.cloud/react-innertext/-/react-innertext-1.1.5.tgz#8147ac54db3f7067d95f49e2d2c05a720d27d8d0"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Runway https://runway.powerhrg.com/backlog_items/PLAY-1851
Review env https://pr4262.playbook.beta.hq.powerapp.cloud/kits/checkbox/react#react-hook-form
Alpha Env https://pr46222.nitro-web.beta.px.powerapp.cloud/human_resources/people_dashboard?mt=People+Headcount+Dashboard
Alpha PR https://github.com/powerhome/nitro-web/pull/46222

Adding support for react hook form in our input kits

React Hook form needs the ref field to be more flexible to pass its props to the input field, so i did that.

Wrapping a field in react-hook-form's `<controller/>` element isn't the approach i went for. Because that is suppose to be used when you don't have access to the `ref` field.

![Screenshot](https://github.com/user-attachments/assets/3fee7d77-5e43-4a99-93da-c008c762e618)
