### PR TITLE
[PLAY-2054] Advanced Table: Expansion Control by Depth

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react"
 import classnames from "classnames"
-import { flexRender, Header, Table } from "@tanstack/react-table"
+import { flexRender, Header, Table, RowModel } from "@tanstack/react-table"
 
 import { GenericObject } from "../../types"
 
@@ -8,9 +8,13 @@ import { GlobalProps } from "../../utilities/globalProps"
 
 import Flex from "../../pb_flex/_flex"
 import Checkbox from "../../pb_checkbox/_checkbox"
+import Dropdown from "../../pb_dropdown/_dropdown"
+import Icon from "../../pb_icon/_icon"
 
 import { SortIconButton } from "./SortIconButton"
 import { ToggleIconButton } from "./ToggleIconButton"
+import { displayIcon } from "../Utilities/IconHelpers"
+import { updateExpandAndCollapseState } from "../Utilities/ExpansionControlHelpers"
 
 import { isChrome } from "../Utilities/BrowserCheck"
 
@@ -40,6 +44,10 @@ export const TableHeaderCell = ({
   table
 }: TableHeaderCellProps) => {
   const {
+    expanded,
+    setExpanded,
+    expandByDepth,
+    toggleExpansionIcon,
     sortControl,
     responsive,
     selectableRows,
@@ -107,6 +115,17 @@ const isToggleExpansionEnabled =
     justifyHeader = isLeafColumn ? "end" : "center";
   }
   
+  const handleExpandDepth = (depth: number) => {
+    const updated = updateExpandAndCollapseState(
+      table.getRowModel(),
+      expanded,
+      undefined,
+      depth
+    )
+    setExpanded(updated)
+  }
+  
+
   return (
     <th
         align="right"
@@ -143,8 +162,33 @@ const isToggleExpansionEnabled =
               />
             )
           }
-          {isToggleExpansionEnabled && hasAnySubRows && (
+          {isToggleExpansionEnabled && hasAnySubRows && !expandByDepth && (
               <ToggleIconButton onClick={handleExpandOrCollapse} />
+            )}
+          {isToggleExpansionEnabled && hasAnySubRows && expandByDepth && (
+              <Dropdown options={expandByDepth}>
+                <Dropdown.Trigger className="gray-icon toggle-all-icon">
+                  <Icon icon={displayIcon(toggleExpansionIcon)[0]} />
+                </Dropdown.Trigger>
+                <Dropdown.Container className="expand-by-depth-dropdown">
+                  {expandByDepth.map((option, index) => (
+                    <Dropdown.Option
+                        key={index}
+                        option={option}
+                        padding="none"
+                    > 
+                      <Flex
+                          alignItems="center"
+                          htmlOptions={{onClick: () => {handleExpandDepth(option.depth)} }}
+                          paddingX="sm"
+                          paddingY="xs"
+                          >
+                            {option.label}
+                          </Flex>
+                    </Dropdown.Option>
+                  ))}
+                </Dropdown.Container>
+              </Dropdown>
             )}
 
           {isToggleExpansionEnabledLoading &&(

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -8,7 +8,8 @@ import { GlobalProps } from "../../utilities/globalProps"
 
 import Flex from "../../pb_flex/_flex"
 import Checkbox from "../../pb_checkbox/_checkbox"
-import Dropdown from "../../pb_dropdown/_dropdown"
+// Import different for Dropdown due to TS issues
+import { Dropdown } from "playbook-ui"
 import Icon from "../../pb_icon/_icon"
 
 import { SortIconButton } from "./SortIconButton"

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -50,6 +50,7 @@ export const TableHeaderCell = ({
     expanded,
     setExpanded,
     expandByDepth,
+    onExpandByDepthClick,
     toggleExpansionIcon,
     sortControl,
     responsive,
@@ -119,6 +120,10 @@ const isToggleExpansionEnabled =
   }
   
   const handleExpandDepth = (depth: number) => {
+    if (onExpandByDepthClick) {
+      const flatRows = table?.getRowModel().flatRows
+      onExpandByDepthClick(depth, flatRows)
+    }
     const updated = updateExpandAndCollapseState(
       table.getRowModel(),
       expanded,
@@ -169,7 +174,9 @@ const isToggleExpansionEnabled =
               <ToggleIconButton onClick={handleExpandOrCollapse} />
             )}
           {isToggleExpansionEnabled && hasAnySubRows && expandByDepth && (
-              <Dropdown options={expandByDepth}>
+              <Dropdown className="expand-by-depth-dropdown-wrapper" 
+                  options={expandByDepth}
+              >
                 <DropdownTrigger className="gray-icon toggle-all-icon">
                   <Icon icon={displayIcon(toggleExpansionIcon)[0]} />
                 </DropdownTrigger>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -8,8 +8,10 @@ import { GlobalProps } from "../../utilities/globalProps"
 
 import Flex from "../../pb_flex/_flex"
 import Checkbox from "../../pb_checkbox/_checkbox"
-// Import different for Dropdown due to TS issues
-import { Dropdown } from "playbook-ui"
+import Dropdown from "../../pb_dropdown/_dropdown"
+import DropdownTrigger from "../../pb_dropdown/subcomponents/DropdownTrigger"
+import DropdownOption from "../../pb_dropdown/subcomponents/DropdownOption"
+import DropdownContainer from "../../pb_dropdown/subcomponents/DropdownContainer"
 import Icon from "../../pb_icon/_icon"
 
 import { SortIconButton } from "./SortIconButton"
@@ -168,12 +170,12 @@ const isToggleExpansionEnabled =
             )}
           {isToggleExpansionEnabled && hasAnySubRows && expandByDepth && (
               <Dropdown options={expandByDepth}>
-                <Dropdown.Trigger className="gray-icon toggle-all-icon">
+                <DropdownTrigger className="gray-icon toggle-all-icon">
                   <Icon icon={displayIcon(toggleExpansionIcon)[0]} />
-                </Dropdown.Trigger>
-                <Dropdown.Container className="expand-by-depth-dropdown">
-                  {expandByDepth.map((option, index) => (
-                    <Dropdown.Option
+                </DropdownTrigger>
+                <DropdownContainer className="expand-by-depth-dropdown">
+                  {expandByDepth.map((option:{ [key: string]: any }, index: number) => (
+                    <DropdownOption
                         key={index}
                         option={option}
                         padding="none"
@@ -186,9 +188,9 @@ const isToggleExpansionEnabled =
                           >
                             {option.label}
                           </Flex>
-                    </Dropdown.Option>
+                    </DropdownOption>
                   ))}
-                </Dropdown.Container>
+                </DropdownContainer>
               </Dropdown>
             )}
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableActions.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableActions.ts
@@ -22,10 +22,9 @@ export function useTableActions({
   // Handle expand/collapse
   const handleExpandOrCollapse = useCallback(async (row: Row<GenericObject>) => {
     onToggleExpansionClick && onToggleExpansionClick(row);
-
     const expandedState = expanded;
     const targetParent = row?.parentId;
-    const updatedRows = await updateExpandAndCollapseState(table.getRowModel(), expandedState, targetParent);
+    const updatedRows = await updateExpandAndCollapseState(table.getRowModel(), expandedState, targetParent, undefined);
     setExpanded(updatedRows);
   }, [expanded, setExpanded, onToggleExpansionClick, table]);
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/ExpansionControlHelpers.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/ExpansionControlHelpers.tsx
@@ -14,16 +14,22 @@ const filterExpandableRows = (expandedState: Record<string, boolean>) => {
 export const updateExpandAndCollapseState = (
   tableRows: RowModel<GenericObject>,
   expanded: Record<string, boolean>,
-  targetParent: string
+  targetParent?: string,
+  targetDepth?: number,
 ) => {
   const updateExpandedRows: Record<string, boolean> = {};
-  const rows = tableRows.rows;
+  const rows = targetDepth !== undefined ? tableRows.flatRows : tableRows.rows;
 
   let isExpansionConsistent = true;
   const areRowsExpanded = new Set<boolean>();
 
   for (const row of rows) {
-    const shouldBeUpdated = targetParent === undefined ? row.depth === 0 : targetParent === row.parentId;
+    const shouldBeUpdated =
+      targetDepth !== undefined
+        ? row.depth <= targetDepth
+        : targetParent === undefined
+        ? row.depth === 0
+        : targetParent === row.parentId;
     
     if (shouldBeUpdated) {
       const isExpanded = row.getIsExpanded();

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -130,6 +130,9 @@
         box-sizing: border-box !important;
       }
     }
+    .expand-by-depth-dropdown {
+      min-width: 150px;
+    }
   }
 
   .pb_advanced_table_body {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -130,8 +130,12 @@
         box-sizing: border-box !important;
       }
     }
+    .expand-by-depth-dropdown-wrapper {
+      position: unset !important;
+    }
     .expand-by-depth-dropdown {
-      min-width: 150px;
+      width: unset !important;
+      text-align: left;
     }
   }
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -38,6 +38,7 @@ type AdvancedTableProps = {
   data?: { [key: string]: string }
   enableToggleExpansion?: "all" | "header" | "none"
   expandedControl?: GenericObject
+  expandByDepth?: { [key: string]: string | number }
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string
   initialLoadingRowsCount?: number
@@ -73,6 +74,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     data = {},
     enableToggleExpansion = "header",
     expandedControl,
+    expandByDepth,
     htmlOptions = {},
     id,
     initialLoadingRowsCount = 10,
@@ -280,6 +282,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             columnDefinitions={columnDefinitions}
             enableToggleExpansion={enableToggleExpansion}
             enableVirtualization={virtualizedRows}
+            expandByDepth={expandByDepth}
             expanded={expanded}
             expandedControl={expandedControl}
             handleExpandOrCollapse={handleExpandOrCollapse}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -39,6 +39,7 @@ type AdvancedTableProps = {
   enableToggleExpansion?: "all" | "header" | "none"
   expandedControl?: GenericObject
   expandByDepth?: { [key: string]: string | number }
+  onExpandByDepthClick?: (arg: number, arg1: any) => void
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string
   initialLoadingRowsCount?: number
@@ -75,6 +76,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     enableToggleExpansion = "header",
     expandedControl,
     expandByDepth,
+    onExpandByDepthClick,
     htmlOptions = {},
     id,
     initialLoadingRowsCount = 10,
@@ -291,6 +293,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             isActionBarVisible={isActionBarVisible}
             isFullscreen={isFullscreen}
             loading={loading}
+            onExpandByDepthClick={onExpandByDepthClick}
             responsive={responsive}
             selectableRows={selectableRows}
             setExpanded={setExpanded}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.jsx
@@ -1,0 +1,65 @@
+import React from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableExpandByDepth = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance Rate",
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed Classes",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Class Completion Rate",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated Students",
+    },
+  ]
+
+  const expandByDepth = [
+    {
+        depth: 0,
+        label: "Year",
+    },
+    {
+        depth: 1,
+        label: "Quarter",
+    },
+    {
+        depth: 2,
+        label: "Month",
+    }
+  ]
+
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          expandByDepth={expandByDepth}
+          tableData={MOCK_DATA}
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default AdvancedTableExpandByDepth

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.jsx
@@ -55,6 +55,7 @@ const AdvancedTableExpandByDepth = (props) => {
       <AdvancedTable
           columnDefinitions={columnDefinitions}
           expandByDepth={expandByDepth}
+          onExpandByDepthClick={(depth, rows) => {console.log(depth, rows)}}
           tableData={MOCK_DATA}
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.md
@@ -6,4 +6,5 @@ The `expandByDepth` prop enables users to expand or collapse table rows by speci
 
 **Collapsing a depth**: Only collapses rows at the selected depth, keeping parent rows expanded for context.
 
+If you want to attach further logic to each option click, the **optional** `onExpandByDepthClick` prop can be used. This click event provides 2 arguments that can be hooked into: the depth level of the clicked item AND all flattened table rows. Any additional functionality provided through this onClick will be applied in addition to the default.
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_expand_by_depth.md
@@ -1,0 +1,9 @@
+The `expandByDepth` prop enables users to expand or collapse table rows by specific levels of nesting. When provided, it renders a dropdown that appears when the toggle icon in the header is clicked.
+
+`expandByDepth` accepts an array of objects, where each object defines the depth level to target and the label to display in the dropdown. When a user selects an option:
+
+**Expanding a depth**: Expands all rows at the selected depth AND all parent levels above it (if parent levels were closed), ensuring nested content is visible.
+
+**Collapsing a depth**: Only collapses rows at the selected depth, keeping parent rows expanded for context.
+
+

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -18,30 +18,31 @@ examples:
 
   react:
   - advanced_table_default: Default (Required Props)
-  - advanced_table_loading: Loading State
-  - advanced_table_sort: Enable Sorting
-  - advanced_table_sort_control: Sort Control
-  - advanced_table_expanded_control: Expanded Control
+  # - advanced_table_loading: Loading State
+  # - advanced_table_sort: Enable Sorting
+  # - advanced_table_sort_control: Sort Control
+  # - advanced_table_expanded_control: Expanded Control
+  - advanced_table_expand_by_depth: Expand by Depth
   - advanced_table_subrow_headers: SubRow Headers
-  - advanced_table_collapsible_trail: Collapsible Trail
-  - advanced_table_table_options: Table Options
-  - advanced_table_table_props: Table Props
-  - advanced_table_sticky_header: Sticky Header
-  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  - advanced_table_sticky_columns: Sticky Columns
-  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  - advanced_table_inline_row_loading: Inline Row Loading
-  - advanced_table_responsive: Responsive Tables
-  - advanced_table_custom_cell: Custom Components for Cells
-  - advanced_table_pagination: Pagination
-  - advanced_table_pagination_with_props: Pagination Props
-  - advanced_table_column_headers: Multi-Header Columns
-  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  # - advanced_table_no_subrows: Table with No Subrows
-  - advanced_table_selectable_rows: Selectable Rows
-  - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
-  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  - advanced_table_inline_editing: Inline Cell Editing
-  - advanced_table_fullscreen: Fullscreen
+  # - advanced_table_collapsible_trail: Collapsible Trail
+  # - advanced_table_table_options: Table Options
+  # - advanced_table_table_props: Table Props
+  # - advanced_table_sticky_header: Sticky Header
+  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  # - advanced_table_sticky_columns: Sticky Columns
+  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  # - advanced_table_inline_row_loading: Inline Row Loading
+  # - advanced_table_responsive: Responsive Tables
+  # - advanced_table_custom_cell: Custom Components for Cells
+  # - advanced_table_pagination: Pagination
+  # - advanced_table_pagination_with_props: Pagination Props
+  # - advanced_table_column_headers: Multi-Header Columns
+  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  # # - advanced_table_no_subrows: Table with No Subrows
+  # - advanced_table_selectable_rows: Selectable Rows
+  # - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
+  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  # - advanced_table_inline_editing: Inline Cell Editing
+  # - advanced_table_fullscreen: Fullscreen

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -18,31 +18,31 @@ examples:
 
   react:
   - advanced_table_default: Default (Required Props)
-  # - advanced_table_loading: Loading State
-  # - advanced_table_sort: Enable Sorting
-  # - advanced_table_sort_control: Sort Control
-  # - advanced_table_expanded_control: Expanded Control
+  - advanced_table_loading: Loading State
+  - advanced_table_sort: Enable Sorting
+  - advanced_table_sort_control: Sort Control
+  - advanced_table_expanded_control: Expanded Control
   - advanced_table_expand_by_depth: Expand by Depth
   - advanced_table_subrow_headers: SubRow Headers
-  # - advanced_table_collapsible_trail: Collapsible Trail
-  # - advanced_table_table_options: Table Options
-  # - advanced_table_table_props: Table Props
-  # - advanced_table_sticky_header: Sticky Header
-  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  # - advanced_table_sticky_columns: Sticky Columns
-  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  # - advanced_table_inline_row_loading: Inline Row Loading
-  # - advanced_table_responsive: Responsive Tables
-  # - advanced_table_custom_cell: Custom Components for Cells
-  # - advanced_table_pagination: Pagination
-  # - advanced_table_pagination_with_props: Pagination Props
-  # - advanced_table_column_headers: Multi-Header Columns
-  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  # # - advanced_table_no_subrows: Table with No Subrows
-  # - advanced_table_selectable_rows: Selectable Rows
-  # - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
-  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  # - advanced_table_inline_editing: Inline Cell Editing
-  # - advanced_table_fullscreen: Fullscreen
+  - advanced_table_collapsible_trail: Collapsible Trail
+  - advanced_table_table_options: Table Options
+  - advanced_table_table_props: Table Props
+  - advanced_table_sticky_header: Sticky Header
+  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  - advanced_table_sticky_columns: Sticky Columns
+  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  - advanced_table_inline_row_loading: Inline Row Loading
+  - advanced_table_responsive: Responsive Tables
+  - advanced_table_custom_cell: Custom Components for Cells
+  - advanced_table_pagination: Pagination
+  - advanced_table_pagination_with_props: Pagination Props
+  - advanced_table_column_headers: Multi-Header Columns
+  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  # - advanced_table_no_subrows: Table with No Subrows
+  - advanced_table_selectable_rows: Selectable Rows
+  - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
+  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  - advanced_table_inline_editing: Inline Cell Editing
+  - advanced_table_fullscreen: Fullscreen

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -26,3 +26,4 @@ export { default as AdvancedTableFullscreen } from './_advanced_table_fullscreen
 export { default as AdvancedTableStickyColumns } from './_advanced_table_sticky_columns.jsx'
 export { default as AdvancedTableStickyHeader } from './_advanced_table_sticky_header.jsx'
 export { default as AdvancedTableStickyColumnsAndHeader } from './_advanced_table_sticky_columns_and_header.jsx'
+export { default as AdvancedTableExpandByDepth } from './_advanced_table_expand_by_depth.jsx'

--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
@@ -35,7 +35,7 @@ type DropdownProps = {
     label?: string;
     onSelect?: (arg: GenericObject) => null;
     options: GenericObject;
-    separators: boolean;
+    separators?: boolean;
     triggerRef?: any;
     variant?: "default" | "subtle";
 };

--- a/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownOption.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownOption.tsx
@@ -22,7 +22,7 @@ type DropdownOptionProps = {
   data?: { [key: string]: string };
   htmlOptions?: { [key: string]: string | number | boolean | (() => void) };
   id?: string;
-  key?: string;
+  key?: string | number;
   option?: GenericObject;
   padding?: string;
 }  & GlobalProps;


### PR DESCRIPTION
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2054)

This PR:

- Adds a new prop called `expandByDepth`
- This prop enables users to expand or collapse table rows by specific levels of nesting. When provided, it renders a dropdown that appears when the toggle icon in the header is clicked.
- `expandByDepth` accepts an array of objects, where each object defines the depth level to target and the label to display in the dropdown. When a user selects an option:
   - Expanding a depth: Expands all rows at the selected depth AND all parent levels above it (if parent levels were closed), ensuring nested content is visible.
   - Collapsing a depth: Only collapses rows at the selected depth, keeping parent rows expanded for context.
- Adds the optional `onExpandByDepthClick` prop. This click event provides 2 arguments that can be hooked into: the depth level of the clicked item AND all flattened table rows. Any additional functionality provided through this onClick will be applied in addition to the default.


https://github.com/user-attachments/assets/640260cb-83ef-4a20-91f9-f388ab3059ba

