### PR TITLE
[PBNTR-751] Advanced Table Rails - Enable Sort Bug Follow Up

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -6,7 +6,7 @@ examples:
   - advanced_table_collapsible_trail_rails: Collapsible Trail
   - advanced_table_table_props: Table Props
   - advanced_table_table_props_sticky_header: Table Props Sticky Header
-  - advanced_table_beta_sort: Enable Sorting
+  # - advanced_table_beta_sort: Enable Sorting
   - advanced_table_responsive: Responsive Tables
   - advanced_table_custom_cell_rails: Custom Components for Cells
   - advanced_table_column_headers: Multi-Header Columns


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-751](https://runway.powerhrg.com/backlog_items/PBNTR-751) was a scss follow up to a [previous bug fix](https://runway.powerhrg.com/backlog_items/PLAY-1741) for the rails Advanced Table sorting doc example. 

A few weeks after that fix was pushed in, the rails Advanced Table kit was [heavily refactored](https://runway.powerhrg.com/backlog_items/PBNTR-771) rendering the fix obsolete. The code changes in the refactoring are very important and take precedence over this bug; this feature is currently achieved on the rails side by utilizing the [Table kit's sort_menu capabilities](https://playbook.powerapp.cloud/kits/table#table-header-1 ), and this refactoring means the best way to achieve this on the rails side is to create a custom sort method like the React Advanced Table has. My full investigation/recommendations are in the ticket comments in Runway.


**How to test?** Steps to confirm the desired behavior:
1. Go to the rails advanced table kit page. The "enable sort" doc example should not be visible for now.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~