### PR TITLE
[PLAY-1963] Icon Button onClick Handler

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon_button/_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_button/_icon_button.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react'
 import classnames from 'classnames'
-import { buildAriaProps, buildCss, buildDataProps } from '../utilities/props'
+import { buildAriaProps, buildCss, buildDataProps, noop } from '../utilities/props'
 import { globalProps } from '../utilities/globalProps'
 
 import Button from '../pb_button/_button'
@@ -17,6 +17,7 @@ type IconButtonProps = {
   id?: string,
   link?: string,
   newWindow?: boolean,
+  onClick?: React.MouseEventHandler<HTMLElement>,
   size?: IconSizes,
   target?: string,
   variant?: 'default' | 'link',
@@ -32,6 +33,7 @@ const IconButton = (props: IconButtonProps) => {
     id,
     link,
     newWindow = false,
+    onClick = noop,
     size = "2x",
     target,
     variant = "default",
@@ -53,6 +55,7 @@ const IconButton = (props: IconButtonProps) => {
           htmlType={htmlType}
           link={link}
           newWindow={newWindow}
+          onClick={onClick}
           target={target}
       >
         <Icon

--- a/playbook/app/pb_kits/playbook/pb_icon_button/docs/_icon_button_click.jsx
+++ b/playbook/app/pb_kits/playbook/pb_icon_button/docs/_icon_button_click.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import IconButton from '../../pb_icon_button/_icon_button'
+
+const IconButtonClick = (props) => (
+  <div>
+    <IconButton
+        {...props}
+        onClick={() => alert('Click!')}
+    />
+  </div>
+)
+
+export default IconButtonClick

--- a/playbook/app/pb_kits/playbook/pb_icon_button/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_icon_button/docs/example.yml
@@ -7,3 +7,4 @@ examples:
   react:
   - icon_button_default: Default
   - icon_button_sizes: Sizes
+  - icon_button_click: Click Handler

--- a/playbook/app/pb_kits/playbook/pb_icon_button/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_button/docs/index.js
@@ -1,2 +1,3 @@
 export { default as IconButtonDefault } from './_icon_button_default.jsx'
 export { default as IconButtonSizes } from './_icon_button_sizes.jsx'
+export { default as IconButtonClick } from './_icon_button_click.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Add onClick to Icon Button kit.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-03-20 at 3 32 52 PM](https://github.com/user-attachments/assets/ae6c18e3-7413-4b28-a835-aa8a7c33dcde)

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/icon_button/react
2. Check out the example

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.