### PR TITLE
[PLAY-1757] Update pb_content_tag

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_textarea/textarea.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_textarea/textarea.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <% if object.label.present? %>
     <%= pb_rails("caption", props: {text: object.label, dark: object.dark}) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_time/time.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_time/time.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%
     # convert deprecated prop values
     size = object.size
@@ -17,7 +13,7 @@
       </span>
     <% end %>
 
-    <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
+    <%= pb_content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
       <span><%= object.format_time_string %></span>
       <% if object.show_timezone %>
         <span><%= object.pb_date_time.to_timezone.upcase %></span>
@@ -31,7 +27,7 @@
       <% end %>
     <% end %>
 
-    <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
+    <%= pb_content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
       <%= pb_rails("body", props: { tag: "span", text: object.format_time_string, classname: "pb_time" }) %>
       <% if object.show_timezone %>
         <%= pb_rails("body", props: { color: "light", tag: "span", text: object.pb_date_time.to_timezone.upcase }) %>
@@ -45,7 +41,7 @@
       <% end %>
     <% end %>
 
-    <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
+    <%= pb_content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
       <%= pb_rails("caption", props: { color: "light", tag: "span", text: object.format_time_string }) do %>
         <%= object.format_time_string %>
         <% if object.show_timezone %>

--- a/playbook/app/pb_kits/playbook/pb_time/time.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_time/time.html.erb
@@ -13,7 +13,7 @@
       </span>
     <% end %>
 
-    <%= pb_content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
+    <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
       <span><%= object.format_time_string %></span>
       <% if object.show_timezone %>
         <span><%= object.pb_date_time.to_timezone.upcase %></span>
@@ -27,7 +27,7 @@
       <% end %>
     <% end %>
 
-    <%= pb_content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
+    <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
       <%= pb_rails("body", props: { tag: "span", text: object.format_time_string, classname: "pb_time" }) %>
       <% if object.show_timezone %>
         <%= pb_rails("body", props: { color: "light", tag: "span", text: object.pb_date_time.to_timezone.upcase }) %>
@@ -41,7 +41,7 @@
       <% end %>
     <% end %>
 
-    <%= pb_content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
+    <%= content_tag(:time, datetime: object.pb_date_time.to_iso) do %>
       <%= pb_rails("caption", props: { color: "light", tag: "span", text: object.format_time_string }) do %>
         <%= object.format_time_string %>
         <% if object.show_timezone %>

--- a/playbook/app/pb_kits/playbook/pb_title/title.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_title/title.html.erb
@@ -1,7 +1,2 @@
-<%= content_tag(object.tag,
-    aria: object.aria,
-    id: object.id,
-    data: object.data,
-    class: object.classname,
-    **combined_html_options) do %><%= content.presence || object.text %><% end %>
+<%= pb_content_tag do %><%= content.presence || object.text %><% end %>
     

--- a/playbook/app/pb_kits/playbook/pb_title/title.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_title/title.html.erb
@@ -1,2 +1,2 @@
-<%= pb_content_tag do %><%= content.presence || object.text %><% end %>
+<%= pb_content_tag(object.tag) do %><%= content.presence || object.text %><% end %>
     

--- a/playbook/app/pb_kits/playbook/pb_toggle/toggle.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_toggle/toggle.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    id: object.id,
-    data: object.data,
-    aria: object.aria,
-    class: object.classname,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <label class="pb_toggle_wrapper">
     <%= content.presence || object.input %>
     <div class="pb_toggle_control"></div>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

This PR updates the `content_tag` to use our new `pb_content_tag` inside the Text Area, Time, Title & Toggle kits.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.