### PR TITLE
[PLAY-1736] Line Graph: Add Ability to Use Line Graph Styles w/o Line Graph

### DIFF
--- a/playbook/app/javascript/theme.js
+++ b/playbook/app/javascript/theme.js
@@ -7,3 +7,4 @@ export { highchartsTheme } from '../pb_kits/playbook/pb_dashboard/pbChartsLightT
 export { highchartsDarkTheme } from '../pb_kits/playbook/pb_dashboard/pbChartsDarkTheme'
 export { default as gaugeTheme } from '../pb_kits/playbook/pb_gauge/gaugeTheme'
 export { default as circleChartTheme } from '../pb_kits/playbook/pb_circle_chart/circleChartTheme'
+export { default as lineGraphTheme } from '../pb_kits/playbook/pb_line_graph/lineGraphTheme'

--- a/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_pb_styles.jsx
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_pb_styles.jsx
@@ -37,7 +37,7 @@ const baseOptions = {
 }
 
 const LineGraphPbStyles = () => {
-  const options = Highcharts.merge({}, lineGraphTheme, baseOptions )
+  const options = Highcharts.merge({}, lineGraphTheme, baseOptions)
 
   return(
     <div>

--- a/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_pb_styles.jsx
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_pb_styles.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import lineGraphTheme from '../lineGraphTheme'
+import Highcharts from "highcharts"
+import HighchartsReact from "highcharts-react-official"
+
+const data = [{
+  name: 'Installation',
+  data: [43934, 52503, 57177, 69658, 97031, 119931, 137133, 154175],
+}, {
+  name: 'Manufacturing',
+  data: [24916, 24064, 29742, 29851, 32490, 30282, 38121, 40434],
+}, {
+  name: 'Sales & Distribution',
+  data: [11744, 17722, 16005, 19771, 20185, 24377, 32147, 39387],
+}, {
+  name: 'Project Development',
+  data: [null, null, 7988, 12169, 15112, 22452, 34400, 34227],
+}, {
+  name: 'Other',
+  data: [12908, 5948, 8105, 11248, 8989, 11816, 18274, 18111],
+}]
+
+const categories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+const baseOptions = {
+  series: data,
+  title: { text: "Solar Employment Growth by Sector, 2010-2016" },
+  subtitle: { text: "Source: thesolarfoundation.com" },
+  xAxis: {
+    categories: categories,
+  },
+  yAxis: {
+    title: {
+      text: "Number of Employees",
+    },
+  },
+}
+
+const LineGraphPbStyles = () => {
+  const options = Highcharts.merge({}, lineGraphTheme, baseOptions )
+
+  return(
+    <div>
+      <HighchartsReact
+          highcharts={Highcharts}
+          options={options}
+      />
+    </div>
+  )
+}
+
+export default LineGraphPbStyles

--- a/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_pb_styles.md
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/docs/_line_graph_pb_styles.md
@@ -1,0 +1,1 @@
+You don't need to use the Line Graph Kit to apply Playbook styles to your Highcharts line graph. Just import lineGraphTheme.ts and merge it with your graph options—Playbook’s styling will apply automatically.

--- a/playbook/app/pb_kits/playbook/pb_line_graph/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/docs/example.yml
@@ -11,6 +11,7 @@ examples:
 
   react:
   - line_graph_default: Default
+  - line_graph_pb_styles: Playbook Styles
   - line_graph_legend: Legend
   - line_graph_legend_position: Legend Position
   - line_graph_legend_nonclickable: Legend Nonclickable

--- a/playbook/app/pb_kits/playbook/pb_line_graph/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/docs/index.js
@@ -4,3 +4,4 @@ export { default as LineGraphLegendPosition } from './_line_graph_legend_positio
 export { default as LineGraphLegendNonclickable } from './_line_graph_legend_nonclickable.jsx'
 export { default as LineGraphHeight } from './_line_graph_height.jsx'
 export { default as LineGraphColors } from './_line_graph_colors.jsx'
+export { default as LineGraphPbStyles } from './_line_graph_pb_styles.jsx'

--- a/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.js
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.js
@@ -1,0 +1,52 @@
+import colors from '../tokens/exports/_colors.module.scss'
+import typography from '../tokens/exports/_typography.module.scss'
+
+const lineGraphTheme = {
+  title: { text: "" },
+  subtitle: { text: "" },
+  chart: {
+    type: "line",
+  },
+  tooltip: {
+    backgroundColor: {
+      linearGradient: { x1: 0, y1: 0, x2: 0, y2: 1 },
+      stops: [
+        [0, colors.bg_dark],
+        [1, colors.bg_dark],
+      ],
+    },
+    pointFormat:
+      '<span style="font-weight: bold; color:{point.color};">●</span>{point.name}: ' +
+      "<b>{point.y}</b>",
+    followPointer: true,
+    shadow: false,
+    borderWidth: 0,
+    borderRadius: 10,
+    style: {
+      fontFamily: typography.font_family_base,
+      color: colors.text_dk_default,
+      fontWeight: typography.regular,
+      fontSize: typography.text_smaller,
+    },
+  },
+  plotOptions: {
+    line: {
+      dataLabels: {
+        enabled: false,
+      },
+    },
+  },
+  credits: { enabled: false },
+  legend: { enabled: false },
+  colors: [
+    colors.data_1,
+    colors.data_2,
+    colors.data_3,
+    colors.data_4,
+    colors.data_5,
+    colors.data_6,
+    colors.data_7,
+  ],
+}
+
+export default lineGraphTheme;

--- a/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.js
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.js
@@ -2,8 +2,24 @@ import colors from '../tokens/exports/_colors.module.scss'
 import typography from '../tokens/exports/_typography.module.scss'
 
 const lineGraphTheme = {
-  title: { text: "" },
-  subtitle: { text: "" },
+  title: {
+    text: "",
+    style: {
+      color: colors.text_lt_default,
+      fontFamily: typography.font_family_base,
+      fontWeight: typography.bold,
+      fontSize: typography.heading_3,
+    },
+  },
+  subtitle: {
+    text: "" ,
+    style: {
+      fontFamily: typography.font_family_base,
+      color: colors.text_lt_light,
+      fontWeight: typography.regular,
+      fontSize: typography.text_base,
+    },
+  },
   chart: {
     type: "line",
   },
@@ -44,6 +60,51 @@ const lineGraphTheme = {
     colors.data_6,
     colors.data_7,
   ],
+  xAxis: {
+    gridLineWidth: 0,
+    lineColor: colors.border_light,
+    tickColor: colors.border_light,
+    labels: {
+      style: {
+        fontFamily: typography.font_family_base,
+        color: colors.text_lt_lighter,
+        fontWeight: typography.bold,
+        fontSize: typography.text_smaller,
+      },
+    },
+    title: {
+      style: {
+        color: colors.text_lt_default,
+        fontFamily: typography.font_family_base,
+        fontWeight: typography.regular,
+        fontSize: typography.heading_4,
+      },
+    },
+  },
+  yAxis: {
+    alternateGridColor: undefined,
+    minorTickInterval: null,
+    gridLineColor: colors.border_light,
+    minorGridLineColor: colors.border_light,
+    lineWidth: 0,
+    tickWidth: 0,
+    labels: {
+      style: {
+        fontFamily: typography.font_family_base,
+        color: colors.text_lt_lighter,
+        fontWeight: typography.bold,
+        fontSize: typography.text_smaller,
+      },
+    },
+    title: {
+      style: {
+        fontFamily: typography.font_family_base,
+        color: colors.text_lt_lighter,
+        fontWeight: typography.bold,
+        fontSize: typography.text_smaller,
+      },
+    },
+  },
 }
 
 export default lineGraphTheme;

--- a/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.js
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.js
@@ -15,9 +15,6 @@ const lineGraphTheme = {
         [1, colors.bg_dark],
       ],
     },
-    pointFormat:
-      '<span style="font-weight: bold; color:{point.color};">●</span>{point.name}: ' +
-      "<b>{point.y}</b>",
     followPointer: true,
     shadow: false,
     borderWidth: 0,

--- a/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.ts
+++ b/playbook/app/pb_kits/playbook/pb_line_graph/lineGraphTheme.ts
@@ -82,8 +82,8 @@ const lineGraphTheme = {
     },
   },
   yAxis: {
-    alternateGridColor: undefined,
-    minorTickInterval: null,
+    alternateGridColor: undefined as string | undefined,
+    minorTickInterval: null as number | null,
     gridLineColor: colors.border_light,
     minorGridLineColor: colors.border_light,
     lineWidth: 0,


### PR DESCRIPTION
[CSB](https://codesandbox.io/p/devbox/busy-cdn-gcxc9p)
[PLAY-1736](https://runway.powerhrg.com/backlog_items/PLAY-1736)
[REVIEW ENV](https://pr4562.playbook.beta.hq.powerapp.cloud/kits/line_graph/react)

This PR allows you to use the Line Graph settings and styles without having to use the Line Graph kit. 

The tick intervals aren't matching for some reason here and I don't know why. That seems to be handled automatically by Highcharts. I'm thinking it's not a huge issue though because the `tickInterval` can be set manually if needed by adding it to the `yAxis` options.
