### PR TITLE
[PBNTR-617] Add grid to Display global prop code and example page

### DIFF
--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/Display.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/Display.tsx
@@ -19,9 +19,10 @@ const UTILITY_CLASSES = [
   { size: 'md', media: '@media screen and (max-width: 768px)', class: '.display_md_inline_block', properties: 'display: inline-block !important' },
   { size: 'lg', media: '@media screen and (max-width: 992px)', class: '.display_lg_inline', properties: 'display: inline !important' },
   { size: 'xl', media: '@media screen and (max-width: 1200px)', class: '.display_xl_flex', properties: 'display: flex !important' },
+  { size: 'xl', media: '@media screen and (max-width: 1200px)', class: '.display_xl_grid', properties: 'display: grid !important' },
 ]
 
-const DISPLAY_VALUES = ['inline', 'flex', 'inline_flex', 'inline_block', 'block', 'none']
+const DISPLAY_VALUES = ['inline', 'flex', 'inline_flex', 'inline_block', 'block', 'none', 'grid']
 
 const Display = ({ example }: { example: string }) => (
   <React.Fragment>

--- a/playbook-website/app/views/pages/code_snippets/display_in_use_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/display_in_use_jsx.txt
@@ -1,4 +1,4 @@
-<Card display="flex">
+<Card display="grid">
   Card content
 <Card/>
 

--- a/playbook/app/pb_kits/playbook/tokens/_display.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_display.scss
@@ -4,10 +4,12 @@ $display_inline_block: inline-block !default;
 $display_flex: flex !default;
 $display_none: none !default;
 $display_inline_flex: inline-flex !default;
+$display_grid: grid !default;
 $displays: (
   display_none:   $display_none,
   display_flex: $display_flex,
   display_inline: $display_inline,
   display_inline_block: $display_inline_block,
-  display_block: $display_block
+  display_block: $display_block,
+  display_grid: $display_grid
 );

--- a/playbook/app/pb_kits/playbook/types/display.ts
+++ b/playbook/app/pb_kits/playbook/types/display.ts
@@ -1,4 +1,4 @@
-export type DisplayType = "none" | "flex" | "inline_flex" | "inline" | "inline_block" | "block"
+export type DisplayType = "none" | "flex" | "inline_flex" | "inline" | "inline_block" | "block" | "grid"
 
 export type Display = {
   display?: DisplayType,

--- a/playbook/app/pb_kits/playbook/utilities/_display.scss
+++ b/playbook/app/pb_kits/playbook/utilities/_display.scss
@@ -24,13 +24,18 @@
     display: none;
 }
 
+.display_grid {
+    display: grid;
+}
+
 $display_values: (
     none: $display_none,
     flex: $display_flex,
     inline: $display_inline,
     inline_block: $display_inline_block,
     inline_flex: $display_inline_flex,
-    block: $display_block
+    block: $display_block,
+    grid: $display_grid
 );
 
 // using a grid here

--- a/playbook/app/pb_kits/playbook/utilities/test/globalProps/display.test.js
+++ b/playbook/app/pb_kits/playbook/utilities/test/globalProps/display.test.js
@@ -9,7 +9,7 @@ const testSubject = 'body'
 
 // %w[block inline_block inline flex inline_flex none]
 test('Global Props: returns proper class name', () => {
-  const propValues = ["block", "inline", "inline_block", "flex", "inline_flex", "none"]
+  const propValues = ["block", "inline", "inline_block", "flex", "inline_flex", "none", "grid" ]
   for(let x = 0, y = propValues.length; x < y; ++x) {
     const testId = `${testSubject}-${propValues[x]}`
     render(

--- a/playbook/lib/playbook/display.rb
+++ b/playbook/lib/playbook/display.rb
@@ -18,7 +18,7 @@ module Playbook
       else
         selected_props.each do |k|
           display_value = send(k)
-          css += "display_#{display_value}" if display_values.include? display_value
+          css += "display_#{display_value} " if display_values.include?(display_value)
         end
       end
       css unless css.blank?
@@ -35,7 +35,7 @@ module Playbook
     end
 
     def display_values
-      %w[block inline_block inline flex inline_flex none]
+      %w[block inline_block inline flex inline_flex none grid]
     end
   end
 end

--- a/playbook/lib/playbook/display.rb
+++ b/playbook/lib/playbook/display.rb
@@ -18,7 +18,7 @@ module Playbook
       else
         selected_props.each do |k|
           display_value = send(k)
-          css += "display_#{display_value} " if display_values.include?(display_value)
+          css += "display_#{display_value}" if display_values.include?(display_value)
         end
       end
       css unless css.blank?

--- a/playbook/spec/playbook/global_props/display_spec.rb
+++ b/playbook/spec/playbook/global_props/display_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Playbook::Flex do
 
   describe "#classname" do
     it "returns proper class name", :aggregate_failures do
-      %w[block inline_block inline flex inline_flex none].each do |word|
+      %w[block inline_block inline flex inline_flex none grid].each do |word|
         expect(subject.new({ display: word }).classname).to include("display_#{word}")
 
         screen_sizes.each do |size|


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-617](https://runway.powerhrg.com/backlog_items/PBNTR-617) requests the addition of the grid value to Playbook's [Display global prop](https://developer.mozilla.org/en-US/docs/Web/CSS/display). This PR adds it to the code and to the Display visual guidelines example page. 

The property was tested locally in doc examples for Rails and React (screenshots below) and [this CSB with alpha](https://codesandbox.io/p/devbox/pbntr-csb-forked-7g54tx) demonstrates it in a user-testable and inspectable environment.

**Screenshots:** Screenshots to visualize your addition/change
Display Visual Guidelines page:
<img width="1301" alt="display vis guidelines" src="https://github.com/user-attachments/assets/81988fbe-53ff-4521-b637-a5f5aad72afd" />
Rails doc ex - flex, button, card (responsive)
<img width="1219" alt="rails flex doc ex" src="https://github.com/user-attachments/assets/8b9b041d-5a39-47ff-9c30-23596f18edb8" />
<img width="1232" alt="rails button doc ex" src="https://github.com/user-attachments/assets/5ff02666-87a4-429d-a9f8-6e68fa81aba9" />
<img width="707" alt="rails card doc ex" src="https://github.com/user-attachments/assets/fa2b316e-0e96-4150-8b21-99c9cbfb74b7" />

React doc ex - flex, button, card (responsive)
<img width="1242" alt="react flex doc ex" src="https://github.com/user-attachments/assets/69902504-ec9f-4421-8d50-9fbb006efaca" />
<img width="1211" alt="react button doc ex" src="https://github.com/user-attachments/assets/a70ae96f-fb25-4be2-9600-76363381ab21" />
<img width="1262" alt="react card doc ex" src="https://github.com/user-attachments/assets/44886255-792e-462c-bec9-4a66cb122434" />

**How to test?** Steps to confirm the desired behavior:
1. Go to [Display visual guidelines page in milano env](https://pr4395.playbook.beta.px.powerapp.cloud/visual_guidelines/display) observe addition of grid to values and examples.
2. Go to [this CSB](https://codesandbox.io/p/devbox/pbntr-csb-forked-7g54tx) - observe grid display property functioning on Playbook kits (can tell by appearance + inspecting the DOM).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.