### PR TITLE
[PLAY-1939] Icon Button Kit: Border Radius

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -90,7 +90,7 @@ kits:
     enhanced_element_used: false
   - name: icon_button
     platforms: *1
-    status: beta
+    status: stable
     icons_used: true
     react_rendered: false
     enhanced_element_used: false

--- a/playbook/app/pb_kits/playbook/pb_icon_button/_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_button/_icon_button.tsx
@@ -49,7 +49,7 @@ const IconButton = (props: IconButtonProps) => {
         id={id}
     >
       <Button
-          borderRadius="lg"
+          borderRadius="xs"
           htmlType={htmlType}
           link={link}
           newWindow={newWindow}

--- a/playbook/app/pb_kits/playbook/pb_icon_button/icon_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon_button/icon_button.html.erb
@@ -4,7 +4,7 @@
                                   new_window:object.new_window,
                                   target: object.target,
                                   dark: object.dark,
-                                  border_radius: "lg" }) do %>
+                                  border_radius: "xs" }) do %>
   <%= pb_rails("icon", props: { icon: object.icon,
                                 fixed_width: true,
                                 dark: object.dark,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Story](https://runway.powerhrg.com/backlog_items/PLAY-1939)

In this PR we change the Icon Button's border radius from `lg` to `xs` as the default.
We also take the kit out of beta.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-03-12 at 11 21 32 AM](https://github.com/user-attachments/assets/7b72f4c2-aad5-4941-aee2-4302ced13263)


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.