### PR TITLE
[PLAY-1754] Convert Kits to Use pb_content_tag (Progress Pills, Simple, Step, and Radio Kit)

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_progress_pills/progress_pills.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_pills/progress_pills.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    aria: object.aria_attributes,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
 
     <div class="progress_pills_status">
       <% object.with_status do |status| %>

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/progress_simple.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/progress_simple.html.erb
@@ -1,13 +1,6 @@
-<%= content_tag(:div,
-class: object.wrapper_classname,
-style: object.style) do %>
-  <%= content_tag(:div,
-  id: object.id,
-  data: object.data_values,
-  class: object.classname,
-  **combined_html_options) do %>
-    <%= content_tag(:div, "",
-      class: "progress_simple_value",
-      style: object.value_style) %>
+<%= pb_content_tag do %>
+  <%= pb_content_tag do %>
+    <%= pb_content_tag(:div, class: "progress_simple_value", style: object.value_style) do %>
+    <% end %>
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_progress_step/progress_step.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/progress_step.html.erb
@@ -1,7 +1,3 @@
-<%= content_tag(:ul,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag(:ul) do %>
   <%= content.presence %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/progress_step_item.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:li,
-  id: object.id,
-  data: object.data,
-  class: object.classname,
-  **combined_html_options) do %>
+<%= pb_content_tag(:li) do %>
   <div class="box" style="max-width: min-content;" id="<%= object.tooltip_trigger_class %>">
     <div class="circle">
       <%= pb_rails("icon", props: { icon: object.icon, size: "xs" }) if object.icon.present? %>

--- a/playbook/app/pb_kits/playbook/pb_radio/radio.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_radio/radio.html.erb
@@ -7,26 +7,20 @@
     data: object.data,
     **combined_html_options
   }) do %>
-    <%= content_tag(:label,
+    <%= pb_content_tag(:label,
       'data-pb-radio-children': 'true',
       checked: object.checked,
-      class: object.classname,
-      id: object.id,
-      value: object.value) do %>
+      ) do %>
       <%= input %>
       <span class="pb_radio_button"></span>
     <% end %>
     <div data-pb-radio-children-wrapper="true"> <%= content %> </div>
   <% end %>
 <% else %>
-  <%= content_tag(:label,
-      aria: object.aria,
+  <%= pb_content_tag(:label,
       checked: object.checked,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
       value: object.value,
-      **combined_html_options) do %>
+      ) do %>
 
       <% if content.present? %>
         <%= content %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Updates Progress Pill, Progress Simple, Progress Step, and Radio kits to no longer use content_tag and use our new pb_content_tag.

Story [PLAY-1754](https://runway.powerhrg.com/backlog_items/PLAY-1754)

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.