### PR TITLE
[PLAY-1854] MultiLevelSelect Kit: React Hook Forms Support 

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -553,6 +553,6 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
 });
 
 MultiLevelSelect.displayName = "MultiLevelSelect";
-MultiLevelSelect.Options = MultiLevelSelectOptions;
+(MultiLevelSelect as any).Options = MultiLevelSelectOptions;
 
 export default MultiLevelSelect;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -35,7 +35,7 @@ type MultiLevelSelectProps = {
   name?: string
   returnAllSelected?: boolean
   treeData?: { [key: string]: string; }[] | any
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onChange?: (event: { target: { name?: string; value: any } }) => void
   onSelect?: (prop: { [key: string]: any }) => void
   selectedIds?: string[] | any
   variant?: "multi" | "single"

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -35,7 +35,7 @@ type MultiLevelSelectProps = {
   name?: string
   returnAllSelected?: boolean
   treeData?: { [key: string]: string; }[] | any
-  onChange?: any
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   onSelect?: (prop: { [key: string]: any }) => void
   selectedIds?: string[] | any
   variant?: "multi" | "single"

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -23,6 +23,13 @@ import {
   getExpandedItems,
 } from "./_helper_functions";
 
+interface MultiLevelSelectComponent
+  extends React.ForwardRefExoticComponent<
+    MultiLevelSelectProps & React.RefAttributes<HTMLInputElement>
+  > {
+  Options: typeof MultiLevelSelectOptions;
+}
+
 type MultiLevelSelectProps = {
   aria?: { [key: string]: string }
   className?: string
@@ -550,9 +557,9 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
       </MultiLevelSelectContext.Provider>
     </div>
   );
-});
+}) as MultiLevelSelectComponent;
 
 MultiLevelSelect.displayName = "MultiLevelSelect";
-(MultiLevelSelect as any).Options = MultiLevelSelectOptions;
+MultiLevelSelect.Options = MultiLevelSelectOptions;
 
 export default MultiLevelSelect;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -55,7 +55,7 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
     name,
     returnAllSelected = false,
     treeData,
-    onChange,
+    onChange = () => null,
     onSelect = () => null,
     selectedIds,
     variant = "multi",

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -401,12 +401,12 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
   // Rendering formattedData to UI based on typeahead
   const renderNestedOptions = (items: { [key: string]: string; }[] | any ) => {
     const hasOptionsChild = React.Children.toArray(props.children).some(
-      (child: any) => child.type === MultiLevelSelect.Options
+      (child) => React.isValidElement(child) && child.type === MultiLevelSelect.Options
     );
 
     if (hasOptionsChild) {
       return React.Children.map(props.children, (child) => {
-        if (child.type === MultiLevelSelect.Options) {
+        if (React.isValidElement(child) && child.type === MultiLevelSelect.Options) {
           return React.cloneElement(child, { items });
         }
         return null;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, forwardRef } from "react";
 import classnames from "classnames";
 import { globalProps, GlobalProps } from "../utilities/globalProps";
 import {
@@ -35,13 +35,14 @@ type MultiLevelSelectProps = {
   name?: string
   returnAllSelected?: boolean
   treeData?: { [key: string]: string; }[] | any
+  onChange?: any
   onSelect?: (prop: { [key: string]: any }) => void
   selectedIds?: string[] | any
   variant?: "multi" | "single"
   pillColor?: "primary" | "neutral" | "success" | "warning" | "error" | "info" | "data_1" | "data_2" | "data_3" | "data_4" | "data_5" | "data_6" | "data_7" | "data_8" | "windows" | "siding" | "roofing" | "doors" | "gutters" | "solar" | "insulation" | "accessories",
 } & GlobalProps
 
-const MultiLevelSelect = (props: MultiLevelSelectProps) => {
+const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((props) => {
   const {
     aria = {},
     className,
@@ -54,6 +55,7 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     name,
     returnAllSelected = false,
     treeData,
+    onChange,
     onSelect = () => null,
     selectedIds,
     variant = "multi",
@@ -285,8 +287,10 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     // Logic for removing items from returnArray or defaultReturn when pills clicked
     if (returnAllSelected) {
       onSelect(getCheckedItems(updatedTree));
+      onChange({ target: { name, value: getCheckedItems(updatedTree) } });
     } else {
       onSelect(getDefaultCheckedItems(updatedTree));
+      onChange({ target: { name, value: getDefaultCheckedItems(updatedTree) } });
     }
   };
 
@@ -312,8 +316,10 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     const updatedTree = changeItem(filtered[0], check);
     if (returnAllSelected) {
       onSelect(getCheckedItems(updatedTree));
+      onChange({ target: { name, value: getCheckedItems(updatedTree) } });
     } else {
       onSelect(getDefaultCheckedItems(updatedTree));
+      onChange({ target: { name, value: getDefaultCheckedItems(updatedTree) } });
     }
   };
 
@@ -346,6 +352,7 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
     setIsDropdownClosed(true);
 
     onSelect(selectedItem);
+    onChange({ target: { name, value: selectedItem } });
   };
 
   // Single select: reset the tree state upon typing
@@ -543,8 +550,9 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
       </MultiLevelSelectContext.Provider>
     </div>
   );
-};
+});
 
+MultiLevelSelect.displayName = "MultiLevelSelect";
 MultiLevelSelect.Options = MultiLevelSelectOptions;
 
 export default MultiLevelSelect;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import MultiLevelSelect from "../_multi_level_select";
+
+const treeData = [
+  {
+    label: "Power Home Remodeling",
+    value: "Power Home Remodeling",
+    id: "powerhome1",
+    expanded: true,
+    children: [
+      {
+        label: "People",
+        value: "People",
+        id: "people1",
+        expanded: true,
+        children: [
+          {
+            label: "Talent Acquisition",
+            value: "Talent Acquisition",
+            id: "talent1",
+          },
+          {
+            label: "Business Affairs",
+            value: "Business Affairs",
+            id: "business1",
+            children: [
+              {
+                label: "Initiatives",
+                value: "Initiatives",
+                id: "initiative1",
+              },
+              {
+                label: "Learning & Development",
+                value: "Learning & Development",
+                id: "development1",
+              },
+            ],
+          },
+          {
+            label: "People Experience",
+            value: "People Experience",
+            id: "experience1",
+          },
+        ],
+      },
+      {
+        label: "Contact Center",
+        value: "Contact Center",
+        id: "contact1",
+        children: [
+          {
+            label: "Appointment Management",
+            value: "Appointment Management",
+            id: "appointment1",
+          },
+          {
+            label: "Customer Service",
+            value: "Customer Service",
+            id: "customer1",
+          },
+          {
+            label: "Energy",
+            value: "Energy",
+            id: "energy1",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const MultiLevelSelectReactHook = (props) => {
+  return (
+    <div>
+      <MultiLevelSelect
+          id='multiselect-default'
+          onSelect={(selectedNodes) =>
+          console.log(
+            "Selected Items",
+            selectedNodes
+          )
+        }
+          treeData={treeData}
+          {...props}
+      />
+    </div>
+  )
+};
+
+export default MultiLevelSelectReactHook;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
@@ -1,5 +1,7 @@
-import React from "react";
-import MultiLevelSelect from "../_multi_level_select";
+import React from "react"
+import MultiLevelSelect from "../_multi_level_select"
+import Title from "../../pb_title/_title"
+import { useForm } from "react-hook-form"
 
 const treeData = [
   {
@@ -67,24 +69,40 @@ const treeData = [
       },
     ],
   },
-];
+]
 
 const MultiLevelSelectReactHook = (props) => {
+  const { register, watch } = useForm()
+  const selectedDepartments = watch("departments")
+  console.log("Selected Departments: ", selectedDepartments)
+
   return (
     <div>
       <MultiLevelSelect
-          id='multiselect-default'
-          onSelect={(selectedNodes) =>
-          console.log(
-            "Selected Items",
-            selectedNodes
-          )
-        }
+          id="multiselect-default"
+          marginBottom="md"
           treeData={treeData}
+          variant="single"
+          {...register("departments")}
           {...props}
       />
+      <Title size="h4">Selected Departments</Title>
+      <ul>
+        {selectedDepartments && selectedDepartments.map((selection) => (
+          <li key={selection.id}>
+            {selection.label}
+            {selection.children && selection.children.length > 0 && (
+              <ul>
+                {selection.children.map((child) => (
+                  <li key={child.id}>{child.label}</li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   )
-};
+}
 
-export default MultiLevelSelectReactHook;
+export default MultiLevelSelectReactHook

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
@@ -1,6 +1,5 @@
 import React from "react"
 import MultiLevelSelect from "../_multi_level_select"
-import Title from "../../pb_title/_title"
 import { useForm } from "react-hook-form"
 
 const treeData = [
@@ -73,8 +72,8 @@ const treeData = [
 
 const MultiLevelSelectReactHook = (props) => {
   const { register, watch } = useForm()
-  const selectedDepartments = watch("departments")
-  console.log("Selected Departments: ", selectedDepartments)
+  const selectedItems = watch("departments")
+  selectedItems && console.log("Selected Items", selectedItems)
 
   return (
     <div>
@@ -82,25 +81,9 @@ const MultiLevelSelectReactHook = (props) => {
           id="multiselect-default"
           marginBottom="md"
           treeData={treeData}
-          variant="single"
           {...register("departments")}
           {...props}
       />
-      <Title size="h4">Selected Departments</Title>
-      <ul>
-        {selectedDepartments && selectedDepartments.map((selection) => (
-          <li key={selection.id}>
-            {selection.label}
-            {selection.children && selection.children.length > 0 && (
-              <ul>
-                {selection.children.map((child) => (
-                  <li key={child.id}>{child.label}</li>
-                ))}
-              </ul>
-            )}
-          </li>
-        ))}
-      </ul>
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.md
@@ -1,1 +1,1 @@
-You can pass `react-hook-form` props to the Typeahead kit. Check your console to see the full data selected from this example.
+You can pass `react-hook-form` props to the MultiLevelSelect kit. Check your console to see the full data selected from this example.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.md
@@ -1,0 +1,1 @@
+You can pass `react-hook-form` props to the Typeahead kit. Check your console to see the full data selected from this example.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
@@ -12,6 +12,7 @@ examples:
 
   react:
   - multi_level_select_default: Default
+  - multi_level_select_react_hook: React Hook
   - multi_level_select_single: Single Select
   - multi_level_select_single_children_only: Single Select w/ Hidden Radios
   - multi_level_select_return_all_selected: Return All Selected

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
@@ -7,3 +7,4 @@ export { default as MultiLevelSelectColor } from './_multi_level_select_color.js
 export { default as MultiLevelSelectWithChildren } from './_multi_level_select_with_children.jsx'
 export { default as MultiLevelSelectWithChildrenWithRadios } from './_multi_level_select_with_children_with_radios.jsx'
 export { default as MultiLevelSelectDisabled } from './_multi_level_select_disabled.jsx'
+export { default as MultiLevelSelectReactHook  } from './_multi_level_select_react_hook.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Story](https://runway.powerhrg.com/backlog_items/PLAY-1854)

In this PR we add `react-hook-form` support to our Multi Level Select kit. Now devs can `...register("name")` any Multi Level Select kit without using `<Controller/>`

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.