### PR TITLE
[PLAY-1755] Update pb_content_tag

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -1,4 +1,4 @@
-<%= pb_content_tag do %>
+<%= pb_content_tag(:div, class: object.classnames) do %>
   <% if object.label %>
     <label class="pb_select_kit_label" for="<%= object.name %>">
       <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -1,8 +1,6 @@
 <%= pb_content_tag(:div,
-  aria: object.aria,
-  data: object.data,
-  class: object.classnames,
-  **combined_html_options) do %>
+  id: nil,
+  class: object.classnames ) do %>
   <% if object.label %>
     <label class="pb_select_kit_label" for="<%= object.name %>">
       <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -2,7 +2,7 @@
   aria: object.aria,
   data: object.data,
   class: object.classnames,
-  **combined_html_options)  do %>
+  **combined_html_options) do %>
   <% if object.label %>
     <label class="pb_select_kit_label" for="<%= object.name %>">
       <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-  aria: object.aria,
-  data: object.data,
-  class: object.classnames,
-  **combined_html_options) do %>
+<%= pb_content_tag do %>
   <% if object.label %>
     <label class="pb_select_kit_label" for="<%= object.name %>">
       <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -1,4 +1,8 @@
-<%= pb_content_tag(:div, class: object.classnames) do %>
+<%= pb_content_tag(:div,
+  aria: object.aria,
+  data: object.data,
+  class: object.classnames,
+  **combined_html_options)  do %>
   <% if object.label %>
     <label class="pb_select_kit_label" for="<%= object.name %>">
       <%= pb_rails("caption", props: { text: object.label, dark: object.dark }) %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card/selectable_card.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-  id: object.id,
-  data: object.data,
-  class: object.classname,
-  **combined_html_options) do %>
+<%= pb_content_tag do %>
 
   <% if object.multi %>
     <%= check_box_tag(object.name, object.value, object.checked, object.additional_input_options) %>

--- a/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_card_icon/selectable_card_icon.html.erb
@@ -1,7 +1,4 @@
-<%= content_tag(:div,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
 
   <%= pb_rails("selectable_card", props: {
     input_id: object.input_id,

--- a/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_icon/selectable_icon.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
 
     <% if object.inputs == "disabled" %>
 

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -148,7 +148,7 @@ module Playbook
 
     def default_options
       options = {
-        id: id,
+        # id: id,
         data: data,
         class: classname,
         aria: aria,

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -148,7 +148,7 @@ module Playbook
 
     def default_options
       options = {
-        # id: id,
+        id: id,
         data: data,
         class: classname,
         aria: aria,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This PR updates the Select, Selectable Card, Selectable Card Icon and Selectable Icon to use the new pb_content_tag.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.