### PR TITLE
[PLAY-1874] Pass Height/Width Global Props To Tooltip - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -29,6 +29,10 @@ type TooltipProps = {
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   icon?: string,
   interaction?: boolean,
+  maxHeight?: string,
+  maxWidth?: string,
+  minHeight?: string,
+  minWidth?: string,
   placement?: Placement,
   position?: "absolute" | "fixed";
   text: string,
@@ -48,6 +52,10 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
     htmlOptions = {},
     icon = null,
     interaction = false,
+    maxHeight,
+    maxWidth,
+    minHeight,
+    minWidth,
     placement: preferredPlacement = "top",
     position = "absolute",
     text,
@@ -123,10 +131,10 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
     return Object.assign(
       {},
       height ? { height: height } : {},
-      // maxHeight ? { maxHeight: maxHeight } : {},
-      // maxWidth ? { maxWidth: maxWidth } : {},
-      // minHeight ? { minHeight: minHeight } : {},
-      // minWidth ? { minWidth: minWidth } : {},
+      maxHeight ? { maxHeight: maxHeight } : {},
+      maxWidth ? { maxWidth: maxWidth } : {},
+      minHeight ? { minHeight: minHeight } : {},
+      minWidth ? { minWidth: minWidth } : {},
       width ? { width: width } : {}
     );
 };

--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -32,6 +32,7 @@ type TooltipProps = {
   placement?: Placement,
   position?: "absolute" | "fixed";
   text: string,
+  width: string,
   showTooltip?: boolean,
   forceOpenTooltip?: boolean,
 } & GlobalProps
@@ -51,6 +52,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
     position = "absolute",
     text,
     showTooltip = true,
+    width,
     zIndex,
     forceOpenTooltip = false,
     ...rest
@@ -125,7 +127,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
       // maxWidth ? { maxWidth: maxWidth } : {},
       // minHeight ? { minHeight: minHeight } : {},
       // minWidth ? { minWidth: minWidth } : {},
-      // width ? { width: width } : {}
+      width ? { width: width } : {}
     );
 };
 

--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.tsx
@@ -25,6 +25,7 @@ type TooltipProps = {
   children: JSX.Element,
   data?: { [key: string]: string },
   delay?: number | Partial<{open: number; close: number}>,
+  height?: string,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   icon?: string,
   interaction?: boolean,
@@ -42,6 +43,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
     children,
     data = {},
     delay = 0,
+    height,
     htmlOptions = {},
     icon = null,
     interaction = false,
@@ -115,6 +117,18 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
     top: "bottom",
   }[placement.split("-")[0]]
 
+  const tooltipSizing = () => {
+    return Object.assign(
+      {},
+      height ? { height: height } : {},
+      // maxHeight ? { maxHeight: maxHeight } : {},
+      // maxWidth ? { maxWidth: maxWidth } : {},
+      // minHeight ? { minHeight: minHeight } : {},
+      // minWidth ? { minWidth: minWidth } : {},
+      // width ? { width: width } : {}
+    );
+};
+
   return (
     <>
       <div
@@ -144,6 +158,7 @@ const Tooltip = forwardRef((props: TooltipProps, ref: ForwardedRef<unknown>): Re
               ref: refs.setFloating,
               role: "tooltip",
               style: {
+                ...tooltipSizing(),
                 position: strategy,
                 top: y ?? 0,
                 left: x ?? 0,

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
@@ -14,6 +14,7 @@ const TooltipSizing = (props) => {
           height='100px'
           placement='top'
           text="Whoa. I'm a Tooltip"
+          width='100px'
           zIndex={10}
           {...props}
       >

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Tooltip, Flex, FlexItem } from 'playbook-ui';
+import { Button, Tooltip, Flex, FlexItem } from 'playbook-ui';
 
 const TooltipSizing = (props) => {
 
@@ -11,14 +11,55 @@ const TooltipSizing = (props) => {
    >
     <FlexItem>
       <Tooltip
-          height='100px'
+          height='150px'
           placement='top'
-          text="Whoa. I'm a Tooltip"
+          text="I'm 150px high and 100px wide!"
           width='100px'
-          zIndex={10}
           {...props}
       >
-        {'Hover here (Top)'}
+        <Button text="Height and Width"/>
+      </Tooltip>
+    </FlexItem>
+    <FlexItem>
+      <Tooltip
+          maxHeight='150px'
+          placement='top'
+          text="I have a maxHeight of 150px! Here is some more text to show the maxHeight."
+          width='200px'
+          {...props}
+      >
+        <Button text="maxHeight"/>
+      </Tooltip>
+    </FlexItem>
+    <FlexItem>
+      <Tooltip
+          maxWidth='150px'
+          placement='top'
+          text="I have a maxWidth of 150px! Here is some more text to show the maxWidth."
+          {...props}
+      >
+        <Button text="maxWidth"/>
+      </Tooltip>
+    </FlexItem>
+    <FlexItem>
+      <Tooltip
+          minWidth='300px'
+          placement='top'
+          text="I have a minWidth of 300px!"
+          {...props}
+      >
+        <Button text="minWidth"/>
+      </Tooltip>
+    </FlexItem>
+    <FlexItem>
+      <Tooltip
+          maxWidth='150px'
+          minHeight='300px'
+          placement='top'
+          text="I have a minHeight of 300px!"
+          {...props}
+      >
+        <Button text="minHeight"/>
       </Tooltip>
     </FlexItem>
    </Flex>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
@@ -22,10 +22,10 @@ const TooltipSizing = (props) => {
     </FlexItem>
     <FlexItem>
       <Tooltip
-          maxHeight='150px'
+          maxHeight='100px'
           placement='top'
-          text="I have a maxHeight of 150px! Here is some more text to show the maxHeight."
-          width='200px'
+          text="I have a maxHeight of 100px! Lorem ipsum dolor sit amet consectetur adipisicing elit."
+          width='250px'
           {...props}
       >
         <Button text="maxHeight"/>
@@ -35,7 +35,7 @@ const TooltipSizing = (props) => {
       <Tooltip
           maxWidth='150px'
           placement='top'
-          text="I have a maxWidth of 150px! Here is some more text to show the maxWidth."
+          text="I have a maxWidth of 150px! Lorem ipsum dolor sit amet consectetur adipisicing elit."
           {...props}
       >
         <Button text="maxWidth"/>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Tooltip, Flex, FlexItem } from 'playbook-ui';
+
+const TooltipSizing = (props) => {
+
+  return (
+   <Flex
+       flexDirection='row'
+       gap='md'
+       wrap
+   >
+    <FlexItem>
+      <Tooltip
+          height='100px'
+          placement='top'
+          text="Whoa. I'm a Tooltip"
+          zIndex={10}
+          {...props}
+      >
+        {'Hover here (Top)'}
+      </Tooltip>
+    </FlexItem>
+   </Flex>
+  )
+}
+
+export default TooltipSizing

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.md
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.md
@@ -1,0 +1,3 @@
+You can customize the `height` and `width` of the tooltip's popover.
+
+When using `maxHeight`, be sure to set a `width` as well. The text needs to truncate within the `width` prop.

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
@@ -7,10 +7,10 @@ examples:
   - tooltip_show_tooltip: Show Tooltip
 
   react:
-  - tooltip_sizing: Tooltip Sizing
   - tooltip_default_react: Default
   - tooltip_interaction: Content Interaction
   - tooltip_margin: Margin
+  - tooltip_sizing: Tooltip Sizing
   - tooltip_icon: Tooltip with Icon
   - tooltip_delay: Delay
   - tooltip_show_tooltip_react: Show Tooltip

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
@@ -7,10 +7,10 @@ examples:
   - tooltip_show_tooltip: Show Tooltip
 
   react:
+  - tooltip_sizing: Tooltip Sizing
   - tooltip_default_react: Default
   - tooltip_interaction: Content Interaction
   - tooltip_margin: Margin
   - tooltip_icon: Tooltip with Icon
   - tooltip_delay: Delay
   - tooltip_show_tooltip_react: Show Tooltip
-

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/index.js
@@ -1,7 +1,7 @@
-export { default as TooltipSizing } from './_tooltip_sizing'
 export { default as TooltipDefaultReact } from './_tooltip_default_react'
 export { default as TooltipInteraction } from './_tooltip_interaction'
 export { default as TooltipMargin } from './_tooltip_margin'
+export { default as TooltipSizing } from './_tooltip_sizing'
 export { default as TooltipIcon } from './_tooltip_icon'
 export { default as TooltipDelay } from './_tooltip_delay'
 export { default as TooltipShowTooltipReact } from './_tooltip_show_tooltip_react'

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/index.js
@@ -1,3 +1,4 @@
+export { default as TooltipSizing } from './_tooltip_sizing'
 export { default as TooltipDefaultReact } from './_tooltip_default_react'
 export { default as TooltipInteraction } from './_tooltip_interaction'
 export { default as TooltipMargin } from './_tooltip_margin'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[PLAY-1874](https://runway.powerhrg.com/backlog_items/PLAY-1874)
- [x] Pass Height, Width, minHeight, maxHeight, minWidth, maxWidth to the Tooltip Kit in React
- [x] Create a new Doc example called 'TOOLTIP SIZING'

**Screenshots:** Screenshots to visualize your addition/change
<img width="1420" alt="Screenshot 2025-02-27 at 2 11 04 PM" src="https://github.com/user-attachments/assets/44a6bb05-7a7f-4de7-a929-71f52d348eac" />


**How to test?** Steps to confirm the desired behavior:
1. Go to kits/tooltip/react
3. Scroll down to 'Tooltip Sizing' doc
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.