### PR TITLE
[PLAY-1880] Bump axe-core to 4.10.2

### DIFF
--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -34,7 +34,7 @@
     "@tiptap/react": "^2.0.2",
     "@tiptap/starter-kit": "^2.0.2",
     "@vitejs/plugin-react": "^4.3.1",
-    "axe-core": "4.10.0",
+    "axe-core": "4.10.2",
     "babel-plugin-react-docgen": "^4.2.1",
     "copy-to-clipboard": "^3.3.3",
     "eslint": "6.8.0",

--- a/playbook/package.json
+++ b/playbook/package.json
@@ -65,7 +65,7 @@
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "@vitejs/plugin-react": "^4.3.1",
-    "axe-core": "4.4.3",
+    "axe-core": "4.10.2",
     "classnames": "2.5.1",
     "eslint": "6.8.0",
     "eslint-plugin-react": "7.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4661,15 +4661,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://npm.powerapp.cloud/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axe-core@4.10.0:
-  version "4.10.0"
-  resolved "https://npm.powerapp.cloud/axe-core/-/axe-core-4.10.0.tgz#d9e56ab0147278272739a000880196cdfe113b59"
-  integrity sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==
-
-axe-core@4.4.3:
-  version "4.4.3"
-  resolved "https://npm.powerapp.cloud/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
-  integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
+axe-core@4.10.2:
+  version "4.10.2"
+  resolved "https://npm.powerapp.cloud/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
+  integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
 
 axe-core@^4.0.1:
   version "4.6.2"


### PR DESCRIPTION
**What does this PR do?**
Bump axe-core from 4.4.3 to 4.10.2

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.