### PR TITLE
[PBNTR-899] MultiLevelSelect Kit: Ability to Disable Options

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_helper_functions.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_helper_functions.tsx
@@ -88,7 +88,11 @@ export const getDefaultCheckedItems = (
     items.forEach((item: { [key: string]: any }) => {
       if (item.checked) {
         if (item.children && item.children.length > 0) {
-          const uncheckedChildren = item.children.filter(
+           // Filter out disabled children (only consider selectable items)
+           const selectableChildren = item.children.filter(
+            (child) => !child.disabled
+          );
+          const uncheckedChildren = selectableChildren.filter(
             (child: { [key: string]: any }) => !child.checked
           );
           if (uncheckedChildren.length === 0) {

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_helper_functions.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_helper_functions.tsx
@@ -90,7 +90,7 @@ export const getDefaultCheckedItems = (
         if (item.children && item.children.length > 0) {
            // Filter out disabled children (only consider selectable items)
            const selectableChildren = item.children.filter(
-            (child) => !child.disabled
+            (child: { [key: string]: any }) => !child.disabled
           );
           const uncheckedChildren = selectableChildren.filter(
             (child: { [key: string]: any }) => !child.checked

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -113,7 +113,9 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
       return;
     }
     return tree.map((item: { [key: string]: any }) => {
-      item.checked = check;
+      if (!item.disabled) {
+        item.checked = check;
+      }
       item.children = modifyRecursive(item.children, check);
       return item;
     });
@@ -244,8 +246,9 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
     return tree.map((item: any) => {
       if (item.id != id) item.children = modifyValue(id, item.children, check);
       else {
-        item.checked = check;
-
+        if (!item.disabled) {
+          item.checked = check;
+        }
         if (variant === "single") {
           // Single select: no children should be checked
           item.children = modifyRecursive(item.children, !check);

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -126,12 +126,16 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
     treeData: { [key: string]: any }[],
     selectedIds: string[],
     parent_id: string | null = null,
-    depth = 0
+    depth = 0,
+    parentDisabled = false
   ) => {
     if (!Array.isArray(treeData)) {
       return;
     }
     return treeData.map((item: { [key: string]: any } | any) => {
+      // An item is disabled if it is explicitly set as disabled or if its parent is disabled
+      const isDisabled = item.disabled || (parentDisabled && !returnAllSelected);
+
       const newItem = {
         ...item,
         checked: Boolean(
@@ -139,6 +143,7 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
         ),
         parent_id,
         depth,
+        disabled: isDisabled,
       };
       if (newItem.children && newItem.children.length > 0) {
         const children =
@@ -149,7 +154,8 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
           children,
           selectedIds,
           newItem.id,
-          depth + 1
+          depth + 1,
+          isDisabled
         );
       }
       return newItem;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.html.erb
@@ -1,72 +1,76 @@
 <% treeData = [{
     label: "Power Home Remodeling",
     value: "Power Home Remodeling",
-    id: "100",
+    id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
         value: "People",
-        id: "101",
+        id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
             value: "Talent Acquisition",
-            id: "102",
+            id: "talent1",
+            disabled: true,
           },
           {
             label: "Business Affairs",
             value: "Business Affairs",
-            id: "103",
+            id: "business1",
             children: [
               {
                 label: "Initiatives",
                 value: "Initiatives",
-                id: "104",
+                id: "initiative1",
+                disabled: true,
               },
               {
                 label: "Learning & Development",
                 value: "Learning & Development",
-                id: "105",
+                id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
             value: "People Experience",
-            id: "106",
+            id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
         value: "Contact Center",
-        id: "107",
+        id: "contact1",
         children: [
           {
             label: "Appointment Management",
             value: "Appointment Management",
-            id: "108",
+            id: "appointment1",
           },
           {
             label: "Customer Service",
             value: "Customer Service",
-            id: "109",
+            id: "customer1",
+            disabled: true,
           },
           {
             label: "Energy",
             value: "Energy",
-            id: "110",
+            id: "energy1",
           },
         ],
       },
     ],
 }] %>
 
+
 <%= pb_rails("multi_level_select", props: {
-    disabled: true,
-    id: "multi-level-select-disabled-rails",
-    name: "my_array",
+    id: "multi-level-select-disabled-options-rails",
+    name: "disabled_options",
+    return_all_selected: true,
     tree_data: treeData
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.jsx
@@ -1,0 +1,94 @@
+import React from "react";
+import MultiLevelSelect from "../_multi_level_select";
+
+const treeData = [
+  {
+    label: "Power Home Remodeling",
+    value: "Power Home Remodeling",
+    id: "powerhome1",
+    expanded: true,
+    children: [
+      {
+        label: "People",
+        value: "People",
+        id: "people1",
+        expanded: true,
+        children: [
+          {
+            label: "Talent Acquisition",
+            value: "Talent Acquisition",
+            id: "talent1",
+            disabled: true,
+          },
+          {
+            label: "Business Affairs",
+            value: "Business Affairs",
+            id: "business1",
+            children: [
+              {
+                label: "Initiatives",
+                value: "Initiatives",
+                id: "initiative1",
+                disabled: true,
+              },
+              {
+                label: "Learning & Development",
+                value: "Learning & Development",
+                id: "development1",
+              },
+            ],
+          },
+          {
+            label: "People Experience",
+            value: "People Experience",
+            id: "experience1",
+          },
+        ],
+      },
+      {
+        label: "Contact Center",
+        value: "Contact Center",
+        id: "contact1",
+        children: [
+          {
+            label: "Appointment Management",
+            value: "Appointment Management",
+            id: "appointment1",
+          },
+          {
+            label: "Customer Service",
+            value: "Customer Service",
+            id: "customer1",
+            disabled: true,
+          },
+          {
+            label: "Energy",
+            value: "Energy",
+            id: "energy1",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const MultiLevelSelectDefault = (props) => {
+  return (
+    <div>
+      <MultiLevelSelect
+          id='multiselect-disabled-options'
+          onSelect={(selectedNodes) =>
+          console.log(
+            "Selected Items",
+            selectedNodes
+          )
+        }
+          returnAllSelected
+          treeData={treeData}
+          {...props}
+      />
+    </div>
+  )
+};
+
+export default MultiLevelSelectDefault;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.md
@@ -1,0 +1,1 @@
+To disable individual items in the treeData, include `disabled:true` within the object on the treeData that you want disabled. See the code snippet below for an example of how to do this.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.md
@@ -1,1 +1,1 @@
-To disable individual items in the treeData, include `disabled:true` within the object on the treeData that you want disabled. See the code snippet below for an example of how to do this.
+individual items can also be disabled by including the `disabled:true` within the object on the treeData for the `returnAllSelected`/`return_all_selected` variant. As noted above, this variant will return data on all checked nodes from the dropdown, irrespective of whether it is a parent or child node.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.html.erb
@@ -71,6 +71,5 @@
 <%= pb_rails("multi_level_select", props: {
     id: "multi-level-select-disabled-options-default-rails",
     name: "disabled_options_default",
-    return_all_selected: true,
     tree_data: treeData
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.html.erb
@@ -1,0 +1,76 @@
+<% treeData = [{
+    label: "Power Home Remodeling",
+    value: "Power Home Remodeling",
+    id: "powerhome1",
+    expanded: true,
+    children: [
+      {
+        label: "People",
+        value: "People",
+        id: "people1",
+        expanded: true,
+        children: [
+          {
+            label: "Talent Acquisition",
+            value: "Talent Acquisition",
+            id: "talent1",
+            disabled: true,
+          },
+          {
+            label: "Business Affairs",
+            value: "Business Affairs",
+            id: "business1",
+            children: [
+              {
+                label: "Initiatives",
+                value: "Initiatives",
+                id: "initiative1",
+                disabled: true,
+              },
+              {
+                label: "Learning & Development",
+                value: "Learning & Development",
+                id: "development1",
+              },
+            ],
+          },
+          {
+            label: "People Experience",
+            value: "People Experience",
+            id: "experience1",
+          },
+        ],
+      },
+      {
+        label: "Contact Center",
+        value: "Contact Center",
+        id: "contact1",
+        children: [
+          {
+            label: "Appointment Management",
+            value: "Appointment Management",
+            id: "appointment1",
+          },
+          {
+            label: "Customer Service",
+            value: "Customer Service",
+            id: "customer1",
+            disabled: true,
+          },
+          {
+            label: "Energy",
+            value: "Energy",
+            id: "energy1",
+          },
+        ],
+      },
+    ],
+}] %>
+
+
+<%= pb_rails("multi_level_select", props: {
+    id: "multi-level-select-disabled-options-default-rails",
+    name: "disabled_options_default",
+    return_all_selected: true,
+    tree_data: treeData
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+import MultiLevelSelect from "../_multi_level_select";
+
+const treeData = [
+  {
+    label: "Power Home Remodeling",
+    value: "Power Home Remodeling",
+    id: "powerhome1",
+    expanded: true,
+    children: [
+      {
+        label: "People",
+        value: "People",
+        id: "people1",
+        expanded: true,
+        children: [
+          {
+            label: "Talent Acquisition",
+            value: "Talent Acquisition",
+            id: "talent1",
+            disabled: true,
+          },
+          {
+            label: "Business Affairs",
+            value: "Business Affairs",
+            id: "business1",
+            children: [
+              {
+                label: "Initiatives",
+                value: "Initiatives",
+                id: "initiative1",
+                disabled: true,
+              },
+              {
+                label: "Learning & Development",
+                value: "Learning & Development",
+                id: "development1",
+              },
+            ],
+          },
+          {
+            label: "People Experience",
+            value: "People Experience",
+            id: "experience1",
+          },
+        ],
+      },
+      {
+        label: "Contact Center",
+        value: "Contact Center",
+        id: "contact1",
+        children: [
+          {
+            label: "Appointment Management",
+            value: "Appointment Management",
+            id: "appointment1",
+          },
+          {
+            label: "Customer Service",
+            value: "Customer Service",
+            id: "customer1",
+            disabled: true,
+          },
+          {
+            label: "Energy",
+            value: "Energy",
+            id: "energy1",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const MultiLevelSelectDisabledOptionsDefault = (props) => {
+  return (
+    <div>
+      <MultiLevelSelect
+          id='multiselect-disabled-options-default'
+          onSelect={(selectedNodes) =>
+          console.log(
+            "Selected Items",
+            selectedNodes
+          )
+        }
+          treeData={treeData}
+          {...props}
+      />
+    </div>
+  )
+};
+
+export default MultiLevelSelectDisabledOptionsDefault;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.md
@@ -1,0 +1,3 @@
+To disable individual items in the treeData, include `disabled:true` within the object on the treeData that you want disabled. See the code snippet below for an example of how to do this.
+
+If a parent is selected, the parent will be returned in the selected items list, even if it has disabled children.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.html.erb
@@ -1,72 +1,75 @@
 <% treeData = [{
     label: "Power Home Remodeling",
     value: "Power Home Remodeling",
-    id: "100",
+    id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
         value: "People",
-        id: "101",
+        id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
             value: "Talent Acquisition",
-            id: "102",
+            id: "talent1",
           },
           {
             label: "Business Affairs",
             value: "Business Affairs",
-            id: "103",
+            id: "business1",
+            expanded: true,
+            disabled: true,
             children: [
               {
                 label: "Initiatives",
                 value: "Initiatives",
-                id: "104",
+                id: "initiative1",
               },
               {
                 label: "Learning & Development",
                 value: "Learning & Development",
-                id: "105",
+                id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
             value: "People Experience",
-            id: "106",
+            id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
         value: "Contact Center",
-        id: "107",
+        id: "contact1",
         children: [
           {
             label: "Appointment Management",
             value: "Appointment Management",
-            id: "108",
+            id: "appointment1",
           },
           {
             label: "Customer Service",
             value: "Customer Service",
-            id: "109",
+            id: "customer1",
           },
           {
             label: "Energy",
             value: "Energy",
-            id: "110",
+            id: "energy1",
           },
         ],
       },
     ],
 }] %>
 
+
 <%= pb_rails("multi_level_select", props: {
-    disabled: true,
-    id: "multi-level-select-disabled-rails",
-    name: "my_array",
+    id: "mls-disabled-options-parent-rails",
+    name: "disabled_options_parent",
+    return_all_selected: true,
     tree_data: treeData
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.jsx
@@ -23,6 +23,7 @@ const treeData = [
             label: "Business Affairs",
             value: "Business Affairs",
             id: "business1",
+            expanded: true,
             disabled: true,
             children: [
               {

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.jsx
@@ -18,18 +18,17 @@ const treeData = [
             label: "Talent Acquisition",
             value: "Talent Acquisition",
             id: "talent1",
-            disabled: true,
           },
           {
             label: "Business Affairs",
             value: "Business Affairs",
             id: "business1",
+            disabled: true,
             children: [
               {
                 label: "Initiatives",
                 value: "Initiatives",
                 id: "initiative1",
-                disabled: true,
               },
               {
                 label: "Learning & Development",
@@ -59,7 +58,6 @@ const treeData = [
             label: "Customer Service",
             value: "Customer Service",
             id: "customer1",
-            disabled: true,
           },
           {
             label: "Energy",
@@ -72,11 +70,11 @@ const treeData = [
   },
 ];
 
-const MultiLevelSelectDisabledOptions = (props) => {
+const MultiLevelSelectDisabledOptionsParent = (props) => {
   return (
     <div>
       <MultiLevelSelect
-          id='multiselect-disabled-options'
+          id='multiselect-disabled-options-parent'
           onSelect={(selectedNodes) =>
           console.log(
             "Selected Items",
@@ -91,4 +89,4 @@ const MultiLevelSelectDisabledOptions = (props) => {
   )
 };
 
-export default MultiLevelSelectDisabledOptions;
+export default MultiLevelSelectDisabledOptionsParent;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.md
@@ -1,0 +1,3 @@
+For the `returnAllSelected` variant, disabling the parent item will NOT automatically disable it's children since this version allows you to select a parent even if all children are unselected. 
+
+You can manually pass `disabled:true` to any and all children of a disabled parent if you want to do so. 

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.md
@@ -1,3 +1,3 @@
-For the `returnAllSelected` variant, disabling the parent item will NOT automatically disable it's children since this version allows you to select a parent even if all children are unselected. 
+For the `returnAllSelected`/`return_all_selected` variant, disabling the parent item will NOT automatically disable it's children since this version allows you to select a parent even if all children are unselected. 
 
 You can manually pass `disabled:true` to any and all children of a disabled parent if you want to do so. 

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.html.erb
@@ -1,72 +1,74 @@
 <% treeData = [{
     label: "Power Home Remodeling",
     value: "Power Home Remodeling",
-    id: "100",
+    id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
         value: "People",
-        id: "101",
+        id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
             value: "Talent Acquisition",
-            id: "102",
+            id: "talent1",
           },
           {
             label: "Business Affairs",
             value: "Business Affairs",
-            id: "103",
+            id: "business1",
+            expanded: true,
+            disabled: true,
             children: [
               {
                 label: "Initiatives",
                 value: "Initiatives",
-                id: "104",
+                id: "initiative1",
               },
               {
                 label: "Learning & Development",
                 value: "Learning & Development",
-                id: "105",
+                id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
             value: "People Experience",
-            id: "106",
+            id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
         value: "Contact Center",
-        id: "107",
+        id: "contact1",
         children: [
           {
             label: "Appointment Management",
             value: "Appointment Management",
-            id: "108",
+            id: "appointment1",
           },
           {
             label: "Customer Service",
             value: "Customer Service",
-            id: "109",
+            id: "customer1",
           },
           {
             label: "Energy",
             value: "Energy",
-            id: "110",
+            id: "energy1",
           },
         ],
       },
     ],
 }] %>
 
+
 <%= pb_rails("multi_level_select", props: {
-    disabled: true,
-    id: "multi-level-select-disabled-rails",
-    name: "my_array",
+    id: "mls-disabled-options-parent-default-rails",
+    name: "disabled_options_parent_default",
     tree_data: treeData
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.jsx
@@ -23,6 +23,7 @@ const treeData = [
             label: "Business Affairs",
             value: "Business Affairs",
             id: "business1",
+            expanded: true,
             disabled: true,
             children: [
               {

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.jsx
@@ -18,18 +18,17 @@ const treeData = [
             label: "Talent Acquisition",
             value: "Talent Acquisition",
             id: "talent1",
-            disabled: true,
           },
           {
             label: "Business Affairs",
             value: "Business Affairs",
             id: "business1",
+            disabled: true,
             children: [
               {
                 label: "Initiatives",
                 value: "Initiatives",
                 id: "initiative1",
-                disabled: true,
               },
               {
                 label: "Learning & Development",
@@ -59,7 +58,6 @@ const treeData = [
             label: "Customer Service",
             value: "Customer Service",
             id: "customer1",
-            disabled: true,
           },
           {
             label: "Energy",
@@ -72,18 +70,17 @@ const treeData = [
   },
 ];
 
-const MultiLevelSelectDisabledOptions = (props) => {
+const MultiLevelSelectDisabledOptionsParentDefault = (props) => {
   return (
     <div>
       <MultiLevelSelect
-          id='multiselect-disabled-options'
+          id='multiselect-disabled-options-parent-default'
           onSelect={(selectedNodes) =>
           console.log(
             "Selected Items",
             selectedNodes
           )
         }
-          returnAllSelected
           treeData={treeData}
           {...props}
       />
@@ -91,4 +88,4 @@ const MultiLevelSelectDisabledOptions = (props) => {
   )
 };
 
-export default MultiLevelSelectDisabledOptions;
+export default MultiLevelSelectDisabledOptionsParentDefault;

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.md
@@ -1,0 +1,3 @@
+For the default variant, disabling the parent item will automatically disable it's children as well. 
+
+If you want to be able to disable a parent WITHOUT disabling it's children, use the returnAllSelected variant.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.md
@@ -1,3 +1,3 @@
-For the default variant, disabling the parent item will automatically disable it's children as well. 
+For the `default` variant, disabling the parent item will automatically disable it's children as well. 
 
-If you want to be able to disable a parent WITHOUT disabling it's children, use the returnAllSelected variant.
+If you want to be able to disable a parent WITHOUT disabling it's children, use the `returnAllSelected`/`return_all_selected` variant.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
@@ -22,3 +22,5 @@ examples:
   - multi_level_select_with_children_with_radios: Single Select With Children
   - multi_level_select_disabled: Disabled
   - multi_level_select_disabled_options: Disabled Options
+  - multi_level_select_disabled_options_parent_default: Disabled Parent Option (Default)
+  - multi_level_select_disabled_options_parent: Disabled Parent Option (Return All Selected)

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
@@ -8,8 +8,9 @@ examples:
   - multi_level_select_with_form: With Form
   - multi_level_select_color: With Pills (Custom Color)
   - multi_level_select_reset: Reset Selection
-  - multi_level_select_disabled: Disabled
-  - multi_level_select_disabled_options: Disabled Options
+  - multi_level_select_disabled: Disabled Input
+  - multi_level_select_disabled_options_default: Disabled Options (Default)
+  - multi_level_select_disabled_options: Disabled Options (Return All Selected)
   - multi_level_select_disabled_options_parent_default: Disabled Parent Option (Default)
   - multi_level_select_disabled_options_parent: Disabled Parent Option (Return All Selected)
 
@@ -23,7 +24,8 @@ examples:
   - multi_level_select_color: With Pills (Custom Color)
   - multi_level_select_with_children: Checkboxes With Children
   - multi_level_select_with_children_with_radios: Single Select With Children
-  - multi_level_select_disabled: Disabled
-  - multi_level_select_disabled_options: Disabled Options
+  - multi_level_select_disabled: Disabled Input
+  - multi_level_select_disabled_options_default: Disabled Options (Default)
+  - multi_level_select_disabled_options: Disabled Options (Return All Selected)
   - multi_level_select_disabled_options_parent_default: Disabled Parent Option (Default)
   - multi_level_select_disabled_options_parent: Disabled Parent Option (Return All Selected)

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
@@ -9,6 +9,9 @@ examples:
   - multi_level_select_color: With Pills (Custom Color)
   - multi_level_select_reset: Reset Selection
   - multi_level_select_disabled: Disabled
+  - multi_level_select_disabled_options: Disabled Options
+  - multi_level_select_disabled_options_parent_default: Disabled Parent Option (Default)
+  - multi_level_select_disabled_options_parent: Disabled Parent Option (Return All Selected)
 
   react:
   - multi_level_select_default: Default

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/example.yml
@@ -21,3 +21,4 @@ examples:
   - multi_level_select_with_children: Checkboxes With Children
   - multi_level_select_with_children_with_radios: Single Select With Children
   - multi_level_select_disabled: Disabled
+  - multi_level_select_disabled_options: Disabled Options

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
@@ -11,3 +11,4 @@ export { default as MultiLevelSelectReactHook  } from './_multi_level_select_rea
 export { default as MultiLevelSelectDisabledOptions } from './_multi_level_select_disabled_options.jsx'
 export { default as MultiLevelSelectDisabledOptionsParent } from './_multi_level_select_disabled_options_parent.jsx'
 export { default as MultiLevelSelectDisabledOptionsParentDefault } from './_multi_level_select_disabled_options_parent_default.jsx'
+export { default as MultiLevelSelectDisabledOptionsDefault } from './_multi_level_select_disabled_options_default.jsx'

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
@@ -8,3 +8,4 @@ export { default as MultiLevelSelectWithChildren } from './_multi_level_select_w
 export { default as MultiLevelSelectWithChildrenWithRadios } from './_multi_level_select_with_children_with_radios.jsx'
 export { default as MultiLevelSelectDisabled } from './_multi_level_select_disabled.jsx'
 export { default as MultiLevelSelectReactHook  } from './_multi_level_select_react_hook.jsx'
+export { default as MultiLevelSelectDisabledOptions } from './_multi_level_select_disabled_options.jsx'

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/index.js
@@ -9,3 +9,5 @@ export { default as MultiLevelSelectWithChildrenWithRadios } from './_multi_leve
 export { default as MultiLevelSelectDisabled } from './_multi_level_select_disabled.jsx'
 export { default as MultiLevelSelectReactHook  } from './_multi_level_select_react_hook.jsx'
 export { default as MultiLevelSelectDisabledOptions } from './_multi_level_select_disabled_options.jsx'
+export { default as MultiLevelSelectDisabledOptionsParent } from './_multi_level_select_disabled_options_parent.jsx'
+export { default as MultiLevelSelectDisabledOptionsParentDefault } from './_multi_level_select_disabled_options_parent_default.jsx'

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/multi_level_select_options.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/multi_level_select_options.tsx
@@ -118,6 +118,7 @@ const classes = classnames(
                     >
                         <input
                             checked={item.checked}
+                            disabled={item.disabled}
                             name={item.label}
                             onChange={(e) => {
                               handledropdownItemClick(e, !item.checked);


### PR DESCRIPTION
[Runway Story](https://runway.powerhrg.com/backlog_items/PBNTR-899)

Covered in this PR (React and Rails):
- ✅ New logic that allows a user to disable individual options while keeping their parent or top-level option enabled
- ✅ When item disabled, it is not checked when checking cascades from parent
- ✅ Returned array should NOT include disabled option
- ✅ New Logic to disable parent options that will automatically disable all children options for default but not for returnAllSelected


![Screenshot 2025-03-17 at 2 07 05 PM](https://github.com/user-attachments/assets/61919a44-789e-4cc5-9ed7-b7e280d6d5fb)

![Screenshot 2025-03-17 at 2 07 23 PM](https://github.com/user-attachments/assets/df61ae3d-0eda-4117-ad5b-d189c2501517)

![Screenshot 2025-03-17 at 2 07 38 PM](https://github.com/user-attachments/assets/869a1df0-7bf8-4efe-8ac6-4235bbfc8275)
