### PR TITLE
[PLAY-2038] Copy Button Kit Go Live and Rails Copy Hook

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -96,7 +96,7 @@ kits:
     enhanced_element_used: false
   - name: copy_button
     platforms: *1
-    status: beta
+    status: stable
     icons_used: false
     react_rendered: false
     enhanced_element_used: true

--- a/playbook/app/entrypoints/playbook-rails.js
+++ b/playbook/app/entrypoints/playbook-rails.js
@@ -3,8 +3,9 @@ import PbTextInput from 'kits/pb_text_input'
 PbTextInput.start()
 
 // Copy Button
-import PbCopyButton from 'kits/pb_copy_button'
+import { PbCopyButton, addCopyEventListeners } from 'kits/pb_copy_button'
 PbCopyButton.start()
+addCopyEventListeners()
 
 // Drawer
 import PbDrawer from 'kits/pb_drawer'

--- a/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.html.erb
@@ -1,0 +1,24 @@
+<%= pb_rails("copy_button", props: { display: "none", from: "hookbody" } ) %>
+
+<div onclick="usePBCopy('hookbody')">
+  <%= pb_rails("body", props: { cursor: "pointer" }) do %>
+    <span id="hookbody">I'm a custom copy hook! Click this body to copy this text!</span>
+  <% end %>
+</div>
+
+<%= pb_rails("tooltip", props: {
+  trigger_element_selector: "#hookbody",
+  tooltip_id: "hookbody_tooltip",
+  position: 'top',
+  trigger_method: "click"
+}) do %>
+  Copied!
+<% end %>
+
+<%= pb_rails("textarea", props: { margin_top: "xs", placeholder: "Paste here" }) %>
+
+<script>
+  const usePBCopy = (id) => {
+    document.dispatchEvent(new CustomEvent(id));
+  };
+</script>

--- a/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.html.erb
@@ -1,8 +1,6 @@
-<div data-external-copy-from="hookbody">
-  <%= pb_rails("body", props: { cursor: "pointer" }) do %>
-    <span id="hookbody">I'm a custom copy hook! Click this body to copy this text!</span>
-  <% end %>
-</div>
+<%= pb_rails("body", props: { cursor: "pointer", data: { "external-copy-from": "hookbody"} }) do %>
+  <span id="hookbody">I'm a custom copy hook! Click this body to copy this text!</span>
+<% end %>
 
 <%= pb_rails("tooltip", props: {
   trigger_element_selector: "#hookbody",

--- a/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.html.erb
@@ -1,6 +1,4 @@
-<%= pb_rails("copy_button", props: { display: "none", from: "hookbody" } ) %>
-
-<div onclick="usePBCopy('hookbody')">
+<div data-external-copy-from="hookbody">
   <%= pb_rails("body", props: { cursor: "pointer" }) do %>
     <span id="hookbody">I'm a custom copy hook! Click this body to copy this text!</span>
   <% end %>
@@ -16,9 +14,3 @@
 <% end %>
 
 <%= pb_rails("textarea", props: { margin_top: "xs", placeholder: "Paste here" }) %>
-
-<script>
-  const usePBCopy = (id) => {
-    document.dispatchEvent(new CustomEvent(id));
-  };
-</script>

--- a/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.md
@@ -1,7 +1,5 @@
-You can use any external control (like the text itself or an icon) to copy. To use this hook, you must first add the "copy_button" kit and set the `from` prop to the copying ID. 
+You can use any external control (like the text itself or an icon) to copy. To use this hook, you must first add the "copy_button" kit and set the `from` prop to the copying ID. This will grab the `innerText` from `your_id` element, or `value` if it is an input element. Alternatively, you can set the `value` prop and copy custom text.
 
-You must apply a unique ID to the element you are copying from. You can then attach an eventListener to the external control of your choice, pass it the ID as an argument and use `document.dispatchEvent(new CustomEvent(id))` to trigger the action. 
-
-This will grab the `innerText` from `your_id` element, or `value` if it is an input element.
+You can then attach an eventListener to the external control of your choice, pass it the id (match the `from` prop) as an argument and use `document.dispatchEvent(new CustomEvent(id))` to trigger the action. 
 
 See the code example for details. 

--- a/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.md
@@ -1,5 +1,3 @@
-You can use any external control (like the text itself or an icon) to copy. To use this hook, you must first add the "copy_button" kit and set the `from` prop to the copying ID. This will grab the `innerText` from `your_id` element, or `value` if it is an input element. Alternatively, you can set the `value` prop and copy custom text.
-
-You can then attach an eventListener to the external control of your choice, pass it the id (match the `from` prop) as an argument and use `document.dispatchEvent(new CustomEvent(id))` to trigger the action. 
+You can use any external control (like the text itself or an icon) to copy. To use this hook, set the `data-external-copy-from` attribute on the external control to the copying ID. This will grab the `innerText` from `your_id` element, or `value` if it is an input element. Alternatively, you can set a `data-external-copy-value` attribute and copy custom text.
 
 See the code example for details. 

--- a/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/docs/_copy_button_hook_rails.md
@@ -1,0 +1,7 @@
+You can use any external control (like the text itself or an icon) to copy. To use this hook, you must first add the "copy_button" kit and set the `from` prop to the copying ID. 
+
+You must apply a unique ID to the element you are copying from. You can then attach an eventListener to the external control of your choice, pass it the ID as an argument and use `document.dispatchEvent(new CustomEvent(id))` to trigger the action. 
+
+This will grab the `innerText` from `your_id` element, or `value` if it is an input element.
+
+See the code example for details. 

--- a/playbook/app/pb_kits/playbook/pb_copy_button/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/docs/example.yml
@@ -2,6 +2,7 @@ examples:
   rails:
   - copy_button_default: Default
   - copy_button_from: Copy From
+  - copy_button_hook_rails: Copy Hook
   
   react:
   - copy_button_default: Default

--- a/playbook/app/pb_kits/playbook/pb_copy_button/index.js
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/index.js
@@ -11,6 +11,12 @@ export default class PbCopyButton extends PbEnhancedElement {
     if (this.button) {
       this.button.addEventListener('click', this.handleClick)
     }
+
+    const fromId = this.element.getAttribute('data-from')
+
+    document.addEventListener(`${fromId}`, () => {
+      this.handleClick()
+    })
   }
 
   disconnect() {

--- a/playbook/app/pb_kits/playbook/pb_copy_button/index.js
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/index.js
@@ -26,6 +26,14 @@ export default class PbCopyButton extends PbEnhancedElement {
   }
 
   handleClick() {
+    const textToCopy = this.element.getAttribute('data-copy-value')
+    if (textToCopy) {
+      navigator.clipboard.writeText(textToCopy)
+        .catch(err => console.error('Failed to copy text', err))
+
+      return
+    }
+
     const fromId = this.element.getAttribute('data-from')
     if (fromId) {
       const fromElement = document.querySelector(`#${fromId}`)
@@ -38,14 +46,7 @@ export default class PbCopyButton extends PbEnhancedElement {
         }
         navigator.clipboard.writeText(contentToCopy)
           .catch(err => console.error('Failed to copy text', err))
-        return
       }
-    }
-
-    const textToCopy = this.element.getAttribute('data-copy-value')
-    if (textToCopy) {
-      navigator.clipboard.writeText(textToCopy)
-        .catch(err => console.error('Failed to copy text', err))
     } else {
       console.warn('No data-copy-value attribute found or data-from element')
     }

--- a/playbook/app/pb_kits/playbook/pb_copy_button/index.js
+++ b/playbook/app/pb_kits/playbook/pb_copy_button/index.js
@@ -1,6 +1,6 @@
 import PbEnhancedElement from "../pb_enhanced_element"
 
-export default class PbCopyButton extends PbEnhancedElement {
+export class PbCopyButton extends PbEnhancedElement {
   static get selector() {
     return '.pb_copy_button_kit'
   }
@@ -11,12 +11,6 @@ export default class PbCopyButton extends PbEnhancedElement {
     if (this.button) {
       this.button.addEventListener('click', this.handleClick)
     }
-
-    const fromId = this.element.getAttribute('data-from')
-
-    document.addEventListener(`${fromId}`, () => {
-      this.handleClick()
-    })
   }
 
   disconnect() {
@@ -51,4 +45,38 @@ export default class PbCopyButton extends PbEnhancedElement {
       console.warn('No data-copy-value attribute found or data-from element')
     }
   }
+}
+
+export function addCopyEventListeners() {
+  const divsWithDataExternalCopyValue = document.querySelectorAll('div[data-external-copy-value]')
+
+  divsWithDataExternalCopyValue.forEach((element) => {
+    element.addEventListener('click', function () {
+      const textToCopy = element.getAttribute('data-external-copy-value')
+      if (textToCopy) {
+        navigator.clipboard.writeText(textToCopy)
+          .catch(err => console.error('Failed to copy text', err))
+      }
+    })
+  })
+
+
+  const divsWithDataExternalCopyFrom = document.querySelectorAll('div[data-external-copy-from]')
+
+  divsWithDataExternalCopyFrom.forEach((element) => {
+    element.addEventListener('click', function () {
+      const fromId = element.getAttribute('data-external-copy-from')
+      const fromElement = document.querySelector(`#${fromId}`)
+      if (fromElement) {
+        let contentToCopy = ''
+        if (fromElement.tagName.toLowerCase() === 'input') {
+          contentToCopy = fromElement.value
+        } else {
+          contentToCopy = fromElement.innerText
+        }
+        navigator.clipboard.writeText(contentToCopy)
+          .catch(err => console.error('Failed to copy text', err))
+      }
+    })
+  })
 }


### PR DESCRIPTION
**What does this PR do?**
- Make the Copy Button Kit live (out of beta)
- In playbook-rails.js, run function, `addCopyEventListeners`, which adds event listeners to any elements with `data-external-copy-value` or `data-external-copy-from`
- Create a "Copy Hook" doc that dispatches an event with the `from` name

https://runway.powerhrg.com/backlog_items/PLAY-2038

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-04-22 at 4 24 53 PM (2)](https://github.com/user-attachments/assets/f4298833-c153-44ad-95b4-1755a7b9ac63)

**How to test?** Steps to confirm the desired behavior:
1. Go to Playbook
2. You should be able to search for Copy Button kit and also click on it from the menu
3. Go to /kits/copy_button/rails#copy-hook
4. The other Rails kits should not be affected

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.