### PR TITLE
[PLAY-1901] Circle Icon Button kit: Add new 20x20 size

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.scss
@@ -53,7 +53,7 @@ $pb_button_styles: (
       }
     }
   }
-  &.small {
+  &.size_small {
     @each $style in $pb_button_styles {
       [class^=pb_button_kit][class*=_#{$style}] {
         width: 20px;

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.scss
@@ -53,4 +53,42 @@ $pb_button_styles: (
       }
     }
   }
+  &.small {
+    @each $style in $pb_button_styles {
+      [class^=pb_button_kit][class*=_#{$style}] {
+        width: 20px;
+        height: 20px;
+        min-height: 20px;
+        border-radius: 10px;
+        line-height: 20px;
+        flex-basis: 20px;
+        min-width: 20px;
+        padding: 0;
+      }
+    }
+    // centering small icon svg
+    .pb_button_content {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      // rails
+      svg.pb_custom_icon {
+        height: 14px;
+        width: 14px;
+        vertical-align: middle;
+      }
+      // react (nested within an additional span)
+      > span {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        > svg.pb_custom_icon {
+          height: 14px;
+          width: 14px;
+          vertical-align: middle;
+          display: inline-block;
+        }
+      }
+    }
+  }
 }

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
@@ -48,7 +48,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
-  const sizeClass = size === 'sm' ? 'small' : ''
+  const sizeClass = size === 'sm' ? 'size_small' : ''
   const classes = classnames(
     buildCss('pb_circle_icon_button_kit'),
     sizeClass,

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
@@ -22,7 +22,7 @@ type CircleIconButtonProps = {
   type?: 'button' | 'submit' | 'reset' | undefined,
   target?: string
   variant?: 'primary' | 'secondary' | 'link',
-  size?: 'default' | 'small',
+  size?: 'default' | 'sm',
 }
 
 const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
@@ -48,7 +48,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
-  const sizeClass = size === 'small' ? 'small' : ''
+  const sizeClass = size === 'sm' ? 'small' : ''
   const classes = classnames(
     buildCss('pb_circle_icon_button_kit'),
     sizeClass,

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
@@ -22,6 +22,7 @@ type CircleIconButtonProps = {
   type?: 'button' | 'submit' | 'reset' | undefined,
   target?: string
   variant?: 'primary' | 'secondary' | 'link',
+  size?: 'default' | 'small',
 }
 
 const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
@@ -41,13 +42,16 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
     link,
     newWindow,
     variant,
+    size = 'default',
   } = props
 
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
+  const sizeClass = size === 'small' ? 'small' : ''
   const classes = classnames(
     buildCss('pb_circle_icon_button_kit'),
+    sizeClass,
     globalProps(props),
     className
   )

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
@@ -27,7 +27,7 @@ module Playbook
       end
 
       def size_class
-        size == "sm" ? " small" : ""
+        size == "sm" ? " size_small" : ""
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
@@ -19,7 +19,7 @@ module Playbook
                         default: false
       prop :target
       prop :size, type: Playbook::Props::Enum,
-                  values: %w[default small],
+                  values: %w[default sm],
                   default: "default"
 
       def classname
@@ -27,7 +27,7 @@ module Playbook
       end
 
       def size_class
-        size == "small" ? " small" : ""
+        size == "sm" ? " small" : ""
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.rb
@@ -18,8 +18,16 @@ module Playbook
       prop :new_window, type: Playbook::Props::Boolean,
                         default: false
       prop :target
+      prop :size, type: Playbook::Props::Enum,
+                  values: %w[default small],
+                  default: "default"
+
       def classname
-        generate_classname("pb_circle_icon_button_kit")
+        generate_classname("pb_circle_icon_button_kit") + size_class
+      end
+
+      def size_class
+        size == "small" ? " small" : ""
       end
     end
   end

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -31,7 +31,7 @@ test('passes loading prop to button', () => {
   expect(button).toBeInTheDocument()
 })
 
-test('adds small class when size is sm', () => {
+test('adds size_small class when size is sm', () => {
   render(
     <CircleIconButton
         data={{ testid: 'small-size-test' }}
@@ -42,5 +42,5 @@ test('adds small class when size is sm', () => {
 
   const kit = screen.getByTestId('small-size-test')
   
-  expect(kit).toHaveClass('pb_circle_icon_button_kit small')
+  expect(kit).toHaveClass('pb_circle_icon_button_kit size_small')
 })

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -31,12 +31,12 @@ test('passes loading prop to button', () => {
   expect(button).toBeInTheDocument()
 })
 
-test('adds small class when size is small', () => {
+test('adds small class when size is sm', () => {
   render(
     <CircleIconButton
         data={{ testid: 'small-size-test' }}
         icon="plus"
-        size="small"
+        size="sm"
     />
   )
 

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.test.js
@@ -30,3 +30,17 @@ test('passes loading prop to button', () => {
   
   expect(button).toBeInTheDocument()
 })
+
+test('adds small class when size is small', () => {
+  render(
+    <CircleIconButton
+        data={{ testid: 'small-size-test' }}
+        icon="plus"
+        size="small"
+    />
+  )
+
+  const kit = screen.getByTestId('small-size-test')
+  
+  expect(kit).toHaveClass('pb_circle_icon_button_kit small')
+})

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.html.erb
@@ -1,0 +1,28 @@
+<%= pb_rails("flex", props: { orientation: "column", gap: "sm" }) do %>
+  <%= pb_rails("circle_icon_button", props: {
+    icon: "plus",
+    size: "small",
+    variant: "primary"
+  }) %>
+
+  <%= pb_rails("circle_icon_button", props: {
+    icon: "pen",
+    loading: true,
+    size: "small",
+    variant: "secondary"
+  }) %>
+
+  <%= pb_rails("circle_icon_button", props: {
+    disabled: true,
+    icon: "times",
+    size: "small"
+  }) %>
+
+  <%= pb_rails("circle_icon_button", props: {
+    icon: "info",
+    link: "https://playbook.powerapp.cloud/",
+    size: "small",
+    target: "child",
+    variant: "link"
+  }) %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.html.erb
@@ -1,27 +1,27 @@
 <%= pb_rails("flex", props: { orientation: "column", gap: "sm" }) do %>
   <%= pb_rails("circle_icon_button", props: {
     icon: "plus",
-    size: "small",
+    size: "sm",
     variant: "primary"
   }) %>
 
   <%= pb_rails("circle_icon_button", props: {
     icon: "pen",
     loading: true,
-    size: "small",
+    size: "sm",
     variant: "secondary"
   }) %>
 
   <%= pb_rails("circle_icon_button", props: {
     disabled: true,
     icon: "times",
-    size: "small"
+    size: "sm"
   }) %>
 
   <%= pb_rails("circle_icon_button", props: {
     icon: "info",
     link: "https://playbook.powerapp.cloud/",
-    size: "small",
+    size: "sm",
     target: "child",
     variant: "link"
   }) %>

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.jsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.jsx
@@ -10,27 +10,27 @@ const CircleIconButtonSize = (props) => (
     >
         <CircleIconButton
             icon="plus"
-            size="small"
+            size="sm"
             variant="primary"
             {...props}
         />
         <CircleIconButton
             icon="pen"
             loading
-            size="small"
+            size="sm"
             variant="secondary"
             {...props}
         />
         <CircleIconButton
             disabled
             icon="times"
-            size="small"
+            size="sm"
             {...props}
         />
         <CircleIconButton
             icon="info"
             link="https://playbook.powerapp.cloud/"
-            size="small"
+            size="sm"
             target="child"
             variant="link"
             {...props}

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.jsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import CircleIconButton from '../_circle_icon_button'
+import Flex from '../../pb_flex/_flex'
+
+const CircleIconButtonSize = (props) => (
+  <>
+    <Flex gap="sm"
+        orientation="column"
+    >
+        <CircleIconButton
+            icon="plus"
+            size="small"
+            variant="primary"
+            {...props}
+        />
+        <CircleIconButton
+            icon="pen"
+            loading
+            size="small"
+            variant="secondary"
+            {...props}
+        />
+        <CircleIconButton
+            disabled
+            icon="times"
+            size="small"
+            {...props}
+        />
+        <CircleIconButton
+            icon="info"
+            link="https://playbook.powerapp.cloud/"
+            size="small"
+            target="child"
+            variant="link"
+            {...props}
+        />
+    </Flex>
+  </>
+)
+
+export default CircleIconButtonSize

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.md
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.md
@@ -1,1 +1,1 @@
-The `size` prop accepts "small" as a value to make the Circle Icon Button 20px x 20px instead of the default 40px x 40px size.
+The `size` prop accepts "sm" as a value to make the Circle Icon Button 20px x 20px instead of the default 40px x 40px size.

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.md
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/_circle_icon_button_size.md
@@ -1,0 +1,1 @@
+The `size` prop accepts "small" as a value to make the Circle Icon Button 20px x 20px instead of the default 40px x 40px size.

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/example.yml
@@ -4,9 +4,11 @@ examples:
   - circle_icon_button_default: Default
   - circle_icon_button_link: Link
   - circle_icon_button_loading: Loading
+  - circle_icon_button_size: Size
   
   react:
   - circle_icon_button_default: Default
   - circle_icon_button_click: Click Handler
   - circle_icon_button_link: Link
   - circle_icon_button_loading: Loading
+  - circle_icon_button_size: Size

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/docs/index.js
@@ -2,3 +2,4 @@ export { default as CircleIconButtonDefault } from './_circle_icon_button_defaul
 export { default as CircleIconButtonClick } from './_circle_icon_button_click.jsx'
 export { default as CircleIconButtonLink } from './_circle_icon_button_link.jsx'
 export { default as CircleIconButtonLoading } from './_circle_icon_button_loading.jsx'
+export { default as CircleIconButtonSize } from './_circle_icon_button_size.jsx'

--- a/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Playbook::PbCircleIconButton::CircleIconButton do
   it { is_expected.to define_boolean_prop(:loading).with_default(false) }
   it { is_expected.to define_boolean_prop(:new_window).with_default(false) }
   it { is_expected.to define_prop(:link) }
+  it {
+    is_expected.to define_enum_prop(:size)
+      .with_default("default")
+      .with_values("default", "small")
+  }
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       icon = "user"
@@ -24,6 +29,11 @@ RSpec.describe Playbook::PbCircleIconButton::CircleIconButton do
 
     it "raises an error when not given an icon" do
       expect { subject.new {} }.to raise_error(Playbook::Props::Error)
+    end
+
+    it "adds small class when size is small" do
+      icon = "user"
+      expect(subject.new(icon: icon, size: "small").classname).to eq "pb_circle_icon_button_kit small"
     end
   end
 end

--- a/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Playbook::PbCircleIconButton::CircleIconButton do
   it {
     is_expected.to define_enum_prop(:size)
       .with_default("default")
-      .with_values("default", "small")
+      .with_values("default", "sm")
   }
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
@@ -31,9 +31,9 @@ RSpec.describe Playbook::PbCircleIconButton::CircleIconButton do
       expect { subject.new {} }.to raise_error(Playbook::Props::Error)
     end
 
-    it "adds small class when size is small" do
+    it "adds small class when size is sm" do
       icon = "user"
-      expect(subject.new(icon: icon, size: "small").classname).to eq "pb_circle_icon_button_kit small"
+      expect(subject.new(icon: icon, size: "sm").classname).to eq "pb_circle_icon_button_kit small"
     end
   end
 end

--- a/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/circle_icon_button_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Playbook::PbCircleIconButton::CircleIconButton do
       expect { subject.new {} }.to raise_error(Playbook::Props::Error)
     end
 
-    it "adds small class when size is sm" do
+    it "adds size_small class when size is sm" do
       icon = "user"
-      expect(subject.new(icon: icon, size: "sm").classname).to eq "pb_circle_icon_button_kit small"
+      expect(subject.new(icon: icon, size: "sm").classname).to eq "pb_circle_icon_button_kit size_small"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1901](https://runway.powerhrg.com/backlog_items/PLAY-1901) requests a small size for the Circle Icon Button kit. The default kit is 40x40, and the new `size` prop now takes "small" as a value to display a 20x20 button. The icon inside the circle is appropriately centered within it. If additional sizes are requested in the future they can easily be added to the kit via this setup.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1377" alt="rails doc ex" src="https://github.com/user-attachments/assets/fca5f8a9-ed4f-4994-88f7-7cde6b987758" />
<img width="1370" alt="react doc ex" src="https://github.com/user-attachments/assets/2035805d-6dfb-4103-b492-6072c9281140" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Circle Icon Kit "Size" doc example in the review environment ([rails](https://pr4543.playbook.beta.gm.powerapp.cloud/kits/circle_icon_button#size), [react](https://pr4543.playbook.beta.gm.powerapp.cloud/kits/circle_icon_button/react#size)) and see the new size for the Circle Icon Button kit.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.