### PR TITLE
[PBNTR-818] Advanced Table: Full Screen Mode for React Investigation

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/FullscreenIconButton.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/FullscreenIconButton.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import Icon from "../../pb_icon/_icon"
+
+type FullscreenIconButtonProps = {
+  isFullscreen: boolean
+  onClick: () => void
+}
+
+export const FullscreenIconButton = ({ isFullscreen, onClick }: FullscreenIconButtonProps) => {
+  return (
+    <>
+        <button
+            className="gray-icon fullscreen-icon"
+            onClick={onClick}
+        >
+            <Icon
+                cursor="pointer"
+                fixedWidth
+                icon={isFullscreen ? "grid-2" : "expand"}
+            />
+        </button>
+    </>
+  )
+}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -11,6 +11,7 @@ import Checkbox from "../../pb_checkbox/_checkbox"
 
 import { SortIconButton } from "./SortIconButton"
 import { ToggleIconButton } from "./ToggleIconButton"
+import { FullscreenIconButton } from "./FullscreenIconButton"
 
 import { isChrome } from "../Utilities/BrowserCheck"
 
@@ -47,6 +48,9 @@ export const TableHeaderCell = ({
     showActionsBar,
     inlineRowLoading,
     isActionBarVisible,
+    isFullscreen,
+    toggleFullscreen,
+    fullscreenable,
   } = useContext(AdvancedTableContext);
 
   type justifyTypes = "none" | "center" | "start" | "end" | "between" | "around" | "evenly"
@@ -103,6 +107,10 @@ const isToggleExpansionEnabled =
   } else {
     justifyHeader = isLeafColumn ? "end" : "center";
   }
+
+  // Fullscreen Icon
+  const isFirstColumn = header?.index === 0
+  const showFullscreenToggle = isFirstColumn && fullscreenable && !loading
   
   return (
     <th
@@ -176,6 +184,12 @@ const isToggleExpansionEnabled =
                 />
               ))}
           </Flex>
+          {showFullscreenToggle && (
+            <FullscreenIconButton
+                isFullscreen={isFullscreen}
+                onClick={toggleFullscreen}
+            />
+          )}
         </Flex>
       )}
     </th>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/SubKits/TableHeader.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/SubKits/TableHeader.tsx
@@ -39,7 +39,10 @@ export const TableHeader = ({
     hasAnySubRows,
     showActionsBar,
     selectableRows,
-    responsive
+    responsive,
+    isFullscreen,
+    toggleFullscreen,
+    fullscreenable
   } = useContext(AdvancedTableContext)
 
   const classes = classnames(
@@ -79,14 +82,17 @@ export const TableHeader = ({
                 <TableHeaderCell
                     enableSorting={enableSorting}
                     enableToggleExpansion={enableToggleExpansion}
+                    fullscreenable={fullscreenable}
                     handleExpandOrCollapse={handleExpandOrCollapse}
                     header={header}
                     headerChildren={children}
+                    isFullscreen={isFullscreen}
                     isPinnedLeft={isPinnedLeft}
                     key={`${header.id}-header`}
                     loading={loading}
                     sortIcon={sortIcon}
                     table={table}
+                    toggleFullscreen={toggleFullscreen}
                 />
               )
             })}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/types.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/types.ts
@@ -4,3 +4,14 @@ export type ExpandedStateObject = Extract<
   ExpandedState,
   Record<string, boolean>
 >
+
+declare global {
+  interface Document {
+    webkitExitFullscreen?: () => Promise<void>
+    msExitFullscreen?: () => Promise<void>
+    webkitRequestFullscreen?: () => Promise<void>
+    msRequestFullscreen?: () => Promise<void>
+    webkitFullscreenElement?: Element | null
+    msFullscreenElement?: Element | null
+  }
+}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -178,6 +178,16 @@
     }
   }
 
+  .fullscreen-icon {
+    @extend .button-icon;
+    @extend %primary-color-pseudo;
+    padding: 2px 0;
+
+    &:focus-visible {
+      border-radius: $border_rad_lighter;
+    }
+  }
+
   // Vertical separator
   .table-header-cells:first-child,
   .table-header-cells-custom:first-child,
@@ -213,6 +223,24 @@
     bottom: 0;
     width: 2px;
   }
+
+  // Fullscreen
+  // .advanced-table-fullscreen {
+  //   position: fixed;
+  //   top: 0;
+  //   left: 0;
+  //   width: 100vw !important;
+  //   height: 100vh !important;
+  //   max-width: none !important;
+  //   max-height: none !important;
+  //   margin: 0;
+  //   padding: 1rem;
+  //   background: #fff;
+  //   z-index: 1000;
+  //   display: flex;
+  //   flex-direction: column;
+  //   overflow: hidden;
+  // }
 
   // Responsive Styles
   @media only screen and (max-width: $screen-xl-min) {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -225,22 +225,20 @@
   }
 
   // Fullscreen
-  // .advanced-table-fullscreen {
-  //   position: fixed;
-  //   top: 0;
-  //   left: 0;
-  //   width: 100vw !important;
-  //   height: 100vh !important;
-  //   max-width: none !important;
-  //   max-height: none !important;
-  //   margin: 0;
-  //   padding: 1rem;
-  //   background: #fff;
-  //   z-index: 1000;
-  //   display: flex;
-  //   flex-direction: column;
-  //   overflow: hidden;
-  // }
+  &.advanced-table-fullscreen {
+    background: $border_light;
+    // background: $text_lt_lightter;
+    overflow-y: auto;
+    &.dark {
+      background: $border_dark;
+      // background: $text_dk_lighter;
+    }
+    .pb_table {
+      th, td, div, button {
+        font-size: calc(100%);
+      }
+    }
+  }
 
   // Responsive Styles
   @media only screen and (max-width: $screen-xl-min) {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -65,6 +65,7 @@ type AdvancedTableProps = {
   onRowSelectionChange?: (arg: RowSelectionState) => void
   fullscreenable?: boolean
   onFullscreenChange?: (isFullscreen: boolean) => void
+  getFullscreenControls?: (controls: { toggleFullscreen: () => void }) => void
 } & GlobalProps
 
 const AdvancedTable = (props: AdvancedTableProps) => {
@@ -99,6 +100,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     onRowSelectionChange,
     fullscreenable = false,
     onFullscreenChange,
+    getFullscreenControls,
   } = props
 
   const [loadingStateRowCount, setLoadingStateRowCount] = useState(
@@ -372,6 +374,12 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     }
   }, [handleFullscreenChange])
 
+  useEffect(() => {
+    if (getFullscreenControls) {
+      getFullscreenControls({ toggleFullscreen })
+    }
+  }, [getFullscreenControls, toggleFullscreen])
+
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
@@ -380,7 +388,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     `advanced-table-responsive-${responsive}`,
     maxHeight ? `advanced-table-max-height-${maxHeight}` : '',
     isFullscreen && 'advanced-table-fullscreen',
-    // isFullscreen ? `advanced-table-fullscreen` : '',
+    fullscreenable && 'advanced-table-fullscreenable',
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { AdvancedTable, Button } from "playbook-ui"
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableFullscreen = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance Rate",
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed Classes",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Class Completion Rate",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated Students",
+    },
+  ]
+
+  return (
+    <div>
+      <Button 
+          fixedWidth
+          icon="expand"
+          marginBottom="sm"
+          tabIndex={0}
+          text="Fullscreen"
+          variant="secondary"
+      />
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          tableData={MOCK_DATA}
+          {...props}
+      >
+          <AdvancedTable.Header enableSorting />
+          <AdvancedTable.Body />
+      </AdvancedTable>
+    </div>
+  )
+}
+
+export default AdvancedTableFullscreen

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
@@ -1,9 +1,11 @@
-import React from "react"
-import { AdvancedTable } from "playbook-ui"
+import React, { useState } from "react"
+import { AdvancedTable, Button, Caption } from "playbook-ui"
 import MOCK_DATA from "./advanced_table_mock_data.json"
 import PAGINATION_MOCK_DATA from "./advanced_table_pagination_mock_data.json"
 
 const AdvancedTableFullscreen = (props) => {
+  const [fullscreenToggle, setFullscreenToggle] = useState(null)
+
   const columnDefinitions = [
     {
       accessor: "year",
@@ -42,21 +44,30 @@ const AdvancedTableFullscreen = (props) => {
 
   return (
     <div>
+      <Caption text="Smaller table showcasing button + icon activation and fullscreen scss (light + dark mode)" />
+      <Button
+          marginBottom="sm"
+          onClick={() => fullscreenToggle?.()}
+          text="Fullscreen"
+          variant="secondary"
+      />
       <AdvancedTable
           columnDefinitions={columnDefinitions}
           fullscreenable
-          responsive="none"
+          getFullscreenControls={({ toggleFullscreen }) => setFullscreenToggle(() => toggleFullscreen)}
           tableData={MOCK_DATA}
-          tableProps={tableProps}
           {...props}
       >
           <AdvancedTable.Header enableSorting />
           <AdvancedTable.Body />
       </AdvancedTable>
+      <Caption 
+          marginTop="xl" 
+          text="Larger table mimicking NetSalesKPI table" 
+      />
       <AdvancedTable
           columnDefinitions={columnDefinitions}
           fullscreenable
-          marginTop="xl"
           responsive="none"
           tableData={PAGINATION_MOCK_DATA}
           tableProps={tableProps}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
@@ -1,6 +1,7 @@
 import React from "react"
-import { AdvancedTable, Button } from "playbook-ui"
+import { AdvancedTable } from "playbook-ui"
 import MOCK_DATA from "./advanced_table_mock_data.json"
+import PAGINATION_MOCK_DATA from "./advanced_table_pagination_mock_data.json"
 
 const AdvancedTableFullscreen = (props) => {
   const columnDefinitions = [
@@ -35,19 +36,30 @@ const AdvancedTableFullscreen = (props) => {
     },
   ]
 
+  const tableProps = {
+    sticky: true
+  }
+
   return (
     <div>
-      <Button 
-          fixedWidth
-          icon="expand"
-          marginBottom="sm"
-          tabIndex={0}
-          text="Fullscreen"
-          variant="secondary"
-      />
       <AdvancedTable
           columnDefinitions={columnDefinitions}
+          fullscreenable
+          responsive="none"
           tableData={MOCK_DATA}
+          tableProps={tableProps}
+          {...props}
+      >
+          <AdvancedTable.Header enableSorting />
+          <AdvancedTable.Body />
+      </AdvancedTable>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          fullscreenable
+          marginTop="xl"
+          responsive="none"
+          tableData={PAGINATION_MOCK_DATA}
+          tableProps={tableProps}
           {...props}
       >
           <AdvancedTable.Header enableSorting />

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -13,25 +13,26 @@ examples:
 
 
   react:
-  - advanced_table_default: Default (Required Props)
-  - advanced_table_loading: Loading State
-  - advanced_table_sort: Enable Sorting
-  - advanced_table_sort_control: Sort Control
-  - advanced_table_expanded_control: Expanded Control
-  - advanced_table_subrow_headers: SubRow Headers
-  - advanced_table_collapsible_trail: Collapsible Trail
-  - advanced_table_table_options: Table Options
-  - advanced_table_table_props: Table Props
-  - advanced_table_table_props_sticky_header: Table Props Sticky Header
-  - advanced_table_inline_row_loading: Inline Row Loading
-  - advanced_table_responsive: Responsive Tables
-  - advanced_table_custom_cell: Custom Components for Cells
-  - advanced_table_pagination: Pagination
-  - advanced_table_pagination_with_props: Pagination Props
-  - advanced_table_column_headers: Multi-Header Columns
-  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  # - advanced_table_no_subrows: Table with No Subrows
-  - advanced_table_selectable_rows: Selectable Rows
-  - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
-  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  # - advanced_table_default: Default (Required Props)
+  # - advanced_table_loading: Loading State
+  # - advanced_table_sort: Enable Sorting
+  # - advanced_table_sort_control: Sort Control
+  # - advanced_table_expanded_control: Expanded Control
+  # - advanced_table_subrow_headers: SubRow Headers
+  # - advanced_table_collapsible_trail: Collapsible Trail
+  # - advanced_table_table_options: Table Options
+  # - advanced_table_table_props: Table Props
+  # - advanced_table_table_props_sticky_header: Table Props Sticky Header
+  # - advanced_table_inline_row_loading: Inline Row Loading
+  # - advanced_table_responsive: Responsive Tables
+  # - advanced_table_custom_cell: Custom Components for Cells
+  # - advanced_table_pagination: Pagination
+  # - advanced_table_pagination_with_props: Pagination Props
+  # - advanced_table_column_headers: Multi-Header Columns
+  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  # # - advanced_table_no_subrows: Table with No Subrows
+  # - advanced_table_selectable_rows: Selectable Rows
+  # - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
+  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  - advanced_table_fullscreen: Fullscreen

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -13,26 +13,26 @@ examples:
 
 
   react:
-  # - advanced_table_default: Default (Required Props)
-  # - advanced_table_loading: Loading State
-  # - advanced_table_sort: Enable Sorting
-  # - advanced_table_sort_control: Sort Control
-  # - advanced_table_expanded_control: Expanded Control
-  # - advanced_table_subrow_headers: SubRow Headers
-  # - advanced_table_collapsible_trail: Collapsible Trail
-  # - advanced_table_table_options: Table Options
-  # - advanced_table_table_props: Table Props
-  # - advanced_table_table_props_sticky_header: Table Props Sticky Header
-  # - advanced_table_inline_row_loading: Inline Row Loading
-  # - advanced_table_responsive: Responsive Tables
-  # - advanced_table_custom_cell: Custom Components for Cells
-  # - advanced_table_pagination: Pagination
-  # - advanced_table_pagination_with_props: Pagination Props
-  # - advanced_table_column_headers: Multi-Header Columns
-  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  # # - advanced_table_no_subrows: Table with No Subrows
-  # - advanced_table_selectable_rows: Selectable Rows
-  # - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
-  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  - advanced_table_default: Default (Required Props)
+  - advanced_table_loading: Loading State
+  - advanced_table_sort: Enable Sorting
+  - advanced_table_sort_control: Sort Control
+  - advanced_table_expanded_control: Expanded Control
+  - advanced_table_subrow_headers: SubRow Headers
+  - advanced_table_collapsible_trail: Collapsible Trail
+  - advanced_table_table_options: Table Options
+  - advanced_table_table_props: Table Props
+  - advanced_table_table_props_sticky_header: Table Props Sticky Header
+  - advanced_table_inline_row_loading: Inline Row Loading
+  - advanced_table_responsive: Responsive Tables
+  - advanced_table_custom_cell: Custom Components for Cells
+  - advanced_table_pagination: Pagination
+  - advanced_table_pagination_with_props: Pagination Props
+  - advanced_table_column_headers: Multi-Header Columns
+  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  # - advanced_table_no_subrows: Table with No Subrows
+  - advanced_table_selectable_rows: Selectable Rows
+  - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
+  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
   - advanced_table_fullscreen: Fullscreen

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -20,3 +20,4 @@ export { default as AdvancedTableNoSubrows } from './_advanced_table_no_subrows.
 export { default as AdvancedTableSelectableRowsHeader } from './_advanced_table_selectable_rows_header.jsx'
 export { default as AdvancedTableSelectableRowsActions } from './_advanced_table_selectable_rows_actions.jsx'
 export { default as AdvancedTableTablePropsStickyHeader } from './_advanced_table_table_props_sticky_header.jsx'
+export { default as AdvancedTableFullscreen } from './_advanced_table_fullscreen.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-818](https://runway.powerhrg.com/backlog_items/PBNTR-818) asks us to explore how we would create a Fullscreen mode for the Advanced Table kit. This PR is a POC PR exploring what this could look like. This [huddle doc](https://huddle.powerapp.cloud/projects/647/artifacts/7838) goes into more detail.

**Screenshots:** Screenshots to visualize your addition/change
Video: https://github.com/user-attachments/assets/555bdb0e-5877-49a9-8548-1eba1e3563b4

<img width="1728" alt="fullscreen overflow table" src="https://github.com/user-attachments/assets/3f6c8edb-7798-4377-8c76-0d4190c704c2" />
<img width="1728" alt="light mode borderlight" src="https://github.com/user-attachments/assets/248ab0ac-a709-4bfa-8765-f1d56767703d" />
<img width="1728" alt="dark mode borderdark" src="https://github.com/user-attachments/assets/9da36168-3e1c-49aa-8247-6a1fae75c5c5" />


**How to test?** Steps to confirm the desired behavior:
1. Go to advanced table [fullscreen doc example](https://pr4279.playbook.beta.gm.powerapp.cloud/kits/advanced_table/react#fullscreen) in milano.
2. Click on full screen triggers for either table (first table external button or expand icon; second table expand icon).
3. Observe full screen mode and interact with the advanced table in full screen mode. Press F12 or the grid-2 icon in the Table Header to exit full screen mode.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~