### PR TITLE
[PLAY-1877] Playground Fixes: Click Anywhere and Scroll

### DIFF
--- a/playbook-website/app/javascript/components/PbKitPlayground/PlaygroundHeader.tsx
+++ b/playbook-website/app/javascript/components/PbKitPlayground/PlaygroundHeader.tsx
@@ -11,7 +11,7 @@ import playgroundLogo from '../../images/playground-logo.svg'
 const PlaygroundHeader = () => {
   return (
     <>
-      <Flex orientation="row" justify="between" marginTop="xs">
+      <Flex orientation="row" justify="between" paddingTop="xs">
         <Flex orientation="row" vertical="stretch">
           <Button
             link="https://playbook.powerapp.cloud/"

--- a/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
+++ b/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
@@ -141,7 +141,7 @@ const PbKitPlayground = () => {
               fontFamily: 'monospace',
               fontSize: 12,
               caretColor: "white",
-              overflow: "scroll",
+              overflow: "visible",
               height: "100%",
             }}
             value={code}

--- a/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
+++ b/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
@@ -130,28 +130,28 @@ const PbKitPlayground = () => {
 
   return (
     <div className="pbDocPlayground-Container">
-    <PlaygroundHeader/>
-    <div className="pbDocPlayground">
-      <div className="pbDocPlayground-Editor">
-        <Editor
-            className="language-erb"
-            highlight={(code) => highlight(code, languages.js)}
-            onValueChange={(code) => saveCode(code)}
-            style={{
-              fontFamily: 'monospace',
-              fontSize: 12,
-              caretColor: "white",
-              overflow: "visible",
-              minHeight: "100%",
-            }}
-            value={code}
-        />
-        {throttleFetch}
+      <PlaygroundHeader/>
+      <div className="pbDocPlayground">
+        <div className="pbDocPlayground-Editor">
+          <Editor
+              className="language-erb"
+              highlight={(code) => highlight(code, languages.js)}
+              onValueChange={(code) => saveCode(code)}
+              style={{
+                fontFamily: 'monospace',
+                fontSize: 12,
+                caretColor: "white",
+                overflow: "visible",
+                minHeight: "100%",
+              }}
+              value={code}
+          />
+          {throttleFetch}
+        </div>
+        <div className="pbDocPlayground-Preview">
+          { showPreview() }
+        </div>
       </div>
-      <div className="pbDocPlayground-Preview">
-        { showPreview() }
-      </div>
-    </div>
     </div>
   )
 }

--- a/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
+++ b/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
@@ -141,6 +141,8 @@ const PbKitPlayground = () => {
               fontFamily: 'monospace',
               fontSize: 12,
               caretColor: "white",
+              overflow: "scroll",
+              height: "100%",
             }}
             value={code}
         />

--- a/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
+++ b/playbook-website/app/javascript/components/PbKitPlayground/index.tsx
@@ -129,7 +129,7 @@ const PbKitPlayground = () => {
   })
 
   return (
-    <>
+    <div className="pbDocPlayground-Container">
     <PlaygroundHeader/>
     <div className="pbDocPlayground">
       <div className="pbDocPlayground-Editor">
@@ -142,7 +142,7 @@ const PbKitPlayground = () => {
               fontSize: 12,
               caretColor: "white",
               overflow: "visible",
-              height: "100%",
+              minHeight: "100%",
             }}
             value={code}
         />
@@ -152,7 +152,7 @@ const PbKitPlayground = () => {
         { showPreview() }
       </div>
     </div>
-    </>
+    </div>
   )
 }
 

--- a/playbook-website/app/javascript/site_styles/docs/_code_snippet.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_code_snippet.scss
@@ -554,7 +554,8 @@
 .pbDocPlayground {
   display: flex;
   width: 100vw;
-  height: 100vh;
+  // TODO: switch out with flex
+  height: calc(100vh - 49px);
   &-Editor {
     background: $bg_dark;
     font-weight: $bolder;
@@ -563,6 +564,8 @@
     padding-right: $space_md;
     flex: 1;
     flex-basis: 50vw;
+    height: 100%;
+    overflow-y: auto;
     textarea {
       outline: 0;
     }

--- a/playbook-website/app/javascript/site_styles/docs/_code_snippet.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_code_snippet.scss
@@ -560,6 +560,7 @@
     font-weight: $bolder;
     padding-top: $space_lg;
     padding-left: $space_md;
+    padding-right: $space_md;
     flex: 1;
     flex-basis: 50vw;
     textarea {

--- a/playbook-website/app/javascript/site_styles/docs/_code_snippet.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_code_snippet.scss
@@ -552,10 +552,15 @@
 // New React Based Editor using Prism
 
 .pbDocPlayground {
+  &-Container {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
   display: flex;
   width: 100vw;
-  // TODO: switch out with flex
-  height: calc(100vh - 49px);
+  flex-grow: 1;
+  overflow: hidden;
   &-Editor {
     background: $bg_dark;
     font-weight: $bolder;


### PR DESCRIPTION
**What does this PR do?** 
- Expand clickable area to the full editor space
- Contain code with a scrollbar if the code is longer than 100vh
- Wrap a flex container so entire page is 100vh
- Add padding on left, top, and right in editor

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-03-12 at 10 14 53 AM (2)](https://github.com/user-attachments/assets/91357879-005b-4c1e-8877-e9893223a720)

**How to test?** Steps to confirm the desired behavior:
1. Go to /kit_playground_rails.
2. Click on the code editor area (below the first line). 
3. You should be editing even though you didn't click the first line.
4. Type enough code so a scroll bar shows.
5. A scroll bar should appear instead of overflowing.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.