### PR TITLE
[PBNTR-953] Vertical Section Separator Documentation

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_vertical.md
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_section_separator_vertical.md
@@ -1,0 +1,1 @@
+To guarantee the vertical section separator displays properly, please add the `vertical: "stretch"`/`vertical="stretch"` property to the parent container (which is commonly a Flex container). This will stretch the container’s child elements vertically and ensure the section separator appears as expected.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBNTR-953](https://runway.powerhrg.com/backlog_items/PBNTR-953) requests the addition of clarifying markdown text to the Rails and React vertical section separator doc example. The requirement for `vertical: "stretch"`/`vertical="stretch"` in the parent container is exhibited in the doc example but not explained or highlighted. A Nitro dev expressed confusion figuring out how to get a Vertical Section Separator to work in a Playbook support room and we figured it would make sense to make this "hidden" requirement more explicit.


**Screenshots:** Screenshots to visualize your addition/change
<img width="1345" alt="rails" src="https://github.com/user-attachments/assets/ca433ced-a24a-4504-9674-93fe1b844553" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Vertical Separator doc example ([rails](https://pr4474.playbook.beta.gm.powerapp.cloud/kits/section_separator#vertical) or [react](https://pr4474.playbook.beta.gm.powerapp.cloud/kits/section_separator/react#vertical)).
2. See markdown text added.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~