### PR TITLE
[PLAY-1758] Typeahead, Tooltip, User, UserBadge Kits: Convert to use Content Tag

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/tooltip.html.erb
@@ -1,7 +1,4 @@
-<%= content_tag(:div,
-      id: object.id,
-      data: object.data,
-      class: object.classname,
+<%= pb_content_tag(:div,
       style: remove_height_properties(combined_html_options[:style]) || "",
       **combined_html_options.except(:style)) do %>
   <div class="tooltip_tooltip" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.height_and_width_helper %>">

--- a/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.html.erb
@@ -1,11 +1,8 @@
 <% if object.is_react? %>
   <%= react_component('Typeahead', object.typeahead_react_options) %>
 <% else %>
-  <%= content_tag(:div,
-                id: object.id,
-                data: object.data,
-                class: object.classname + object.inline_class,
-                **combined_html_options) do %>
+  <%= pb_content_tag(:div,
+                     class: object.classname + object.inline_class) do %>
     <div class="pb_typeahead_wrapper">
       <div class="pb_typeahead_loading_indicator" data-pb-typeahead-kit-loading-indicator>
         <%= pb_rails("icon", props: {

--- a/playbook/app/pb_kits/playbook/pb_user/user.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_user/user.html.erb
@@ -1,9 +1,4 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <% if object.avatar_url.present? || object.avatar %>
     <%= pb_rails("avatar", props: {
       name: object.name,

--- a/playbook/app/pb_kits/playbook/pb_user_badge/user_badge.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_user_badge/user_badge.html.erb
@@ -1,8 +1,3 @@
-<%= content_tag(:div,
-    aria: object.aria,
-    class: object.classname,
-    data: object.data,
-    id: object.id,
-    **combined_html_options) do %>
+<%= pb_content_tag do %>
   <%= content_tag(:div, object.display_badge, class: "pb_user_badge_wrapper") %>
 <% end %>

--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -91,11 +91,11 @@ module Playbook
     # rubocop:disable Layout/CommentIndentation
     # pb_content_tag information (potentially to be abstracted into its own dev doc in the future)
     # The pb_content_tag generates HTML content tags for rails kits with flexible options.
-    # Modify a generated kit.html.erb file accordingly (the default_options listed below no longer need to be explictly outlined in that file, only modifications).
+    # Modify a generated kit.html.erb file accordingly (the kit_base_default_options listed below no longer need to be explictly outlined in that file, only modifications).
     # name - the first argument is for HTML tag. The default is :div.
     # content_or_options_with_block - additional content or options for the tag (i.e., the customizations a dev adds to kit.html.erb).
     # options - Within combined_options, the empty options hash allows for customizations to
-        # merge with the default_options and combined_html_options.
+        # merge with the kit_base_default_options and combined_html_options.
     # escape - set to true, this allows for HTML-escape.
     # block - an optional block for content inside the tag.
     # The return is a HTML tag that includes any provided customizations. If nothing is specified in kit.html.erb, the default shape is:
@@ -111,7 +111,7 @@ module Playbook
     def pb_content_tag(name = :div, content_or_options_with_block = {}, options = {}, escape = true, &block)
       combined_options = options
                          .merge(combined_html_options)
-                         .merge(default_options.merge(content_or_options_with_block))
+                         .merge(kit_base_default_options.merge(content_or_options_with_block))
       content_tag(name, combined_options, options, escape, &block)
     end
     # rubocop:enable Style/OptionalBooleanParameter
@@ -146,7 +146,7 @@ module Playbook
 
   private
 
-    def default_options
+    def kit_base_default_options
       options = {
         id: id,
         data: data,


### PR DESCRIPTION
Runway https://runway.powerhrg.com/backlog_items/PLAY-1758
Nitro Alpha https://github.com/powerhome/nitro-web/pull/47331

Updates kits to use `pb_content_tag` which is our own take on rail's `content_tag`

these kits: 

typeahead 
tooltip
user
user_badge