### PR TITLE
[PBNTR-881] Advanced Table kit: Full Screen Mode - React only

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -229,6 +229,53 @@
     max-height: 1920px;
     overflow-y: auto;
   }
+  
+  // Fullscreen
+  &.advanced-table-fullscreenable {
+    transition: all 0.3s ease;
+  }
+  
+  &.advanced-table-fullscreen {
+    background-color: $border_light;
+    box-sizing: border-box;
+    height: 100%;
+    left: 0;
+    overflow: auto;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: $z_10;
+
+    .pb_table {
+      th, td, div, button {
+        font-size: calc(100%);
+      }
+      box-sizing: border-box;
+      margin: $space_lg;
+      max-width: calc(100% - 64px);
+      width: calc(100% - 64px);
+    }
+
+    .pb_table.sticky-header {
+      thead,
+      .pb_advanced_table_header {
+        position: sticky !important;
+        top: 44px !important;
+        z-index: $z_10;
+      }
+    }
+  }
+  
+  .advanced-table-fullscreen-header {
+    background-color: $white;
+    height: 44px;
+    padding: 13px 20px;
+    position: sticky;
+    top: 0;
+    width: 100%;
+    z-index: $z_10;
+  }
+
   // Icons
   .button-icon {
     display: flex;
@@ -274,6 +321,16 @@
 
     &:focus-visible {
       border-radius: $border_rad_heavier;
+    }
+  }
+
+  .fullscreen-icon {
+    @extend .button-icon;
+    @extend %primary-color-pseudo;
+    padding: 2px 0;
+
+    &:focus-visible {
+      border-radius: $border_rad_lighter;
     }
   }
 
@@ -464,6 +521,18 @@
     .pb_table_td:first-child,
     .checkbox-cell.checkbox-cell-header:first-child {
       box-shadow: 1px 0px 0px 0px $border_dark !important;
+    }
+
+    // Fullscreen
+    &.advanced-table-fullscreen {
+      background: $border_dark;
+    }
+
+    .advanced-table-fullscreen-header {
+      background-color: $bg_dark_card;
+      position: sticky;
+      top: 0;
+      z-index: $z_10;
     }
 
     // Dark Mode Responsive Styles

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -499,3 +499,16 @@ test("customRenderer prop functions as expected", () => {
   const pill = kit.querySelector(".pb_pill_kit_success_lowercase")
   expect(pill).toBeInTheDocument()
 })
+
+test("fullscreenable prop adds fullscreen class", () => {
+  render(
+    <AdvancedTable
+        columnDefinitions={columnDefinitions}
+        fullscreenable
+        tableData={MOCK_DATA}
+    />
+  )
+
+  const tableContainer = screen.getByRole("table").closest("div")
+  expect(tableContainer).toHaveClass("advanced-table-fullscreenable")
+})

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.jsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react"
+import { AdvancedTable, Button, Flex } from "playbook-ui"
+import MOCK_DATA from "./advanced_table_mock_data.json"
+import PAGINATION_MOCK_DATA from "./advanced_table_pagination_mock_data.json"
+
+const AdvancedTableFullscreen = (props) => {
+  const [fullscreenToggleSmall, setFullscreenToggleSmall] = useState(null)
+  const [fullscreenToggleLarge, setFullscreenToggleLarge] = useState(null)
+
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance Rate",
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed Classes",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Class Completion Rate",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated Students",
+    },
+  ]
+
+  const tableProps = {
+    sticky: true
+  }
+
+  return (
+    <div>
+      <Flex justify="end">
+          <Button
+              marginBottom="sm"
+              onClick={() => fullscreenToggleSmall?.()}
+              text="Fullscreen Small Table"
+              variant="secondary"
+          />
+      </Flex>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          fullscreenable
+          getFullscreenControls={({ toggleFullscreen }) => setFullscreenToggleSmall(() => toggleFullscreen)}
+          tableData={MOCK_DATA}
+          {...props}
+      >
+          <AdvancedTable.Header enableSorting />
+          <AdvancedTable.Body />
+      </AdvancedTable>
+      <Flex justify="end">
+          <Button
+              marginY="sm"
+              onClick={() => fullscreenToggleLarge?.()}
+              text="Fullscreen Large Table"
+              variant="secondary"
+          />
+      </Flex>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          fullscreenable
+          getFullscreenControls={({ toggleFullscreen }) => setFullscreenToggleLarge(() => toggleFullscreen)}
+          responsive="none"
+          tableData={PAGINATION_MOCK_DATA}
+          tableProps={tableProps}
+          {...props}
+      >
+          <AdvancedTable.Header enableSorting />
+          <AdvancedTable.Body />
+      </AdvancedTable>
+    </div>
+  )
+}
+
+export default AdvancedTableFullscreen

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_fullscreen.md
@@ -1,0 +1,3 @@
+Trigger Fullscreen mode with the `fullscreenable`and `getFullscreenControls` props.  `fullscreenable` is a boolean that enables Fullscreen functionality for an Advanced Table. `getFullscreenControls` is a callback function that receives an object containing the table's internal `toggleFullscreen` function, allowing you to store and trigger Fullscreen from the parent component. An external trigger (like a button) must be used to activate Fullscreen mode.
+
+Exit Fullscreen mode by clicking the minimize top-right-corner icon or by pressing the "Escape" keyboard key.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -40,3 +40,4 @@ examples:
   - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
   - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
   - advanced_table_inline_editing: Inline Cell Editing
+  - advanced_table_fullscreen: Fullscreen

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -22,3 +22,4 @@ export { default as AdvancedTableSelectableRowsActions } from './_advanced_table
 export { default as AdvancedTableTablePropsStickyHeader } from './_advanced_table_table_props_sticky_header.jsx'
 export { default as AdvancedTableColumnHeadersCustomCell } from './_advanced_table_column_headers_custom_cell.jsx'
 export { default as AdvancedTableInlineEditing } from './_advanced_table_inline_editing.jsx'
+export { default as AdvancedTableFullscreen } from './_advanced_table_fullscreen.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-881](https://runway.powerhrg.com/backlog_items/PBNTR-881) brings the React Advanced Table Fullscreen mode to life. It is based off the [previous POC](https://huddle.powerapp.cloud/projects/647/artifacts/7838) in [PBNTR-818](https://runway.powerhrg.com/backlog_items/PBNTR-818) but modified to include design standards set in [NUX-4132](https://runway.powerhrg.com/backlog_items/NUX-4132) and account for the kit refactoring done in [PBNTR-866](https://github.com/powerhome/playbook/pull/4323).

The new look Fullscreen mode accounts for the following:
- Fullscreen mode is enabled by an external trigger only (NO internal icon) and can be exited via the minimize icon in the fullscreen header OR by pressing the Escape key on the keyboard (custom implementation, no longer using browser fullscreen API methods/properties).
- The fullscreen header is sticky and remains visible on top of a sticky header (see Large Table example). I have set the color of the header to match the default background for the table's rows (light and dark mode).
- The large size margin (32px) from the handoff surrounds the table in Fullscreen.
- The table and table content magnifies larger in Fullscreen.


**Screenshots:** Screenshots to visualize your addition/change
<img width="1346" alt="both tables" src="https://github.com/user-attachments/assets/147d192b-e600-4310-9c26-097f010b1e7f" />
<img width="1727" alt="small table fullscreen" src="https://github.com/user-attachments/assets/49b813e8-5bc0-4453-b568-8c62ab6d5d1c" />
<img width="1725" alt="large table fullscreen" src="https://github.com/user-attachments/assets/5744b620-ce37-4acd-ba94-1df68d50be0e" />
<img width="1726" alt="small table darkmode" src="https://github.com/user-attachments/assets/8d18f5e0-4fb4-4e71-8dba-52e3e6daa9f6" />
<img width="1313" alt="markdown" src="https://github.com/user-attachments/assets/ffd93085-0edc-4b68-9544-0855fafa5680" />

**How to test?** Steps to confirm the desired behavior:
1. Go to the React Advanced Table [Fullscreen doc example](link to come).
2. Click on the small table's fullscreen button to enter fullscreen mode.
3. When in fullscreen mode, interact with the table as you typically can (open rows/hit expand all toggles/change sort order). The header bar with the minimize icon should be at the top of the screen.
4. Click the minimize icon or press "Escape" on the keyboard to exit fullscreen mode.
5. Click on the large table's fullscreen button to enter fullscreen mode. 
6. Interact with the large table as above; additionally, observe that the sticky header remains in place underneath the fullscreen header when you scroll down the table.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.