### PR TITLE
[PLAY-1714] Add Values to Icon Kit Color Prop

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon/_icon.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon/_icon.scss
@@ -1,10 +1,18 @@
 @import "../tokens/colors";
 
+$additional_colors: (
+  "default": $text_lt_default,
+  "light": $text_lt_light,
+  "lighter": $text_lt_lighter,
+  "link": $primary
+);
+
 // All the merges below create $icon_colors, a map of all color tokens in colors.scss
 $merge_kits1: map-merge($status_colors, $category_colors);
 $merge_kits2: map-merge($merge_kits1, $product_colors);
 $merge_kits3: map-merge($merge_kits2, $text_colors);
-$icon_colors: map-merge($merge_kits3, $data_colors);
+$merge_kits4: map-merge($merge_kits3, $data_colors);
+$icon_colors: map-merge($merge_kits4, $additional_colors);
 
 .pb_custom_icon, .pb_icon_kit {
   @each $color_name, $color_value in $icon_colors {

--- a/playbook/app/pb_kits/playbook/pb_icon/_icon.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon/_icon.scss
@@ -1,7 +1,6 @@
 @import "../tokens/colors";
 
 $additional_colors: (
-  "default": $text_lt_default,
   "light": $text_lt_light,
   "lighter": $text_lt_lighter,
   "link": $primary

--- a/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.html.erb
@@ -1,4 +1,4 @@
-<%= pb_rails("flex", props: {margin_bottom: "sm"}) do %>
+<%= pb_rails("flex", props: { margin_bottom: "sm" }) do %>
     <%= pb_rails("icon", props: { icon: "user", fixed_width: true, color: "primary", size: "2x" }) %>
     <%= pb_rails("icon", props: { icon: "recycle", fixed_width: true, color: "data_4", size: "2x" }) %>
     <%= pb_rails("icon", props: { icon: "roofing", fixed_width: true, color: "product_5_background", size: "2x" }) %>
@@ -7,5 +7,5 @@
 <%= pb_rails("flex", props: {}) do %>
     <%= pb_rails("icon", props: { icon: "user", fixed_width: true, color: "light", size: "2x" }) %>
     <%= pb_rails("icon", props: { icon: "recycle", fixed_width: true, color: "lighter", size: "2x" }) %>
-    <%= pb_rails("icon", props: { icon: "roofing", fixed_width: true, color: "error", size: "2x" }) %>
+    <%= pb_rails("icon", props: { icon: "roofing", fixed_width: true, color: "default", size: "2x" }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.html.erb
@@ -1,5 +1,11 @@
-<%= pb_rails("flex", props: {orientation: "column"}) do %>
-    <%= pb_rails("icon", props: { icon: "user", fixed_width: true, color: "primary", padding_bottom: "sm", size: "2x" }) %>
-    <%= pb_rails("icon", props: { icon: "recycle", fixed_width: true, color: "data_4", padding_bottom: "sm", size: "2x" }) %>
+<%= pb_rails("flex", props: {margin_bottom: "sm"}) do %>
+    <%= pb_rails("icon", props: { icon: "user", fixed_width: true, color: "primary", size: "2x" }) %>
+    <%= pb_rails("icon", props: { icon: "recycle", fixed_width: true, color: "data_4", size: "2x" }) %>
     <%= pb_rails("icon", props: { icon: "roofing", fixed_width: true, color: "product_5_background", size: "2x" }) %>
+<% end %>
+
+<%= pb_rails("flex", props: {}) do %>
+    <%= pb_rails("icon", props: { icon: "user", fixed_width: true, color: "light", size: "2x" }) %>
+    <%= pb_rails("icon", props: { icon: "recycle", fixed_width: true, color: "lighter", size: "2x" }) %>
+    <%= pb_rails("icon", props: { icon: "roofing", fixed_width: true, color: "error", size: "2x" }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.html.erb
@@ -7,5 +7,5 @@
 <%= pb_rails("flex", props: {}) do %>
     <%= pb_rails("icon", props: { icon: "user", fixed_width: true, color: "light", size: "2x" }) %>
     <%= pb_rails("icon", props: { icon: "recycle", fixed_width: true, color: "lighter", size: "2x" }) %>
-    <%= pb_rails("icon", props: { icon: "roofing", fixed_width: true, color: "default", size: "2x" }) %>
+    <%= pb_rails("icon", props: { icon: "roofing", fixed_width: true, color: "link", size: "2x" }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.jsx
@@ -45,7 +45,7 @@ const IconDefault = (props) => {
             {...props}
         />
         <Icon
-            color="default"
+            color="link"
             fixedWidth
             icon="product-roofing"
             size="2x"

--- a/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_color.jsx
@@ -1,32 +1,57 @@
 import React from "react"
 import Icon from "../_icon"
+import Flex from "../../pb_flex/_flex"
 
 const IconDefault = (props) => {
   return (
-    <div style={{ display: "flex", flexDirection: "column"}}>
-      <Icon
-          color="primary"
-          fixedWidth
-          icon="user"
-          paddingBottom="sm"
-          size="2x"
-          {...props}
-      />
-      <Icon
-          color="data_4"
-          fixedWidth
-          icon="recycle"
-          paddingBottom="sm"
-          size="2x"
-          {...props}
-      />
-      <Icon
-          color="product_5_background"
-          fixedWidth
-          icon="product-roofing"
-          size="2x"
-          {...props}
-      />
+    <div>
+      <Flex marginBottom="sm">
+        <Icon
+            color="primary"
+            fixedWidth
+            icon="user"
+            size="2x"
+            {...props}
+        />
+        <Icon
+            color="data_4"
+            fixedWidth
+            icon="recycle"
+            size="2x"
+            {...props}
+        />
+        <Icon
+            color="product_5_background"
+            fixedWidth
+            icon="product-roofing"
+            size="2x"
+            {...props}
+        />
+      </Flex>
+
+      <Flex>
+        <Icon
+            color="light"
+            fixedWidth
+            icon="user"
+            size="2x"
+            {...props}
+        />
+        <Icon
+            color="lighter"
+            fixedWidth
+            icon="recycle"
+            size="2x"
+            {...props}
+        />
+        <Icon
+            color="default"
+            fixedWidth
+            icon="product-roofing"
+            size="2x"
+            {...props}
+        />
+      </Flex>
     </div>
   )
 }


### PR DESCRIPTION
Adding the ability to pass the same text color values as the body kit including light and lighter. 

This seemed like the most straightforward and least disruptive way to do it. If more color options are required, there may be a better way. Let me know what you think.

[PLAY-1714](https://runway.powerhrg.com/backlog_items/PLAY-1714)
[Review ENV](https://pr4402.playbook.beta.gm.powerapp.cloud/kits/icon/rails)