### PR TITLE
[PLAY-2066] Advanced Table Kit Double Icon In Nitro

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
@@ -31,6 +31,8 @@ export default class PbAdvancedTable extends PbEnhancedElement {
         this.toggleElement(this.target);
       }
     });
+    
+    this.hideCloseIcon()
 
     const nestedButtons = this.element
       .closest("table")
@@ -48,6 +50,11 @@ export default class PbAdvancedTable extends PbEnhancedElement {
       });
     });
   }
+
+  hideCloseIcon() {
+    const closeIcon = this.element.querySelector(UP_ARROW_SELECTOR);
+    closeIcon.style.display = "none";
+}
 
   showElement(elements) {
     elements.forEach((elem) => {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
@@ -30,7 +30,7 @@
                                     class="gray-icon expand-toggle-icon"
                                     data-advanced-table="true">
                                     <%= pb_rails("icon", props: { id: "advanced-table_open_icon", icon: "circle-play", cursor: "pointer" }) %>
-                                    <%= pb_rails("icon", props: { id: "advanced-table_close_icon", display: "none", icon: "circle-play", cursor: "pointer", rotation: 90 }) %>
+                                    <%= pb_rails("icon", props: { id: "advanced-table_close_icon", icon: "circle-play", cursor: "pointer", rotation: 90 }) %>
                                 </button>
                             <% end %>
                         <% end %>


### PR DESCRIPTION
[PLAY-2066](https://runway.powerhrg.com/backlog_items/PLAY-2066)

This PR makes sure that the kit doesn't render both collapsible icons within Nitro


**How to test?** Steps to confirm the desired behavior:
1. Go to the Rails Advanced Table Kit and confirm everythign looks right.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.