### PR TITLE
[PLAY-1873] Playbook and Rails 8

### DIFF
--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       actionview (>= 5.2.4.5)
       activesupport (>= 5.2.4.5)
       react-rails (= 2.6.1)
-      view_component (= 2.83.0)
+      view_component (= 3.21.0)
       webpacker-react (~> 0.3.2)
 
 GEM
@@ -278,8 +278,8 @@ GEM
     tzinfo-data (1.2024.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
-    view_component (2.83.0)
-      activesupport (>= 5.2.0, < 8.0)
+    view_component (3.21.0)
+      activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     vite_rails (3.0.17)

--- a/playbook/Gemfile.lock
+++ b/playbook/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       actionview (>= 5.2.4.5)
       activesupport (>= 5.2.4.5)
       react-rails (= 2.6.1)
-      view_component (= 2.83.0)
+      view_component (= 3.21.0)
       webpacker-react (~> 0.3.2)
 
 GEM
@@ -270,8 +270,8 @@ GEM
     tzinfo-data (1.2018.9)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
-    view_component (2.83.0)
-      activesupport (>= 5.2.0, < 8.0)
+    view_component (3.21.0)
+      activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     vite_rails (3.0.17)

--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionview", ">= 5.2.4.5"
   s.add_dependency "activesupport", ">= 5.2.4.5"
   s.add_dependency "react-rails", "2.6.1"
-  s.add_dependency "view_component", "2.83.0"
+  s.add_dependency "view_component", "3.21.0"
   s.add_dependency "webpacker-react", "~> 0.3.2"
 
   s.add_development_dependency "brakeman", "7.0.0"


### PR DESCRIPTION
**What does this PR do?**
- Bump view_component gem to latest, 3.21.0, so activesupport works with Rails 8

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.