### PR TITLE
[PLAY-1965] Overlay Kit: Add a "Full Screen" prop - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_overlay/_overlay.scss
+++ b/playbook/app/pb_kits/playbook/pb_overlay/_overlay.scss
@@ -100,23 +100,24 @@ $overlay_colors: (
 
     &.no_gradient {
       @each $color_name, $color in $overlay_colors {
-        .overlay_#{$color_name} {
-          @each $name, $size in $overlay_sizes {
-            @each $position in $overlay_positions {
-              &_#{$position}_#{$name} {
-                @include overlay($position, $size, $color, false);
-              }
-            }
+        &[data-overlay-color="#{$color_name}"] {
+          &::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: $color;
+            pointer-events: none;
           }
         }
       }
     }
 
     @each $key, $value in $opacity {
-      &.#{$key} {
-        [class^=overlay] {
-          opacity: $value;
-        }
+      &.#{$key}::before {
+        opacity: $value;
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_overlay/_overlay.scss
+++ b/playbook/app/pb_kits/playbook/pb_overlay/_overlay.scss
@@ -88,6 +88,17 @@ $overlay_colors: (
     }
   }
 
+ &.overlay-full-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 9999;
+  }
+
   &.no_gradient {
     @each $color_name, $color in $overlay_colors {
       .overlay_#{$color_name} {

--- a/playbook/app/pb_kits/playbook/pb_overlay/_overlay.scss
+++ b/playbook/app/pb_kits/playbook/pb_overlay/_overlay.scss
@@ -88,7 +88,7 @@ $overlay_colors: (
     }
   }
 
- &.overlay-full-screen {
+  &.overlay-full-screen {
     position: fixed;
     top: 0;
     left: 0;
@@ -97,6 +97,28 @@ $overlay_colors: (
     width: 100vw;
     height: 100vh;
     z-index: 9999;
+
+    &.no_gradient {
+      @each $color_name, $color in $overlay_colors {
+        .overlay_#{$color_name} {
+          @each $name, $size in $overlay_sizes {
+            @each $position in $overlay_positions {
+              &_#{$position}_#{$name} {
+                @include overlay($position, $size, $color, false);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @each $key, $value in $opacity {
+      &.#{$key} {
+        [class^=overlay] {
+          opacity: $value;
+        }
+      }
+    }
   }
 
   &.no_gradient {

--- a/playbook/app/pb_kits/playbook/pb_overlay/_overlay.tsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/_overlay.tsx
@@ -21,6 +21,7 @@ type OverlayProps = {
     color: "card_light" | "bg_light" | "card_dark" | "bg_dark" | "black" | "white" | "success" | "error",
     data?: { [key: string]: string },
     dynamic?: false,
+    fullScreen?: boolean,
     gradient?: boolean,
     htmlOptions?: { [key: string]: string | number | boolean | (() => void) },
     id?: string,
@@ -38,6 +39,7 @@ const Overlay = (props: OverlayProps) => {
         color = "card_light",
         data = {},
         dynamic = false,
+        fullScreen = false,
         gradient = true,
         htmlOptions = {},
         id,
@@ -51,6 +53,7 @@ const Overlay = (props: OverlayProps) => {
     const classes = classnames(
         buildCss('pb_overlay'),
         { 'overlay-hide-scrollbar': scrollBarNone },
+        { 'overlay-full-screen': fullScreen },
         globalProps(props),
         gradient === false ? 'no_gradient' : '',
         opacity,
@@ -64,6 +67,9 @@ const Overlay = (props: OverlayProps) => {
     }
 
     const getSize = () => {
+        if (fullScreen) {
+            return "100%"
+        }
         return Object.values(layout)[0]
     }
 
@@ -76,7 +82,17 @@ const Overlay = (props: OverlayProps) => {
             {...htmlProps}
             className={classes}
             id={id}
-            style={dynamicInlineProps}
+            style={{
+                ...(fullScreen ? {
+                    position: 'fixed',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    zIndex: 9999,
+                } : {}),
+                ...dynamicInlineProps
+            }}
         >
             {isSizePercentage ?
                 OverlayPercentage({

--- a/playbook/app/pb_kits/playbook/pb_overlay/_overlay.tsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/_overlay.tsx
@@ -9,6 +9,7 @@ export type OverlayChildrenProps = {
     children: React.ReactNode[] | React.ReactNode,
     color: "card_light" | "bg_light" | "card_dark" | "bg_dark" | "black" | "white" | "success" | "error",
     dynamic?: boolean,
+    gradient?: boolean,
     position: string,
     size: string,
     scrollBarNone?: boolean,
@@ -81,34 +82,37 @@ const Overlay = (props: OverlayProps) => {
             {...dataProps}
             {...htmlProps}
             className={classes}
+            data-overlay-color={color}
             id={id}
             style={{
                 ...(fullScreen ? {
-                    position: 'fixed',
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    zIndex: 9999,
-                    background: gradient === false ? color : undefined,
+                  position: 'fixed',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  zIndex: 9999,
+                  '--overlay-color': `var(--${color})`,
                 } : {}),
                 ...dynamicInlineProps
-            }}
+              }}
         >
             {isSizePercentage ?
                 OverlayPercentage({
                     children,
                     color,
+                    gradient,
                     position: getPosition(),
                     scrollBarNone,
-                    size: getSize()
+                    size: getSize(),
                 }) : OverlayToken({
                     children,
                     color,
                     dynamic: dynamic,
+                    gradient,
                     position: getPosition(),
                     scrollBarNone,
-                    size: getSize()
+                    size: getSize(),
                 })
             }
         </div>

--- a/playbook/app/pb_kits/playbook/pb_overlay/_overlay.tsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/_overlay.tsx
@@ -54,8 +54,8 @@ const Overlay = (props: OverlayProps) => {
         buildCss('pb_overlay'),
         { 'overlay-hide-scrollbar': scrollBarNone },
         { 'overlay-full-screen': fullScreen },
+        { 'no_gradient': gradient === false },
         globalProps(props),
-        gradient === false ? 'no_gradient' : '',
         opacity,
         className
     )
@@ -90,6 +90,7 @@ const Overlay = (props: OverlayProps) => {
                     right: 0,
                     bottom: 0,
                     zIndex: 9999,
+                    background: gradient === false ? color : undefined,
                 } : {}),
                 ...dynamicInlineProps
             }}

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_background.jsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_background.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import Overlay from '../../pb_overlay/_overlay'
+import Button from '../../pb_button/_button'
+import FixedConfirmationToast from '../../pb_fixed_confirmation_toast/_fixed_confirmation_toast'
+
+const OverlayFullscreenBackground = () => {
+  const [openBackground, setOpenBackground] = useState(false)
+
+  const handleClickBackground = () => {
+    setOpenBackground(true)
+  }
+
+  const handleCloseBackground = () => {
+    setOpenBackground(false)
+  }
+
+  return (
+    <>
+      <div>
+        <Button
+            onClick={handleClickBackground}
+            text="Background Dark"
+            variant="secondary"
+        />
+
+        {openBackground && (
+          <Overlay
+              color="bg_dark"
+              fullScreen
+              gradient={false}
+          >
+            <FixedConfirmationToast
+                closeable
+                horizontal='center'
+                onClose={handleCloseBackground}
+                open={openBackground}
+                status="tip"
+                text='Lost connection. Check your internet connectivity.'
+                vertical='top'
+            />
+          </Overlay>
+        )}
+      </div>
+    </>
+  )
+}
+
+export default OverlayFullscreenBackground

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_background.jsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_background.jsx
@@ -28,6 +28,7 @@ const OverlayFullscreenBackground = () => {
               color="bg_dark"
               fullScreen
               gradient={false}
+              opacity="opacity_4"
           >
             <FixedConfirmationToast
                 closeable
@@ -35,7 +36,7 @@ const OverlayFullscreenBackground = () => {
                 onClose={handleCloseBackground}
                 open={openBackground}
                 status="tip"
-                text='Lost connection. Check your internet connectivity.'
+                text='Fullscreen Overlay with color set to Background Dark.'
                 vertical='top'
             />
           </Overlay>

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_background.md
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_background.md
@@ -1,0 +1,1 @@
+The `fullScreen` prop also allows you to use `color` along with it.

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.jsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.jsx
@@ -49,7 +49,7 @@ const OverlayFullscreenOpacity = () => {
                   onClose={handleCloseOpacity40}
                   open={openOpacity40}
                   status="tip"
-                  text='Lost connection. Check your internet connectivity.'
+                  text='Fullscreen Overlay at 40% Opacity.'
                   vertical='top'
               />
             </Overlay>
@@ -68,7 +68,7 @@ const OverlayFullscreenOpacity = () => {
                   onClose={handleCloseOpacity80}
                   open={openOpacity80}
                   status="tip"
-                  text='Lost connection. Check your internet connectivity.'
+                  text='Fullscreen Overlay at 80% Opacity.'
                   vertical='top'
               />
             </Overlay>

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.jsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.jsx
@@ -24,56 +24,56 @@ const OverlayFullscreenOpacity = () => {
 
   return (
     <>
-      <Button
-          onClick={handleClickOpacity40}
-          text="40% Opacity"
-          variant="secondary"
-      />
-      {' '}
-      <Button
-          onClick={handleClickOpacity80}
-          text="80% Opacity"
-          variant="secondary"
-      />
+      <div>
+        <Button
+            onClick={handleClickOpacity40}
+            text="40% Opacity"
+            variant="secondary"
+        />
+        {' '}
+        <Button
+            onClick={handleClickOpacity80}
+            text="80% Opacity"
+            variant="secondary"
+        />
 
-      {openOpacity40 && (
-          <Overlay
-              color="black"
-              fullScreen
-              gradient={false}
-              opacity="opacity_4"
-          >
-            <FixedConfirmationToast
-                closeable
-                horizontal='center'
-                onClose={handleCloseOpacity40}
-                open={openOpacity40}
-                status="tip"
-                text='Lost connection. Check your internet connectivity.'
-                vertical='top'
-            />
-          </Overlay>
-      )}
+        {openOpacity40 && (
+            <Overlay
+                fullScreen
+                gradient={false}
+                opacity="opacity_4"
+            >
+              <FixedConfirmationToast
+                  closeable
+                  horizontal='center'
+                  onClose={handleCloseOpacity40}
+                  open={openOpacity40}
+                  status="tip"
+                  text='Lost connection. Check your internet connectivity.'
+                  vertical='top'
+              />
+            </Overlay>
+        )}
 
-      {openOpacity80 && (
-          <Overlay
-              color="black"
-              fullScreen
-              gradient={false}
-              opacity="opacity_8"
-          >
-            <FixedConfirmationToast
-                closeable
-                display="block"
-                horizontal='center'
-                onClose={handleCloseOpacity80}
-                open={openOpacity80}
-                status="tip"
-                text='Lost connection. Check your internet connectivity.'
-                vertical='top'
-            />
-          </Overlay>
-      )}
+        {openOpacity80 && (
+            <Overlay
+                fullScreen
+                gradient={false}
+                opacity="opacity_8"
+            >
+              <FixedConfirmationToast
+                  closeable
+                  display="block"
+                  horizontal='center'
+                  onClose={handleCloseOpacity80}
+                  open={openOpacity80}
+                  status="tip"
+                  text='Lost connection. Check your internet connectivity.'
+                  vertical='top'
+              />
+            </Overlay>
+        )}
+      </div>
     </>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.jsx
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react'
+
+import Overlay from '../../pb_overlay/_overlay'
+import Button from '../../pb_button/_button'
+import FixedConfirmationToast from '../../pb_fixed_confirmation_toast/_fixed_confirmation_toast'
+
+const OverlayFullscreenOpacity = () => {
+  const [openOpacity40, setOpenOpacity40] = useState(false)
+  const [openOpacity80, setOpenOpacity80] = useState(false)
+
+  const handleClickOpacity40 = () => {
+    setOpenOpacity40(true)
+  }
+  const handleCloseOpacity40 = () => {
+    setOpenOpacity40(false)
+  }
+
+  const handleClickOpacity80 = () => {
+    setOpenOpacity80(true)
+  }
+  const handleCloseOpacity80 = () => {
+    setOpenOpacity80(false)
+  }
+
+  return (
+    <>
+      <Button
+          onClick={handleClickOpacity40}
+          text="40% Opacity"
+          variant="secondary"
+      />
+      {' '}
+      <Button
+          onClick={handleClickOpacity80}
+          text="80% Opacity"
+          variant="secondary"
+      />
+
+      {openOpacity40 && (
+          <Overlay
+              color="black"
+              fullScreen
+              gradient={false}
+              opacity="opacity_4"
+          >
+            <FixedConfirmationToast
+                closeable
+                horizontal='center'
+                onClose={handleCloseOpacity40}
+                open={openOpacity40}
+                status="tip"
+                text='Lost connection. Check your internet connectivity.'
+                vertical='top'
+            />
+          </Overlay>
+      )}
+
+      {openOpacity80 && (
+          <Overlay
+              color="black"
+              fullScreen
+              gradient={false}
+              opacity="opacity_8"
+          >
+            <FixedConfirmationToast
+                closeable
+                display="block"
+                horizontal='center'
+                onClose={handleCloseOpacity80}
+                open={openOpacity80}
+                status="tip"
+                text='Lost connection. Check your internet connectivity.'
+                vertical='top'
+            />
+          </Overlay>
+      )}
+    </>
+  )
+}
+
+export default OverlayFullscreenOpacity

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.md
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/_overlay_fullscreen_opacity.md
@@ -1,0 +1,1 @@
+To enable the overlay to cover the full size of your screen, you can pass the `fullScreen` prop. You can also pass an opacity along with it.

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/example.yml
@@ -8,6 +8,8 @@ examples:
   - overlay_vertical_dynamic_multi_directional: Vertical Dynamic Multi-directional
   - overlay_toggle: Toggle
   - overlay_hide_scroll_bar: Hide Scroll Bar
+  - overlay_fullscreen_opacity: Full Page Opacity
+  - overlay_fullscreen_background: Full Page Using Background Color Tokens
 
   rails:
   - overlay_default: Default

--- a/playbook/app/pb_kits/playbook/pb_overlay/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_overlay/docs/index.js
@@ -6,3 +6,5 @@ export { default as OverlayMultiDirectional } from './_overlay_multi_directional
 export { default as OverlayToggle } from './_overlay_toggle.jsx'
 export { default as OverlayVerticalDynamicMultiDirectional } from './_overlay_vertical_dynamic_multi_directional.jsx'
 export { default as OverlayHideScrollBar } from './_overlay_hide_scroll_bar.jsx'
+export { default as OverlayFullscreenOpacity } from './_overlay_fullscreen_opacity.jsx'
+export { default as OverlayFullscreenBackground } from './_overlay_fullscreen_background.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-1965)

As a Playbook user,
I want to to be able to customize the color and opacity of a non gradient Overlay,
So that I can ensure clarity and legibility of text when over images.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-04-22 at 1 34 34 PM](https://github.com/user-attachments/assets/91154cb7-8269-4190-b2ce-80a284d2b24e)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
