### PR TITLE
[PLAY-1756] Update pb_content_tag for Selectable List, Star Rating, Text Input, and Table

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_selectable_list/selectable_list.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <% if enable_drag %>
     <%= pb_rails("draggable", props: {initial_items: object.items}) do %>
       <%= pb_rails("draggable/draggable_container") do %>

--- a/playbook/app/pb_kits/playbook/pb_star_rating/star_rating.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_star_rating/star_rating.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-  id: object.id,
-  data: object.data,
-  class: object.classname,
-  **combined_html_options) do %>
+<%= pb_content_tag do %>
   <% if layout_option == "number" %>
     <% case object.size %>
       <% when "xs", "sm" %>

--- a/playbook/app/pb_kits/playbook/pb_table/table.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table.html.erb
@@ -6,21 +6,11 @@
 
 <%= content_tag(:div, class: responsive_class, 'data-pb-table-wrapper' => true) do %>
   <% if object.tag == "table" %>
-    <%= content_tag(:table,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag(:table) do %>
       <%= content.presence %>
     <% end %>
   <% else %>
-    <%= content_tag(:div,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag do %>
       <%= content.presence %>
     <% end %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_body.html.erb
@@ -4,22 +4,12 @@
         <%= content.presence %>
       <% end %>
     <% else %>
-      <%= content_tag(:tbody,
-        aria: object.aria,
-        class: object.classname,
-        data: object.data,
-        id: object.id,
-        **combined_html_options) do %>
+      <%= pb_content_tag(:tbody) do %>
         <%= content.presence %>
       <% end %>
     <% end %>
 <% else %>
-    <%= content_tag(:div,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag do %>
       <%= content.presence %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_cell.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_cell.html.erb
@@ -1,19 +1,9 @@
 <% if object.tag == "table" %>
-    <%= content_tag(:td,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag(:td) do %>
       <%= content.presence || object.text %>
     <% end %>
 <% else %>
-    <%= content_tag(:div,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag do %>
       <%= content.presence || object.text %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_head.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_head.html.erb
@@ -1,19 +1,9 @@
 <% if object.tag == "table" %>
-    <%= content_tag(:thead,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag(:thead) do %>
       <%= content.presence %>
     <% end %>
 <% else %>
-    <%= content_tag(:div,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag do %>
       <%= content.presence %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_header.html.erb
@@ -1,11 +1,7 @@
 <% if object.tag == "table" %>  
-  <%= content_tag(:th,
+  <%= pb_content_tag(:th,
       colspan: object.colspan,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: "pb-th#{object.id}",
-      **combined_html_options) do %>
+      id: "pb-th#{object.id}") do %>
     <% unless sorting_style? %>
         <%= content.presence || object.text %>
     <% else %>
@@ -46,12 +42,7 @@
     <% end %>
   <% end %>
 <% else %>
-  <%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+  <%= pb_content_tag do %>
       <% unless sorting_style? %>
         <%= content.presence || object.text %>
       <% else %>

--- a/playbook/app/pb_kits/playbook/pb_table/table_row.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/table_row.html.erb
@@ -1,12 +1,9 @@
 <% if object.collapsible && object.tag == "table" %>
-    <%= content_tag(:tr,
-    aria: object.aria,
+    <%= pb_content_tag(:tr,
     class: object.classname + " collapsible-tr",
-    data: object.data.merge(id: object.id),  
-    id: object.id,
+    data: object.data.merge(id: object.id),
     'data-pb-table-collapsible-wrapper' => true,
-    'data-pb-table-collapsible-cell-id' => object.toggle_cell_id,
-    **combined_html_options) do %>
+    'data-pb-table-collapsible-cell-id' => object.toggle_cell_id) do %>
     <%= content.presence %>
   <% end %>
 
@@ -24,22 +21,12 @@
         <%= content.presence %>
       <% end %>
     <% else %>
-      <%= content_tag(:tr,
-        aria: object.aria,
-        class: object.classname,
-        data: object.data,
-        id: object.id,
-        **combined_html_options) do %>
+      <%= pb_content_tag(:tr) do %>
         <%= content.presence %>
       <% end %>
     <% end %>
 <% else %>
-    <%= content_tag(:div,
-      aria: object.aria,
-      class: object.classname,
-      data: object.data,
-      id: object.id,
-      **combined_html_options) do %>
+    <%= pb_content_tag do %>
       <%= content.presence %>
     <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
@@ -1,4 +1,4 @@
-<%= pb_content_tag do %>
+<%= pb_content_tag(:div, id: nil ) do  %>
   <% if object.label.present? %>
     <%= pb_rails("caption", props: { text: object.label, dark: object.dark, classname: "pb_text_input_kit_label" }) %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
@@ -1,8 +1,4 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <% if object.label.present? %>
     <%= pb_rails("caption", props: { text: object.label, dark: object.dark, classname: "pb_text_input_kit_label" }) %>
   <% end %>


### PR DESCRIPTION
**What does this PR do?** 
This PR DRYs up code by replacing pb_content_tag for Selectable List, Star Rating, Text Input, and Table.

**Screenshots:** Screenshots to visualize your addition/change

**How to test?** Steps to confirm the desired behavior:
1. Test in Playbook
2. Test cases in Nitro

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.