### PR TITLE
[PLAY-2048] Phone Number Input kit: Add Country Search

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -39,6 +39,9 @@ $flag-min-resolution: 192dpi;
     color: $charcoal;
   }
 
+  .iti__country-list {
+    min-width: $dropdown-min-width;
+  }
   // iti-spacer-horizontal's default is 8px, or $space_xs 
   .iti__country-list .iti__flag, .iti__country-name {
     margin-right: $space_xs;
@@ -227,6 +230,16 @@ $flag-min-resolution: 192dpi;
     .iti__dropdown-content {
       border-radius: $space_xs; 
       border: 1px solid $border_dark !important;
+      .iti__search-input {
+        background-color: $bg_dark_card;
+        &:hover {
+          background-color: $bg_dark_card;
+        }      
+        &:active,
+        &:focus {
+          background-color: $card_dark;
+        }
+      }
     }
 
     .iti__divider {

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -37,6 +37,7 @@ type PhoneNumberInputProps = {
   required?: boolean,
   value?: string,
   formatAsYouType?: boolean,
+  countrySearch?: boolean,
 }
 
 enum ValidationError {
@@ -91,6 +92,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
     preferredCountries = [],
     value = "",
     formatAsYouType = false,
+    countrySearch = false,
   } = props
 
   const ariaProps = buildAriaProps(aria)
@@ -242,7 +244,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.MutableRefOb
       autoInsertDialCode: false,
       initialCountry: initialCountry || fallbackCountry,
       onlyCountries,
-      countrySearch: false,
+      countrySearch: countrySearch,
       fixDropdownWidth: false,
       formatAsYouType: formatAsYouType,
       hiddenInput: hiddenInputs ? () => ({

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_country_search.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_country_search.html.erb
@@ -1,0 +1,10 @@
+<%= pb_rails("phone_number_input", props: {
+    country_search: true, 
+    id: "country-search",
+}) %>
+
+<%= pb_rails("phone_number_input", props: {
+    country_search: true, 
+    id: "country-search-limited",
+    only_countries: ["br", "us", "ph", "gb"],
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_country_search.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_country_search.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import PhoneNumberInput from '../_phone_number_input'
+
+const PhoneNumberInputCountrySearch = (props) => (
+    <>
+        <PhoneNumberInput
+            countrySearch
+            id='country-search'
+            {...props} 
+        />
+        <PhoneNumberInput
+            countrySearch
+            id='country-search-limited'
+            onlyCountries={["br", "us", "ph", "gb"]}
+            {...props} 
+        />
+    </>
+)
+
+export default PhoneNumberInputCountrySearch

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_country_search.md
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_country_search.md
@@ -1,0 +1,1 @@
+Set `country_search` / `countrySearch` to true to allow users to search for a specific Country within the dropdown. If the range of countries has been limited, only the selected countries will be searchable.

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/example.yml
@@ -9,6 +9,7 @@ examples:
   - phone_number_input_clear_field: Clearing the Input Field
   - phone_number_input_access_input_element: Accessing the Input Element
   - phone_number_input_format: Format as You Type
+  - phone_number_input_country_search: Country Search
 
   rails:
   - phone_number_input_default: Default
@@ -18,4 +19,5 @@ examples:
   - phone_number_input_validation: Form Validation
   - phone_number_input_format: Format as You Type
   - phone_number_input_hidden_inputs: Hidden Inputs
+  - phone_number_input_country_search: Country Search
   

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/index.js
@@ -6,3 +6,4 @@ export { default as PhoneNumberInputValidation } from './_phone_number_input_val
 export { default as PhoneNumberInputClearField } from './_phone_number_input_clear_field'
 export { default as PhoneNumberInputAccessInputElement } from './_phone_number_input_access_input_element'
 export { default as PhoneNumberInputFormat } from './_phone_number_input_format'
+export { default as PhoneNumberInputCountrySearch } from './_phone_number_input_country_search'

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
@@ -25,6 +25,8 @@ module Playbook
                                 default: false
       prop :hidden_inputs, type: Playbook::Props::Boolean,
                            default: false
+      prop :country_search, type: Playbook::Props::Boolean,
+                            default: false
 
       def classname
         generate_classname("pb_phone_number_input")
@@ -45,6 +47,7 @@ module Playbook
           preferredCountries: preferred_countries,
           required: required,
           value: value,
+          countrySearch: country_search,
         }
       end
     end

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.test.js
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.test.js
@@ -139,3 +139,22 @@ test("should format phone number as '555-555-5555' with formatAsYouType and 'us'
 
     expect(input.value).toBe("555-555-5555");
 });
+
+test("should pass countrySearch prop to component", () => {
+    window.intlTelInput = jest.fn(() => ({
+      getSelectedCountryData: jest.fn(() => ({})),
+      isValidNumber: jest.fn(() => true),
+      getValidationError: jest.fn(() => 0),
+    }));
+    
+    const props = {
+      id: testId,
+      countrySearch: true,
+      data: { testid: 'phone-input-with-search' }
+    };
+  
+    render(<PhoneNumberInput {...props} />);
+    
+    const wrapper = screen.getByTestId('phone-input-with-search');
+    expect(wrapper).toBeInTheDocument();
+});

--- a/playbook/spec/pb_kits/playbook/kits/phone_number_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/phone_number_input_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Playbook::PbPhoneNumberInput do
   it { is_expected.to define_prop(:error).with_default("") }
   it { is_expected.to define_prop(:value).with_default("") }
   it { is_expected.to define_boolean_prop(:format_as_you_type).with_default(false) }
+  it { is_expected.to define_boolean_prop(:country_search).with_default(false) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2048](https://runway.powerhrg.com/backlog_items/PLAY-2048) prop enables a relatively new-ish feature from the intl-tel-input library, `countrySearch`. `countrySearch` allows a user to search for the country via an input prepended to the country selection dropdown. 

This PR creates a boolean prop to enable this feature for both React and Rails implementations, and adds a doc example demonstrating its use. I also locally tested its look on the [form kit page](https://playbook.powerapp.cloud/kits/form) but did not push this up - see screenshot below from local test. This PR also re-adds a minimum width to the country dropdown - the kit was initially created with this prop, but it was removed in error in a previous PR from last year - see my explainer diagram below for why it was important to re-implement this in this PR.
<img width="953" alt="adding back width explainer" src="https://github.com/user-attachments/assets/80aa62a9-6cb9-4bf7-993e-be3a72fdaddd" />


**Screenshots:** Screenshots to visualize your addition/change
<img width="1348" alt="doc ex for PR" src="https://github.com/user-attachments/assets/0c580535-8bb3-4837-972c-eb1640224cde" />
<img width="438" alt="first search react" src="https://github.com/user-attachments/assets/5f8576e7-2784-4e2c-a782-8eebd03bdba8" />
<img width="433" alt="first search rails dark diff search term" src="https://github.com/user-attachments/assets/b36051a3-da2b-43e6-82fa-198f31787c61" />
Form kit example (screenshot from local testing)
<img width="661" alt="form page country search for PR" src="https://github.com/user-attachments/assets/c83281cf-e837-4040-b1a8-329e21b599f5" />

**How to test?** Steps to confirm the desired behavior:
1. Go to the Phone Number Input kit "Country Search" doc example ([rails](https://pr4560.playbook.beta.hq.powerapp.cloud/kits/phone_number_input#country-search-1), [react](https://pr4560.playbook.beta.hq.powerapp.cloud/kits/phone_number_input/react#country-search-1)).
2. Click on one of the inputs and see the country dropdown appear with an input at the top of the dropdown.
3. Type to search from the available countries (the first example has all countries available, the second has a limited set available).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.