### PR TITLE
[PBNTR-907] Filter kit: popoverProps width removing internal padding of filter elements

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
@@ -84,7 +84,7 @@ const Popover = (props: PbPopoverProps) => {
   } = props;
 
   const items = globalProps(props).split(' ')
-  const filteredItems = items.filter(item => !item.includes('min_width'))
+  const filteredItems = items.filter(item => !item.includes('min-width') && !item.includes('width'))
   const filteredGlobalProps = filteredItems.join(' ')
   const popoverSpacing =
     filteredGlobalProps.includes("dark") || !filteredGlobalProps

--- a/playbook/app/pb_kits/playbook/pb_popover/popover.test.js
+++ b/playbook/app/pb_kits/playbook/pb_popover/popover.test.js
@@ -181,7 +181,7 @@ const PopoverTestClicktoClose3 = () => {
     const btn = screen.getByText(/click me/i)
     fireEvent.click(btn);
     const kit = screen.getByText("Click Anywhere");
-    expect(kit).toHaveClass("pb_popover_body max_width_240px overflow_handling");
+    expect(kit).toHaveClass("pb_popover_body p_sm overflow_handling");
   });
 
   test("closes Popover on click anywhere", async () => {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-907](https://runway.powerhrg.com/backlog_items/PBNTR-907) addresses a bug observed first in the React Filter kit with Popover Props used in the React Basic Data Table Template, and then confirmed in the React Filter kit's [Popover Props doc example](https://playbook.powerapp.cloud/kits/filter/react#popover-props). Adding a width property to the filter popover is removing the internal padding. 
The Rails side was unaffected (in doc example and template pages). This PR sets out to address this issue (which was not present when this prop was created, see screenshots in PR for [PBNTR-595](https://github.com/powerhome/playbook/pull/3827)). This PR will also be alpha testing to confirm this fix adjusts the internal padding for the filter popover in the React Basic Data Table, and in its RC I will publish the finalized template to the [All Templates page in Nitro](https://nitro.powerhrg.com/dev_docs/playbook/templates?mt=Playbook+Templates).

**Screenshots:** Screenshots to visualize your addition/change
Doc example in production currently showing removal of padding and width_250px in the pb_popover_body class
<img width="1637" alt="from doc example width no padding in pb_popover_body class" src="https://github.com/user-attachments/assets/667ef018-643b-4573-abf5-52ef9ca44198" />
Fixed doc example showing p_sm and width applied in style tag as other popoverProps are.
<img width="1645" alt="for PR" src="https://github.com/user-attachments/assets/3d48919c-8adb-4691-969a-88c6d92bbc91" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the react filter kit [popover props doc example in milano env](https://pr4369.playbook.beta.hq.powerapp.cloud/kits/filter/react#popover-props). Click to open the filter popover, and the internal padding should be present.
2. In the alpha review env in Nitro, go to the React Basic Data Table. Click to open the table's filter popover which should also have internal padding present.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~