### PR TITLE
[PLAY-2035] Dialog kit: Add Turbo support

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -28,7 +28,7 @@ kits:
     status: stable
     icons_used: true
     react_rendered: false
-    enhanced_element_used: false
+    enhanced_element_used: true
   - name: fixed_confirmation_toast
     platforms: *1
     description: Fixed Confirmation Toast is used as an alert. Success is used when

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -1,7 +1,16 @@
 <div
     class="pb_dialog_wrapper_rails <%= object.full_height_style %>"
     data-pb-dialog-wrapper="true"
-    data-overlay-click= <%= object.overlay_close %>
+    data-overlay-click="<%= object.overlay_close %>"
+    <% if object.custom_event_type.present? %>
+        data-custom-event-type="<%= object.custom_event_type %>"
+    <% end %>
+    <% if object.confirm_button_id.present? %>
+        data-confirm-button-id="<%= object.confirm_button_id %>"
+    <% end %>
+    <% if object.cancel_button_id.present? %>
+        data-cancel-button-id="<%= object.cancel_button_id %>"
+    <% end %>
 >
     <%= pb_content_tag(:dialog) do %>
             <% if object.status === "" && object.title %>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.rb
@@ -21,6 +21,8 @@ module Playbook
       prop :status, type: Playbook::Props::Enum,
                     values: ["info", "caution", "delete", "error", "success", "default", ""],
                     default: ""
+      prop :custom_event_type, type: Playbook::Props::String,
+                               default: ""
 
       def classname
         generate_classname("pb_dialog pb_dialog_rails pb_dialog_#{size}_#{placement}")

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_turbo_frames.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_turbo_frames.html.erb
@@ -1,0 +1,117 @@
+<%= pb_rails("flex", props:{ gap: "xs", wrap:true}) do %>
+    <%= pb_rails("button", props: { id: "button-open-example-turbo-frames", margin_right: "md", text: "Open Dialog via Custom Event" }) %>
+    <%= pb_rails("button", props: { id: "open-dialog-button", data: { open_dialog: "dialog-confirm-turbo-frames" }, margin_right: "md", text: "Custom Event Linked to Confirm Button" }) %>
+    <%= pb_rails("button", props: { id: "button-open-multi-dialog", text: "Mutliple Events Example" }) %>
+<% end %>
+
+<!-- Example 1: Basic dialog with custom event opening -->
+<%= pb_rails("dialog", props: { 
+  id: "dialog-open-turbo-frames", 
+  title: "Click Event Simulation", 
+  text: "Demonstrating Opening the Dialog with a Custom Event.",
+  custom_event_type: "dialogOpen",
+  cancel_button: "Cancel Button",
+  confirm_button: "Okay", 
+  confirm_button_id: "confirm-button-turbo-frames"
+}) %>
+
+<script>
+    document.getElementById("button-open-example-turbo-frames").addEventListener("click", () => {
+        console.log("📣 Dispatching 'dialogOpen' custom event")
+
+        window.dispatchEvent(new CustomEvent("dialogOpen", { 
+            bubbles: true,
+            detail: { 
+                dialogId: "dialog-open-turbo-frames",
+                action: "open"
+            }
+        }))
+
+        console.log("✅ Custom event dispatched - dialog should open")
+    })
+</script>
+
+<!-- Example 2: Dialog with custom event linking confirm button to closing the dialog-->
+<%= pb_rails("dialog", props: { 
+  id: "dialog-confirm-turbo-frames", 
+  title: "Custom Event Button Action", 
+  text: "Clicking this dialog's confirm button triggers closing the dialog as well.",
+  custom_event_type: "turboResponse",
+  cancel_button: "Cancel",
+  cancel_button_id: "cancel-button-id-turbo-frames",
+  confirm_button: "Confirm Button", 
+  confirm_button_id: "confirm-button-id-turbo-frames"
+}) %>
+
+<script>
+  window.addEventListener("turboResponse", (event) => {
+    const { dialogId, action, cancelButtonId } = event.detail || {}
+    console.log("📦 turboResponse event triggered:", { dialogId, action, cancelButtonId })
+
+    if (action === "close" && cancelButtonId) {
+        const dialog = document.getElementById(dialogId)
+        if (dialog?.close) {
+          console.log("🚪 Closing dialog programmatically")
+          dialog.close()
+        }
+    }
+  })
+
+  document.getElementById("confirm-button-id-turbo-frames").addEventListener("click", function () {
+    console.log("✅ Confirm button clicked! Triggering cancel via turboResponse")
+
+    window.dispatchEvent(new CustomEvent("turboResponse", {
+      detail: {
+        dialogId: "dialog-confirm-turbo-frames",
+        action: "close", 
+        cancelButtonId: "cancel-button-id-turbo-frames"
+      }
+    }))
+  })
+</script>
+
+<!-- Example 3: Dialog with multiple custom event types -->
+<%= pb_rails("dialog", props: { 
+  id: "multi-event-dialog", 
+  title: "Multiple Event Types", 
+  text: "This dialog responds to multiple custom event types - see console logs.",
+  custom_event_type: "dialogOpenMutli,turboResponseMulti",
+  cancel_button: "Cancel",
+  cancel_button_id: "multi-event-cancel",
+  confirm_button: "Confirm", 
+  confirm_button_id: "multi-event-confirm"
+}) %>
+
+<script>
+  document.getElementById("button-open-multi-dialog").addEventListener("click", () => {
+    console.log("📣 Dispatching 'dialogOpenMutli' custom event")
+    window.dispatchEvent(new CustomEvent("dialogOpenMutli", { 
+      detail: { 
+        dialogId: "multi-event-dialog",
+        action: "open"
+      }
+    }))
+  })
+
+  document.getElementById("multi-event-confirm")?.addEventListener("click", function() {
+    console.log("✅ Confirm clicked — dispatching 'turboResponseMulti' to simulate dialog close")
+
+    window.dispatchEvent(new CustomEvent("turboResponseMulti", {
+      detail: {
+        dialogId: "multi-event-dialog",
+        action: "close",
+        cancelButtonId: "multi-event-cancel"
+      }
+    }))
+  })
+
+  window.addEventListener("turboResponseMulti", (event) => {
+    const { dialogId, action, cancelButtonId } = event.detail || {}
+  
+    if (action === "close" && dialogId) {
+      const dialog = document.getElementById(dialogId)
+      dialog.close?.()
+      console.log("🚪 Closing dialog programmatically")
+    }
+  })
+</script>

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_turbo_frames_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_turbo_frames_rails.md
@@ -1,0 +1,9 @@
+The `custom_event_type` prop allows you to specify custom events that will trigger the dialog's initialization or control its behavior. This is especially useful when working with Turbo Frame updates where standard DOM events might not suffice.
+
+The examples demonstrate two use cases:
+1) Opening a dialog via custom event dispatch: The first example shows how to configure a dialog to listen for a specific custom event (dialogOpen). When this event is dispatched, the dialog will automatically open, making it easy to trigger the dialog from JavaScript or after Turbo Frame operations.
+2) Controlling dialog button actions with custom events: The second example demonstrates how to set up a dialog that can have its confirm button triggered through external events (turboResponse). This pattern is useful when you need to programmatically confirm a dialog after some background operation completes.
+3) Multiple custom events: The third example combines the first two to show how `custom_event_type` prop can support multiple event types separated by a comma.
+
+For Turbo integration, you can use standard Turbo events like turbo:frame-load or turbo:submit-end as your `custom_event_type` to ensure the dialog responds properly after Turbo navigation or form submissions. The dialog component will listen for these events automatically.
+The implementation handles various actions including 'open', 'close', 'clickConfirm', and 'clickCancel', making it flexible for different interaction patterns in your Turbo-enhanced application.

--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/example.yml
@@ -11,6 +11,7 @@ examples:
   - dialog_full_height: Full Height
   - dialog_full_height_placement: Full Height Placement
   - dialog_loading: Loading
+  - dialog_turbo_frames: Within Turbo Frames
 
 
   react:

--- a/playbook/app/pb_kits/playbook/pb_dialog/index.js
+++ b/playbook/app/pb_kits/playbook/pb_dialog/index.js
@@ -10,6 +10,81 @@ export default class PbDialog extends PbEnhancedElement {
   connect() {
     window.addEventListener("DOMContentLoaded", () => this.setupDialog())
     window.addEventListener("turbo:frame-load", () => this.setupDialog())
+
+    // Code for custom_event_type setup (can take multiple events in a string separated by commas)
+    const customEventTypeString = this.element.dataset.customEventType
+    if (customEventTypeString && !this.element.hasAttribute("data-custom-event-handled")) {
+      this.customEventTypes = customEventTypeString.split(",").map(e => e.trim()).filter(Boolean)
+      this.customEventTypes.forEach(eventType => {
+        window.addEventListener(eventType, this.handleCustomEvent)
+      })
+
+      this.element.setAttribute("data-custom-event-handled", "true")
+    }
+  }
+
+  disconnect() {
+    if (this.customEventTypes && Array.isArray(this.customEventTypes)) {
+      this.customEventTypes.forEach(eventType => {
+        window.removeEventListener(eventType, this.handleCustomEvent)
+      })
+    }
+  }
+
+  handleCustomEvent = (event) => {
+    const dialogId = event.detail?.dialogId || this.element.querySelector("dialog")?.id
+    const dialog = dialogId && document.getElementById(dialogId)
+  
+    if (!dialog) {
+      console.warn(`[PbDialog] Could not find dialog with ID '${dialogId}'`)
+      return
+    }
+  
+    this.setupDialog()
+  
+    const action = event.detail?.action || 'open'
+  
+    // Known Actions - four "standard" dialog actions that felt like things devs might want to do
+    const knownActions = ['open', 'close', 'clickConfirm', 'clickCancel'];
+  
+    if (knownActions.includes(action)) {
+      switch (action) {
+        case 'open':
+          if (!dialog.open) dialog.showModal()
+          break
+        case 'close':
+          if (dialog.open) dialog.close(event.detail?.returnValue)
+          break
+        case 'clickConfirm':
+          this.triggerButtonClick(dialog, event, 'confirm')
+          break
+        case 'clickCancel':
+          this.triggerButtonClick(dialog, event, 'cancel')
+          break
+      }
+    } 
+    // Custom Actions - flexible for Turbo or other integration
+    else if (typeof event.detail?.customAction === 'function') {
+      event.detail.customAction({ dialog, event })
+    } else if (window.pbDialogActions?.[action]) {
+      // Can register custom actions globally
+      window.pbDialogActions[action]({ dialog, event })
+    } else {
+      console.warn(`[PbDialog] Unknown action: ${action}`)
+    }
+  }
+
+  triggerButtonClick(dialog, event, type) {
+    const buttonId = event.detail?.[`${type}ButtonId`] || 
+                     dialog.closest('[data-pb-dialog-wrapper]')?.dataset[`${type}ButtonId`]
+    const button = buttonId ? document.getElementById(buttonId) : 
+                  dialog.querySelector(`[data-${type}-button]`)
+  
+    if (button) {
+      button.click()
+    } else {
+      console.warn(`[PbDialog] Could not find ${type} button for dialog`)
+    }
   }
 
   setupDialog() {
@@ -18,7 +93,7 @@ export default class PbDialog extends PbEnhancedElement {
     const dialogs = document.querySelectorAll(".pb_dialog_rails")
 
     const loadingButton = document.querySelector('[data-disable-with="Loading"]');
-    if (loadingButton) {
+    if (loadingButton && !loadingButton.dataset.listenerAttached) {
       loadingButton.addEventListener("click", function () {
         const okayLoadingButton = document.querySelector('[data-disable-with="Loading"]');
         const cancelButton = document.querySelector('[data-disable-cancel-with="Loading"]');
@@ -35,27 +110,42 @@ export default class PbDialog extends PbEnhancedElement {
         okayLoadingButton.className = newClass;
         if (cancelButton) cancelButton.className = newCancelClass;
       });
+    
+      // Prevent multiple registrations
+      loadingButton.dataset.listenerAttached = "true";
     }
-
+    
     openTrigger.forEach((open) => {
-      open.addEventListener("click", () => {
-        var openTriggerData = open.dataset.openDialog;
-        var targetDialog = document.getElementById(openTriggerData)
-        if (targetDialog.open) return;
-        targetDialog.showModal();
-      });
+      const originalClickHandler = open._openDialogClickHandler
+      if (originalClickHandler) open.removeEventListener("click", originalClickHandler)
+
+      open._openDialogClickHandler = () => {
+        const openTriggerData = open.dataset.openDialog;
+        const targetDialogOpen = document.getElementById(openTriggerData)
+        if (targetDialogOpen && !targetDialogOpen.open) targetDialogOpen.showModal()
+      };
+
+      open.addEventListener("click", open._openDialogClickHandler)
     });
 
     closeTrigger.forEach((close) => {
-      close.addEventListener("click", () => {
-        var closeTriggerData = close.dataset.closeDialog;
-        document.getElementById(closeTriggerData).close();
-      });
+      const originalClickHandler = close._closeDialogClickHandler
+      if (originalClickHandler) close.removeEventListener("click", originalClickHandler)
+
+      close._closeDialogClickHandler = () => {
+        const closeTriggerData = close.dataset.closeDialog;
+        const targetDialogClose = document.getElementById(closeTriggerData)
+        if (targetDialogClose) targetDialogClose.close();
+      };
+
+      close.addEventListener("click", close._closeDialogClickHandler)
     });
 
     // Close dialog box on outside click
     dialogs.forEach((dialogElement) => {
-      dialogElement.addEventListener("mousedown", (event) => {
+      const originalMousedownHandler = dialogElement._outsideClickHandler
+      if (originalMousedownHandler) dialogElement.removeEventListener("mousedown", originalMousedownHandler)
+      dialogElement._outsideClickHandler = (event) => {
         const dialogParentDataset = dialogElement.parentElement.dataset
         if (dialogParentDataset.overlayClick === "overlay_close") return
 
@@ -69,7 +159,9 @@ export default class PbDialog extends PbEnhancedElement {
           dialogElement.close()
           event.stopPropagation()
         }
-      })
+      }
+
+      dialogElement.addEventListener("mousedown", dialogElement._outsideClickHandler);
     })
   }
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2035](https://runway.powerhrg.com/backlog_items/PLAY-2035) is part of our effort to expand Playbook's Turbo support. It adds a `custom_event_type` prop which can be used as a hook for a dev to get any desired event (e.g. click, keyboard, or Turbo) to re-trigger a DOMContentLoaded event. Nitro devs can use this to update something while interacting with a Rails Dialog kit without reloading the entire page.

[PBNTR-892](https://runway.powerhrg.com/backlog_items/PBNTR-892) updated the Rails Dialog kit to have an enhanced element file, which this PR builds upon. The doc example demonstrates a lot - a custom event to open a dialog, a custom event to close the dialog after clicking confirm, and a third example showing both linked together (since the prop supports multiple events).

**Screenshots:** Screenshots to visualize your addition/change
<img width="1375" alt="enhanced element" src="https://github.com/user-attachments/assets/749ffb61-b227-4fe5-a379-6373564cf9bb" />
<img width="1153" alt="button 1 ss 1" src="https://github.com/user-attachments/assets/db183b57-2ca4-4d4e-b156-73467aa08281" />
<img width="1161" alt="button 2 ss 1" src="https://github.com/user-attachments/assets/14d4ad81-1bdc-4f1a-aeb1-e2ce553b4cf7" />
<img width="1100" alt="button 3 ss 1" src="https://github.com/user-attachments/assets/e5482928-f2bc-4d8f-90a9-5b2276282d79" />
<img width="1119" alt="button 3 ss 2" src="https://github.com/user-attachments/assets/db5a37ab-aa78-47ce-adff-28713a2fc78c" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the "Within Turbo Frames" Rails [doc example in the review env](https://pr4514.playbook.beta.hq.powerapp.cloud/kits/dialog/rails#within-turbo-frames)). 
2. Open the console and click on one of the example buttons. See logging indicating custom event firing - a little differently for each example.
3. Go to [alpha PR](https://github.com/powerhome/nitro-web/pull/47893) and test locations there.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~