### PR TITLE
[PBNTR-902] Multi Level Select it - Return All Selected Bug

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -459,6 +459,18 @@ const MultiLevelSelect = (props: MultiLevelSelectProps) => {
                     ))
                   : null}
 
+                {!returnAllSelected
+                  ? defaultReturn.map((item) => (
+                      <input
+                          disabled={disabled}
+                          key={item.id} 
+                          name={`${name}[]`}
+                          type="hidden"
+                          value={item.id}
+                      />
+                    ))
+                  : null}
+
                 {returnAllSelected &&
                 returnedArray.length !== 0 &&
                 inputDisplay === "pills"

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/multi_level_select.rb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/multi_level_select.rb
@@ -40,7 +40,7 @@ module Playbook
           treeData: tree_data,
           returnAllSelected: return_all_selected,
           selectedIds: selected_ids,
-          input_name: input_name,
+          inputName: input_name,
           variant: variant,
           pillColor: pill_color,
           wrapped: wrapped,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-902](https://runway.powerhrg.com/backlog_items/PBNTR-902) requests that we expose the hidden inputs for the default MultiLevelSelect kit option, where returnAllSelected is false and variant is multi. A playbook support inquiry revealed that while we can see the hidden inputs with data populated for returnAllSelected true and the variant = single doc examples, the default case did not have them available for devs. 

Hidden inputs are typically used for rails kits in forms. Because this is a react-rendered-rails kits, the changes made affect both the Rails and React versions of the kit and their doc examples (this bug was technically present in the React side as well). 

This PR also camel cases the key for one of props in the react-rendered-rails option hash in multi_level_select.rb (inputName from input_name). This prop is related to giving a name to a Radio input for the single select variants and is not in use in Nitro.

**Screenshots:** Screenshots to visualize your addition/change 
Note: Screenshots were not included for the two Single Select doc examples for Rails/React as they were 1) working fine and 2) unaffected by the change.
Current production Rails - no hidden inputs seen in default doc example; hidden inputs seen in return_all_selected: true doc example
<img width="1659" alt="rails returnallselectedfalse no inputs" src="https://github.com/user-attachments/assets/820b261f-6fa1-4cbc-9eb4-e68fdadeb4e5" />
<img width="1556" alt="react returnallselectedtrue inputs seen" src="https://github.com/user-attachments/assets/e88ffa2a-7e80-472f-a3a9-6eb1ff8ef7b5" />
Current production React - no hidden inputs seen in default doc example; hidden inputs seen in returnAllSelected={true} doc example
<img width="1463" alt="react returnallselectedfalse no inputs" src="https://github.com/user-attachments/assets/3086a0e1-3787-45a5-a036-927a2c38de50" />
<img width="1556" alt="react returnallselectedtrue inputs seen" src="https://github.com/user-attachments/assets/c48fa892-3fc3-4641-8ea3-f71f471a8454" />

with PR update:
Rails: hidden inputs seen for default doc example, return_all_selected: true doc example unaffected
<img width="1466" alt="rails fix returnallfalse one input" src="https://github.com/user-attachments/assets/26c8b9fd-13cc-42d0-8d0b-7d13db3f339d" />
<img width="1043" alt="rails returnallselected true unaffected by fix" src="https://github.com/user-attachments/assets/955fc164-294f-4dc6-97a3-a402e9ff1140" />
React: hidden inputs seen for default doc example, returnAllSelected={true} doc example unaffected
<img width="728" alt="react fix returnallfalse one input" src="https://github.com/user-attachments/assets/3c96f697-26c8-440a-9b85-5e691108571c" />
<img width="1331" alt="react returnallselected true unaffected by fix" src="https://github.com/user-attachments/assets/45cad627-e826-4ba4-8e73-c6c35ec4776f" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the MLS default doc example in the review environment ([rails](https://pr4376.playbook.beta.px.powerapp.cloud/kits/multi_level_select/rails#default) / [react](https://pr4376.playbook.beta.px.powerapp.cloud/kits/multi_level_select/react#default) links to come).
2. Inspect the DOM, open the div with class="input_inner_container". Make selections in the multi level select - hidden inputs should appear matching the parent category/categories based on your selections. 
3. Scroll down to the return all selected doc example in the review environment ([rails](https://pr4376.playbook.beta.px.powerapp.cloud/kits/multi_level_select/rails#return-all-selected) / [react](https://pr4376.playbook.beta.px.powerapp.cloud/kits/multi_level_select/react#return-all-selected) links to come).
4. Inspect the DOM, open the div with class="input_inner_container". Make selections in the multi level select - hidden inputs should appear matching all selected items (any parents + their children in addition to singletons) based on your selections. 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~