### PR TITLE
[PLAY-1950] Playbook Website: Fix Incorrect Links on Getting Started Page

### DIFF
--- a/playbook-website/app/views/guides/_docs_index_list.html.erb
+++ b/playbook-website/app/views/guides/_docs_index_list.html.erb
@@ -5,7 +5,6 @@
   <%= pb_rails("layout", props: { layout: "collection", margin_y: "xl", padding_bottom: "xl" }) do %>
     <%= pb_rails("layout/body") do %>
       <% @navigation[:pages].each do |page_name| %>
-
         <% link_path = if missing_token_pages.include?(page_name[:page_id])
                          "/guides/tokens/#{page_name[:page_id]}"
                        elsif missing_global_pages.include?(page_name[:page_id])

--- a/playbook-website/app/views/guides/_docs_index_list.html.erb
+++ b/playbook-website/app/views/guides/_docs_index_list.html.erb
@@ -5,12 +5,13 @@
   <%= pb_rails("layout", props: { layout: "collection", margin_y: "xl", padding_bottom: "xl" }) do %>
     <%= pb_rails("layout/body") do %>
       <% @navigation[:pages].each do |page_name| %>
+
         <% link_path = if missing_token_pages.include?(page_name[:page_id])
                          "/guides/tokens/#{page_name[:page_id]}"
                        elsif missing_global_pages.include?(page_name[:page_id])
                          "/guides/global_props/#{page_name[:page_id]}"
                        else
-                         "/visual_guidelines/#{page_name[:page_id]}"
+                         "/#{page_name[:url]}"
                        end %>
         <%= link_to link_path, class: "display_flex align_items_stretch" do %>
           <%= pb_rails("card", props: { padding: "none", hover: { shadow: "deep" }, flex: 1 } ) do %>

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -205,4 +205,9 @@
       border-top-left-radius: 0;
     }
   }
+
+  .pb_text_input_kit.error + * input,
+  .pb_text_input_kit.error + * select {
+    border-left-color: $red;
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -205,9 +205,4 @@
       border-top-left-radius: 0;
     }
   }
-
-  .pb_text_input_kit.error + * input,
-  .pb_text_input_kit.error + * select {
-    border-left-color: $red;
-  }
 }


### PR DESCRIPTION
This fixes the links on the Getting Started Page. There is other logic on the page to account for missing token pages and missing global pages. None of that is being triggered currently on the page but I left it as is for now. Let me know if I should remove it.

[PLAY-1950](https://runway.powerhrg.com/backlog_items/PLAY-1950)
[Review ENV](https://pr4432.playbook.beta.px.powerapp.cloud/)