### PR TITLE
[PBNTR-897] Typeahead Kit - Disabled Prop for Rails and React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.scss
@@ -126,6 +126,9 @@
         color: $text_lt_default;
       }
       &__control {
+        &--is-disabled {
+          background-color: shade($white, 5%);
+        }
         &--is-focused {
           @include pb_textarea_focus;
           @include transition_default;
@@ -252,6 +255,7 @@
           color: $text_dk_default;
         }
         &__control {
+        
           &--is-focused {
             @include pb_textarea_focus;
             @include transition_default;

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -38,6 +38,7 @@ type TypeaheadProps = {
   createable?: boolean,
   dark?: boolean,
   data?: { [key: string]: string },
+  disabled?: boolean,
   error?: string,
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
@@ -79,6 +80,7 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
   createable,
   error = "",
   data = {},
+  disabled = false,
   getOptionLabel,
   getOptionValue,
   htmlOptions = {},
@@ -205,6 +207,7 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
       <Tag
           classNamePrefix="typeahead-kit-select"
           error={error}
+          isDisabled={disabled}
           onChange={handleOnChange}
           {...selectProps}
       />

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_disabled.html.erb
@@ -8,7 +8,7 @@
 %>
 
 <%= pb_rails("typeahead", props: {
-    id: "typeahead-default",
+    id: "typeahead-disabled",
     disabled: true,
     placeholder: "All Colors",
     options: options,
@@ -17,13 +17,3 @@
     is_multi: false
   })
 %>
-
-<%= javascript_tag defer: "defer" do %>
-  document.addEventListener("pb-typeahead-kit-typeahead-default-result-option-select", function(event) {
-    console.log('Single Option selected')
-    console.dir(event.detail)
-  })
-  document.addEventListener("pb-typeahead-kit-typeahead-default-result-clear", function() {
-    console.log('All options cleared')
-  })
-<% end %>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_disabled.html.erb
@@ -1,0 +1,29 @@
+<%
+  options = [
+    { label: 'Orange', value: '#FFA500' },
+    { label: 'Red', value: '#FF0000' },
+    { label: 'Green', value: '#00FF00' },
+    { label: 'Blue', value: '#0000FF' },
+  ]
+%>
+
+<%= pb_rails("typeahead", props: {
+    id: "typeahead-default",
+    disabled: true,
+    placeholder: "All Colors",
+    options: options,
+    label: "Colors",
+    name: :foo,
+    is_multi: false
+  })
+%>
+
+<%= javascript_tag defer: "defer" do %>
+  document.addEventListener("pb-typeahead-kit-typeahead-default-result-option-select", function(event) {
+    console.log('Single Option selected')
+    console.dir(event.detail)
+  })
+  document.addEventListener("pb-typeahead-kit-typeahead-default-result-clear", function() {
+    console.log('All options cleared')
+  })
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_disabled.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_disabled.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import Typeahead from '../_typeahead'
+
+const options = [
+  { label: 'Orange', value: '#FFA500' },
+  { label: 'Red', value: '#FF0000' },
+  { label: 'Green', value: '#00FF00' },
+  { label: 'Blue', value: '#0000FF' },
+]
+
+const TypeaheadDisabled = (props) => {
+  return (
+    <Typeahead
+        disabled
+        label="Colors"
+        options={options}
+        {...props}
+    />
+  )
+}
+
+export default TypeaheadDisabled

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
@@ -14,6 +14,7 @@ examples:
     - typeahead_truncated_text: Truncated Text
     - typeahead_dynamic_options: Dynamic Options
     - typeahead_dynamic_options_pure_rails: Dynamic Options (Pure Rails)
+    - typeahead_disabled: Disabled
 
   react:
     - typeahead_default: Default
@@ -32,3 +33,4 @@ examples:
     - typeahead_margin_bottom: Margin Bottom
     - typeahead_with_pills_color: With Pills (Custom Color)
     - typeahead_truncated_text: Truncated Text
+    - typeahead_disabled: Disabled

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/index.js
@@ -14,3 +14,4 @@ export { default as TypeaheadMarginBottom } from './_typeahead_margin_bottom.jsx
 export { default as TypeaheadWithPillsColor } from './_typeahead_with_pills_color.jsx'
 export { default as TypeaheadTruncatedText } from './_typeahead_truncated_text.jsx'
 export { default as TypeaheadReactHook } from './_typeahead_react_hook.jsx'
+export { default as TypeaheadDisabled } from './_typeahead_disabled.jsx'

--- a/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -52,6 +52,8 @@ module Playbook
                                 default: {}
       prop :search_context_selector, type: Playbook::Props::String,
                                      default: nil
+      prop :disabled, type: Playbook::Props::Boolean,
+                      default: false
 
       def classname
         default_margin_bottom = margin_bottom.present? ? "" : " mb_sm"
@@ -100,6 +102,7 @@ module Playbook
           searchContextSelector: search_context_selector,
           optionsByContext: options_by_context,
           clearOnContextChange: clear_on_context_change,
+          disabled: disabled,
         }
 
         base_options[:getOptionLabel] = get_option_label if get_option_label.present?


### PR DESCRIPTION
[PBNTR-897](https://runway.powerhrg.com/backlog_items/PBNTR-897)


Added `disabled` prop to Typeahead kit.

<img width="787" alt="Screenshot 2025-03-19 at 9 54 46 AM" src="https://github.com/user-attachments/assets/34460b83-ab52-4c0d-9bef-03fefed73169" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Typeahead kit and check out the last doc example.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.