### PR TITLE
[PLAY-2056] Advanced Table kit: Add Support for Different Column Border Colors for Column Groups - Rails & React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -386,8 +386,8 @@
 
   // Make sure all horizontal borders use the default border color
   tr, th, td {
-    border-top: 1px solid $border_light !important;
-    border-bottom: 1px solid $border_light !important;
+    border-top-color: $border_light !important;
+    border-bottom-color: $border_light !important;
   }
 
   // Apply border colors when columnGroupBorderColor is set

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -600,8 +600,8 @@
 
     // Make sure all horizontal borders use the default border color in dark mode
     tr, th, td {
-      border-top: 1px solid $border_dark !important;
-      border-bottom: 1px solid $border_dark !important;
+      border-top-color: $border_dark !important;
+      border-bottom-color: $border_dark !important;
     }
 
     .bg-white {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -13,6 +13,26 @@
 .pb_advanced_table {
   $border-color: 1px solid $border_light;
 
+  // Setup default border color for columns
+  --column-border-color: #{$border_light};
+
+  // Define color tokens once
+  $border_color_options: (
+    "text_lt_default": $text_lt_default,
+    "text_lt_light": $text_lt_light,
+    "text_lt_lighter": $text_lt_lighter,
+    "text_dk_default": $text_dk_default,
+    "text_dk_light": $text_dk_light,
+    "text_dk_lighter": $text_dk_lighter
+  );
+
+  // Generate classes for each color option
+  @each $color_name, $color_value in $border_color_options {
+    &.column-group-border-#{$color_name} {
+      --column-border-color: #{$color_value};
+    }
+  }
+
   [id$="-span"] {
     word-wrap: normal;
   }
@@ -143,6 +163,13 @@
     .last-cell {
       border-right: 1px solid $border_light !important;
     }
+
+    // Add vertical border colors to all body cells EXCEPT the last one
+    tr td:not(:last-child),
+    tr .pb_table_td:not(:last-child) {
+      border-right: 1px solid var(--column-border-color) !important;
+    }
+
     tr td:first-child {
       padding-left: 8px !important;
     }
@@ -178,6 +205,11 @@
         td:first-child {
           background-color: $info_subtle;
         }
+      }
+
+      // Add border color to all virtualized table cells EXCEPT the last one
+      td:not(:last-child) {
+        border-right: 1px solid var(--column-border-color) !important;
       }
     }
     td {
@@ -346,13 +378,19 @@
     }
   }
 
-  // Vertical separator
   .table-header-cells:first-child,
   .table-header-cells-custom:first-child,
-  td:first-child,
-  .pb_table_td:first-child,
   .checkbox-cell.checkbox-cell-header:first-child {
     box-shadow: 1px 0px 0px 0px $border_light !important;
+  }
+
+  td:first-child,
+  .pb_table_td:first-child {
+    box-shadow: 1px 0px 0px 0px var(--column-border-color) !important;
+  }
+
+  .collapsible-trail {
+    background-color: var(--column-border-color);
   }
 
   @include chrome_styles($border-color);
@@ -376,11 +414,32 @@
   }
 
   .collapsible-trail {
-    background-color: $border_light;
+    background-color: var(--column-border-color);
     position: absolute;
     top: 0;
     bottom: 0;
     width: 2px;
+  }
+
+  // Mixin to apply sticky column styles for different color modes and themes
+  @mixin apply-sticky-colors($theme) {
+    @each $color_name, $color_value in $border_color_options {
+      &.column-group-border-#{$color_name} {
+        @if $theme == "light" {
+          @include advanced-table-sticky-mixin(
+            $color_value,
+            $white,
+            lighten($silver, $opacity_7)
+          );
+        } @else if $theme == "dark" {
+          @include advanced-table-sticky-mixin(
+            $color_value,
+            $bg_dark_card,
+            $bg_dark
+          );
+        }
+      }
+    }
   }
 
   // Sticky Left Columns Styling
@@ -397,6 +456,9 @@
       $white,
       lighten($silver, $opacity_7)
     );
+
+    // Apply border colors for sticky columns
+    @include apply-sticky-colors("light");
   }
 
   // Responsive Styles
@@ -409,6 +471,9 @@
         $white,
         lighten($silver, $opacity_7)
       );
+
+      // Apply border colors for responsive mode
+      @include apply-sticky-colors("light");
     }
   }
   @media only screen and (min-width: $screen-xl-min) {
@@ -418,6 +483,9 @@
   }
 
   &.dark {
+    // Override default border color for dark mode
+    --column-border-color: #{$border_dark};
+
     .bg-white {
       background: $bg_dark_card;
     }
@@ -443,16 +511,40 @@
           background: $bg_dark;
         }
       }
+
+      // Add border color to virtualized rows in dark mode (except last column)
+      td:not(:last-child) {
+        border-right: 1px solid var(--column-border-color) !important;
+      }
     }
 
+    // Keep header borders with default dark color
     .table-header-cells:first-child,
-    td:first-child,
-    .pb_table_td:first-child {
+    .table-header-cells-custom:first-child,
+    .checkbox-cell.checkbox-cell-header:first-child {
       box-shadow: 1px 0px 0px 0px $border_dark !important;
     }
 
+    td:first-child,
+    .pb_table_td:first-child {
+      box-shadow: 1px 0px 0px 0px var(--column-border-color) !important;
+    }
+
+    // Dark mode body cell borders
+    .pb_advanced_table_body {
+      .last-cell {
+        border-right: 1px solid $border_dark !important;
+      }
+
+      // Border color to affect ONLY the table body
+      tr td:not(:last-child),
+      tr .pb_table_td:not(:last-child) {
+        border-right: 1px solid var(--column-border-color) !important;
+      }
+    }
+
     .collapsible-trail {
-      background-color: $border_dark !important;
+      background-color: var(--column-border-color) !important;
     }
 
     .sort-button-icon,
@@ -484,15 +576,6 @@
       }
     }
 
-    // Vertical separator
-    .table-header-cells:first-child,
-    .table-header-cells-custom:first-child,
-    td:first-child,
-    .pb_table_td:first-child,
-    .checkbox-cell.checkbox-cell-header:first-child {
-      box-shadow: 1px 0px 0px 0px $border_dark !important;
-    }
-
     // Fullscreen
     &.advanced-table-fullscreen {
       background: $bg_dark;
@@ -514,6 +597,9 @@
         $bg_dark_card,
         $bg_dark
       );
+
+      // Apply border colors for dark mode sticky columns
+      @include apply-sticky-colors("dark");
     }
 
     // Dark Mode Responsive Styles
@@ -531,6 +617,9 @@
           $bg_dark_card,
           $bg_dark
         );
+
+        // Apply border colors for dark mode
+        @include apply-sticky-colors("dark");
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -377,11 +377,17 @@
 
   // Color for collapsible trail
   .collapsible-trail {
-    background-color: var(--column-border-color);
+    background-color: $border_light !important;
     position: absolute;
     top: 0;
     bottom: 0;
     width: 2px;
+  }
+
+  // Make sure all horizontal borders use the default border color
+  tr, th, td {
+    border-top: 1px solid $border_light !important;
+    border-bottom: 1px solid $border_light !important;
   }
 
   // Apply border colors when columnGroupBorderColor is set
@@ -435,7 +441,7 @@
     // Sub-row headers
     .toggle-content {
       td {
-        border-bottom: 1px solid var(--column-border-color) !important;
+        border-bottom: 1px solid $border_light !important;
       }
     }
   }
@@ -587,6 +593,17 @@
     // Override default border color for dark mode
     --column-border-color: #{$border_dark};
 
+    // Dark mode default border colors for trails and horizontal borders
+    .collapsible-trail {
+      background-color: $border_dark !important;
+    }
+
+    // Make sure all horizontal borders use the default border color in dark mode
+    tr, th, td {
+      border-top: 1px solid $border_dark !important;
+      border-bottom: 1px solid $border_dark !important;
+    }
+
     .bg-white {
       background: $bg_dark_card;
     }
@@ -624,9 +641,9 @@
 
     // Apply border colors in dark mode
     &[class*="column-group-border-"] {
-      // For top-level column groups
+      // For top-level column groups (ENROLLMENT DATA, PERFORMANCE DATA)
       .pb_advanced_table_header {
-        // The main column group headers
+        // The main column group headers - NOT the last column
         > tr:first-child {
           th[colspan]:not([colspan="1"]):not(:last-child) {
             border-right: 1px solid var(--column-border-color) !important;
@@ -673,7 +690,7 @@
       // Sub-row headers
       .toggle-content {
         td {
-          border-bottom: 1px solid var(--column-border-color) !important;
+          border-bottom: 1px solid $border_dark !important;
         }
       }
     }
@@ -713,10 +730,6 @@
           }
         }
       }
-    }
-
-    .collapsible-trail {
-      background-color: var(--column-border-color) !important;
     }
 
     .sort-button-icon,

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -13,7 +13,7 @@
 .pb_advanced_table {
   $border-color: 1px solid $border_light;
 
-  // Setup default border color for columns
+  // Base vertical border color variable setup
   --column-border-color: #{$border_light};
 
   // Define color tokens once
@@ -163,13 +163,6 @@
     .last-cell {
       border-right: 1px solid $border_light !important;
     }
-
-    // Add vertical border colors to all body cells EXCEPT the last one
-    tr td:not(:last-child),
-    tr .pb_table_td:not(:last-child) {
-      border-right: 1px solid var(--column-border-color) !important;
-    }
-
     tr td:first-child {
       padding-left: 8px !important;
     }
@@ -205,11 +198,6 @@
         td:first-child {
           background-color: $info_subtle;
         }
-      }
-
-      // Add border color to all virtualized table cells EXCEPT the last one
-      td:not(:last-child) {
-        border-right: 1px solid var(--column-border-color) !important;
       }
     }
     td {
@@ -378,19 +366,127 @@
     }
   }
 
+  // First column separator/border
   .table-header-cells:first-child,
   .table-header-cells-custom:first-child,
-  .checkbox-cell.checkbox-cell-header:first-child {
-    box-shadow: 1px 0px 0px 0px $border_light !important;
-  }
-
   td:first-child,
-  .pb_table_td:first-child {
+  .pb_table_td:first-child,
+  .checkbox-cell.checkbox-cell-header:first-child {
     box-shadow: 1px 0px 0px 0px var(--column-border-color) !important;
   }
 
+  // Color for collapsible trail
   .collapsible-trail {
     background-color: var(--column-border-color);
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+  }
+
+  // Apply border colors when columnGroupBorderColor is set
+  &[class*="column-group-border-"] {
+    // For top-level column groups
+    .pb_advanced_table_header {
+      // The main column group headers
+      > tr:first-child {
+        th[colspan]:not([colspan="1"]):not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+      }
+
+      // Subgroup headers
+      > tr:nth-child(2) {
+        th[colspan]:not([colspan="1"]):not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+
+        // Last cell in each subgroup
+        th.last-header-cell:not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+      }
+
+      // Individual column headers at subgroup boundaries
+      > tr:last-child {
+        // Last cell in each subgroup
+        th.last-header-cell:not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+      }
+    }
+
+    // For data cells at column group boundaries
+    .pb_advanced_table_body {
+      // Apply to cells that are at column group boundaries
+      td.last-cell:not(:last-child),
+      .pb_table_td.last-cell:not(:last-child) {
+        border-right: 1px solid var(--column-border-color) !important;
+      }
+
+      // Virtualized row cells at column group boundaries
+      tr.virtualized-table-row {
+        td.last-cell:not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+      }
+    }
+
+    // Sub-row headers
+    .toggle-content {
+      td {
+        border-bottom: 1px solid var(--column-border-color) !important;
+      }
+    }
+  }
+
+  // Restore vertical border styling when verticalBorder is true
+  .pb_table[data-vertical-border="true"] {
+    .pb_advanced_table_header {
+      > tr:not(:first-child) {
+        th:not(:last-child) {
+          border-right: 1px solid $border_light !important;
+        }
+      }
+    }
+
+    .pb_advanced_table_body {
+      td:not(:last-child),
+      .pb_table_td:not(:last-child) {
+        border-right: 1px solid $border_light !important;
+      }
+    }
+
+    tr.virtualized-table-row {
+      td:not(:last-child) {
+        border-right: 1px solid $border_light !important;
+      }
+    }
+
+    // When both verticalBorder AND columnGroupBorderColor are set,
+    // override the default border-light with the custom color
+    &.pb_advanced_table[class*="column-group-border-"] {
+      .pb_advanced_table_header {
+        > tr:not(:first-child) {
+          th:not(:last-child) {
+            border-right: 1px solid var(--column-border-color) !important;
+          }
+        }
+      }
+
+      .pb_advanced_table_body {
+        td:not(:last-child),
+        .pb_table_td:not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+      }
+
+      tr.virtualized-table-row {
+        td:not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+      }
+    }
   }
 
   @include chrome_styles($border-color);
@@ -411,14 +507,6 @@
   .toggle-content.is-visible {
     display: table-row !important;
     height: auto;
-  }
-
-  .collapsible-trail {
-    background-color: var(--column-border-color);
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 2px;
   }
 
   // Mixin to apply sticky column styles for different color modes and themes
@@ -466,16 +554,29 @@
     &[class*="advanced-table-responsive-scroll"] {
       overflow-x: auto;
       width: 100%;
+
+      // These are the responsive borders that should NOT inherit the custom color
       @include advanced-table-sticky-mixin(
         $border_light,
         $white,
         lighten($silver, $opacity_7)
       );
 
-      // Apply border colors for responsive mode
-      @include apply-sticky-colors("light");
+      // Override any columnGroupBorderColor inheritance for responsive borders
+      .sticky-left {
+        box-shadow: $shadow_deep !important;
+      }
+
+      .pb_advanced_table_header,
+      .pb_advanced_table_body {
+        th.sticky-left,
+        td.sticky-left {
+          border-right: 1px solid $border_light !important;
+        }
+      }
     }
   }
+
   @media only screen and (min-width: $screen-xl-min) {
     &[class*="advanced-table-responsive-scroll"] {
       overflow-x: visible;
@@ -511,35 +612,106 @@
           background: $bg_dark;
         }
       }
-
-      // Add border color to virtualized rows in dark mode (except last column)
-      td:not(:last-child) {
-        border-right: 1px solid var(--column-border-color) !important;
-      }
     }
 
-    // Keep header borders with default dark color
     .table-header-cells:first-child,
     .table-header-cells-custom:first-child,
-    .checkbox-cell.checkbox-cell-header:first-child {
-      box-shadow: 1px 0px 0px 0px $border_dark !important;
-    }
-
     td:first-child,
-    .pb_table_td:first-child {
+    .pb_table_td:first-child,
+    .checkbox-cell.checkbox-cell-header:first-child {
       box-shadow: 1px 0px 0px 0px var(--column-border-color) !important;
     }
 
-    // Dark mode body cell borders
-    .pb_advanced_table_body {
-      .last-cell {
-        border-right: 1px solid $border_dark !important;
+    // Apply border colors in dark mode
+    &[class*="column-group-border-"] {
+      // For top-level column groups
+      .pb_advanced_table_header {
+        // The main column group headers
+        > tr:first-child {
+          th[colspan]:not([colspan="1"]):not(:last-child) {
+            border-right: 1px solid var(--column-border-color) !important;
+          }
+        }
+
+        // Subgroup headers
+        > tr:nth-child(2) {
+          th[colspan]:not([colspan="1"]):not(:last-child) {
+            border-right: 1px solid var(--column-border-color) !important;
+          }
+
+          // Last cell in each subgroup
+          th.last-header-cell:not(:last-child) {
+            border-right: 1px solid var(--column-border-color) !important;
+          }
+        }
+
+        // Individual column headers at subgroup boundaries
+        > tr:last-child {
+          // Last cell in each subgroup
+          th.last-header-cell:not(:last-child) {
+            border-right: 1px solid var(--column-border-color) !important;
+          }
+        }
       }
 
-      // Border color to affect ONLY the table body
-      tr td:not(:last-child),
-      tr .pb_table_td:not(:last-child) {
-        border-right: 1px solid var(--column-border-color) !important;
+      // For data cells at column group boundaries in dark mode
+      .pb_advanced_table_body {
+        // Apply to cells that are at column group boundaries
+        td.last-cell:not(:last-child),
+        .pb_table_td.last-cell:not(:last-child) {
+          border-right: 1px solid var(--column-border-color) !important;
+        }
+
+        // Virtualized row cells at column group boundaries
+        tr.virtualized-table-row {
+          td.last-cell:not(:last-child) {
+            border-right: 1px solid var(--column-border-color) !important;
+          }
+        }
+      }
+
+      // Sub-row headers
+      .toggle-content {
+        td {
+          border-bottom: 1px solid var(--column-border-color) !important;
+        }
+      }
+    }
+
+    // Restore vertical border styling in dark mode when verticalBorder is true
+    .pb_table[data-vertical-border="true"] {
+      .pb_advanced_table_header {
+        > tr:not(:first-child) {
+          th:not(:last-child) {
+            border-right: 1px solid $border_dark !important;
+          }
+        }
+      }
+
+      .pb_advanced_table_body {
+        td:not(:last-child),
+        .pb_table_td:not(:last-child) {
+          border-right: 1px solid $border_dark !important;
+        }
+      }
+
+      // When both verticalBorder AND columnGroupBorderColor are set in dark mode,
+      // override the default border-dark with the custom color
+      &.pb_advanced_table[class*="column-group-border-"] {
+        .pb_advanced_table_header {
+          > tr:not(:first-child) {
+            th:not(:last-child) {
+              border-right: 1px solid var(--column-border-color) !important;
+            }
+          }
+        }
+
+        .pb_advanced_table_body {
+          td:not(:last-child),
+          .pb_table_td:not(:last-child) {
+            border-right: 1px solid var(--column-border-color) !important;
+          }
+        }
       }
     }
 
@@ -597,9 +769,6 @@
         $bg_dark_card,
         $bg_dark
       );
-
-      // Apply border colors for dark mode sticky columns
-      @include apply-sticky-colors("dark");
     }
 
     // Dark Mode Responsive Styles
@@ -612,14 +781,26 @@
             }
           }
         }
+
+        // These are the responsive borders that should NOT inherit the custom color
         @include advanced-table-sticky-mixin(
           $border_dark,
           $bg_dark_card,
           $bg_dark
         );
 
-        // Apply border colors for dark mode
-        @include apply-sticky-colors("dark");
+        // Override any columnGroupBorderColor inheritance for responsive borders in dark mode
+        .sticky-left {
+          box-shadow: $shadow_deep !important;
+        }
+
+        .pb_advanced_table_header,
+        .pb_advanced_table_body {
+          th.sticky-left,
+          td.sticky-left {
+            border-right: 1px solid $border_dark !important;
+          }
+        }
       }
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -34,6 +34,7 @@ type AdvancedTableProps = {
   children?: React.ReactNode | React.ReactNode[]
   className?: string
   columnDefinitions: GenericObject[]
+  columnGroupBorderColor?: "text_lt_default" | "text_lt_light" | "text_lt_lighter" | "text_dk_default" | "text_dk_light" | "text_dk_lighter"
   dark?: boolean
   data?: { [key: string]: string }
   enableToggleExpansion?: "all" | "header" | "none"
@@ -71,6 +72,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     children,
     className,
     columnDefinitions,
+    columnGroupBorderColor,
     dark = false,
     data = {},
     enableToggleExpansion = "header",
@@ -239,6 +241,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
       'advanced-table-allow-fullscreen': allowFullScreen
     },
     {'advanced-table-sticky-left-columns': stickyLeftColumn && stickyLeftColumn.length > 0},
+    columnGroupBorderColor ? `column-group-border-${columnGroupBorderColor}` : '',
     globalProps(props),
     className
   );
@@ -282,6 +285,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
         {renderFullscreenHeader()}
         <AdvancedTableProvider
             columnDefinitions={columnDefinitions}
+            columnGroupBorderColor={columnGroupBorderColor}
             enableToggleExpansion={enableToggleExpansion}
             enableVirtualization={virtualizedRows}
             expandByDepth={expandByDepth}
@@ -334,7 +338,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             </Table>
           </React.Fragment>
         </AdvancedTableProvider>
-     
+
       </div>
       {/* Bottom Pagination */}
       {pagination && (

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.rb
@@ -7,6 +7,9 @@ module Playbook
                         default: []
       prop :column_definitions, type: Playbook::Props::Array,
                                 default: []
+      prop :column_group_border_color, type: Playbook::Props::Enum,
+                                       values: %w[text_lt_default text_lt_light text_lt_lighter text_dk_default text_dk_light text_dk_lighter none],
+                                       default: "none"
       prop :enable_toggle_expansion, type: Playbook::Props::Enum,
                                      values: %w[all header none],
                                      default: "header"
@@ -24,7 +27,9 @@ module Playbook
                              default: false
 
       def classname
-        generate_classname("pb_advanced_table", responsive_classname, max_height_classname, separator: " ")
+        additional_classes = [responsive_classname, max_height_classname]
+        additional_classes << "column-group-border-#{column_group_border_color}" if column_group_border_color != "none"
+        generate_classname("pb_advanced_table", *additional_classes, separator: " ")
       end
 
       def responsive_classname

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.jsx
@@ -1,0 +1,60 @@
+import React from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableColumnBorderColors = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      label: "Enrollment Data",
+      columns: [
+        {
+          accessor: "newEnrollments",
+          label: "New Enrollments",
+        },
+        {
+          accessor: "scheduledMeetings",
+          label: "Scheduled Meetings",
+        },
+      ],
+    },
+    {
+      label: "Performance Data",
+      columns: [
+        {
+          accessor: "attendanceRate",
+          label: "Attendance Rate",
+        },
+        {
+          accessor: "completedClasses",
+          label: "Completed Classes",
+        },
+        {
+          accessor: "classCompletionRate",
+          label: "Class Completion Rate",
+        },
+        {
+          accessor: "graduatedStudents",
+          label: "Graduated Students",
+        },
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          columnGroupBorderColor="text_lt_default"
+          tableData={MOCK_DATA}
+          {...props}
+      />
+    </>
+  )
+}
+
+export default AdvancedTableColumnBorderColors

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.jsx
@@ -13,12 +13,17 @@ const AdvancedTableColumnBorderColors = (props) => {
       label: "Enrollment Data",
       columns: [
         {
-          accessor: "newEnrollments",
-          label: "New Enrollments",
-        },
-        {
-          accessor: "scheduledMeetings",
-          label: "Scheduled Meetings",
+          label: "Enrollment Stats",
+          columns: [
+            {
+              accessor: "newEnrollments",
+              label: "New Enrollments",
+            },
+            {
+              accessor: "scheduledMeetings",
+              label: "Scheduled Meetings",
+            },
+          ],
         },
       ],
     },
@@ -26,20 +31,30 @@ const AdvancedTableColumnBorderColors = (props) => {
       label: "Performance Data",
       columns: [
         {
-          accessor: "attendanceRate",
-          label: "Attendance Rate",
+          label: "Completion Metrics",
+          columns: [
+            {
+              accessor: "completedClasses",
+              label: "Completed Classes",
+            },
+            {
+              accessor: "classCompletionRate",
+              label: "Class Completion Rate",
+            },
+          ],
         },
         {
-          accessor: "completedClasses",
-          label: "Completed Classes",
-        },
-        {
-          accessor: "classCompletionRate",
-          label: "Class Completion Rate",
-        },
-        {
-          accessor: "graduatedStudents",
-          label: "Graduated Students",
+          label: "Attendance",
+          columns: [
+            {
+              accessor: "attendanceRate",
+              label: "Attendance Rate",
+            },
+            {
+              accessor: "scheduledMeetings",
+              label: "Scheduled Meetings",
+            },
+          ],
         },
       ],
     },

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.jsx
@@ -45,12 +45,17 @@ const AdvancedTableColumnBorderColors = (props) => {
     },
   ];
 
+  const tableProps = {
+    verticalBorder: true
+  }
+
   return (
     <>
       <AdvancedTable
           columnDefinitions={columnDefinitions}
           columnGroupBorderColor="text_lt_default"
           tableData={MOCK_DATA}
+          tableProps={tableProps}
           {...props}
       />
     </>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.md
@@ -1,3 +1,3 @@
-The borders of column groups can be set to a different color using the `columnGroupBorderColor` prop. By default, these borders will use the default color set for table borders.
+The borders of column groups can be set to a different color using the `columnGroupBorderColor` prop.  In order for these borders to be visible, this prop must be used with `tableProps` and `verticalBorder` set to true.
 
 The available colors for the border are Playbook's Text Colors, which can be found [here](https://playbook.powerapp.cloud/visual_guidelines/colors).

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color.md
@@ -1,0 +1,3 @@
+The borders of column groups can be set to a different color using the `columnGroupBorderColor` prop. By default, these borders will use the default color set for table borders.
+
+The available colors for the border are Playbook's Text Colors, which can be found [here](https://playbook.powerapp.cloud/visual_guidelines/colors).

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.html.erb
@@ -1,0 +1,58 @@
+<% column_definitions = [
+  {
+    accessor: "year",
+    label: "Year",
+    cellAccessors: ["quarter", "month", "day"],
+  },
+  {
+    label: "Enrollment Data",
+    columns: [
+      {
+        label: "Enrollment Stats",
+        columns: [
+          {
+            accessor: "newEnrollments",
+            label: "New Enrollments",
+          },
+          {
+            accessor: "scheduledMeetings",
+            label: "Scheduled Meetings",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: "Performance Data",
+    columns: [
+      {
+        label: "Completion Metrics",
+        columns: [
+          {
+            accessor: "completedClasses",
+            label: "Completed Classes",
+          },
+          {
+            accessor: "classCompletionRate",
+            label: "Class Completion Rate",
+          },
+        ],
+      },
+      {
+        label: "Attendance",
+        columns: [
+          {
+            accessor: "attendanceRate",
+            label: "Attendance Rate",
+          },
+          {
+            accessor: "scheduledMeetings",
+            label: "Scheduled Meetings",
+          },
+        ],
+      },
+    ],
+  },
+] %>
+
+<%= pb_rails("advanced_table", props: { id: "beta_table_with_muilti_headers", table_data: @table_data, column_definitions: column_definitions, column_group_border_color: "text_lt_default" }) %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.html.erb
@@ -55,4 +55,4 @@
   },
 ] %>
 
-<%= pb_rails("advanced_table", props: { id: "beta_table_with_muilti_headers", table_data: @table_data, column_definitions: column_definitions, column_group_border_color: "text_lt_default" }) %>
+<%= pb_rails("advanced_table", props: { id: "beta_table_with_muilti_headers", table_data: @table_data, column_definitions: column_definitions, column_group_border_color: "text_lt_default", table_props: { vertical_border: true } }) %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.md
@@ -1,3 +1,3 @@
-The borders of column groups can be set to a different color using the `column_group_border_color` prop. By default, these borders will use the default color set for table borders.
+The borders of column groups can be set to a different color using the `column_group_border_color` prop. In order for these borders to be visible, this prop must be used with `table_props` and `vertical_border` set to true.
 
 The available colors for the border are Playbook's Text Colors, which can be found [here](https://playbook.powerapp.cloud/visual_guidelines/colors).

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_border_color_rails.md
@@ -1,0 +1,3 @@
+The borders of column groups can be set to a different color using the `column_group_border_color` prop. By default, these borders will use the default color set for table borders.
+
+The available colors for the border are Playbook's Text Colors, which can be found [here](https://playbook.powerapp.cloud/visual_guidelines/colors).

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -14,6 +14,7 @@ examples:
   - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
   # - advanced_table_selectable_rows: Selectable Rows
   # - advanced_table_selectable_rows_no_subrows: Selectable Rows (No Subrows)
+  - advanced_table_column_border_color_rails: Column Group Border Color
 
 
   react:
@@ -46,3 +47,4 @@ examples:
   - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
   - advanced_table_inline_editing: Inline Cell Editing
   - advanced_table_fullscreen: Fullscreen
+  - advanced_table_column_border_color: Column Group Border Color

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -27,3 +27,4 @@ export { default as AdvancedTableStickyColumns } from './_advanced_table_sticky_
 export { default as AdvancedTableStickyHeader } from './_advanced_table_sticky_header.jsx'
 export { default as AdvancedTableStickyColumnsAndHeader } from './_advanced_table_sticky_columns_and_header.jsx'
 export { default as AdvancedTableExpandByDepth } from './_advanced_table_expand_by_depth.jsx'
+export { default as AdvancedTableColumnBorderColor} from './_advanced_table_column_border_color.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2056)

As a Playbook user, 
I want provide options for border colors for the vertical borders between Column Groups when using the multi header column logic for the Advanced Table

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-04-29 at 9 01 31 AM](https://github.com/user-attachments/assets/d4dad6c4-37b9-4035-93c2-597aa7227196)

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
