### PR TITLE
[PLAY-2037] Select kit: Inline Error Misaligns Arrow

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -143,6 +143,16 @@
       select {
         font-size: 12px;
       }
+      .pb_select_kit_wrapper.error {
+        .pb_select_kit_caret {
+          top: 13.7px;
+        }
+      }
+    }
+    .pb_select_kit_wrapper.error {
+      .pb_select_kit_caret {
+        top: 16.2px;
+      }
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2037](https://runway.powerhrg.com/backlog_items/PLAY-2037) addresses a visual UX bug (Rails + React) wherein the Select arrow is misaligned when the inline or inline + compact versions of the kit are in an error state. A [previous PR](https://github.com/powerhome/playbook/pull/2253) fixed the same issue for the default kit. 

Can see the update in action comparing these two CSBs:
[CSB Before - Reproduces Initial Issue](https://codesandbox.io/p/devbox/flamboyant-wilson-wv5vmt)
[CSB with Alpha](https://codesandbox.io/p/devbox/play-2037-reproduce-issue-select-inline-error-forked-kc7x6y)

**Screenshots:** Screenshots to visualize your addition/change
Before: 
<img width="1286" alt="rails before" src="https://github.com/user-attachments/assets/a02c1d0c-9a37-497c-8a4d-2312063d239e" />
After Rails: 
<img width="1298" alt="inline error rails for PR" src="https://github.com/user-attachments/assets/2b9c76aa-97ab-4a1e-80e0-966c0a8e1a0e" />
<img width="1298" alt="compact inline error rails for PR" src="https://github.com/user-attachments/assets/456e49e4-7a5b-4af4-b2e1-8800cbc5233c" />
After React:
<img width="1305" alt="inline error react for PR" src="https://github.com/user-attachments/assets/37f730e1-d845-47e2-b472-f9b6f685ee52" />
<img width="1296" alt="compact inline error react for PR" src="https://github.com/user-attachments/assets/c641f8e8-8eec-48b6-8d4f-fc4b14e546c5" />
CSBs side by side:
<img width="1419" alt="csbs side by side" src="https://github.com/user-attachments/assets/c57de2b1-489d-4dcb-a23a-6fe5033de838" />


**How to test?** Steps to confirm the desired behavior:
1. Go to [CSB Before](https://codesandbox.io/p/devbox/flamboyant-wilson-wv5vmt) which reproduces the initial issue.
2. Compare to [CSB with Alpha](https://codesandbox.io/p/devbox/play-2037-reproduce-issue-select-inline-error-forked-kc7x6y) which shows the same examples with the fix added - arrows should be aligned as expected. 
3. Can look through doc examples in review env ([rails](https://pr4572.playbook.beta.gm.powerapp.cloud/kits/select/rails)/[react](https://pr4572.playbook.beta.gm.powerapp.cloud/kits/select/react)) to see nothing else has been affected - there are no visible changes related to this since there are no inline + error / inline + compact + error doc examples on page.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~