### PR TITLE
[PLAY-1929] Bracket Layout - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -10,7 +10,7 @@ $list-header-height: $space_lg;
 $list-footer-height: $space_lg;
 $list-border-radius: $border_rad_lighter;
 $card-border-radius: $border_rad_lightest;
-$bracket-connector-width: 20px;
+$bracket-connector-width: 45px;
 $bracket-line-width: 4px;
 
 

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -195,7 +195,7 @@ $bracket-line-width: 4px;
       border-bottom-right-radius: $border_radius_lg;
     }
 
-    .layout_round .layout_game {
+    .layout_round .layout_game:not(:only-child) {
       position: relative;
       &::after {
         content: '';

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -10,6 +10,8 @@ $list-header-height: $space_lg;
 $list-footer-height: $space_lg;
 $list-border-radius: $border_rad_lighter;
 $card-border-radius: $border_rad_lightest;
+$bracket-connector-width: 50px;
+$bracket-line-width: 4px;
 
 
 [class^=pb_layout_kit] {
@@ -168,6 +170,64 @@ $card-border-radius: $border_rad_lightest;
     }
   }
 
+  &[class*=_bracket]{
+    display: flex;
+
+    div.layout_round {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+    }
+
+    .connector_container {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+    }
+
+    .left_connector, .right_connector {
+      border-top: $bracket-line-width solid $border_light;
+      width: $bracket-connector-width;
+    }
+
+    .layout_round .layout_item {
+      position: relative;
+    }
+
+    .layout_round .layout_item:not(:only-child)::after {
+      content: '';
+      position: absolute;
+      width: $bracket-line-width;
+      height: 100%;
+      background-color: $border_light;
+    }
+
+    .layout_round.eight_games .layout_item:not(:only-child)::after {
+      height: 100%;
+    }
+
+    .layout_round.eight_games + .layout_round.four_games .layout_item:not(:only-child)::after {
+      height: 200%;
+    }
+
+    .layout_round.four_games + .layout_round.two_games .layout_item:not(:only-child)::after {
+      height: 200%;
+    }
+
+    .layout_round.eight_games ~ .layout_round.four_games ~ .layout_round.two_games .layout_item:not(:only-child)::after {
+      height: 400%;
+    }
+    
+    .layout_round .layout_item:nth-child(even)::after {
+      right: -$bracket-connector-width;
+      bottom: 50%;
+    }
+    
+    .layout_round .layout_item:nth-child(odd)::after {
+      right: -$bracket-connector-width;
+      top: 50%;
+    }
+  }
 
   &[class*=_sidebar]{
     $layout_sizes: (

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -192,34 +192,22 @@ $bracket-border-width: 4px;
       margin-left: $bracket-connector-width;
     }
 
-    .layout_round .layout_game:not(:only-child) {
+    .layout_round .layout_game {
       position: relative;
-      &:nth-child(odd)::after {
-        content: '';
-        position: absolute;
-        top: calc(50% - $bracket-border-width / 2);
-        height: calc(100% + $bracket-border-width);
-        width: $bracket-connector-width;
-        right: -$bracket-connector-width;
-        border-top-right-radius: $border_radius_lg;
-        border-bottom-right-radius: $border_radius_lg;
-        border-top: $bracket-border-width solid $border_light;
-        border-bottom: $bracket-border-width solid $border_light;
-        border-right: $bracket-border-width solid $border_light;
-      }
     }
 
-    .layout_round.games_16 ~ .layout_round.games_8 .layout_game:not(:only-child)::after,
-    .layout_round.games_8 ~ .layout_round.games_4 .layout_game:not(:only-child)::after,
-    .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
-      height: calc(200% + $bracket-border-width);
-    }
-    .layout_round.games_16 ~ .layout_round.games_8 ~ .layout_round.games_4 .layout_game:not(:only-child)::after,
-    .layout_round.games_8 ~ .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
-      height: calc(400% + $bracket-border-width);
-    }
-    .layout_round.games_16 ~ .layout_round.games_8 ~ .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
-      height: calc(800% + $bracket-border-width);
+    .half_box {
+      content: '';
+      position: absolute;
+      top: calc(50% - $bracket-border-width / 2);
+      height: calc(100% + $bracket-border-width);
+      width: $bracket-connector-width;
+      right: -$bracket-connector-width;
+      border-top-right-radius: $border_radius_lg;
+      border-bottom-right-radius: $border_radius_lg;
+      border-top: $bracket-border-width solid $border_light;
+      border-bottom: $bracket-border-width solid $border_light;
+      border-right: $bracket-border-width solid $border_light;
     }
 
     .layout_round_label {

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -197,8 +197,8 @@ $bracket-border-width: 4px;
       &:nth-child(odd)::after {
         content: '';
         position: absolute;
-        top: 50%;
-        height: 100%;
+        top: calc(50% - $bracket-border-width / 2);
+        height: calc(100% + $bracket-border-width);
         width: $bracket-connector-width;
         right: -$bracket-connector-width;
         border-top-right-radius: $border_radius_lg;
@@ -210,14 +210,14 @@ $bracket-border-width: 4px;
     }
 
     .layout_round.eight_games .layout_game:not(:only-child)::after {
-      height: 100%;
+      height: calc(100% + $bracket-border-width);
     }
     .layout_round.eight_games ~ .layout_round.four_games .layout_game:not(:only-child)::after,
     .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
-      height: 200%;
+      height: calc(200% + $bracket-border-width);
     }
     .layout_round.eight_games ~ .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
-      height: 400%;
+      height: calc(400% + $bracket-border-width);
     }
     .layout_round_label {
       display: none;

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -229,6 +229,23 @@ $bracket-line-width: 4px;
       right: -$bracket-connector-width;
       top: 50%;
     }
+
+    .layout_round_label {
+      display: none;
+    }
+
+    @media (max-width: $screen-md-max) {
+      flex-direction: column;
+
+      .layout_round_label {
+        display: block;
+      }
+
+      .layout_round .layout_game::after, .connector_container {
+        display: none;
+      }
+    }
+    
   }
 
   &[class*=_sidebar]{

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -192,11 +192,11 @@ $bracket-line-width: 4px;
       width: $bracket-connector-width;
     }
 
-    .layout_round .layout_item {
+    .layout_round .layout_game {
       position: relative;
     }
 
-    .layout_round .layout_item:not(:only-child)::after {
+    .layout_round .layout_game:not(:only-child)::after {
       content: '';
       position: absolute;
       width: $bracket-line-width;
@@ -204,28 +204,28 @@ $bracket-line-width: 4px;
       background-color: $border_light;
     }
 
-    .layout_round.eight_games .layout_item:not(:only-child)::after {
+    .layout_round.eight_games .layout_game:not(:only-child)::after {
       height: 100%;
     }
 
-    .layout_round.eight_games ~ .layout_round.four_games .layout_item:not(:only-child)::after {
+    .layout_round.eight_games ~ .layout_round.four_games .layout_game:not(:only-child)::after {
       height: 200%;
     }
 
-    .layout_round.four_games ~ .layout_round.two_games .layout_item:not(:only-child)::after {
+    .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
       height: 200%;
     }
 
-    .layout_round.eight_games ~ .layout_round.four_games ~ .layout_round.two_games .layout_item:not(:only-child)::after {
+    .layout_round.eight_games ~ .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
       height: 400%;
     }
     
-    .layout_round .layout_item:nth-child(even)::after {
+    .layout_round .layout_game:nth-child(even)::after {
       right: -$bracket-connector-width;
       bottom: 50%;
     }
     
-    .layout_round .layout_item:nth-child(odd)::after {
+    .layout_round .layout_game:nth-child(odd)::after {
       right: -$bracket-connector-width;
       top: 50%;
     }

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -209,16 +209,19 @@ $bracket-border-width: 4px;
       }
     }
 
-    .layout_round.games_8 .layout_game:not(:only-child)::after {
-      height: calc(100% + $bracket-border-width);
-    }
+    .layout_round.games_16 ~ .layout_round.games_8 .layout_game:not(:only-child)::after,
     .layout_round.games_8 ~ .layout_round.games_4 .layout_game:not(:only-child)::after,
     .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
       height: calc(200% + $bracket-border-width);
     }
+    .layout_round.games_16 ~ .layout_round.games_8 ~ .layout_round.games_4 .layout_game:not(:only-child)::after,
     .layout_round.games_8 ~ .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
       height: calc(400% + $bracket-border-width);
     }
+    .layout_round.games_16 ~ .layout_round.games_8 ~ .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
+      height: calc(800% + $bracket-border-width);
+    }
+
     .layout_round_label {
       display: none;
     }

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -206,11 +206,11 @@ $bracket-line-width: 4px;
       height: 100%;
     }
 
-    .layout_round.eight_games + .layout_round.four_games .layout_item:not(:only-child)::after {
+    .layout_round.eight_games ~ .layout_round.four_games .layout_item:not(:only-child)::after {
       height: 200%;
     }
 
-    .layout_round.four_games + .layout_round.two_games .layout_item:not(:only-child)::after {
+    .layout_round.four_games ~ .layout_round.two_games .layout_item:not(:only-child)::after {
       height: 200%;
     }
 

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -191,6 +191,11 @@ $bracket-line-width: 4px;
       border-top: $bracket-line-width solid $border_light;
       width: $bracket-connector-width;
     }
+    
+    .left_connector {
+      border-top-right-radius: $border_radius_lg;
+      border-bottom-right-radius: $border_radius_lg;
+    }
 
     .layout_round .layout_game {
       position: relative;

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -186,12 +186,10 @@ $bracket-line-width: 4px;
       flex-direction: column;
       justify-content: space-around;
     }
-
     .left_connector, .right_connector {
       border-top: $bracket-line-width solid $border_light;
       width: $bracket-connector-width;
     }
-    
     .left_connector {
       border-top-right-radius: $border_radius_lg;
       border-bottom-right-radius: $border_radius_lg;
@@ -199,58 +197,48 @@ $bracket-line-width: 4px;
 
     .layout_round .layout_game {
       position: relative;
-    }
+      &::after {
+        content: '';
+        position: absolute;
+        height: 100%;
+        width: $bracket-line-width;
+        background-color: $border_light;
+        right: -$bracket-connector-width;
+      }
 
-    .layout_round .layout_game:not(:only-child)::after {
-      content: '';
-      position: absolute;
-      width: $bracket-line-width;
-      height: 100%;
-      background-color: $border_light;
+      &:nth-child(even)::after {
+        bottom: 50%;
+      }
+
+      &:nth-child(odd)::after {
+        top: 50%;
+      }
     }
 
     .layout_round.eight_games .layout_game:not(:only-child)::after {
       height: 100%;
     }
-
-    .layout_round.eight_games ~ .layout_round.four_games .layout_game:not(:only-child)::after {
-      height: 200%;
-    }
-
+    .layout_round.eight_games ~ .layout_round.four_games .layout_game:not(:only-child)::after,
     .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
       height: 200%;
     }
-
     .layout_round.eight_games ~ .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
       height: 400%;
     }
-    
-    .layout_round .layout_game:nth-child(even)::after {
-      right: -$bracket-connector-width;
-      bottom: 50%;
-    }
-    
-    .layout_round .layout_game:nth-child(odd)::after {
-      right: -$bracket-connector-width;
-      top: 50%;
-    }
-
     .layout_round_label {
       display: none;
     }
 
     @media (max-width: $screen-md-max) {
       flex-direction: column;
-
       .layout_round_label {
         display: block;
       }
-
-      .layout_round .layout_game::after, .connector_container {
+      .layout_round .layout_game::after,
+      .connector_container {
         display: none;
       }
     }
-    
   }
 
   &[class*=_sidebar]{

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -10,7 +10,7 @@ $list-header-height: $space_lg;
 $list-footer-height: $space_lg;
 $list-border-radius: $border_rad_lighter;
 $card-border-radius: $border_rad_lightest;
-$bracket-connector-width: 50px;
+$bracket-connector-width: 20px;
 $bracket-line-width: 4px;
 
 
@@ -172,11 +172,13 @@ $bracket-line-width: 4px;
 
   &[class*=_bracket]{
     display: flex;
+    overflow-x: scroll;
 
     div.layout_round {
       display: flex;
       flex-direction: column;
       justify-content: space-around;
+      flex-grow: 1;
     }
 
     .connector_container {

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -11,7 +11,7 @@ $list-footer-height: $space_lg;
 $list-border-radius: $border_rad_lighter;
 $card-border-radius: $border_rad_lightest;
 $bracket-connector-width: 45px;
-$bracket-line-width: 4px;
+$bracket-border-width: 4px;
 
 
 [class^=pb_layout_kit] {
@@ -186,32 +186,26 @@ $bracket-line-width: 4px;
       flex-direction: column;
       justify-content: space-around;
     }
-    .left_connector, .right_connector {
-      border-top: $bracket-line-width solid $border_light;
+    .right_connector {
+      border-top: $bracket-border-width solid $border_light;
       width: $bracket-connector-width;
-    }
-    .left_connector {
-      border-top-right-radius: $border_radius_lg;
-      border-bottom-right-radius: $border_radius_lg;
+      margin-left: $bracket-connector-width;
     }
 
     .layout_round .layout_game:not(:only-child) {
       position: relative;
-      &::after {
+      &:nth-child(odd)::after {
         content: '';
         position: absolute;
-        height: 100%;
-        width: $bracket-line-width;
-        background-color: $border_light;
-        right: -$bracket-connector-width;
-      }
-
-      &:nth-child(even)::after {
-        bottom: 50%;
-      }
-
-      &:nth-child(odd)::after {
         top: 50%;
+        height: 100%;
+        width: $bracket-connector-width;
+        right: -$bracket-connector-width;
+        border-top-right-radius: $border_radius_lg;
+        border-bottom-right-radius: $border_radius_lg;
+        border-top: $bracket-border-width solid $border_light;
+        border-bottom: $bracket-border-width solid $border_light;
+        border-right: $bracket-border-width solid $border_light;
       }
     }
 

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -220,8 +220,9 @@ $bracket-border-width: 4px;
         display: block;
       }
       .layout_round .layout_game::after,
-      .connector_container {
-        display: none;
+      .connector_container,
+      .half_box {
+        display: none !important;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.scss
@@ -209,14 +209,14 @@ $bracket-border-width: 4px;
       }
     }
 
-    .layout_round.eight_games .layout_game:not(:only-child)::after {
+    .layout_round.games_8 .layout_game:not(:only-child)::after {
       height: calc(100% + $bracket-border-width);
     }
-    .layout_round.eight_games ~ .layout_round.four_games .layout_game:not(:only-child)::after,
-    .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
+    .layout_round.games_8 ~ .layout_round.games_4 .layout_game:not(:only-child)::after,
+    .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
       height: calc(200% + $bracket-border-width);
     }
-    .layout_round.eight_games ~ .layout_round.four_games ~ .layout_round.two_games .layout_game:not(:only-child)::after {
+    .layout_round.games_8 ~ .layout_round.games_4 ~ .layout_round.games_2 .layout_game:not(:only-child)::after {
       height: calc(400% + $bracket-border-width);
     }
     .layout_round_label {

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -161,6 +161,7 @@ const Game = (props: LayoutGameProps) => {
             style={dynamicInlineProps}
         >
           <Card
+              marginBottom="md"
               padding="none"
               shadow="deep"
           >
@@ -195,6 +196,7 @@ const Game = (props: LayoutGameProps) => {
         style={dynamicInlineProps}
     >
       <Card
+          marginBottom="md"
           padding="none"
           shadow="deep"
       >

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -177,9 +177,9 @@ const Layout = (props: LayoutPropTypes) => {
   )
 
   const numberOfRounds = Array.isArray(nonSideChildren) ? React.Children.toArray(children).filter(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
-    (child) => child.type === Layout.Round
+    (child) => {
+      return (child as React.ReactElement).type === Layout.Round;
+    }
   ).length : 0
   const bracketChildren = nonSideChildren.map(child =>
     React.isValidElement(child) ? React.cloneElement(child, { numberOfRounds }) : child

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -136,25 +136,18 @@ const Footer = (props: LayoutFooterProps) => {
   )
 }
 
-// Helper function for Round
-const generateConnectors = (type: 'left' | 'right', count: number) => {
-  const connectorClass = type === 'left' ? 'left_connector' : 'right_connector'
-  return Array.from({ length: count }, (_, index) => (
-    <div
-        className={connectorClass}
-        key={`${connectorClass}_${index}`}
-    />
-  ))
-}
-
 // Round component (based off Body)
 const Round = (props: LayoutRoundProps) => {
   const { children, className } = props
   const dynamicInlineProps = globalInlineProps(props)
   const numberOfChildren = Array.isArray(children) ? children.length : 0
 
-  const leftConnectors = generateConnectors('left', numberOfChildren)
-  const rightConnectors = generateConnectors('right', numberOfChildren / 2)
+  const rightConnectors = Array.from({ length: numberOfChildren / 2 }, (_, index) => (
+    <div
+        className="right_connector"
+        key={`right_connector_${index}`}
+    />
+  ))
 
   const numberOfGamesClass = 
     numberOfChildren === 8 ? 'eight_games' :
@@ -169,7 +162,6 @@ const Round = (props: LayoutRoundProps) => {
       >
         {children}
       </div>
-      <div className="connector_container">{leftConnectors}</div>
       <div className="connector_container">{rightConnectors}</div>
     </>
   )

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -136,43 +136,41 @@ const Footer = (props: LayoutFooterProps) => {
   )
 }
 
+// Helper function for Round
+const generateConnectors = (type: 'left' | 'right', count: number) => {
+  const connectorClass = type === 'left' ? 'left_connector' : 'right_connector'
+  return Array.from({ length: count }, (_, index) => (
+    <div
+        className={connectorClass}
+        key={`${connectorClass}_${index}`}
+    />
+  ))
+}
+
 // Round component (based off Body)
 const Round = (props: LayoutRoundProps) => {
   const { children, className } = props
   const dynamicInlineProps = globalInlineProps(props)
-
   const numberOfChildren = Array.isArray(children) ? children.length : 0
 
-  const leftConnectors = Array.from({ length: numberOfChildren }, (_, index) => (
-    <div
-        className='left_connector'
-        key={'left_connector' + index}
-    />
-  ));
+  const leftConnectors = generateConnectors('left', numberOfChildren)
+  const rightConnectors = generateConnectors('right', numberOfChildren / 2)
 
-  const rightConnectors = Array.from({ length: numberOfChildren / 2 }, (_, index) => (
-    <div
-        className='right_connector'
-        key={'right_connector' + index}
-    />
-  ));
-
-  const numberOfGamesClass = numberOfChildren === 8 ? "eight_games" : numberOfChildren === 4 ? "four_games" : numberOfChildren === 2 ? "two_games" : ""
+  const numberOfGamesClass = 
+    numberOfChildren === 8 ? 'eight_games' :
+    numberOfChildren === 4 ? 'four_games' :
+    numberOfChildren === 2 ? 'two_games' : ''
 
   return (
     <>
-    <div
-        className={classnames('layout_round', globalProps(props), className, numberOfGamesClass)}
-        style={dynamicInlineProps}
-    >
-      {children}
-    </div>
-    <div className='connector_container'>
-      {leftConnectors}
-    </div>
-    <div className='connector_container'>
-      {rightConnectors}
-    </div>
+      <div
+          className={classnames('layout_round', globalProps(props), className, numberOfGamesClass)}
+          style={dynamicInlineProps}
+      >
+        {children}
+      </div>
+      <div className="connector_container">{leftConnectors}</div>
+      <div className="connector_container">{rightConnectors}</div>
     </>
   )
 }
@@ -185,8 +183,7 @@ const Game = (props: LayoutGameProps) => {
   const numberOfChildren = Array.isArray(children) ? children.length : 0
 
   if (numberOfChildren === 2) {
-    const firstChild = React.Children.toArray(children)[0];
-    const secondChild = React.Children.toArray(children)[1];
+    const [firstChild, secondChild] = React.Children.toArray(children)
 
     if (React.isValidElement(firstChild) && React.isValidElement(secondChild)) { 
       return (
@@ -199,49 +196,33 @@ const Game = (props: LayoutGameProps) => {
               padding="none"
               shadow="deep"
           >
-            <Card.Body padding="xs">
-              { firstChild }
-            </Card.Body>
+            <Card.Body padding="xs">{firstChild}</Card.Body>
             <SectionSeparator />
-            <Card.Body padding="xs">
-              { secondChild }
-            </Card.Body>
+            <Card.Body padding="xs">{secondChild}</Card.Body>
           </Card>
         </div>
       )
     }
   }
 
-  if (numberOfChildren >= 1) {
-    return (
-      <div
-          className={classnames('layout_game', globalProps(props), className)}
-          style={dynamicInlineProps}
-      >
-        {children}
-      </div>
-    )
-  }
-
-  // To be determined...
   return (
     <div
         className={classnames('layout_game', globalProps(props), className)}
         style={dynamicInlineProps}
     >
-      <Card
-          marginY="xs"
-          padding="none"
-          shadow="deep"
-      >
-        <Card.Body padding="xs">
-          To be determined...
-        </Card.Body>
-        <SectionSeparator />
-        <Card.Body padding="xs">
-          To be determined...
-        </Card.Body>
-      </Card>
+      {numberOfChildren >= 1 ? (
+        children
+      ) : (
+        <Card
+            marginY="xs"
+            padding="none"
+            shadow="deep"
+        >
+          <Card.Body padding="xs">To be determined...</Card.Body>
+          <SectionSeparator />
+          <Card.Body padding="xs">To be determined...</Card.Body>
+        </Card>
+      )}
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -177,6 +177,8 @@ const Layout = (props: LayoutPropTypes) => {
   )
 
   const numberOfRounds = Array.isArray(nonSideChildren) ? React.Children.toArray(children).filter(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
     (child) => child.type === Layout.Round
   ).length : 0
   const bracketChildren = nonSideChildren.map(child =>

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -93,6 +93,49 @@ const Body = (props: LayoutBodyProps) => {
   )
 }
 
+// Item component
+const Item = (props: LayoutItemProps) => {
+  const { children, className, size = 'sm' } = props
+  const sizeClass = `size_${size}`
+  const dynamicInlineProps = globalInlineProps(props)
+  return (
+    <div
+        className={classnames('layout_item', sizeClass, globalProps(props), className)}
+        style={dynamicInlineProps}
+    >
+      {children}
+    </div>
+  )
+}
+
+// Header component
+const Header = (props: LayoutHeaderProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+  return (
+    <div
+        className={classnames('layout_header', globalProps(props), className)}
+        style={dynamicInlineProps}
+    >
+      {children}
+    </div>
+  )
+}
+
+// Footer component
+const Footer = (props: LayoutFooterProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+  return (
+    <div
+        className={classnames('layout_footer', globalProps(props), className)}
+        style={dynamicInlineProps}
+    >
+      {children}
+    </div>
+  )
+}
+
 // Round component (based off Body)
 const Round = (props: LayoutRoundProps) => {
   const { children, className } = props
@@ -131,21 +174,6 @@ const Round = (props: LayoutRoundProps) => {
       {rightConnectors}
     </div>
     </>
-  )
-}
-
-// Item component
-const Item = (props: LayoutItemProps) => {
-  const { children, className, size = 'sm' } = props
-  const sizeClass = `size_${size}`
-  const dynamicInlineProps = globalInlineProps(props)
-  return (
-    <div
-        className={classnames('layout_item', sizeClass, globalProps(props), className)}
-        style={dynamicInlineProps}
-    >
-      {children}
-    </div>
   )
 }
 
@@ -225,34 +253,6 @@ const RoundLabel = (props: LayoutRoundLabelProps) => {
   return (
     <div
         className={classnames('layout_round_label', className)}
-        style={dynamicInlineProps}
-    >
-      {children}
-    </div>
-  )
-}
-
-// Header component
-const Header = (props: LayoutHeaderProps) => {
-  const { children, className } = props
-  const dynamicInlineProps = globalInlineProps(props)
-  return (
-    <div
-        className={classnames('layout_header', globalProps(props), className)}
-        style={dynamicInlineProps}
-    >
-      {children}
-    </div>
-  )
-}
-
-// Footer component
-const Footer = (props: LayoutFooterProps) => {
-  const { children, className } = props
-  const dynamicInlineProps = globalInlineProps(props)
-  return (
-    <div
-        className={classnames('layout_footer', globalProps(props), className)}
         style={dynamicInlineProps}
     >
       {children}

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -176,7 +176,9 @@ const Layout = (props: LayoutPropTypes) => {
     (child: React.ReactElement & {type: {displayName: string}}) => child.type?.displayName !== 'Side'
   )
 
-  const numberOfRounds = Array.isArray(nonSideChildren) ? nonSideChildren.filter((child: any) => child.type?.name === 'Round').length : 0
+  const numberOfRounds = Array.isArray(nonSideChildren) ? React.Children.toArray(children).filter(
+    (child) => child.type === Layout.Round
+  ).length : 0
   const bracketChildren = nonSideChildren.map(child =>
     React.isValidElement(child) ? React.cloneElement(child, { numberOfRounds }) : child
   )

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -45,6 +45,12 @@ type LayoutGameProps = {
   className?: string,
 } & GlobalProps
 
+type LayoutRoundLabelProps = {
+  children: React.ReactNode[] | React.ReactNode,
+  className?: string,
+} & GlobalProps
+
+
 type LayoutRoundProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
@@ -212,6 +218,20 @@ const Game = (props: LayoutGameProps) => {
   )
 }
 
+// Round Label component (modeled after Item)
+const RoundLabel = (props: LayoutRoundLabelProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+  return (
+    <div
+        className={classnames('layout_round_label', className)}
+        style={dynamicInlineProps}
+    >
+      {children}
+    </div>
+  )
+}
+
 // Header component
 const Header = (props: LayoutHeaderProps) => {
   const { children, className } = props
@@ -331,5 +351,6 @@ Layout.Header = Header
 Layout.Footer = Footer
 Layout.Round = Round
 Layout.Game = Game
+Layout.RoundLabel = RoundLabel
 
 export default Layout

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -92,7 +92,7 @@ const Round = (props: LayoutRoundProps) => {
   const { children, className } = props
   const dynamicInlineProps = globalInlineProps(props)
 
-  const numberOfChildren = Array.isArray(children) ? children.length : 0
+  const numberOfChildren = React.Children.count(children)
 
   const leftConnectors = Array.from({ length: numberOfChildren }, (_, index) => (
     <div
@@ -148,28 +148,33 @@ const Game = (props: LayoutGameProps) => {
   const { children, className } = props
   const dynamicInlineProps = globalInlineProps(props)
 
-  const numberOfChildren = Array.isArray(children) ? children.length : 0
+  const numberOfChildren = React.Children.count(children)
 
-  if (numberOfChildren === 2 && Array.isArray(children)) {
-    return (
-      <div
-          className={classnames('layout_game', globalProps(props), className)}
-          style={dynamicInlineProps}
-      >
-        <Card
-            padding="none"
-            shadow="deep"
+  if (numberOfChildren === 2) {
+    const firstChild = React.Children.toArray(children)[0];
+    const secondChild = React.Children.toArray(children)[1];
+
+    if (React.isValidElement(firstChild) && React.isValidElement(secondChild)) { 
+      return (
+        <div
+            className={classnames('layout_game', globalProps(props), className)}
+            style={dynamicInlineProps}
         >
-          <Card.Body padding="xs">
-            { children[0] }
-          </Card.Body>
-          <SectionSeparator />
-          <Card.Body padding="xs">
-            { children[1] }
-          </Card.Body>
-        </Card>
-      </div>
-    )
+          <Card
+              padding="none"
+              shadow="deep"
+          >
+            <Card.Body padding="xs">
+              { firstChild }
+            </Card.Body>
+            <SectionSeparator />
+            <Card.Body padding="xs">
+              { secondChild }
+            </Card.Body>
+          </Card>
+        </div>
+      )
+    }
   }
 
   if (numberOfChildren >= 1) {

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -167,7 +167,7 @@ const Game = (props: LayoutGameProps) => {
             style={dynamicInlineProps}
         >
           <Card
-              marginBottom="md"
+              marginY="xs"
               padding="none"
               shadow="deep"
           >
@@ -202,7 +202,7 @@ const Game = (props: LayoutGameProps) => {
         style={dynamicInlineProps}
     >
       <Card
-          marginBottom="md"
+          marginY="xs"
           padding="none"
           shadow="deep"
       >

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -283,7 +283,7 @@ const Layout = (props: LayoutPropTypes) => {
   const htmlProps = buildHtmlProps(htmlOptions)
 
   const layoutCss =
-    layout == 'collection'
+    (layout == 'collection' || layout == 'bracket')
       ? `pb_layout_kit_${layout}`
       : layout == 'kanban'
         ? `pb_layout_kit_${layout}${responsiveClass}`
@@ -294,11 +294,9 @@ const Layout = (props: LayoutPropTypes) => {
         })
 
   const layoutCollapseCss =
-    layout == 'collection'
+    (layout == 'collection' || layout == 'kanban' || layout == 'bracket')
       ? ''
-      : layout == 'kanban'
-        ? ''
-        : buildCss('layout', position, 'collapse', collapse)
+      : buildCss('layout', position, 'collapse', collapse)
 
   const layoutChildren = React.Children.toArray(children)
 

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -176,6 +176,11 @@ const Layout = (props: LayoutPropTypes) => {
     (child: React.ReactElement & {type: {displayName: string}}) => child.type?.displayName !== 'Side'
   )
 
+  const numberOfRounds = Array.isArray(nonSideChildren) ? nonSideChildren.filter((child: any) => child.type?.name === 'Round').length : 0
+  const bracketChildren = nonSideChildren.map(child =>
+    React.isValidElement(child) ? React.cloneElement(child, { numberOfRounds }) : child
+  )
+  
   const filteredProps = {...props}
   delete filteredProps?.position
 
@@ -197,7 +202,7 @@ const Layout = (props: LayoutPropTypes) => {
         style={dynamicInlineProps}
     >
       {subComponentTags('Side')}
-      {nonSideChildren}
+      {layout === 'bracket' ? bracketChildren : nonSideChildren}
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -4,6 +4,9 @@ import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../uti
 
 import { GlobalProps, globalProps, globalInlineProps } from '../utilities/globalProps'
 
+import Card from '../pb_card/_card'
+import SectionSeparator from '../pb_section_separator/_section_separator'
+
 type LayoutPropTypes = {
   aria?: {[key: string]: string},
   children?: React.ReactChild[] | React.ReactChild,
@@ -35,6 +38,16 @@ type LayoutItemProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
   size?: "sm" | "md" | "lg"
+} & GlobalProps
+
+type LayoutGameProps = {
+  children: React.ReactNode[] | React.ReactNode,
+  className?: string,
+} & GlobalProps
+
+type LayoutRoundProps = {
+  children: React.ReactNode[] | React.ReactNode,
+  className?: string,
 } & GlobalProps
 
 type LayoutHeaderProps = {
@@ -75,7 +88,7 @@ const Body = (props: LayoutBodyProps) => {
 }
 
 // Round component (based off Body)
-const Round = (props: LayoutBodyProps) => {
+const Round = (props: LayoutRoundProps) => {
   const { children, className } = props
   const dynamicInlineProps = globalInlineProps(props)
 
@@ -126,6 +139,68 @@ const Item = (props: LayoutItemProps) => {
         style={dynamicInlineProps}
     >
       {children}
+    </div>
+  )
+}
+
+// Game component (modeled after Item)
+const Game = (props: LayoutGameProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+
+  const numberOfChildren = Array.isArray(children) ? children.length : 0
+
+  if (numberOfChildren === 2 && Array.isArray(children)) {
+    return (
+      <div
+          className={classnames('layout_game', globalProps(props), className)}
+          style={dynamicInlineProps}
+      >
+        <Card
+            padding="none"
+            shadow="deep"
+        >
+          <Card.Body padding="xs">
+            { children[0] }
+          </Card.Body>
+          <SectionSeparator />
+          <Card.Body padding="xs">
+            { children[1] }
+          </Card.Body>
+        </Card>
+      </div>
+    )
+  }
+
+  if (numberOfChildren >= 1) {
+    return (
+      <div
+          className={classnames('layout_game', globalProps(props), className)}
+          style={dynamicInlineProps}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  // To be determined...
+  return (
+    <div
+        className={classnames('layout_game', globalProps(props), className)}
+        style={dynamicInlineProps}
+    >
+      <Card
+          padding="none"
+          shadow="deep"
+      >
+        <Card.Body padding="xs">
+          To be determined...
+        </Card.Body>
+        <SectionSeparator />
+        <Card.Body padding="xs">
+          To be determined...
+        </Card.Body>
+      </Card>
     </div>
   )
 }
@@ -248,5 +323,6 @@ Layout.Item = Item
 Layout.Header = Header
 Layout.Footer = Footer
 Layout.Round = Round
+Layout.Game = Game
 
 export default Layout

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -4,8 +4,8 @@ import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../uti
 
 import { GlobalProps, globalProps, globalInlineProps } from '../utilities/globalProps'
 
-import Card from '../pb_card/_card'
-import SectionSeparator from '../pb_section_separator/_section_separator'
+import { Round, RoundLabel } from "./subcomponents/_round";
+import Game from "./subcomponents/_game";
 
 type LayoutPropTypes = {
   aria?: {[key: string]: string},
@@ -38,22 +38,6 @@ type LayoutItemProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
   size?: "sm" | "md" | "lg"
-} & GlobalProps
-
-type LayoutGameProps = {
-  children: React.ReactNode[] | React.ReactNode,
-  className?: string,
-} & GlobalProps
-
-type LayoutRoundLabelProps = {
-  children: React.ReactNode[] | React.ReactNode,
-  className?: string,
-} & GlobalProps
-
-
-type LayoutRoundProps = {
-  children: React.ReactNode[] | React.ReactNode,
-  className?: string,
 } & GlobalProps
 
 type LayoutHeaderProps = {
@@ -129,103 +113,6 @@ const Footer = (props: LayoutFooterProps) => {
   return (
     <div
         className={classnames('layout_footer', globalProps(props), className)}
-        style={dynamicInlineProps}
-    >
-      {children}
-    </div>
-  )
-}
-
-// Round component (based off Body)
-const Round = (props: LayoutRoundProps) => {
-  const { children, className } = props
-  const dynamicInlineProps = globalInlineProps(props)
-  const numberOfChildren = Array.isArray(children) ? children.length : 0
-
-  const rightConnectors = Array.from({ length: numberOfChildren / 2 }, (_, index) => (
-    <div
-        className="right_connector"
-        key={`right_connector_${index}`}
-    />
-  ))
-
-  const numberOfGamesClass = 
-    numberOfChildren === 8 ? 'eight_games' :
-    numberOfChildren === 4 ? 'four_games' :
-    numberOfChildren === 2 ? 'two_games' : ''
-
-  return (
-    <>
-      <div
-          className={classnames('layout_round', globalProps(props), className, numberOfGamesClass)}
-          style={dynamicInlineProps}
-      >
-        {children}
-      </div>
-      <div className="connector_container">{rightConnectors}</div>
-    </>
-  )
-}
-
-// Game component (modeled after Item)
-const Game = (props: LayoutGameProps) => {
-  const { children, className } = props
-  const dynamicInlineProps = globalInlineProps(props)
-
-  const numberOfChildren = Array.isArray(children) ? children.length : 0
-
-  if (numberOfChildren === 2) {
-    const [firstChild, secondChild] = React.Children.toArray(children)
-
-    if (React.isValidElement(firstChild) && React.isValidElement(secondChild)) { 
-      return (
-        <div
-            className={classnames('layout_game', globalProps(props), className)}
-            style={dynamicInlineProps}
-        >
-          <Card
-              marginY="xs"
-              padding="none"
-              shadow="deep"
-          >
-            <Card.Body padding="xs">{firstChild}</Card.Body>
-            <SectionSeparator />
-            <Card.Body padding="xs">{secondChild}</Card.Body>
-          </Card>
-        </div>
-      )
-    }
-  }
-
-  return (
-    <div
-        className={classnames('layout_game', globalProps(props), className)}
-        style={dynamicInlineProps}
-    >
-      {numberOfChildren >= 1 ? (
-        children
-      ) : (
-        <Card
-            marginY="xs"
-            padding="none"
-            shadow="deep"
-        >
-          <Card.Body padding="xs">To be determined...</Card.Body>
-          <SectionSeparator />
-          <Card.Body padding="xs">To be determined...</Card.Body>
-        </Card>
-      )}
-    </div>
-  )
-}
-
-// Round Label component (modeled after Item)
-const RoundLabel = (props: LayoutRoundLabelProps) => {
-  const { children, className } = props
-  const dynamicInlineProps = globalInlineProps(props)
-  return (
-    <div
-        className={classnames('layout_round_label', className)}
         style={dynamicInlineProps}
     >
       {children}

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -18,7 +18,7 @@ type LayoutPropTypes = {
   size?: "xs" | "sm" | "md" | "base" | "lg" | "xl",
   variant?: "light" | "dark" | "gradient",
   transparent?: boolean,
-  layout?: "sidebar" | "collection" | "kanban" | "content" | "masonry",
+  layout?: "sidebar" | "collection" | "kanban" | "content" | "masonry" | "bracket",
 } & GlobalProps
 
 type LayoutSideProps = {
@@ -71,6 +71,47 @@ const Body = (props: LayoutBodyProps) => {
     >
       {children}
     </div>
+  )
+}
+
+// Round component (based off Body)
+const Round = (props: LayoutBodyProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+
+  const numberOfChildren = Array.isArray(children) ? children.length : 0
+
+  const leftConnectors = Array.from({ length: numberOfChildren }, (_, index) => (
+    <div
+        className='left_connector'
+        key={'left_connector' + index}
+    />
+  ));
+
+  const rightConnectors = Array.from({ length: numberOfChildren / 2 }, (_, index) => (
+    <div
+        className='right_connector'
+        key={'right_connector' + index}
+    />
+  ));
+
+  const numberOfGamesClass = numberOfChildren === 8 ? "eight_games" : numberOfChildren === 4 ? "four_games" : numberOfChildren === 2 ? "two_games" : ""
+
+  return (
+    <>
+    <div
+        className={classnames('layout_round', globalProps(props), className, numberOfGamesClass)}
+        style={dynamicInlineProps}
+    >
+      {children}
+    </div>
+    <div className='connector_container'>
+      {leftConnectors}
+    </div>
+    <div className='connector_container'>
+      {rightConnectors}
+    </div>
+    </>
   )
 }
 
@@ -206,5 +247,6 @@ Layout.Body = Body
 Layout.Item = Item
 Layout.Header = Header
 Layout.Footer = Footer
+Layout.Round = Round
 
 export default Layout

--- a/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/_layout.tsx
@@ -92,7 +92,7 @@ const Round = (props: LayoutRoundProps) => {
   const { children, className } = props
   const dynamicInlineProps = globalInlineProps(props)
 
-  const numberOfChildren = React.Children.count(children)
+  const numberOfChildren = Array.isArray(children) ? children.length : 0
 
   const leftConnectors = Array.from({ length: numberOfChildren }, (_, index) => (
     <div
@@ -148,7 +148,7 @@ const Game = (props: LayoutGameProps) => {
   const { children, className } = props
   const dynamicInlineProps = globalInlineProps(props)
 
-  const numberOfChildren = React.Children.count(children)
+  const numberOfChildren = Array.isArray(children) ? children.length : 0
 
   if (numberOfChildren === 2) {
     const firstChild = React.Children.toArray(children)[0];

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
@@ -8,7 +8,6 @@ const LayoutBracket = () => {
   return (
     <div>
       <Layout
-          height="800px"
           layout="bracket"
       >
         <Layout.Round>

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
@@ -3,6 +3,9 @@ import React from 'react'
 import Layout from '../../pb_layout/_layout'
 import Flex from '../../pb_flex/_flex'
 import Body from '../../pb_body/_body'
+import Caption from '../../pb_caption/_caption'
+import Title from '../../pb_title/_title'
+import SectionSeparator from '../../pb_section_separator/_section_separator'
 
 const LayoutBracket = () => {
   return (
@@ -10,6 +13,10 @@ const LayoutBracket = () => {
       <Layout
           layout="bracket"
       >
+        <Layout.RoundLabel>
+          <Caption>Wild Card</Caption>
+          <SectionSeparator marginY="sm"/>
+        </Layout.RoundLabel>
         <Layout.Round>
           <Layout.Game>
             <Flex justify="between">
@@ -88,6 +95,10 @@ const LayoutBracket = () => {
             </Flex>
           </Layout.Game>
         </Layout.Round>
+        <Layout.RoundLabel>
+          <Caption>Divisional</Caption>
+          <SectionSeparator marginY="sm"/>
+        </Layout.RoundLabel>
         <Layout.Round>
           <Layout.Game>
             <Flex justify="between">
@@ -130,6 +141,10 @@ const LayoutBracket = () => {
             </Flex>
           </Layout.Game>
         </Layout.Round>
+        <Layout.RoundLabel>
+          <Caption>Conference</Caption>
+          <SectionSeparator marginY="sm"/>
+        </Layout.RoundLabel>
         <Layout.Round>
           <Layout.Game>
             <Flex justify="between">
@@ -152,6 +167,10 @@ const LayoutBracket = () => {
             </Flex>
           </Layout.Game>
         </Layout.Round>
+        <Layout.RoundLabel>
+          <Title>Super Bowl</Title>
+          <SectionSeparator marginY="sm"/>
+        </Layout.RoundLabel>
         <Layout.Round>
           <Layout.Game>
             <Flex justify="between">

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
@@ -1,67 +1,169 @@
 import React from 'react'
 
-import Card from '../../pb_card/_card'
 import Layout from '../../pb_layout/_layout'
+import Flex from '../../pb_flex/_flex'
+import Body from '../../pb_body/_body'
 
 const LayoutBracket = () => {
   return (
     <div>
       <Layout
-          height="1000px"
+          height="800px"
           layout="bracket"
       >
         <Layout.Round>
-            <Layout.Item>
-              <Card>Game 1</Card>
-            </Layout.Item>
-            <Layout.Item>
-              <Card>Game 2</Card>
-            </Layout.Item>
-            <Layout.Item>
-              <Card>Game 3</Card>
-            </Layout.Item>
-            <Layout.Item>
-              <Card>Game 4</Card>
-            </Layout.Item>
-            <Layout.Item>
-              <Card>Game 5</Card>
-            </Layout.Item>
-            <Layout.Item>
-              <Card>Game 6</Card>
-            </Layout.Item>
-            <Layout.Item>
-              <Card>Game 7</Card>
-            </Layout.Item>
-            <Layout.Item>
-              <Card>Game 8</Card>
-            </Layout.Item>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Packers</Body>
+              <Body>10</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Eagles</strong></Body>
+              <Body>22</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Vikings</Body>
+              <Body>9</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Rams</strong></Body>
+              <Body>27</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body><strong>Lions</strong></Body>
+            </Flex>
+            <Flex justify="between">
+              <Body>BYE</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body><strong>Commanders</strong></Body>
+              <Body>23</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body>Buccaneers</Body>
+              <Body>20</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body><strong>Chiefs</strong></Body>
+            </Flex>
+            <Flex justify="between">
+              <Body>BYE</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Chargers</Body>
+              <Body>12</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Texans</strong></Body>
+              <Body>32</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Broncos</Body>
+              <Body>7</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Bills</strong></Body>
+              <Body>31</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Steelers</Body>
+              <Body>14</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Ravens</strong></Body>
+              <Body>28</Body>
+            </Flex>
+          </Layout.Game>
         </Layout.Round>
         <Layout.Round>
-          <Layout.Item>
-            <Card>Game 9</Card>
-          </Layout.Item>
-          <Layout.Item>
-            <Card>Game 10</Card>
-          </Layout.Item>
-          <Layout.Item>
-            <Card>Game 11</Card>
-          </Layout.Item>
-          <Layout.Item>
-            <Card>Game 12</Card>
-          </Layout.Item>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Rams</Body>
+              <Body>22</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Eagles</strong></Body>
+              <Body>28</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body><strong>Commanders</strong></Body>
+              <Body>45</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body>Lions</Body>
+              <Body>31</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Texans</Body>
+              <Body>14</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Chiefs</strong></Body>
+              <Body>23</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Ravens</Body>
+              <Body>25</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Bills</strong></Body>
+              <Body>27</Body>
+            </Flex>
+          </Layout.Game>
         </Layout.Round>
         <Layout.Round>
-          <Layout.Item>
-            <Card>Game 13</Card>
-          </Layout.Item>
-          <Layout.Item>
-            <Card>Game 14</Card>
-          </Layout.Item>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Commanders</Body>
+              <Body>23</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Eagles</strong></Body>
+              <Body>55</Body>
+            </Flex>
+          </Layout.Game>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Bills</Body>
+              <Body>29</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Chiefs</strong></Body>
+              <Body>32</Body>
+            </Flex>
+          </Layout.Game>
         </Layout.Round>
         <Layout.Round>
-          <Layout.Item>
-            <Card>Final Game</Card>
-          </Layout.Item>
+          <Layout.Game>
+            <Flex justify="between">
+              <Body>Chiefs</Body>
+              <Body>22</Body>
+            </Flex>
+            <Flex justify="between">
+              <Body><strong>Eagles</strong></Body>
+              <Body>40</Body>
+            </Flex>
+          </Layout.Game>
         </Layout.Round>
       </Layout>
     </div>

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
@@ -4,7 +4,6 @@ import Layout from '../../pb_layout/_layout'
 import Flex from '../../pb_flex/_flex'
 import Body from '../../pb_body/_body'
 import Caption from '../../pb_caption/_caption'
-import Title from '../../pb_title/_title'
 import SectionSeparator from '../../pb_section_separator/_section_separator'
 
 const LayoutBracket = () => {
@@ -168,7 +167,7 @@ const LayoutBracket = () => {
           </Layout.Game>
         </Layout.Round>
         <Layout.RoundLabel>
-          <Title>Super Bowl</Title>
+          <Caption>Super Bowl</Caption>
           <SectionSeparator marginY="sm"/>
         </Layout.RoundLabel>
         <Layout.Round>

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
@@ -16,7 +16,7 @@ const LayoutBracket = () => {
           <Caption>Wild Card</Caption>
           <SectionSeparator marginY="sm"/>
         </Layout.RoundLabel>
-        <Layout.Round>
+        <Layout.Round marginBottom={{ xs: "md", sm: "md" }}>
           <Layout.Game>
             <Flex justify="between">
               <Body>Packers</Body>
@@ -98,7 +98,7 @@ const LayoutBracket = () => {
           <Caption>Divisional</Caption>
           <SectionSeparator marginY="sm"/>
         </Layout.RoundLabel>
-        <Layout.Round>
+        <Layout.Round marginBottom={{ xs: "md", sm: "md" }}>
           <Layout.Game>
             <Flex justify="between">
               <Body>Rams</Body>
@@ -144,7 +144,7 @@ const LayoutBracket = () => {
           <Caption>Conference</Caption>
           <SectionSeparator marginY="sm"/>
         </Layout.RoundLabel>
-        <Layout.Round>
+        <Layout.Round marginBottom={{ xs: "md", sm: "md" }}>
           <Layout.Game>
             <Flex justify="between">
               <Body>Commanders</Body>

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+
+import Card from '../../pb_card/_card'
+import Layout from '../../pb_layout/_layout'
+
+const LayoutBracket = () => {
+  return (
+    <div>
+      <Layout layout="bracket">
+        <Layout.Round>
+            <Layout.Item>
+              <Card>Game 1</Card>
+            </Layout.Item>
+            <Layout.Item>
+              <Card>Game 2</Card>
+            </Layout.Item>
+            <Layout.Item>
+              <Card>Game 3</Card>
+            </Layout.Item>
+            <Layout.Item>
+              <Card>Game 4</Card>
+            </Layout.Item>
+            <Layout.Item>
+              <Card>Game 5</Card>
+            </Layout.Item>
+            <Layout.Item>
+              <Card>Game 6</Card>
+            </Layout.Item>
+            <Layout.Item>
+              <Card>Game 7</Card>
+            </Layout.Item>
+            <Layout.Item>
+              <Card>Game 8</Card>
+            </Layout.Item>
+        </Layout.Round>
+        <Layout.Round>
+          <Layout.Item>
+            <Card>Game 9</Card>
+          </Layout.Item>
+          <Layout.Item>
+            <Card>Game 10</Card>
+          </Layout.Item>
+          <Layout.Item>
+            <Card>Game 11</Card>
+          </Layout.Item>
+          <Layout.Item>
+            <Card>Game 12</Card>
+          </Layout.Item>
+        </Layout.Round>
+        <Layout.Round>
+          <Layout.Item>
+            <Card>Game 13</Card>
+          </Layout.Item>
+          <Layout.Item>
+            <Card>Game 14</Card>
+          </Layout.Item>
+        </Layout.Round>
+        <Layout.Round>
+          <Layout.Item>
+            <Card>Final Game</Card>
+          </Layout.Item>
+        </Layout.Round>
+      </Layout>
+    </div>
+  )
+}
+
+export default LayoutBracket

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.jsx
@@ -6,7 +6,10 @@ import Layout from '../../pb_layout/_layout'
 const LayoutBracket = () => {
   return (
     <div>
-      <Layout layout="bracket">
+      <Layout
+          height="1000px"
+          layout="bracket"
+      >
         <Layout.Round>
             <Layout.Item>
               <Card>Game 1</Card>

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.md
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.md
@@ -1,3 +1,5 @@
 Use `<Layout.RoundLabel>`, `<Layout.Round>`, and `<Layout.Game>` to make a bracket layout.
 
 On mobile devices, `<Layout.RoundLabel>` will display (on desktop these components are hidden) and the bracket will be in one column.
+
+Ensure that each `<Layout.Game>` maintains a consistent height for the bracket lines to lay out properly.

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.md
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.md
@@ -1,0 +1,3 @@
+Use `<Layout.RoundLabel>`, `<Layout.Round>`, and `<Layout.Game>` to make a bracket layout. This supports up to four rounds.
+
+On mobile devices, `<Layout.RoundLabel>` will display (on desktop these components are hidden) and the bracket will be in one column.

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.md
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_layout_bracket.md
@@ -1,3 +1,3 @@
-Use `<Layout.RoundLabel>`, `<Layout.Round>`, and `<Layout.Game>` to make a bracket layout. This supports up to four rounds.
+Use `<Layout.RoundLabel>`, `<Layout.Round>`, and `<Layout.Game>` to make a bracket layout.
 
 On mobile devices, `<Layout.RoundLabel>` will display (on desktop these components are hidden) and the bracket will be in one column.

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/example.yml
@@ -10,6 +10,7 @@ examples:
   - layout_masonry: Masonry Layout
 
   react:
+  - layout_bracket: Bracket Layout
   - layout_colors: Colors
   - layout_transparent: Transparent
   - layout_sizes: Sizes
@@ -18,5 +19,4 @@ examples:
   - layout_kanban: Kanban Layout
   - layout_content: Content Layout
   - layout_masonry: Masonry Layout
-  - layout_bracket: Bracket Layout
 

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/example.yml
@@ -10,7 +10,6 @@ examples:
   - layout_masonry: Masonry Layout
 
   react:
-  - layout_bracket: Bracket Layout
   - layout_colors: Colors
   - layout_transparent: Transparent
   - layout_sizes: Sizes
@@ -19,4 +18,5 @@ examples:
   - layout_kanban: Kanban Layout
   - layout_content: Content Layout
   - layout_masonry: Masonry Layout
+  - layout_bracket: Bracket Layout
 

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/example.yml
@@ -10,6 +10,7 @@ examples:
   - layout_masonry: Masonry Layout
 
   react:
+  - layout_bracket: Bracket Layout
   - layout_colors: Colors
   - layout_transparent: Transparent
   - layout_sizes: Sizes

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/index.js
@@ -7,4 +7,5 @@ export { default as LayoutKanbanResponsive } from './_layout_kanban_responsive.j
 export { default as LayoutCollectionDetail } from './_layout_collection_detail.jsx'
 export { default as LayoutContent } from './_layout_content.jsx'
 export { default as LayoutMasonry } from './_layout_masonry.jsx'
+export { default as LayoutBracket } from './_layout_bracket.jsx'
 

--- a/playbook/app/pb_kits/playbook/pb_layout/layout.test.js
+++ b/playbook/app/pb_kits/playbook/pb_layout/layout.test.js
@@ -82,6 +82,10 @@ test("render all layout variants", () => {
       layout: "masonry",
       expected: "pb_layout_kit_masonry_size_md_left_light",
     },
+    {
+      layout: "bracket",
+      expected: "pb_layout_kit_bracket",
+    },
   ]
 
   testValues.forEach(({ layout, expected }) => {

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -51,7 +51,7 @@ const Game = (props: LayoutGameProps) => {
         {isOdd && numberOfGames > 1  &&
           <div
               className="half_box"
-              style={{ height: `calc(${ratio}00% + 4px)` }}
+              style={{ height: `calc(${ratio} * 100% + 4px)` }}
           />
         }
       </div>
@@ -80,7 +80,7 @@ const Game = (props: LayoutGameProps) => {
       {isOdd && numberOfGames > 1  &&
         <div
             className="half_box"
-            style={{ height: `calc(${ratio}00% + 4px)` }}
+            style={{ height: `calc(${ratio} * 100% + 4px)` }}
         />
       }
     </div>

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -80,7 +80,7 @@ const Game = (props: LayoutGameProps) => {
       {isOdd && numberOfGames > 1  &&
         <div
             className="half_box"
-            style={{ height: `calc(${ratio} * 100% + 4px)` }}
+            style={{ height: `calc(${ratio}00% + 4px)` }}
         />
       }
     </div>

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -19,7 +19,8 @@ const Game = (props: LayoutGameProps) => {
   const { children, className, numberOfRounds, numberOfGames, isOdd } = props
   const dynamicInlineProps = globalInlineProps(props)
   
-  const numberOfChildren = Array.isArray(children) ? children.length : 0
+  const isMultiple = Array.isArray(children)
+  const numberOfChildren = isMultiple ? children.length : 0
 
   let ratio = 0
   let exponent
@@ -62,7 +63,7 @@ const Game = (props: LayoutGameProps) => {
         className={classnames('layout_game', globalProps(props), className)}
         style={dynamicInlineProps}
     >
-    {numberOfChildren >= 1 ? (
+    {((!isMultiple && children) || numberOfChildren >= 1 )? (
       children
     ) : (
       <Card

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -51,7 +51,7 @@ const Game = (props: LayoutGameProps) => {
         {isOdd && numberOfGames > 1  &&
           <div
               className="half_box"
-              style={{ height: `calc(${ratio} * 100% + 4px)` }}
+              style={{ height: `calc(${ratio}00% + 4px)` }}
           />
         }
       </div>

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import classnames from 'classnames'
+
+import { GlobalProps, globalProps, globalInlineProps } from '../../utilities/globalProps'
+
+import Card from '../../pb_card/_card'
+import SectionSeparator from '../../pb_section_separator/_section_separator'
+
+type LayoutGameProps = {
+  children: React.ReactNode[] | React.ReactNode,
+  className?: string,
+} & GlobalProps
+
+// Game component (modeled after Item)
+const Game = (props: LayoutGameProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+  
+  const numberOfChildren = Array.isArray(children) ? children.length : 0
+  
+  if (numberOfChildren === 2) {
+    const [firstChild, secondChild] = React.Children.toArray(children)
+  
+    if (React.isValidElement(firstChild) && React.isValidElement(secondChild)) { 
+    return (
+      <div
+          className={classnames('layout_game', globalProps(props), className)}
+          style={dynamicInlineProps}
+      >
+        <Card
+            marginY="xs"
+            padding="none"
+            shadow="deep"
+        >
+          <Card.Body padding="xs">{firstChild}</Card.Body>
+          <SectionSeparator />
+          <Card.Body padding="xs">{secondChild}</Card.Body>
+        </Card>
+      </div>
+      )
+    }
+  }
+  
+  return (
+    <div
+        className={classnames('layout_game', globalProps(props), className)}
+        style={dynamicInlineProps}
+    >
+    {numberOfChildren >= 1 ? (
+      children
+    ) : (
+      <Card
+          marginY="xs"
+          padding="none"
+          shadow="deep"
+      >
+        <Card.Body padding="xs">To be determined...</Card.Body>
+        <SectionSeparator />
+        <Card.Body padding="xs">To be determined...</Card.Body>
+      </Card>
+    )}
+    </div>
+  )
+}
+
+export default Game

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -9,14 +9,24 @@ import SectionSeparator from '../../pb_section_separator/_section_separator'
 type LayoutGameProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
+  numberOfRounds: number,
+  numberOfGames: number,
+  isOdd: boolean,
 } & GlobalProps
 
 // Game component (modeled after Item)
 const Game = (props: LayoutGameProps) => {
-  const { children, className } = props
+  const { children, className, numberOfRounds, numberOfGames, isOdd } = props
   const dynamicInlineProps = globalInlineProps(props)
   
   const numberOfChildren = Array.isArray(children) ? children.length : 0
+
+  let ratio = 0
+  let exponent
+  if (numberOfGames > 1) {
+    exponent = (numberOfRounds) - Math.log2(numberOfGames) - 1
+    ratio = 2 ** exponent
+  }
   
   if (numberOfChildren === 2) {
     const [firstChild, secondChild] = React.Children.toArray(children)
@@ -36,6 +46,12 @@ const Game = (props: LayoutGameProps) => {
           <SectionSeparator />
           <Card.Body padding="xs">{secondChild}</Card.Body>
         </Card>
+        {isOdd && numberOfGames > 1  &&
+          <div
+              className="half_box"
+              style={{ height: `calc(${ratio} * 100% + 4px)` }}
+          />
+        }
       </div>
       )
     }
@@ -59,6 +75,12 @@ const Game = (props: LayoutGameProps) => {
         <Card.Body padding="xs">To be determined...</Card.Body>
       </Card>
     )}
+      {isOdd && numberOfGames > 1  &&
+        <div
+            className="half_box"
+            style={{ height: `calc(${ratio} * 100% + 4px)` }}
+        />
+      }
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -44,12 +44,6 @@ const Game = (props: LayoutGameProps) => {
             padding="none"
             shadow="deep"
         >
-          {/* TODO: Remove these lines! */}
-          <div>numberOfRounds: {numberOfRounds}</div>
-          <div>numberOfGames: {numberOfGames}</div>
-          <div>ratio: {ratio}</div>
-          <div>exponent: {exponent}</div>
-          <div>height: {`calc(${ratio} * 100% + 4px)`}</div>
           <Card.Body padding="xs">{firstChild}</Card.Body>
           <SectionSeparator />
           <Card.Body padding="xs">{secondChild}</Card.Body>

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -19,9 +19,10 @@ const Game = (props: LayoutGameProps) => {
   const { children, className, numberOfRounds, numberOfGames, isOdd } = props
   const dynamicInlineProps = globalInlineProps(props)
   
+  const numberOfChildren = Array.isArray(children) ? children.length : 0
+  
   const isMultiple = Array.isArray(children)
-  const numberOfChildren = isMultiple ? children.length : 0
-
+  
   let ratio = 0
   let exponent
   if (numberOfGames > 1) {

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_game.tsx
@@ -44,6 +44,12 @@ const Game = (props: LayoutGameProps) => {
             padding="none"
             shadow="deep"
         >
+          {/* TODO: Remove these lines! */}
+          <div>numberOfRounds: {numberOfRounds}</div>
+          <div>numberOfGames: {numberOfGames}</div>
+          <div>ratio: {ratio}</div>
+          <div>exponent: {exponent}</div>
+          <div>height: {`calc(${ratio} * 100% + 4px)`}</div>
           <Card.Body padding="xs">{firstChild}</Card.Body>
           <SectionSeparator />
           <Card.Body padding="xs">{secondChild}</Card.Body>

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
@@ -24,12 +24,17 @@ export const RoundLabel = (props: LayoutRoundLabelProps) => {
 type LayoutRoundProps = {
   children: React.ReactNode[] | React.ReactNode,
   className?: string,
+  numberOfRounds: number,
 } & GlobalProps
 
 export const Round = (props: LayoutRoundProps) => {
-  const { children, className } = props
+  const { children, className, numberOfRounds } = props
   const dynamicInlineProps = globalInlineProps(props)
   const numberOfChildren = Array.isArray(children) ? children.length : 0
+
+  const childrenWithProps = Array.isArray(children) ? children.map((child, index) =>
+    React.isValidElement(child) ? React.cloneElement(child, { numberOfRounds, numberOfGames: numberOfChildren, isOdd: index % 2 === 0 }) : child
+  ) : children
 
   const rightConnectors = Array.from({ length: numberOfChildren / 2 }, (_, index) => (
     <div
@@ -38,15 +43,13 @@ export const Round = (props: LayoutRoundProps) => {
     />
   ))
 
-  const numberOfGamesClass = `games_${numberOfChildren}`
-
   return (
     <>
       <div
-          className={classnames('layout_round', globalProps(props), className, numberOfGamesClass)}
+          className={classnames('layout_round', globalProps(props), className)}
           style={dynamicInlineProps}
       >
-        {children}
+        {childrenWithProps}
       </div>
       <div className="connector_container">{rightConnectors}</div>
     </>

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
@@ -38,10 +38,7 @@ export const Round = (props: LayoutRoundProps) => {
     />
   ))
 
-  const numberOfGamesClass = 
-    numberOfChildren === 8 ? 'eight_games' :
-    numberOfChildren === 4 ? 'four_games' :
-    numberOfChildren === 2 ? 'two_games' : ''
+  const numberOfGamesClass = `games_${numberOfChildren}`
 
   return (
     <>

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
@@ -33,7 +33,7 @@ export const Round = (props: LayoutRoundProps) => {
   const numberOfChildren = Array.isArray(children) ? children.length : 0
 
   const childrenWithProps = Array.isArray(children) ? children.map((child, index) =>
-    React.isValidElement(child) ? React.cloneElement(child, { numberOfRounds, numberOfGames: numberOfChildren, isOdd: index % 2 === 0 }) : child
+    React.isValidElement(child) ? React.cloneElement(child, { numberOfRounds, numberOfGames: numberOfChildren, isOdd: index % 2 === 0, key: `child_${index}` }) : child
   ) : children
 
   const rightConnectors = Array.from({ length: numberOfChildren / 2 }, (_, index) => (

--- a/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
+++ b/playbook/app/pb_kits/playbook/pb_layout/subcomponents/_round.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import classnames from 'classnames'
+
+import { GlobalProps, globalProps, globalInlineProps } from '../../utilities/globalProps'
+
+type LayoutRoundLabelProps = {
+  children: React.ReactNode[] | React.ReactNode,
+  className?: string,
+} & GlobalProps
+
+export const RoundLabel = (props: LayoutRoundLabelProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+  return (
+    <div
+        className={classnames('layout_round_label', className)}
+        style={dynamicInlineProps}
+    >
+      {children}
+    </div>
+  )
+}
+
+type LayoutRoundProps = {
+  children: React.ReactNode[] | React.ReactNode,
+  className?: string,
+} & GlobalProps
+
+export const Round = (props: LayoutRoundProps) => {
+  const { children, className } = props
+  const dynamicInlineProps = globalInlineProps(props)
+  const numberOfChildren = Array.isArray(children) ? children.length : 0
+
+  const rightConnectors = Array.from({ length: numberOfChildren / 2 }, (_, index) => (
+    <div
+        className="right_connector"
+        key={`right_connector_${index}`}
+    />
+  ))
+
+  const numberOfGamesClass = 
+    numberOfChildren === 8 ? 'eight_games' :
+    numberOfChildren === 4 ? 'four_games' :
+    numberOfChildren === 2 ? 'two_games' : ''
+
+  return (
+    <>
+      <div
+          className={classnames('layout_round', globalProps(props), className, numberOfGamesClass)}
+          style={dynamicInlineProps}
+      >
+        {children}
+      </div>
+      <div className="connector_container">{rightConnectors}</div>
+    </>
+  )
+}


### PR DESCRIPTION
**What does this PR do?**
- Add a 'bracket' option for `layout` prop in React Layout kit
  - Display flex and scroll overflow
  - Pass numberOfRounds down to <Layout.Game />
- Add a <Layout.Round /> component
  - Flex column, justify-content: space-around
  - Add horizontal "right" lines by dividing by 2
  - Pass numberOfGames down to <Layout.Game />
- Add a <Layout.Game /> component
  - Take first and second child and separate by a section separator in a card
  - If there's nothing provided, show "To be determined..."
  - If one child or more than two children are provided, fill in
  - Add a "half box" based on numberOfRounds and numberOfGames
  - Flex grow
- Add a <Layout.RoundLabel /> component
  - Fill in any child
  - Default: display none, but on mobile, show
- Make responsiveness. On mobile, flex-direction: column


**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-03-20 at 10 35 17 AM](https://github.com/user-attachments/assets/db27cd43-304c-48e7-af16-d65cc025b2d2)
![Screenshot 2025-03-27 at 1 00 31 PM](https://github.com/user-attachments/assets/ef2d1190-be1c-47e1-bd34-4b457a6ba2ae)


**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/layout/react
2. Review the layout
3. Test on mobile


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.