### PR TITLE
[PLAY-319] Remove Font Awesome from Tests

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -338,8 +338,8 @@ test("enableExpansionIcon changes icon", () => {
 
   const kit = screen.getByTestId(testId)
   const tableHead = kit.querySelector('table')
-  const toggleIcon= tableHead.querySelector(".pb_icon_kit")
-  expect(toggleIcon).toHaveClass("fa-chevron-up")
+  const toggleIcon = tableHead.querySelector(".pb_custom_icon")
+  expect(toggleIcon).toBeInTheDocument()
 })
 
 test("sortIcon changes icon", () => {
@@ -360,8 +360,8 @@ test("sortIcon changes icon", () => {
 
   const kit = screen.getByTestId(testId)
   const sortIcon = kit.querySelector('.sort-button-icon')
-  const icon= sortIcon.querySelector(".pb_icon_kit")
-  expect(icon).toHaveClass("fa-chevron-down")
+  const icon = sortIcon.querySelector(".pb_custom_icon")
+  expect(icon).toBeInTheDocument()
 })
 
 test("Sort icon renders with enableSorting + sortControl works as expected", () => {
@@ -452,7 +452,7 @@ test("inlineRowLoading prop renders inline loading if true", () => {
   const rowButton = kit.querySelector(".gray-icon.expand-toggle-icon")
   expect(rowButton).toBeInTheDocument()
   rowButton.click()
-  const inlineLoading = kit.querySelector(".fa-spinner")
+  const inlineLoading = kit.querySelector(".pb_custom_icon")
   expect(inlineLoading).toBeInTheDocument()
 })
 

--- a/playbook/app/pb_kits/playbook/pb_collapsible/__snapshots__/collapsible.test.js.snap
+++ b/playbook/app/pb_kits/playbook/pb_collapsible/__snapshots__/collapsible.test.js.snap
@@ -27,13 +27,20 @@ exports[`html structure is correct 1`] = `
               class="icon_wrapper"
               style="vertical-align: middle; color: rgb(193, 205, 214);"
             >
-              <i
-                class="pb_icon_kit far fa-lg fa-fw fa-lg fa-chevron-down"
-              />
-              <span
-                aria-label="chevron-down icon"
-                hidden=""
-              />
+              <svg
+                class="pb_custom_icon svg-inline--fa svg_lg svg_fw"
+                color="currentColor"
+                fill="none"
+                height="auto"
+                viewBox="0 0 30 25"
+                width="auto"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M14.203 19.297l-9-9c-.469-.422-.469-1.125 0-1.594.422-.422 1.125-.422 1.594 0L15 16.953l8.203-8.203c.422-.469 1.125-.469 1.594 0a1.103 1.103 0 010 1.547l-9.047 9a1.027 1.027 0 01-1.547 0z"
+                  fill="#242B42"
+                />
+              </svg>
             </div>
           </div>
         </div>

--- a/playbook/app/pb_kits/playbook/pb_contact/contact.test.js
+++ b/playbook/app/pb_kits/playbook/pb_contact/contact.test.js
@@ -75,15 +75,15 @@ test('returns correct icon', () => {
     </>
   )
 
-  expect(screen.getByTestId('test-cell').querySelector('.pb_icon_kit')).toHaveClass('fa-mobile')
-  expect(screen.getByTestId('test-home').querySelector('.pb_icon_kit')).toHaveClass('fa-phone')
+  expect(screen.getByTestId('test-cell').querySelector('.pb_custom_icon')).toBeInTheDocument()
+  expect(screen.getByTestId('test-home').querySelector('.pb_custom_icon')).toBeInTheDocument()
   expect(screen.getByTestId('test-work').querySelector('.pb_icon_kit')).toHaveClass('fa-phone-office')
-  expect(screen.getByTestId('test-work-cell').querySelector('.pb_icon_kit')).toHaveClass('fa-phone-laptop')
-  expect(screen.getByTestId('test-email').querySelector('.pb_custom_icon')).toHaveClass('envelope')
-  expect(screen.getByTestId('test-wrong-phone').querySelector('.pb_icon_kit')).toHaveClass('fa-phone-slash')
-  expect(screen.getByTestId('test-wrong-type').querySelector('.pb_icon_kit')).toHaveClass('fa-phone')
+  expect(screen.getByTestId('test-work-cell').querySelector('.pb_custom_icon')).toBeInTheDocument()
+  expect(screen.getByTestId('test-email').querySelector('.pb_custom_icon')).toBeInTheDocument()
+  expect(screen.getByTestId('test-wrong-phone').querySelector('.pb_custom_icon')).toBeInTheDocument()
+  expect(screen.getByTestId('test-wrong-type').querySelector('.pb_custom_icon')).toBeInTheDocument()
   expect(screen.getByTestId('test-extension').querySelector('.pb_icon_kit')).toHaveClass('fa-phone-plus')
-  expect(screen.getByTestId('test-empty').querySelector('.pb_icon_kit')).toHaveClass('fa-phone')
+  expect(screen.getByTestId('test-empty').querySelector('.pb_custom_icon')).toBeInTheDocument()
 })
 
 test("not compliant values return null in phone related contact types", () => {

--- a/playbook/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_range_inline/date_range_inline.test.js
@@ -62,7 +62,7 @@ describe("DateRangeInline Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        const arrow = kit.querySelector('.pb_icon_kit.fa-fw.fa-long-arrow-right')
+        const arrow = kit.querySelector('.pb_custom_icon')
         expect(arrow).toBeInTheDocument()
     })
 
@@ -93,7 +93,7 @@ describe("DateRangeInline Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        const calendar = kit.querySelector('.pb_icon_kit.fa-fw.fa-calendar-alt')
+        const calendar = kit.querySelector('.pb_custom_icon')
         expect(calendar).toBeInTheDocument()
     })
 

--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/date_range_stacked.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/date_range_stacked.test.js
@@ -58,7 +58,7 @@ describe("DateRangeStacked Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        const arrowicon = kit.querySelector('.pb_icon_kit.fa-fw.pb_date_range_stacked_arrow')
+        const arrowicon = kit.querySelector('.pb_custom_icon')
         expect(arrowicon).toBeInTheDocument()
     })
 

--- a/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_draggable/draggable.test.jsx
@@ -165,7 +165,7 @@ test("generated dragHandle with List", () => {
 
   const list = kit.querySelector(".pb_list_kit");
   expect(list).toBeInTheDocument();
-  const dragHandle = list.querySelector(".fa-grip-dots-vertical");
+  const dragHandle = list.querySelector(".pb_custom_icon");
   expect(dragHandle).toBeInTheDocument();
 });
 
@@ -175,7 +175,7 @@ test("generated dragHandle with SelectableList", () => {
 
   const selectabellist = kit.querySelector(".pb_selectable_list_kit");
   expect(selectabellist).toBeInTheDocument();
-  const dragHandle = selectabellist.querySelector(".fa-grip-dots-vertical");
+  const dragHandle = selectabellist.querySelector(".pb_custom_icon");
   expect(dragHandle).toBeInTheDocument();
 });
 
@@ -185,6 +185,6 @@ test("generated dragHandle with Card", () => {
 
   const card = kit.querySelector(".pb_card_kit_deselected_border_radius_md");
   expect(card).toBeInTheDocument();
-  const dragHandle = card.querySelector(".fa-grip-dots-vertical");
+  const dragHandle = card.querySelector(".pb_custom_icon");
   expect(dragHandle).toBeInTheDocument();
 });

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -95,7 +95,7 @@ test('generated customDisplay for trigger', () => {
 
   const kit = screen.getByTestId(testId)
   const trigger = kit.querySelector('.pb_dropdown_trigger')
-  const customDisplay = trigger.querySelector('.fa-flag.pb_icon_kit.fa-fw')
+  const customDisplay = trigger.querySelector('.pb_custom_icon')
   expect(customDisplay).toBeInTheDocument()
 })
 
@@ -170,7 +170,7 @@ test('generated custom Trigger', () => {
         options={options}
     >
       <Dropdown.Trigger>
-          <Icon icon="elephant" />
+          <Icon icon="flag" />
       </Dropdown.Trigger>
       {options.map((option) => (
       <Dropdown.Option key={option.id} 
@@ -182,7 +182,7 @@ test('generated custom Trigger', () => {
 
   const kit = screen.getByTestId(testId)
   const trigger = kit.querySelector('.pb_dropdown_trigger')
-  const customTrigger = trigger.querySelector('.fa-elephant.pb_icon_kit.fa-fw')
+  const customTrigger = trigger.querySelector('.pb_custom_icon')
   expect(customTrigger).toBeInTheDocument()
 })
 

--- a/playbook/app/pb_kits/playbook/pb_icon/icon.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon/icon.test.js
@@ -16,7 +16,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("fa-user pb_icon_kit fa-fw far")
+        expect(kit).toHaveClass("pb_custom_icon svg-inline--fa svg_fw")
     })
 
     test("renders rotate prop", () => {[
@@ -31,7 +31,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass(`fa-user pb_icon_kit fa-fw fa-rotate-${rotateProp} far`)
+        expect(kit).toHaveClass(`pb_custom_icon svg-inline--fa rotate_${rotateProp} svg_fw`)
 
         cleanup()
     })
@@ -48,7 +48,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("fa-user pb_icon_kit fa-fw fa-flip-horizontal far")
+        expect(kit).toHaveClass("pb_custom_icon svg-inline--fa flip_horizontal svg_fw")
     })
 
 
@@ -63,7 +63,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("fa-spinner pb_icon_kit fa-fw fa-spin far")
+        expect(kit).toHaveClass("pb_custom_icon svg-inline--fa spin svg_fw")
     })
 
     test("renders pull icon", () => {
@@ -77,7 +77,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("fa-arrow-left pb_icon_kit fa-fw fa-pull-left far")
+        expect(kit).toHaveClass("pb_custom_icon svg-inline--fa svg_fw pull_left")
     })
 
     test("renders pull icon", () => {
@@ -91,7 +91,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("fa-arrow-left pb_icon_kit fa-fw fa-pull-left far")
+        expect(kit).toHaveClass("pb_custom_icon svg-inline--fa svg_fw pull_left")
     })
 
     test("renders border around icon", () => {
@@ -105,7 +105,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("fa-user pb_icon_kit fa-border fa-fw far")
+        expect(kit).toHaveClass("pb_custom_icon svg-inline--fa svg_border svg_fw")
     })
 
     test("renders size prop", () => {
@@ -132,7 +132,7 @@ describe("Icon Kit", () => {
             )
     
             const kit = screen.getByTestId(testId)
-            expect(kit).toHaveClass(`pb_icon_kit fa-user fa-fw fa-${sizeProp} far`)
+            expect(kit).toHaveClass(`pb_custom_icon svg-inline--fa svg_${sizeProp} svg_fw`)
 
             cleanup()
         }) 
@@ -149,7 +149,7 @@ describe("Icon Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        expect(kit).toHaveClass("fa-user pb_icon_kit fa-fw fas")
+        expect(kit).toHaveClass("pb_custom_icon svg-inline--fa svg_fw")
     })
 
     test("renders with color prop", () => {

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/icon_circle.test.js
@@ -29,7 +29,7 @@ describe("IconCircle Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        const icon = kit.querySelector('.pb_icon_kit')
+        const icon = kit.querySelector('.pb_custom_icon')
         expect(icon).toBeInTheDocument()
     })
 

--- a/playbook/app/pb_kits/playbook/pb_icon_stat_value/icon_stat_value.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_stat_value/icon_stat_value.test.js
@@ -33,7 +33,7 @@ describe("IconStatValue Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        const icon = kit.querySelector(".fa-lightbulb-on.pb_icon_kit.fa-fw")
+        const icon = kit.querySelector(".pb_custom_icon")
         expect(icon).toBeInTheDocument()
     })
 

--- a/playbook/app/pb_kits/playbook/pb_icon_value/icon_value.test.js
+++ b/playbook/app/pb_kits/playbook/pb_icon_value/icon_value.test.js
@@ -29,7 +29,7 @@ describe("IconValue Kit", () => {
         )
 
         const kit = screen.getByTestId(testId)
-        const icon = kit.querySelector(".fa-clipboard.pb_icon_kit.fa-fw")
+        const icon = kit.querySelector(".pb_custom_icon")
         expect(icon).toBeInTheDocument()
     })
 

--- a/playbook/app/pb_kits/playbook/pb_label_value/label_value.test.js
+++ b/playbook/app/pb_kits/playbook/pb_label_value/label_value.test.js
@@ -56,7 +56,7 @@ describe("LabelValue Kit", () => {
             />
         )
         const kit = screen.getByTestId(testId)
-        const icon = kit.querySelector(".fa-truck.pb_icon_kit.fa-fw")
+        const icon = kit.querySelector(".pb_custom_icon")
         expect(icon).toBeInTheDocument()
     })
 

--- a/playbook/app/pb_kits/playbook/pb_link/link.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_link/link.test.jsx
@@ -73,7 +73,7 @@ test('adds icon', () => {
 
   const kit = screen.getByTestId('icon-test')
 
-  const icon = kit.querySelector('.pb_icon_kit')
+  const icon = kit.querySelector('.pb_custom_icon')
   expect(icon).toBeInTheDocument();
 })
 
@@ -87,7 +87,7 @@ test('adds icon right', () => {
 
   const kit = screen.getByTestId('icon-right-test')
 
-  const icon = kit.querySelector('.pb_icon_kit')
+  const icon = kit.querySelector('.pb_custom_icon')
   expect(icon).toBeInTheDocument();
 })
 

--- a/playbook/app/pb_kits/playbook/pb_nav/_nav_item.test.js
+++ b/playbook/app/pb_kits/playbook/pb_nav/_nav_item.test.js
@@ -95,11 +95,13 @@ test('should not have a left border', () => {
 test('should have a right icon', () => {
     render(<NavDefault iconRight="angle-down" />)
     const kit = screen.getByTestId(itemTestId)
-    expect(kit).toContainHTML('<i class="pb_icon_kit far pb_nav_list_item_icon_right fa-fw fa-angle-down" />')
+    const icon = kit.querySelector(".pb_custom_icon.pb_nav_list_item_icon_right")
+    expect(icon).toBeInTheDocument()
 })
 
 test('should have a left icon', () => {
-    render(<NavDefault iconLeft="users-class" />)
+    render(<NavDefault iconLeft="angle-up" />)
     const kit = screen.getByTestId(itemTestId)
-    expect(kit).toContainHTML('<i class="pb_icon_kit far pb_nav_list_item_icon_left fa-fw fa-users-class" />')
+    const icon = kit.querySelector(".pb_custom_icon.pb_nav_list_item_icon_left")
+    expect(icon).toBeInTheDocument()
 })

--- a/playbook/app/pb_kits/playbook/pb_stat_change/stat_change.test.js
+++ b/playbook/app/pb_kits/playbook/pb_stat_change/stat_change.test.js
@@ -19,23 +19,27 @@ test('it renders preset icon', () => {
     render(
       <StatChange
           change="increase"
+          id="preset-icon"
           value="28.4"
       />
     )
 
-    const kit = screen.getByLabelText('arrow-up icon')
-    expect(kit).toBeTruthy
+    const kit = document.querySelector('#preset-icon')
+    const icon = kit.querySelector(".pb_custom_icon")
+    expect(icon).toBeInTheDocument()
 })
 
 test('it renders custom icon', () => {
     render(
       <StatChange
           icon="chart-line-down"
+          id="custom-icon"
           value={6.1}
       />
 
     )
 
-    const kit = screen.getByLabelText('chart-line-down icon')
-    expect(kit).toBeTruthy
+    const kit = document.querySelector('#custom-icon')
+    const icon = kit.querySelector(".pb_custom_icon")
+    expect(icon).toBeInTheDocument()
 })

--- a/playbook/jest.setup.js
+++ b/playbook/jest.setup.js
@@ -1,9 +1,26 @@
 import '@testing-library/jest-dom';
 import failOnConsole from 'jest-fail-on-console'
 
+import * as icons from "@powerhome/playbook-icons-react"
+
 failOnConsole()
 
 // or with options:
 failOnConsole({
   shouldFailOnWarn: false,
+})
+
+window.PB_ICONS = {}
+
+function pascalToKebabCase(str) {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/([a-zA-Z])([0-9])/g, '$1-$2')
+    .replace(/([0-9])([a-zA-Z])/g, '$1-$2')
+    .toLowerCase(); 
+}
+
+Object.entries(icons).forEach(([key, value]) => {
+  const iconName = pascalToKebabCase(key)
+  window.PB_ICONS[iconName] = value
 })

--- a/playbook/spec/pb_kits/playbook/kits/icon_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/icon_spec.rb
@@ -75,18 +75,17 @@ RSpec.describe Playbook::PbIcon::Icon do
       rotation = 90
       size = "sm"
 
-      expect(subject.new(icon: icon, border: true, fixed_width: false).classname).to eq "pb_icon_kit far fa-user fa-border"
-      expect(subject.new(icon: icon).classname).to eq "pb_icon_kit far fa-user fa-fw"
-      expect(subject.new(icon: icon, flip: "horizontal").classname).to eq "pb_icon_kit far fa-user fa-fw fa-flip-horizontal"
-      expect(subject.new(icon: icon).classname).to eq "pb_icon_kit far fa-user fa-fw"
-      expect(subject.new(icon: icon, inverse: true).classname).to eq "pb_icon_kit far fa-user fa-fw fa-inverse"
-      expect(subject.new(icon: icon, list_item: true).classname).to eq "pb_icon_kit far fa-user fa-fw fa-li"
-      expect(subject.new(icon: icon, pull: pull).classname).to eq "pb_icon_kit far fa-user fa-fw fa-pull-#{pull}"
-      expect(subject.new(icon: icon, pulse: true).classname).to eq "pb_icon_kit far fa-user fa-fw fa-pulse"
-      expect(subject.new(icon: icon, rotation: rotation).classname).to eq "pb_icon_kit far fa-user fa-fw fa-rotate-#{rotation}"
-      expect(subject.new(icon: icon, size: size).classname).to eq "pb_icon_kit far fa-user fa-fw fa-#{size}"
-      expect(subject.new(icon: icon, spin: true).classname).to eq "pb_icon_kit far fa-user fa-fw fa-spin"
-      expect(subject.new(icon: icon, classname: "additional_class").classname).to eq "pb_icon_kit far fa-user fa-fw additional_class"
+      expect(subject.new(icon: icon).classname).to include("user")
+      expect(subject.new(icon: icon, border: true, fixed_width: false).classname).to include("border")
+      expect(subject.new(icon: icon, flip: "horizontal").classname).to include("horizontal")
+      expect(subject.new(icon: icon, inverse: true).classname).to include("inverse")
+      expect(subject.new(icon: icon, list_item: true).classname).to include("li")
+      expect(subject.new(icon: icon, pull: pull).classname).to include("pull", pull)
+      expect(subject.new(icon: icon, pulse: true).classname).to include("pulse")
+      expect(subject.new(icon: icon, rotation: rotation).classname).to include("rotate", "90")
+      expect(subject.new(icon: icon, size: size).classname).to include(size)
+      expect(subject.new(icon: icon, spin: true).classname).to include("spin")
+      expect(subject.new(icon: icon, classname: "additional_class").classname).to include("additional_class")
     end
     it "includes color class when color prop is provided", :aggregate_failures do
       icon = "user"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
- In React/Jest tests, add Playbook Icons to window so custom icons are used
  - Replace Font Awesome icon classes with Playbook Icon classes
- In Rails/Spec Icon test, test for variations instead of exact Font Awesome class names. 

**How to test?** Steps to confirm the desired behavior:
The build for this PR should pass CI. 

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.