### PR TITLE
[PLAY-1960] Button Kit: Fix Disable Prop on Danger Variant

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.scss
@@ -63,11 +63,6 @@ $pb_button_sizes: (
     color: $text_lt_lighter;
   }
 
-  // Disabled =================
-  &[class*=_disabled]  {
-    @include pb_button_disabled;
-  }
-
   // Block ====================
   &[class*=_block]  {
     @include pb_button_block;
@@ -81,6 +76,11 @@ $pb_button_sizes: (
   // Danger ===================
   &[class*=_danger] {
     @include pb_button_danger;
+  }
+
+  // Disabled =================
+  &[class*=_disabled]  {
+    @include pb_button_disabled;
   }
 
   // Dark Variants =============


### PR DESCRIPTION
Moved the disable code further down the file so it overrides the danger styles.

[PLAY-1960](https://runway.powerhrg.com/backlog_items/PLAY-1960)
[Review ENV]()
[CSB](https://codesandbox.io/p/devbox/disabled-button-forked-57vwhq?file=%2Fsrc%2FApp.js&workspaceId=ws_Ni9WCwV5jk56bH746ZU8Ee)