### PR TITLE
[PLAY-2041] Draggable Event Listeners Doc

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_event_listeners.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_event_listeners.html.erb
@@ -1,0 +1,42 @@
+<% initial_items = [
+  {
+    id: "100",
+    url: "https://unsplash.it/500/400/?image=638",
+  },
+  {
+    id: "200",
+    url: "https://unsplash.it/500/400/?image=639",
+  },
+  {
+    id: "300",
+    url: "https://unsplash.it/500/400/?image=640",
+  },
+] %>
+
+<%= pb_rails("draggable", props: {initial_items: initial_items}) do %>
+  <%= pb_rails("draggable/draggable_container") do %>
+    <%= pb_rails("flex") do %>
+      <% initial_items.each do |item| %>
+        <%= pb_rails("draggable/draggable_item", props:{drag_id: item[:id]}) do %>
+          <%= pb_rails("image", props: { alt: item[:id], size: "md", url: item[:url], margin: "xs" }) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<script>
+  const itemIds = ["item_100", "item_200", "item_300"];
+
+  itemIds.forEach((id) => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.addEventListener("dragstart", (event) => {
+        console.log(`${id} drag start!`);
+      });
+      element.addEventListener("dragend", (event) => {
+        console.log(`${id} drag end!`);
+      });
+    }
+  });
+</script>

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_event_listeners.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_event_listeners.md
@@ -1,0 +1,1 @@
+You can add drag event listeners for `drag`, `dragend`, `dragenter`, `dragleave`, `dragover`, `dragstart`, and `drop`.

--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/example.yml
@@ -17,4 +17,5 @@ examples:
   - draggable_with_cards: Draggable with Cards
   - draggable_with_table: Draggable with Table
   - draggable_multiple_containers: Dragging Across Multiple Containers
+  - draggable_event_listeners: Draggable Event Listeners
 


### PR DESCRIPTION
**What does this PR do?** 
- Create a Rails "Draggable Event Listeners" doc which shows how to add event listeners like `dragstart` or `dragend`. 

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-04-23 at 10 20 33 AM](https://github.com/user-attachments/assets/271be794-5176-4d8d-bd2f-a407fbc99672)


**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/draggable/rails#draggable-event-listeners
2. Drag an item and let go
3. Check the console for console.logs for each event


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.