### PR TITLE
[PLAY-1942] Fullscreen Button - Advanced Table, Multi Level Select, and Drawer Examples

### DIFF
--- a/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
@@ -23,7 +23,8 @@
         <ul>
           <% if full_screen %>
             <li>
-              <%= pb_rails("button", props: { id: "fullscreen-#{example_key}", icon: "expand", text: "Fullscreen", classname: dark ? "dark" : "", variant: "link", size: "sm" }) %>
+              <%= pb_rails("button", props: { id: "fullscreen-open-#{example_key}", icon: "expand", text: "Fullscreen", classname: "hide_fullscreen#{' dark' if dark}", variant: "link", size: "sm" }) %>
+              <%= pb_rails("button", props: { id: "fullscreen-close-#{example_key}", icon: "arrow-down-left-and-arrow-up-right-to-center", text: "Fullscreen", classname: "hide_not_fullscreen#{' dark' if dark}", variant: "link", size: "sm" }) %>
             </li>
           <% end %>
           <% hide_button = type == "rails" ? 'flex' : 'none' %>
@@ -83,14 +84,17 @@
     })
   }
 
-  var fullscreenButton = document.getElementById('<%= "fullscreen-#{example_key}" %>')
-  if (fullscreenButton) {
-    fullscreenButton.addEventListener('click', function() {
-      if (document.fullscreenElement){
-        document.exitFullscreen()
-      } else {
-        document.getElementById('<%= "pb--doc-#{example_key}" %>').requestFullscreen()
-      }
+  var fullscreenOpenButton = document.getElementById('<%= "fullscreen-open-#{example_key}" %>')
+  if (fullscreenOpenButton) {
+    fullscreenOpenButton.addEventListener('click', function() {
+      document.getElementById('<%= "pb--doc-#{example_key}" %>').requestFullscreen()
+    })
+  }
+
+  var fullscreenCloseButton = document.getElementById('<%= "fullscreen-close-#{example_key}" %>')
+  if (fullscreenCloseButton) {
+    fullscreenCloseButton.addEventListener('click', function() {
+      document.exitFullscreen()
     })
   }
 </script>

--- a/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
@@ -1,6 +1,6 @@
 <% example_html = ERB.new(example).result %>
 
-<%= pb_rails("card", props: { classname: "pb--doc", padding: "none", dark: dark }) do %>
+<%= pb_rails("card", props: { classname: "pb--doc", padding: "none", dark: dark, id: "pb--doc-#{example_key}" }) do %>
   <% unless (type == "swift") %>
     <div class="pb--kit-example">
       <%= pb_rails("caption", props: { text: example_title, dark: dark }) %>
@@ -21,13 +21,18 @@
     <div id="code-wrapper">
       <div class="pb--codeControls">
         <ul>
+          <% if example_key == "drawer_menu" %>
+            <li>
+              <%= pb_rails("button", props: { id: "fullscreen-#{example_key}", icon: "expand", text: "Fullscreen", classname: dark ? "dark" : "", variant: "link", size: "sm" }) %>
+            </li>
+          <% end %>
           <% hide_button = type == "rails" ? 'flex' : 'none' %>
             <li>
-            <%= pb_rails("button", props: { id:"copy-html-#{example_key}", icon: "copy", text: "Copy HTML", classname: dark ? "dark" : "", variant: "link", size: "sm", display: hide_button }) %>
+            <%= pb_rails("button", props: { id:"copy-html-#{example_key}", icon: "copy", text: "Copy HTML", classname: "hide_fullscreen#{' dark' if dark}", variant: "link", size: "sm", display: hide_button }) %>
             </li>
           <li>
-            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-opened", classname: dark ? "dark" : "", text: "Close Code", variant: "link", size: "sm", display: "none" }) %>
-            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-closed", classname: dark ? "dark" : "", text: "Show Code", variant: "link", size: "sm" }) %>
+            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-opened", classname: "hide_fullscreen#{' dark' if dark}", text: "Close Code", variant: "link", size: "sm", display: "none" }) %>
+            <%= pb_rails("button", props: { icon: "code", id:"toggle-open-closed", classname: "hide_fullscreen#{' dark' if dark}", text: "Show Code", variant: "link", size: "sm" }) %>
           </li>
         </ul>
       </div>
@@ -75,6 +80,17 @@
       setTimeout(function() {
         fadeAwayDiv.classList.add('hide')
       }, 3001)
+    })
+  }
+
+  var fullscreenButton = document.getElementById('<%= "fullscreen-#{example_key}" %>')
+  if (fullscreenButton) {
+    fullscreenButton.addEventListener('click', function() {
+      if (document.fullscreenElement){
+        document.exitFullscreen()
+      } else {
+        document.getElementById('<%= "pb--doc-#{example_key}" %>').requestFullscreen()
+      }
     })
   }
 </script>

--- a/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.html.erb
@@ -21,7 +21,7 @@
     <div id="code-wrapper">
       <div class="pb--codeControls">
         <ul>
-          <% if example_key == "drawer_menu" %>
+          <% if full_screen %>
             <li>
               <%= pb_rails("button", props: { id: "fullscreen-#{example_key}", icon: "expand", text: "Fullscreen", classname: dark ? "dark" : "", variant: "link", size: "sm" }) %>
             </li>

--- a/playbook-website/app/components/playbook/pb_docs/kit_example.rb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.rb
@@ -60,6 +60,11 @@ module Playbook
         end
       end
 
+      def full_screen
+        full_screen_kits = ["drawer_menu"]
+        full_screen_kits.include?(example_key)
+      end
+
     private
 
       def exec_in_fork

--- a/playbook-website/app/components/playbook/pb_docs/kit_example.rb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.rb
@@ -61,7 +61,7 @@ module Playbook
       end
 
       def full_screen
-        full_screen_kits = %w[advanced_table]
+        full_screen_kits = %w[advanced_table multi_level_select]
         full_screen_kit_docs = %w[drawer_menu]
         full_screen_kits.include?(kit) || full_screen_kit_docs.include?(example_key)
       end

--- a/playbook-website/app/components/playbook/pb_docs/kit_example.rb
+++ b/playbook-website/app/components/playbook/pb_docs/kit_example.rb
@@ -61,8 +61,9 @@ module Playbook
       end
 
       def full_screen
-        full_screen_kits = ["drawer_menu"]
-        full_screen_kits.include?(example_key)
+        full_screen_kits = %w[advanced_table]
+        full_screen_kit_docs = %w[drawer_menu]
+        full_screen_kits.include?(kit) || full_screen_kit_docs.include?(example_key)
       end
 
     private

--- a/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
@@ -143,4 +143,10 @@
       }
     }
   }
+
+  &:fullscreen {
+    .hide_fullscreen {
+      display: none;
+    }
+  }
 }

--- a/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
@@ -146,7 +146,7 @@
 
   &:fullscreen {
     .hide_fullscreen {
-      display: none;
+      display: none !important;
     }
   }
 }

--- a/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
@@ -145,6 +145,8 @@
   }
 
   &:fullscreen {
+    overflow: auto;
+
     .hide_fullscreen {
       display: none !important;
     }

--- a/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_kit_doc.scss
@@ -144,8 +144,16 @@
     }
   }
 
+  .hide_not_fullscreen {
+    display: none !important;
+  }
+
   &:fullscreen {
     overflow: auto;
+
+    .hide_not_fullscreen {
+      display: block !important;
+    }
 
     .hide_fullscreen {
       display: none !important;


### PR DESCRIPTION
**What does this PR do?**

- Add a fullscreen button that uses `requestFullscreen()`
- Add an id to wrapping card to be targeted for fullscreen
- Add to all Advanced Table and Multi Level Select kits as well as one of the Drawer Menu examples
- Hide the "Show Code" and "Copy HTML" buttons when in fullscreen
- Be able to scroll if the example goes farther than the screen

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-03-31 at 11 26 53 AM](https://github.com/user-attachments/assets/b999701a-5f78-4077-a88f-fbac676ed7a4)

**How to test?** Steps to confirm the desired behavior:
1. For Advanced Table and Multi Level Select docs:
2. Click Fullscreen
3. Exit
4. Look at rails and react. 
5. Also, look at the drawer kit for the "menu" example
6. Other kit docs should not have the fullscreen button


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.