### PR TITLE
[PLAY-2063] From Group: Phone Number Input and Select with Select on the Right

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -85,8 +85,16 @@
     .text_input_wrapper input, [class^=pb_text_input_kit] .text_input_wrapper .text_input {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
-      border-right-width: 0;
+      border-right-color: transparent;
     }
+    [class^=pb_text_input_kit] .text_input_wrapper input:focus,
+    [class^=pb_text_input_kit] .text_input_wrapper .text_input:focus {
+      border-right-color: $primary;
+    } 
+    [class^=pb_text_input_kit].error .text_input_wrapper input,
+    [class^=pb_text_input_kit].error .text_input_wrapper .text_input {
+      border-right-color: $error;
+    }   
   }
 
   & > [class^=pb_phone_number_input]:not(:first-child) {
@@ -107,7 +115,7 @@
     .text_input {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
-      border-right: none;
+      border-right-color: transparent;
     }
   }
 

--- a/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_form_group.scss
@@ -117,6 +117,14 @@
       border-top-right-radius: 0;
       border-right-color: transparent;
     }
+    [class^=pb_text_input_kit] .text_input_wrapper input:focus,
+    [class^=pb_text_input_kit] .text_input_wrapper .text_input:focus {
+      border-right-color: $primary;
+    } 
+    [class^=pb_text_input_kit].error .text_input_wrapper input,
+    [class^=pb_text_input_kit].error .text_input_wrapper .text_input {
+      border-right-color: $error;
+    }  
   }
 
   &[class*=rails] > [class^=pb_date_picker_kit] {

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.html.erb
@@ -1,5 +1,4 @@
-<div>
-
+<%= pb_rails("flex", props: {orientation: "column", row_gap:"md"}) do %>
   <%= pb_rails("form_group") do %>
     <%= pb_rails("text_input", props: { placeholder: "Enter Artist Name" }) %>
     <%= pb_rails("select", props: {
@@ -17,8 +16,6 @@
       ]
     }) %>
   <% end %>
-  <br>
-  <br>
   <%= pb_rails("form_group") do %>
     <%= pb_rails("select", props: {
         blank_selection: "Phone",
@@ -32,8 +29,6 @@
         id: "phone"
     }) %>
   <% end %>
-  <br>
-  <br>
   <%= pb_rails("form_group") do %>
       <%= pb_rails("phone_number_input", props: {
         id: "phone2"
@@ -47,4 +42,4 @@
         ]
       }) %>
   <% end %>
-</div>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.html.erb
@@ -32,4 +32,19 @@
         id: "phone"
     }) %>
   <% end %>
+  <br>
+  <br>
+  <%= pb_rails("form_group") do %>
+      <%= pb_rails("phone_number_input", props: {
+        id: "phone2"
+      }) %>
+      <%= pb_rails("select", props: {
+        blank_selection: "Phone",
+        options: [
+          { value: "Cell" },
+          { value: "Work" },
+          { value: "Home" },
+        ]
+      }) %>
+  <% end %>
 </div>

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.jsx
@@ -4,6 +4,7 @@ import FormGroup from '../_form_group'
 import PhoneNumberInput from '../../pb_phone_number_input/_phone_number_input'
 import Select from '../../pb_select/_select'
 import TextInput from '../../pb_text_input/_text_input'
+import Flex from '../../pb_flex/_flex'
 
 const FormGroupSelect = (props) => {
   const options = [
@@ -25,7 +26,10 @@ const FormGroupSelect = (props) => {
   ]
 
   return (
-    <div>
+    <Flex 
+        orientation="column" 
+        rowGap="md"
+    >
       <FormGroup>
         <TextInput
             placeholder="Enter Artist Name"
@@ -37,29 +41,29 @@ const FormGroupSelect = (props) => {
             {...props}
         />
       </FormGroup>
-      <br />
-      <br />
       <FormGroup>
         <Select
             blankSelection="Phone"
             options={phoneOptions}
-            />
+            {...props}
+        />
         <PhoneNumberInput
             id='default'
+            {...props}
         />
     </FormGroup>
-    <br />
-    <br />
     <FormGroup>
       <PhoneNumberInput
           id='default-2'
+          {...props}
       />
       <Select
           blankSelection="Phone"
           options={phoneOptions}
+          {...props}
       />
     </FormGroup>
-    </div>
+    </Flex>
   )
 }
 

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.jsx
@@ -48,6 +48,17 @@ const FormGroupSelect = (props) => {
             id='default'
         />
     </FormGroup>
+    <br />
+    <br />
+    <FormGroup>
+      <PhoneNumberInput
+          id='default-2'
+      />
+      <Select
+          blankSelection="Phone"
+          options={phoneOptions}
+      />
+    </FormGroup>
     </div>
   )
 }


### PR DESCRIPTION
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2063)

Styling fixes for active and error states for the Phone Number Input kit when used in a FormGroup with a Select on the right instead of the left.

![Screenshot 2025-04-16 at 4 31 20 PM](https://github.com/user-attachments/assets/5aa61bd7-2c36-4e46-a651-e74c4b0549de)

![Screenshot 2025-04-16 at 4 36 47 PM](https://github.com/user-attachments/assets/32746a6f-6bf8-4554-8573-d0b97c5ae5c7)
