### PR TITLE
[PLAY-2043] Playbook Website: Add Warning Icon to Error Docs - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_error.jsx
@@ -1,11 +1,14 @@
 import React from 'react'
 
 import DatePicker from '../_date_picker'
+import Icon from '../../pb_icon/_icon'
 
 const DatePickerError = (props) => (
   <div>
     <DatePicker
-        error="Invalid date. Please pick a valid date."
+        error={<>
+          <Icon icon="warning" /> Invalid date. Please pick a valid date.
+        </>}
         pickerId="date-picker-error"
         {...props}
     />

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_error.jsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react'
 import Dropdown from '../../pb_dropdown/_dropdown'
+import Icon from '../../pb_icon/_icon'
 
 const DropdownError = (props) => {
     const [selectedOption, setSelectedOption] = useState()
-    const error = selectedOption?.value ? null : "Please make a valid selection"
+    const error = selectedOption?.value ? null : (<>
+        <Icon icon="warning" /> Please make a valid selection
+    </>)
     const options = [
         {
             label: "United States",

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_validation.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_validation.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import Button from '../../pb_button/_button'
 import FixedConfirmationToast from '../../pb_fixed_confirmation_toast/_fixed_confirmation_toast'
 import PhoneNumberInput from '../../pb_phone_number_input/_phone_number_input'
+import Icon from '../../pb_icon/_icon'
 
 const PhoneNumberInputValidation = (props) => {
     const [formErrors, setFormErrors] = useState("");
@@ -29,6 +30,12 @@ const PhoneNumberInputValidation = (props) => {
         setShowFormErrors(formErrors.length > 0);
     }, [formErrors]);
 
+    const error = (
+        <>
+            <Icon icon="warning" /> Missing phone number.
+        </>
+    )
+
     return (
         <form
             action=""
@@ -43,7 +50,7 @@ const PhoneNumberInputValidation = (props) => {
                 />
             )}
             <PhoneNumberInput
-                error="Missing phone number."
+                error={error}
                 id="validation"
                 initialCountry={countryCode}
                 onChange={handleOnChange}

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Body from '../../pb_body/_body'
 import Select from '../../pb_select/_select'
+import Icon from '../../pb_icon/_icon'
 
 const SelectError = (props) => {
   const options = [
@@ -18,10 +19,14 @@ const SelectError = (props) => {
     },
   ]
 
+  const error = (<>
+    <Icon icon="warning" /> Please make a valid selection
+  </>)
+
   return (
     <div>
       <Select
-          error="Please make a valid selection"
+          error={error}
           label="Favorite Food"
           name="food"
           options={options}
@@ -29,7 +34,7 @@ const SelectError = (props) => {
           {...props}
       />
       <Body
-          error="Please make a valid selection"
+          error={error}
           status="negative"
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 
 import TextInput from '../_text_input'
+import Icon from '../../pb_icon/_icon'
 
 const TextInputError = (props) => {
   const [email, setEmail] = useState('')
@@ -8,11 +9,18 @@ const TextInputError = (props) => {
   const handleUpdateEmail = ({ target }) => {
     setEmail(target.value)
   }
+
+  const error = (
+    <>
+      <Icon icon="warning" /> Please enter a valid email address
+    </>
+  )
+  
   return (
     <div>
       <TextInput
           addOn={{ icon: 'user', alignment: 'left', border: true }}
-          error="Please enter a valid email address"
+          error={error}
           label="Email Address"
           onChange={handleUpdateEmail}
           placeholder="Enter email address"

--- a/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.jsx
@@ -1,15 +1,21 @@
 import React, {useState} from 'react'
 import Textarea from '../../pb_textarea/_textarea'
+import Icon from '../../pb_icon/_icon'
 
 const TextareaError = (props) => {
   const [value, setValue] = useState('default value text')
   const handleChange = (event) => {
     setValue(event.target.value)
   }
+  const error = (
+    <>
+        <Icon icon="warning" /> This field has an error!
+    </>
+  )
   return (
     <div>
       <Textarea
-          error="This field has an error!"
+          error={error}
           label="Label"
           name="comment"
           onChange={(e)=> handleChange(e)}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_error_state.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_error_state.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 
 import Typeahead from '../_typeahead'
+import Icon from '../../pb_icon/_icon'
 
 const options = [
   { label: 'Orange', value: '#FFA500' },
@@ -10,7 +11,10 @@ const options = [
 ]
 
 const TypeaheadErrorState = (props) => {
-  const [errorState, setErrorState] = useState("Please make a valid selection");
+  const error = (<>
+    <Icon icon="warning" /> Please make a valid selection
+  </>)
+  const [errorState, setErrorState] = useState(error);
   const [searchValue, setSearchValue] = useState(null);
   
   const handleOnChange = (value) => setSearchValue(value)
@@ -19,7 +23,7 @@ const TypeaheadErrorState = (props) => {
       if(searchValue) {
         setErrorState("")
       } else {
-        setErrorState("Please make a valid selection")
+        setErrorState(error)
       }
     }, [searchValue])
   


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Add warning icon next to error docs for accessibility
- Phone Number Input, Text Input, Textarea, Typeahead, Date Picker, Dropdown, and Select

https://runway.powerhrg.com/backlog_items/PLAY-2043

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-04-25 at 8 57 30 AM](https://github.com/user-attachments/assets/a8c0229f-ae94-444b-b44d-f097a0fd2e16)


**How to test?** Steps to confirm the desired behavior:
1. Go to these docs and make sure there is a 'warning' icon next to the error message

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.