### PR TITLE
[PLAY-1907] Tooltip Kit - Pass Global Props Height and Width to Tooltip - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
@@ -90,7 +90,6 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
       margin-bottom: $space_sm;
       color: $white;
       background-color: rgba($black, $opacity_9);
-      // width: 500px; // this is a placeholder for the width of the tooltip
       &.fade_out {
         animation-name: fadeOut;
         animation-duration: 150ms;

--- a/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/_tooltip.scss
@@ -54,7 +54,7 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
       margin-bottom: 50px;
     }
 
-    &.visible, 
+    &.visible,
     &.show {
       z-index: $z_9;
       padding: $space_xs $space_sm;
@@ -90,6 +90,7 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
       margin-bottom: $space_sm;
       color: $white;
       background-color: rgba($black, $opacity_9);
+      // width: 500px; // this is a placeholder for the width of the tooltip
       &.fade_out {
         animation-name: fadeOut;
         animation-duration: 150ms;
@@ -117,7 +118,7 @@ $tooltip_shadow: rgba(60, 106, 172, 0.18);
         color: $charcoal;
         background-color: $white;
       }
-      .arrow {        
+      .arrow {
         border-color: $white transparent transparent transparent;
         opacity: $opacity_10;
       }

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
@@ -16,7 +16,7 @@
     I have a min_width of 300px!
   <% end %>
   <%= pb_rails "button", props: { id: "tool-tip-sizing-5", text: "min_height" } %>
-  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-5", tooltip_id: "tool-tip-sizing-5", position: "top", min_height: "300px" } do %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-5", tooltip_id: "tool-tip-sizing-5", position: "top", min_height: "300px", height: "200px", html_options: { style: { color: "blue" }} } do %>
     I have a min_height of 300px!
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
@@ -16,7 +16,7 @@
     I have a min_width of 300px!
   <% end %>
   <%= pb_rails "button", props: { id: "tool-tip-sizing-5", text: "min_height" } %>
-  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-5", tooltip_id: "tool-tip-sizing-5", position: "top", min_height: "300px", height: "200px", html_options: { tab_index: 5, style: { color: "blue" }},  } do %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-5", tooltip_id: "tool-tip-sizing-5", position: "top", min_height: "300px", height: "200px"  } do %>
     I have a min_height of 300px!
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
@@ -16,7 +16,7 @@
     I have a min_width of 300px!
   <% end %>
   <%= pb_rails "button", props: { id: "tool-tip-sizing-5", text: "min_height" } %>
-  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-5", tooltip_id: "tool-tip-sizing-5", position: "top", min_height: "300px", height: "200px", html_options: { style: { color: "blue" }} } do %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-5", tooltip_id: "tool-tip-sizing-5", position: "top", min_height: "300px", height: "200px", html_options: { tab_index: 5, style: { color: "blue" }},  } do %>
     I have a min_height of 300px!
   <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/_tooltip_sizing.html.erb
@@ -1,0 +1,22 @@
+<%= pb_rails "flex", props: { flex_direction: "row", gap: "md", wrap: true } do %>
+  <%= pb_rails "button", props: { id: "tool-tip-sizing-1", text: "Height and Width" } %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-1", tooltip_id: "tool-tip-sizing-1", position: "top", height: "150px", width: "100px" } do %>
+    I'm 150px high and 100px wide!
+  <% end %>
+  <%= pb_rails "button", props: { id: "tool-tip-sizing-2", text: "max_height" } %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-2", tooltip_id: "tool-tip-sizing-2", position: "top", width: "250px", max_height: "100px" } do %>
+    I have a max_height of 100px! Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  <% end %>
+  <%= pb_rails "button", props: { id: "tool-tip-sizing-3", text: "max_width" } %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-3", tooltip_id: "tool-tip-sizing-3", position: "top", max_width: "150px" } do %>
+    I have a max_width of 150px! Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  <% end %>
+  <%= pb_rails "button", props: { id: "tool-tip-sizing-4", text: "min_width" } %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-4", tooltip_id: "tool-tip-sizing-4", position: "top", min_width: "300px" } do %>
+    I have a min_width of 300px!
+  <% end %>
+  <%= pb_rails "button", props: { id: "tool-tip-sizing-5", text: "min_height" } %>
+  <%= pb_rails "tooltip", props: { trigger_element_selector: "#tool-tip-sizing-5", tooltip_id: "tool-tip-sizing-5", position: "top", min_height: "300px" } do %>
+    I have a min_height of 300px!
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
@@ -1,19 +1,21 @@
 examples:
 
   rails:
-  - tooltip_default: Default
-  - tooltip_interaction: Content Interaction
-  - tooltip_selectors: Using Common Selectors
-  - tooltip_icon_rails: Tooltip with Icon
-  - tooltip_with_icon_circle: Icon Circle Tooltip
-  - tooltip_delay_rails: Delay
-  - tooltip_show_tooltip: Show Tooltip
+  # - tooltip_default: Default
+  # - tooltip_interaction: Content Interaction
+  # - tooltip_selectors: Using Common Selectors
+  # - tooltip_margin: Margin
+    - tooltip_sizing: Tooltip Sizing
+    - tooltip_icon_rails: Tooltip with Icon
+  # - tooltip_with_icon_circle: Icon Circle Tooltip
+  # - tooltip_delay_rails: Delay
+  # - tooltip_show_tooltip: Show Tooltip
 
   react:
-  - tooltip_default_react: Default
-  - tooltip_interaction: Content Interaction
-  - tooltip_margin: Margin
-  - tooltip_sizing: Tooltip Sizing
-  - tooltip_icon: Tooltip with Icon
-  - tooltip_delay: Delay
-  - tooltip_show_tooltip_react: Show Tooltip
+  # - tooltip_default_react: Default
+  # - tooltip_interaction: Content Interaction
+  # - tooltip_margin: Margin
+    - tooltip_sizing: Tooltip Sizing
+  # - tooltip_icon: Tooltip with Icon
+  # - tooltip_delay: Delay
+  # - tooltip_show_tooltip_react: Show Tooltip

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
@@ -4,7 +4,6 @@ examples:
   - tooltip_default: Default
   - tooltip_interaction: Content Interaction
   - tooltip_selectors: Using Common Selectors
-  - tooltip_margin: Margin
   - tooltip_sizing: Tooltip Sizing
   - tooltip_icon_rails: Tooltip with Icon
   - tooltip_with_icon_circle: Icon Circle Tooltip

--- a/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/docs/example.yml
@@ -1,21 +1,21 @@
 examples:
 
   rails:
-  # - tooltip_default: Default
-  # - tooltip_interaction: Content Interaction
-  # - tooltip_selectors: Using Common Selectors
-  # - tooltip_margin: Margin
-    - tooltip_sizing: Tooltip Sizing
-    - tooltip_icon_rails: Tooltip with Icon
-  # - tooltip_with_icon_circle: Icon Circle Tooltip
-  # - tooltip_delay_rails: Delay
-  # - tooltip_show_tooltip: Show Tooltip
+  - tooltip_default: Default
+  - tooltip_interaction: Content Interaction
+  - tooltip_selectors: Using Common Selectors
+  - tooltip_margin: Margin
+  - tooltip_sizing: Tooltip Sizing
+  - tooltip_icon_rails: Tooltip with Icon
+  - tooltip_with_icon_circle: Icon Circle Tooltip
+  - tooltip_delay_rails: Delay
+  - tooltip_show_tooltip: Show Tooltip
 
   react:
-  # - tooltip_default_react: Default
-  # - tooltip_interaction: Content Interaction
-  # - tooltip_margin: Margin
-    - tooltip_sizing: Tooltip Sizing
-  # - tooltip_icon: Tooltip with Icon
-  # - tooltip_delay: Delay
-  # - tooltip_show_tooltip_react: Show Tooltip
+  - tooltip_default_react: Default
+  - tooltip_interaction: Content Interaction
+  - tooltip_margin: Margin
+  - tooltip_sizing: Tooltip Sizing
+  - tooltip_icon: Tooltip with Icon
+  - tooltip_delay: Delay
+  - tooltip_show_tooltip_react: Show Tooltip

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
@@ -3,7 +3,7 @@
   data: object.data,
   class: object.classname,
   **combined_html_options) do %>
-  <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip">
+  <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.sizing_helper %>">
     <%= content.presence %>
     <div class="arrow" id="<%= object.tooltip_id %>-arrow"></div>
   </div>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
@@ -2,7 +2,7 @@
   id: object.id,
   data: object.data,
   class: object.classname,
-  **combined_html_options) do %>
+  **combined_html_options.except(:style)) do %>
   <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.sizing_helper %>">
     <%= content.presence %>
     <div class="arrow" id="<%= object.tooltip_id %>-arrow"></div>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
@@ -2,8 +2,8 @@
       id: object.id,
       data: object.data,
       class: object.classname,
-      style: remove_height_properties(combined_html_options[:style]) || "") do %>
-
+      style: remove_height_properties(combined_html_options[:style]) || "",
+      **combined_html_options.except(:style)) do %>
   <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.height_and_width_helper %>">
     <%= content.presence %>
     <div class="arrow" id="<%= object.tooltip_id %>-arrow"></div>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
@@ -2,11 +2,9 @@
       id: object.id,
       data: object.data,
       class: object.classname,
-      style: combined_html_options[:style]&.gsub(/min-height:[^;]+;?/, '').gsub(/min-width:[^;]+;?/, '').gsub(/max-height:[^;]+;?/, '').gsub(/max-width:[^;]+;?/, '')&.strip,
-      **combined_html_options.except(:style)) do %>
+      style: remove_height_properties(combined_html_options[:style]) || "") do %>
 
-
-  <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.sizing_helper %>">
+  <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.height_and_width_helper %>">
     <%= content.presence %>
     <div class="arrow" id="<%= object.tooltip_id %>-arrow"></div>
   </div>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
@@ -1,8 +1,11 @@
 <%= content_tag(:div,
-  id: object.id,
-  data: object.data,
-  class: object.classname,
-  **combined_html_options.except(:style)) do %>
+      id: object.id,
+      data: object.data,
+      class: object.classname,
+      style: combined_html_options[:style]&.gsub(/min-height:[^;]+;?/, '').gsub(/min-width:[^;]+;?/, '').gsub(/max-height:[^;]+;?/, '').gsub(/max-width:[^;]+;?/, '')&.strip,
+      **combined_html_options.except(:style)) do %>
+
+
   <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.sizing_helper %>">
     <%= content.presence %>
     <div class="arrow" id="<%= object.tooltip_id %>-arrow"></div>

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.rb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.rb
@@ -3,22 +3,39 @@
 module Playbook
   module PbTooltip
     class Tooltip < Playbook::KitBase
-      prop :position
-      prop :trigger_element_selector
-      prop :trigger_element_id, deprecated: true
-      prop :tooltip_id
-      prop :interaction, type: Playbook::Props::Boolean,
-                         default: false
-      prop :delay_open
-      prop :delay_close
       prop :dark, type: Playbook::Props::Boolean,
                   default: false
+      prop :delay_open
+      prop :delay_close
+      prop :height
+      prop :interaction, type: Playbook::Props::Boolean,
+                         default: false
+      prop :max_height
+      prop :max_width
+      prop :min_height
+      prop :min_width
+      prop :position
+      prop :tooltip_id
+      prop :trigger_element_selector
+      prop :trigger_element_id, deprecated: true
       prop :trigger_method, type: Playbook::Props::Enum,
                             values: %w[hover click],
                             default: "hover"
+      prop :width
 
       def classname
         generate_classname("pb_tooltip_kit", dark_class)
+      end
+
+      def sizing_helper
+        out = ""
+        out += "width: #{width};" if width.present?
+        out += "height: #{height};" if height.present?
+        out += "max-height: #{max_height};" if max_height.present?
+        out += "max-width: #{max_width};" if max_width.present?
+        out += "min-height: #{min_height};" if min_height.present?
+        out += "min-width: #{min_width};" if min_width.present?
+        out
       end
 
       def data

--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.rb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.rb
@@ -27,7 +27,15 @@ module Playbook
         generate_classname("pb_tooltip_kit", dark_class)
       end
 
-      def sizing_helper
+      def remove_height_properties(combined_html_options_style)
+        return nil if combined_html_options_style.nil?
+
+        combined_html_options_style.gsub(/\s*(height|min-height|max-height)\s*:[^;]*;?\s*/, "")
+                                   .strip
+                                   .presence
+      end
+
+      def height_and_width_helper
         out = ""
         out += "width: #{width};" if width.present?
         out += "height: #{height};" if height.present?


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1907](https://runway.powerhrg.com/backlog_items/PLAY-1907)

- [x] Pass Height, Width, Max_Height, Max_Width, Min_Height, and Min_Width  Global Props to Rails
- [x] Create new Sizing Doc Example

**Screenshots:** Screenshots to visualize your addition/change
<img width="1486" alt="Screenshot 2025-03-13 at 12 04 22 PM" src="https://github.com/user-attachments/assets/56953725-602b-4ae3-8d47-798b4e55522f" />

https://github.com/user-attachments/assets/e5189372-0c9b-4213-802d-8e76300369eb

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/tooltip/rails
2. Scroll down to 'Tooltip Sizing'
3. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.