### PR TITLE
[PLAY-1846] Breaking Samples Into Components

### DIFF
--- a/playbook-website/app/helpers/sample_helper.rb
+++ b/playbook-website/app/helpers/sample_helper.rb
@@ -19,7 +19,7 @@ module SampleHelper
     sample.exist? ? sample.read : ""
   end
 
-  def get_sample_code_content(sample, type)
+  def get_sample_code_content(sample, type, start_code, end_code)
     case type
     when "rails"
       rouge_type = "erb"
@@ -27,7 +27,18 @@ module SampleHelper
       rouge_type = "react"
     end
     code = get_raw_code(sample, type)
-    raw render_code(code, rouge_type)
+    raw render_code(code, rouge_type, start_code, end_code)
+  end
+
+  def get_sample_code(sample, type, start_code, end_code)
+    case type
+    when "rails"
+      rouge_type = "erb"
+    when "react"
+      rouge_type = "react"
+    end
+    code = get_raw_code(sample, type)
+    raw render_code_with_markers(code, rouge_type, start_code, end_code)
   end
 
   def get_category(sample)

--- a/playbook-website/app/helpers/sample_helper.rb
+++ b/playbook-website/app/helpers/sample_helper.rb
@@ -30,15 +30,9 @@ module SampleHelper
     raw render_code(code, rouge_type, start_code, end_code)
   end
 
-  def get_sample_code(sample, type, start_code, end_code)
-    case type
-    when "rails"
-      rouge_type = "erb"
-    when "react"
-      rouge_type = "react"
-    end
-    code = get_raw_code(sample, type)
-    raw render_code_with_markers(code, rouge_type, start_code, end_code)
+  def get_sample_code(sample, start_code, end_code)
+    code = get_raw_code(sample, "rails")
+    raw render_code_with_markers(code, "erb", start_code, end_code)
   end
 
   def get_category(sample)

--- a/playbook-website/app/views/samples/analytics_dashboard/index.html.erb
+++ b/playbook-website/app/views/samples/analytics_dashboard/index.html.erb
@@ -74,18 +74,8 @@
   <% end %>
 <% end %>
 
-<!-- code-sample-ignore-start -->
-<div class="pb--kit-show">
-    <div class="pb--doc light_ui">
-        <div class="pb--codeCopy close" >
-            <a class="pb--close-toggle copy-clipboard" href="#">Copy to Clipboard</a>
-            <div class="hiddenCodeforCopy"><%= get_raw_code(@sample, current_sample_type) %></div>
-            <pre class="highlight"><%= get_sample_code_content(@sample, current_sample_type) %></pre>
-          </div>
-      </div>
-    </div>
-</div>
-<!-- code-sample-ignore-end -->
+
+  
 
 
 

--- a/playbook-website/app/views/samples/analytics_dashboard/index.html.erb
+++ b/playbook-website/app/views/samples/analytics_dashboard/index.html.erb
@@ -74,8 +74,18 @@
   <% end %>
 <% end %>
 
-
-  
+<!-- code-sample-ignore-start -->
+<div class="pb--kit-show">
+    <div class="pb--doc light_ui">
+        <div class="pb--codeCopy close" >
+            <a class="pb--close-toggle copy-clipboard" href="#">Copy to Clipboard</a>
+            <div class="hiddenCodeforCopy"><%= get_raw_code(@sample, current_sample_type) %></div>
+            <pre class="highlight"><%= get_sample_code_content(@sample, current_sample_type) %></pre>
+          </div>
+      </div>
+    </div>
+</div>
+<!-- code-sample-ignore-end -->
 
 
 

--- a/playbook-website/app/views/samples/card_dashboard/index.html.erb
+++ b/playbook-website/app/views/samples/card_dashboard/index.html.erb
@@ -69,7 +69,7 @@
 
 
   <%# Completion Chart %>
-
+<!-- completion-chart-code-start -->
     <%= pb_rails("card", props: { padding: "none", border_none: true, shadow: "deeper",margin: "sm" }) do %>
       <%= pb_rails("flex", props: {vertical: "center",spacing: "between"}) do %>
         <%= pb_rails("title", props: { text: "Pipeline Chart", tag: "h4", size: 4, padding: "sm" }) %> 
@@ -98,13 +98,14 @@
             <% end %>
       <% end %>
     <% end %>
-
+<!-- completion-chart-code-end -->
+<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- completion-chart-code-start -->", "<!-- completion-chart-code-end -->") %></pre>
  
 
  
 
-  <%# Grid %>
- 
+<%# Grid %>
+<!-- grid-code-start -->
     <%= pb_rails("card", props: { border_none: true, shadow: "deeper",padding:"none", margin: "sm"}) do %>
       <div class="gridone">
         <% ticket_data.each do |ticket|%>
@@ -118,11 +119,12 @@
         <% end %>
       </div>
     <% end %>
-
+<!-- grid-code-end -->
+<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- grid-code-start -->", "<!-- grid-code-end -->") %></pre>
 
 
   <%# Bar Graph with Legend %>
-  
+<!-- bar-graph-code-start -->
     <%= pb_rails("card", props: { padding: "none", margin: "sm", border_none: true, shadow: "deeper" }) do %>
 
       <%= pb_rails("flex", props: {vertical: "center",spacing: "between"}) do %>
@@ -167,11 +169,11 @@
         <% end %>
 
     <% end %>
-
-
+<!-- bar-graph-code-end -->
+<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- bar-graph-code-start -->", "<!-- bar-graph-code-end -->") %></pre>
 
   <%# Number Grid %>
-
+<!-- pipeline-code-start -->
     <%= pb_rails("card", props: { border_none: true, shadow: "deeper", margin:"sm", padding:"none" }) do %>
       
         <div class="gridtwo">
@@ -197,10 +199,12 @@
         </div>
  
     <% end %>
+<!-- pipeline-code-end -->
+<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- pipeline-code-start -->", "<!-- pipeline-code-end -->") %></pre>
 
 
   <%# Gauge With Legend %>
-
+<!-- gauge-code-start -->
     <%= pb_rails("card", props: { padding: "none", border_none: true, shadow: "deeper", margin: "sm" }) do %>
 
      <%= pb_rails("flex", props: {vertical: "center",spacing: "between"}) do %>
@@ -243,6 +247,9 @@
       <% end %>
 
     <% end %>
+<!-- gauge-code-end -->
+<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- gauge-code-start -->", "<!-- gauge-code-end -->") %></pre>
+
 <style>
 [class^=grid]{
   display: grid;

--- a/playbook-website/app/views/samples/card_dashboard/index.html.erb
+++ b/playbook-website/app/views/samples/card_dashboard/index.html.erb
@@ -99,7 +99,7 @@
       <% end %>
     <% end %>
 <!-- completion-chart-code-end -->
-<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- completion-chart-code-start -->", "<!-- completion-chart-code-end -->") %></pre>
+<pre class="highlight"><%= get_sample_code(@sample, "<!-- completion-chart-code-start -->", "<!-- completion-chart-code-end -->") %></pre>
  
 
  
@@ -120,7 +120,7 @@
       </div>
     <% end %>
 <!-- grid-code-end -->
-<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- grid-code-start -->", "<!-- grid-code-end -->") %></pre>
+<pre class="highlight"><%= get_sample_code(@sample, "<!-- grid-code-start -->", "<!-- grid-code-end -->") %></pre>
 
 
   <%# Bar Graph with Legend %>
@@ -170,7 +170,7 @@
 
     <% end %>
 <!-- bar-graph-code-end -->
-<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- bar-graph-code-start -->", "<!-- bar-graph-code-end -->") %></pre>
+<pre class="highlight"><%= get_sample_code(@sample, "<!-- bar-graph-code-start -->", "<!-- bar-graph-code-end -->") %></pre>
 
   <%# Number Grid %>
 <!-- pipeline-code-start -->
@@ -200,7 +200,7 @@
  
     <% end %>
 <!-- pipeline-code-end -->
-<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- pipeline-code-start -->", "<!-- pipeline-code-end -->") %></pre>
+<pre class="highlight"><%= get_sample_code(@sample, "<!-- pipeline-code-start -->", "<!-- pipeline-code-end -->") %></pre>
 
 
   <%# Gauge With Legend %>
@@ -248,7 +248,7 @@
 
     <% end %>
 <!-- gauge-code-end -->
-<pre class="highlight"><%= get_sample_code(@sample, current_sample_type, "<!-- gauge-code-start -->", "<!-- gauge-code-end -->") %></pre>
+<pre class="highlight"><%= get_sample_code(@sample, "<!-- gauge-code-start -->", "<!-- gauge-code-end -->") %></pre>
 
 <style>
 [class^=grid]{

--- a/playbook-website/app/views/samples/card_dashboard/index.jsx
+++ b/playbook-website/app/views/samples/card_dashboard/index.jsx
@@ -18,6 +18,7 @@ import {
   SectionSeparator,
   Title,
 } from 'playbook-ui'
+import rawContent from './index.jsx?raw'
 
 ////////////////////////////////////////////////////
 //
@@ -85,12 +86,37 @@ const clientData = {
   ],
 }
 
+const CodeSnippet = ({ source, startMarker, endMarker }) => {
+  let snippet = source
+
+  if (startMarker && endMarker) {
+    // Create a regex that matches code between markers written as JavaScript single-line comments.
+    const regex = new RegExp(
+      `\\/\\/\\s*${startMarker}\\s*\\n([\\s\\S]*?)\\n\\/\\/\\s*${endMarker}`,
+      'm'
+    )
+    const match = regex.exec(source)
+    if (match) {
+      snippet = match[1].trim()
+    }
+  }
+
+  return (
+    <pre style={{ background: '#f5f5f5', padding: '1rem', overflowX: 'auto' }}>
+      <code>{snippet}</code>
+    </pre>
+  )
+}
+
+// const snippet = getCodeSnippet(fileSource, 'grid-code-start', 'grid-code-end')
+
 ////////////////////////////////////////////////////
 //
 // Components
 //
 ////////////////////////////////////////////////////
 
+// fullfillment-chart-start
 const FulfillmentChart = ({ chartData, title }) => (
   <Card
       borderNone
@@ -158,7 +184,10 @@ const FulfillmentChart = ({ chartData, title }) => (
 
   </Card>
 )
+// fullfillment-chart-end
 
+
+// grid-code-start
 const GridRowFill = ({ data }) => (
   <Card.Body padding="none">
     <Flex
@@ -181,7 +210,9 @@ const GridRowFill = ({ data }) => (
     </Flex>
   </Card.Body>
 )
+// grid-code-end
 
+// icon-grid-start
 const IconGrid = ({ gridData }) => (
   <Card
       borderNone
@@ -193,6 +224,7 @@ const IconGrid = ({ gridData }) => (
     <GridRowFill data={gridData.slice(2)} />
   </Card>
 )
+// icon-grid-end
 
 const Legend = ({ name, data }) => {
   name = name.toLowerCase().replace(/\s/g, '-')
@@ -228,6 +260,7 @@ const Legend = ({ name, data }) => {
   )
 }
 
+// gauge-start
 const GaugeLegend = ({ title, data, legendData }) => (
   <Card
       borderNone
@@ -276,7 +309,9 @@ const GaugeLegend = ({ title, data, legendData }) => (
     </Card.Body>
   </Card>
 )
+// gauge-end
 
+// bar-graph-start
 const BarGraphLegend = ({ title, data, legendData }) => (
   <Card
       borderNone
@@ -317,6 +352,7 @@ const BarGraphLegend = ({ title, data, legendData }) => (
 
   </Card>
 )
+// bar-graph-end
 
 const GridBlock = ({ data }) => {
   const unit = data.hasOwnProperty('unit') ? `${data.unit}` : ''
@@ -360,6 +396,7 @@ const GridBlock = ({ data }) => {
   )
 }
 
+// number-grid-start
 const NumberGrid = ({ data }) => {
   return (
     <Card
@@ -385,6 +422,7 @@ const NumberGrid = ({ data }) => {
     </Card>
   )
 }
+// number-grid-end
 
 ////////////////////////////////////////////////////
 //
@@ -398,14 +436,39 @@ const CardDashboard = () => {
     <div id="main-dashboard-content">
 
       <FulfillmentChart {...pipelineData} />
-
+      <CodeSnippet 
+        source={rawContent}
+        startMarker={'fullfillment-chart-start'}
+        endMarker={'fullfillment-chart-end'}
+      />
+  
       <IconGrid {...ticketData} />
+      <CodeSnippet 
+        source={rawContent}
+        startMarker={'icon-grid-start'}
+        endMarker={'icon-grid-end'}
+      />
 
       <BarGraphLegend {...salesReport} />
+      <CodeSnippet 
+        source={rawContent}
+        startMarker={'bar-graph-start'}
+        endMarker={'bar-graph-end'}
+      />
 
       <NumberGrid {...clientData} />
+      <CodeSnippet 
+        source={rawContent}
+        startMarker={'number-grid-start'}
+        endMarker={'number-grid-end'}
+      />
 
       <GaugeLegend {...totalRevenue} />
+      <CodeSnippet 
+        source={rawContent}
+        startMarker={'gauge-start'}
+        endMarker={'gauge-end'}
+      />
 
     </div>
   )

--- a/playbook-website/app/views/samples/show.html.erb
+++ b/playbook-website/app/views/samples/show.html.erb
@@ -88,16 +88,3 @@
   <% end %>
 
 <% end %>
-
-
-
-  <div class="pb--kit-show">
-      <div class="pb--doc light_ui">
-          <div class="pb--codeCopy close" >
-              <a class="pb--close-toggle copy-clipboard" href="#">Copy to Clipboard</a>
-              <div class="hiddenCodeforCopy"><%= get_raw_code(@sample, current_sample_type) %></div>
-              <pre class="highlight"><%= get_sample_code_content(@sample, current_sample_type) %></pre>
-          </div>
-      </div>
-  </div>
-</div>

--- a/playbook-website/lib/markdown_helper.rb
+++ b/playbook-website/lib/markdown_helper.rb
@@ -74,8 +74,11 @@ module PlaybookWebsite
         lexer = Rouge::Lexer.find(language)
 
         lexer = Rouge::Lexers::PlainText.new if lexer.nil?
+        puts "::::::::text #{text}"
+        code = text.gsub(/<!--\s*code-sample-ignore-start\s*-->.*?<!--\s*code-sample-ignore-end\s*-->/m, "")
+        puts "::::::::code #{code}"
 
-        formatter.format(lexer.lex(text))
+        formatter.format(lexer.lex(code))
       end
 
       class HTML < Redcarpet::Render::HTML

--- a/playbook-website/lib/markdown_helper.rb
+++ b/playbook-website/lib/markdown_helper.rb
@@ -75,10 +75,23 @@ module PlaybookWebsite
 
         lexer = Rouge::Lexers::PlainText.new if lexer.nil?
         puts "::::::::text #{text}"
-        code = text.gsub(/<!--\s*code-sample-ignore-start\s*-->.*?<!--\s*code-sample-ignore-end\s*-->/m, "")
+        # code = text.gsub(/<!--\s*code-sample-ignore-start\s*-->.*?<!--\s*code-sample-ignore-end\s*-->/m, "")
         puts "::::::::code #{code}"
 
-        formatter.format(lexer.lex(code))
+        formatter.format(lexer.lex(extracted_code))
+      end
+
+      def render_code_with_markers(text, language, start_code, end_code)
+        formatter = Rouge::Formatters::HTML.new(scope: ".highlight")
+        lexer = Rouge::Lexer.find(language)
+
+        lexer = Rouge::Lexers::PlainText.new if lexer.nil?
+
+        regex = /#{Regexp.escape(start_code)}(.*?)#{Regexp.escape(end_code)}/m
+
+        extracted = text =~ regex ? ::Regexp.last_match(1).strip : text
+
+        formatter.format(lexer.lex(extracted))
       end
 
       class HTML < Redcarpet::Render::HTML

--- a/playbook-website/lib/markdown_helper.rb
+++ b/playbook-website/lib/markdown_helper.rb
@@ -74,11 +74,8 @@ module PlaybookWebsite
         lexer = Rouge::Lexer.find(language)
 
         lexer = Rouge::Lexers::PlainText.new if lexer.nil?
-        puts "::::::::text #{text}"
-        # code = text.gsub(/<!--\s*code-sample-ignore-start\s*-->.*?<!--\s*code-sample-ignore-end\s*-->/m, "")
-        puts "::::::::code #{code}"
 
-        formatter.format(lexer.lex(extracted_code))
+        formatter.format(lexer.lex(text))
       end
 
       def render_code_with_markers(text, language, start_code, end_code)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Story](https://runway.powerhrg.com/backlog_items/PLAY-1846)
This PR is for an investigation into Breaking down our samples page into separate components.

This is a prototype that is a little messy that would need polishing.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.