### PR TITLE
[PLAY-2129] Advanced Table: ColumnVisibility Control

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
@@ -93,7 +93,17 @@ export const RegularTableView = ({
 
               {row.getVisibleCells().map((cell: Cell<GenericObject, unknown>, i: number) => {
                 const isPinnedLeft = columnPinning.left.includes(cell.column.id);
-                const isLastCell = cell.column.parent?.columns?.at(-1)?.id === cell.column.id;
+                const isLastCell = (() => {
+                  const parent = cell.column.parent;
+                    if (!parent) {
+                      const last = row.getVisibleCells().at(-1);
+                      return last?.column.id === cell.column.id;
+                    }
+                  
+                    const visibleSiblings = parent.columns.filter(col => col.getIsVisible());
+                    return visibleSiblings.at(-1)?.id === cell.column.id;
+                   })();
+
                 const { column } = cell;
                 return (
                   <td

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -92,7 +92,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
             text={node.label}
         />
         <Flex flexDirection="column" 
-            paddingLeft="sm"
+            paddingLeft="lg"
         >
           {node?.children?.map((child) =>
             child.children ? renderGroup(child) : renderLeaf(child.id, child.label),

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -45,6 +45,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
   // ----------- Column visibility logic -----------
   const includeIds = columnVisibilityControl?.includeIds;
   const tree = buildVisibilityTree(columnDefinitions, includeIds);
+
   const renderLeaf = (id: string, label: string) => {
     const col   = table.getColumn(id);
     const show  = col.getIsVisible();
@@ -60,8 +61,15 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
     );
   };
 
+  const gatherLeafIds = (node: VisibilityNode): string[] =>
+    node.children && node.children.length
+      ? node.children.flatMap(gatherLeafIds)
+      : node.id
+      ? [node.id]
+      : [];
+
   const renderGroup = (node: VisibilityNode ) => {
-    const leaves   = node?.children?.map((c) => (c.children ? [] : c.id)).flat();
+     const leaves = gatherLeafIds(node);
     const visibleArray   = leaves.map((id) => table.getColumn(id).getIsVisible());
     const allOn    = visibleArray.every(Boolean);
     const someOn   = visibleArray.some(Boolean);

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -1,23 +1,42 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useContext } from "react";
+
+import AdvancedTableContext from "../Context/AdvancedTableContext";
 import Card from "../../pb_card/_card";
 import Caption from "../../pb_caption/_caption";
 import Flex from "../../pb_flex/_flex";
 import FlexItem from "../../pb_flex/_flex_item";
-import { showActionBar, hideActionBar } from "../Utilities/ActionBarAnimationHelper";
+import Dropdown from "../../pb_dropdown/_dropdown";
+import DropdownContainer from "../../pb_dropdown/subcomponents/DropdownContainer";
+import DropdownTrigger from "../../pb_dropdown/subcomponents/DropdownTrigger";
+import Icon from "../../pb_icon/_icon";
+import Checkbox from "../../pb_checkbox/_checkbox";
+
+import {
+  showActionBar,
+  hideActionBar,
+} from "../Utilities/ActionBarAnimationHelper";
 
 interface TableActionBarProps {
   isVisible: boolean;
   selectedCount: number;
   actions?: React.ReactNode[] | React.ReactNode;
+  type?: string;
 }
 
 const TableActionBar: React.FC<TableActionBarProps> = ({
   isVisible,
   selectedCount,
-  actions
+  actions,
+  type = "row-selection",
 }) => {
   const cardRef = useRef(null);
+  const { table, columnVisibilityControl, columnDefinitions } =
+    useContext(AdvancedTableContext);
+  const includeIds = columnVisibilityControl?.includeIds;
 
+  const columns = table
+    .getAllLeafColumns()
+    .filter((col) => !includeIds?.length || includeIds.includes(col.id));
   useEffect(() => {
     if (cardRef.current) {
       if (isVisible) {
@@ -31,22 +50,58 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
   return (
     <Card
         borderNone={!isVisible}
-        className={`${isVisible && "show-action-card row-selection-actions-card"}`}
+        className={`${
+          isVisible && "show-action-card row-selection-actions-card"
+        }`}
         htmlOptions={{ ref: cardRef as any }}
         padding={`${isVisible ? "xs" : "none"}`}
     >
       <Flex
           alignItems="center"
-          justify="between"
+          justify={type === "row-selection" ? "space-between" : "end"}
       >
-        <Caption
-            color="light"
-            paddingLeft="xs"
-            size="xs"
-        >
-          {selectedCount} Selected
-        </Caption>
-        <FlexItem>{actions}</FlexItem>
+        {type === "row-selection" ? (
+          <>
+            <Caption color="light" 
+                paddingLeft="xs" 
+                size="xs"
+            >
+              {selectedCount} Selected
+            </Caption>
+            <FlexItem>{actions}</FlexItem>
+          </>
+        ) : (
+          <Dropdown
+              className="column-visibility-dropdown-wrapper"
+              options={columnDefinitions}
+          >
+            <DropdownTrigger>
+              <Icon 
+                  color="primary" 
+                  cursor="pointer" 
+                  icon="sliders" 
+              />
+            </DropdownTrigger>
+            <DropdownContainer
+                className="column-visibility-dropdown"
+                padding="xs"
+            >
+              {columns.map((col) => (
+                <Flex cursor="pointer" 
+                    flexDirection="column" 
+                    key={col.id}
+                    padding="xs"
+                >
+                  <Checkbox
+                      checked={col.getIsVisible()}
+                      onChange={() => col.toggleVisibility()}
+                      text={col.columnDef.header}
+                  />
+                </Flex>
+              ))}
+            </DropdownContainer>
+          </Dropdown>
+        )}
       </Flex>
     </Card>
   );

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -133,7 +133,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
               <Icon 
                   color="primary" 
                   cursor="pointer" 
-                  icon="sliders" 
+                  icon="sliders-h" 
               />
             </DropdownTrigger>
             <DropdownContainer

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -150,7 +150,8 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
             </DropdownTrigger>
             <DropdownContainer
                 className="column-visibility-dropdown"
-                padding="xs"
+                paddingTop="xs"
+                paddingX="xs"
             >
               {tree.map((node: VisibilityNode) => (
                 <Flex cursor="pointer" 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -17,9 +17,10 @@ import {
   showActionBar,
   hideActionBar,
 } from "../Utilities/ActionBarAnimationHelper";
+import { GenericObject } from "../../types";
 
 interface TableActionBarProps {
-  isVisible: boolean;
+  isVisible: boolean | GenericObject | undefined;
   selectedCount: number;
   actions?: React.ReactNode[] | React.ReactNode;
   type?: string;
@@ -105,7 +106,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
     >
       <Flex
           alignItems="center"
-          justify={type === "row-selection" ? "space-between" : "end"}
+          justify={type === "row-selection" ? "between" : "end"}
       >
         {type === "row-selection" ? (
           <>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -88,7 +88,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
             text={node.label}
         />
         <Flex flexDirection="column" 
-            paddingLeft="xs"
+            paddingLeft="sm"
         >
           {node?.children?.map((child) =>
             child.children ? renderGroup(child) : renderLeaf(child.id, child.label),

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -12,6 +12,8 @@ import DropdownContainer from "../../pb_dropdown/subcomponents/DropdownContainer
 import DropdownTrigger from "../../pb_dropdown/subcomponents/DropdownTrigger";
 import Icon from "../../pb_icon/_icon";
 import Checkbox from "../../pb_checkbox/_checkbox";
+import SectionSeparator from "../../pb_section_separator/_section_separator";
+import Tooltip from "../../pb_tooltip/_tooltip";
 
 import {
   showActionBar,
@@ -142,25 +144,39 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
               options={columnDefinitions}
           >
             <DropdownTrigger>
-              <Icon 
-                  color="primary" 
-                  cursor="pointer" 
-                  icon="sliders-h" 
-              />
+            <Tooltip 
+                placement='top' 
+                text="Column Configuration" 
+                zIndex={10}
+            >
+                <Icon 
+                    color="primary" 
+                    cursor="pointer" 
+                    icon="sliders-h" 
+                />
+            </Tooltip>
             </DropdownTrigger>
             <DropdownContainer
                 className="column-visibility-dropdown"
-                paddingTop="xs"
-                paddingX="xs"
+                paddingTop="sm"
             >
+              <>
+              <Caption 
+                  paddingBottom="sm" 
+                  text="Columns Config"
+                  textAlign="center" 
+              />
+              <SectionSeparator paddingBottom="xs" />
               {tree.map((node: VisibilityNode) => (
                 <Flex cursor="pointer" 
                     flexDirection="column" 
                     key={node.id}
+                    paddingX="xs"
                 >
                   {node.children ? renderGroup(node) : renderLeaf(node.id, node.label)}
                 </Flex>
               ))}
+              </>
             </DropdownContainer>
           </Dropdown>
         )}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -44,7 +44,11 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
 
   // ----------- Column visibility logic -----------
   const includeIds = columnVisibilityControl?.includeIds;
-  const tree = buildVisibilityTree(columnDefinitions, includeIds);
+  const firstLeafId = table.getAllLeafColumns()[0]?.id;
+  // Get the first leaf column ID to exclude it from the visibility tree
+  // This is to avoid showing the first column in the dropdown
+  // as toggling it's visibility breaks the expanded row functionality
+  const tree = buildVisibilityTree(columnDefinitions, includeIds).filter(node => node.id !== firstLeafId);
 
   const renderLeaf = (id: string, label: string) => {
     const col   = table.getColumn(id);

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -26,6 +26,12 @@ interface TableActionBarProps {
   type?: string;
 }
 
+interface VisibilityNode {
+  id?: string | undefined;
+  label?: string | undefined;
+  children?: VisibilityNode[];
+}
+
 const TableActionBar: React.FC<TableActionBarProps> = ({
   isVisible,
   selectedCount,
@@ -54,8 +60,8 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
     );
   };
 
-  const renderGroup = (node) => {
-    const leaves   = node.children.map((c) => (c.children ? [] : c.id)).flat();
+  const renderGroup = (node: VisibilityNode ) => {
+    const leaves   = node?.children?.map((c) => (c.children ? [] : c.id)).flat();
     const visibleArray   = leaves.map((id) => table.getColumn(id).getIsVisible());
     const allOn    = visibleArray.every(Boolean);
     const someOn   = visibleArray.some(Boolean);
@@ -76,7 +82,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
         <Flex flexDirection="column" 
             paddingLeft="xs"
         >
-          {node.children.map((child) =>
+          {node?.children?.map((child) =>
             child.children ? renderGroup(child) : renderLeaf(child.id, child.label),
           )}
         </Flex>
@@ -86,7 +92,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
 // ------------ End of column visibility logic --------
 
   useEffect(() => {
-    if (cardRef.current) {
+    if (cardRef.current && type === "row-selection") {
       if (isVisible) {
         showActionBar(cardRef.current);
       } else {
@@ -134,7 +140,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
                 className="column-visibility-dropdown"
                 padding="xs"
             >
-              {tree.map((node) => (
+              {tree.map((node: VisibilityNode) => (
                 <Flex cursor="pointer" 
                     flexDirection="column" 
                     key={node.id}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -79,9 +79,26 @@ export const TableHeaderCell = ({
   header?.column.getLeafColumns().length === 1 &&
   header?.column.getLeafColumns()[0].id === header.column.id
 
-  const isLastHeaderCell =
-    header?.column.parent?.columns.at(-1) === header?.column ||
-    (header?.colSpan > 1 && header?.column.parent !== undefined);
+  const columnHasVisibleLeaf = (col: any): boolean =>
+    col.getIsVisible?.() ||
+    (Array.isArray(col.columns) &&
+      col.columns.some((child: any) => columnHasVisibleLeaf(child)));
+      
+   // Check on column position in stack + visibility to add the vertical border 
+  const isLastHeaderCell = (() => {
+    if (!header) return false;
+  
+    if (header.colSpan > 1 && header.column.parent !== undefined) return true;
+  
+    const parent = header.column.parent;
+  
+    if (!parent) {
+      const topHeaders = table?.getHeaderGroups()[0].headers.filter((h: any) => columnHasVisibleLeaf(h.column));
+      return topHeaders?.at(-1)?.id === header.id;
+    }
+    const visibleSiblings = parent.columns.filter(columnHasVisibleLeaf);
+    return visibleSiblings.at(-1) === header.column;
+  })();
  
 const cellClassName = classnames(
   "table-header-cells",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -53,8 +53,8 @@ export function useTableState({
   // Determine whether to use the prop or the local state
   const expanded = expandedControl ? expandedControl.value : localExpanded;
   const setExpanded = expandedControl ? expandedControl.onChange : setLocalExpanded;
-  const columnVisibility = columnVisibilityControl ? columnVisibilityControl.value : localColumnVisibility;
-  const setColumnVisibility = columnVisibilityControl ? columnVisibilityControl.onChange : setLocalColumnVisibility;
+  const columnVisibility = (columnVisibilityControl && columnVisibilityControl.value) ? columnVisibilityControl.value : localColumnVisibility;
+  const setColumnVisibility = (columnVisibilityControl && columnVisibilityControl.onChange) ? columnVisibilityControl.onChange : setLocalColumnVisibility;
 
   // Virtualized data handling (chunked loading)
   const fetchSize = 20; // Number of rows per "page"

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -26,6 +26,8 @@ interface UseTableStateProps {
   virtualizedRows?: boolean;
   tableOptions?: GenericObject;
   onRowSelectionChange?: (arg: RowSelectionState) => void;
+  columnVisibilityControl?: GenericObject;
+
 }
 
 export function useTableState({
@@ -40,16 +42,19 @@ export function useTableState({
   pagination = false,
   paginationProps,
   virtualizedRows = false,
-  tableOptions
+  tableOptions,
+  columnVisibilityControl
 }: UseTableStateProps) {
   // Create a local state for expanded and setExpanded if expandedControl not used
   const [localExpanded, setLocalExpanded] = useState({});
   const [loadingStateRowCount, setLoadingStateRowCount] = useState(initialLoadingRowsCount);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-
+  const [localColumnVisibility, setLocalColumnVisibility] = useState({});
   // Determine whether to use the prop or the local state
   const expanded = expandedControl ? expandedControl.value : localExpanded;
   const setExpanded = expandedControl ? expandedControl.onChange : setLocalExpanded;
+  const columnVisibility = columnVisibilityControl ? columnVisibilityControl.value : localColumnVisibility;
+  const setColumnVisibility = columnVisibilityControl ? columnVisibilityControl.onChange : setLocalColumnVisibility;
 
   // Virtualized data handling (chunked loading)
   const fetchSize = 20; // Number of rows per "page"
@@ -104,17 +109,21 @@ export function useTableState({
   }]), [columnDefinitions, sortControl]);
 
   // Custom state based on features enabled
-  const customState = useCallback(() => {
-    if (sortControl && selectableRows) {
-      return { state: { expanded, sorting, rowSelection } };
-    } else if (sortControl) {
-      return { state: { expanded, sorting } };
-    } else if (selectableRows) {
-      return { state: { expanded, rowSelection } };
-    } else {
-      return { state: { expanded } };
-    }
-  }, [expanded, rowSelection, sortControl, selectableRows, sorting]);
+  const customState = useCallback(() => ({
+    state: {
+      expanded,
+      ...(sortControl     && { sorting }),
+      ...(selectableRows  && { rowSelection }),
+      ...(columnVisibility && { columnVisibility }),
+    },
+  }), [
+    expanded,
+    sortControl,
+    sorting,
+    selectableRows,
+    rowSelection,
+    columnVisibility,
+  ]);
 
   // Pagination configuration
   const paginationInitializer = useMemo(() => {
@@ -145,6 +154,7 @@ export function useTableState({
     sortDescFirst: true,
     onRowSelectionChange: setRowSelection,
     getRowId: selectableRows ? row => row.id : undefined,
+    onColumnVisibilityChange: setColumnVisibility,
     meta: {
       columnDefinitions
     },

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/VisibilityTree.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/VisibilityTree.ts
@@ -1,0 +1,21 @@
+export const buildVisibilityTree = (
+  defs: any[],
+  allowed?: string[] | null
+): { id: string; label: string; children?: any[] }[] =>
+  defs
+    .map((def) => {
+      // leaf column
+      if (!def.columns || def.columns.length === 0) {
+        if (allowed && allowed.length && !allowed.includes(def.id)) return null;
+        return { id: def.id, label: def.label };
+      }
+
+      // column group
+      const children = buildVisibilityTree(def.columns, allowed).filter(
+        Boolean
+      );
+      if (children.length === 0) return null;
+
+      return { id: def.id, label: def.label, children };
+    })
+    .filter(Boolean);

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/VisibilityTree.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/VisibilityTree.ts
@@ -1,21 +1,47 @@
+export interface VisibilityNode {
+  id: string;
+  label: string;
+  children?: VisibilityNode[];
+}
 export const buildVisibilityTree = (
   defs: any[],
   allowed?: string[] | null
-): { id: string; label: string; children?: any[] }[] =>
+): VisibilityNode[] =>
   defs
     .map((def) => {
-      // leaf column
-      if (!def.columns || def.columns.length === 0) {
-        if (allowed && allowed.length && !allowed.includes(def.id)) return null;
-        return { id: def.id, label: def.label };
+      const isGroup = Array.isArray(def.columns) && def.columns.length > 0;
+
+      // No filter at all → keep it
+      if (!allowed?.length) {
+        return isGroup
+          ? {
+              id: def.id,
+              label: def.label,
+              children: buildVisibilityTree(def.columns, allowed),
+            }
+          : { id: def.id, label: def.label };
       }
 
-      // column group
-      const children = buildVisibilityTree(def.columns, allowed).filter(
-        Boolean
-      );
-      if (children.length === 0) return null;
+      // 1️⃣ If *this* ID is explicitly allowed → keep it & all its children
+      if (allowed.includes(def.id)) {
+        return isGroup
+          ? {
+              id: def.id,
+              label: def.label,
+              children: buildVisibilityTree(def.columns, null),
+            }
+          : { id: def.id, label: def.label };
+      }
 
-      return { id: def.id, label: def.label, children };
+      // Otherwise, if it’s a group, recurse & keep only if kids survive
+      if (isGroup) {
+        const kids = buildVisibilityTree(def.columns, allowed).filter(Boolean);
+        return kids.length
+          ? { id: def.id, label: def.label, children: kids }
+          : null;
+      }
+
+      // Leaf not allowed → drop it
+      return null;
     })
     .filter(Boolean);

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -53,6 +53,15 @@
     width: 100%;
   }
 
+  .column-visibility-dropdown-wrapper {
+    position: unset !important;
+  }
+  .column-visibility-dropdown {
+    width: unset !important;
+    right: $space_xxs;
+    text-align: left;
+  }
+
   // Virtualized table styles
   .virtualized-table-row {
     display: table !important;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -35,6 +35,7 @@ type AdvancedTableProps = {
   className?: string
   columnDefinitions: GenericObject[]
   columnGroupBorderColor?: "text_lt_default" | "text_lt_light" | "text_lt_lighter" | "text_dk_default" | "text_dk_light" | "text_dk_lighter"
+  columnVisibilityControl?: GenericObject
   dark?: boolean
   data?: { [key: string]: string }
   enableToggleExpansion?: "all" | "header" | "none"
@@ -73,6 +74,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     className,
     columnDefinitions,
     columnGroupBorderColor,
+    columnVisibilityControl,
     dark = false,
     data = {},
     enableToggleExpansion = "header",
@@ -132,7 +134,8 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     paginationProps,
     virtualizedRows,
     tableOptions,
-    onRowSelectionChange
+    onRowSelectionChange,
+    columnVisibilityControl,
   });
 
   // Initialize table actions
@@ -252,7 +255,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     : {};
 
   // Visibility flag for action bar
-  const isActionBarVisible = selectableRows && showActionsBar && selectedRowsLength > 0;
+  const isActionBarVisible = (selectableRows && showActionsBar && selectedRowsLength > 0) || columnVisibilityControl;
 
   return (
     <>
@@ -286,6 +289,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
         <AdvancedTableProvider
             columnDefinitions={columnDefinitions}
             columnGroupBorderColor={columnGroupBorderColor}
+            columnVisibilityControl={columnVisibilityControl}
             enableToggleExpansion={enableToggleExpansion}
             enableVirtualization={virtualizedRows}
             expandByDepth={expandByDepth}
@@ -316,6 +320,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
                 actions={actions}
                 isVisible={isActionBarVisible}
                 selectedCount={selectedRowsLength}
+                type={columnVisibilityControl ? "column-visibility" : "row-selection"}
             />
 
             {/* Main Table */}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableColumnVisibility = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+      id: "year"
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+      id: "newEnrollments"
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+      id: "scheduledMeetings"
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance Rate",
+      id: "attendanceRate"
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed Classes",
+      id: "completedClasses"
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Class Completion Rate",
+      id: "classCompletionRate"
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated Students",
+      id: "graduatedStudents"
+    },
+  ]
+
+  const [columnVisibility, setColumnVisibility] = useState({
+    newEnrollments: false,
+    
+  })
+
+  const columnVisibilityControl = {
+    value: columnVisibility,
+    onChange: setColumnVisibility,
+    includeIds:[],
+  }
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          columnVisibilityControl={columnVisibilityControl}
+          tableData={MOCK_DATA}
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default AdvancedTableColumnVisibility

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility.md
@@ -1,0 +1,4 @@
+The `columnVisibilityControl` prop allows users to toggle the visibility of table columns dynamically.
+
+The default can be enabled simply by passing `{ default:true }` to the prop as shown. This will render the header with the icon enabled dropdown. The dropdown contains all columns present in the Table and any can be toggled on or off via the checkboxes. 
+

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility.md
@@ -1,4 +1,4 @@
 The `columnVisibilityControl` prop allows users to toggle the visibility of table columns dynamically.
 
 The default can be enabled simply by passing `{ default:true }` to the prop as shown. This will render the header with the icon enabled dropdown. The dropdown contains all columns present in the Table and any can be toggled on or off via the checkboxes. 
-
+**NOTE**: The first column will not be shown in the dropdown as an option since all the expansion logic/functionality lives there and it should always be visible. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_custom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_custom.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import AdvancedTable from '../../pb_advanced_table/_advanced_table'
 import MOCK_DATA from "./advanced_table_mock_data.json"
 
-const AdvancedTableColumnVisibility = (props) => {
+const AdvancedTableColumnVisibilityCustom = (props) => {
   const columnDefinitions = [
     {
       accessor: "year",
@@ -42,14 +42,14 @@ const AdvancedTableColumnVisibility = (props) => {
     },
   ]
 
-  const [columnVisibility, setColumnVisibility] = useState({
-    newEnrollments: false 
-  })
-
+  const [columnVisibility, setColumnVisibility] = useState()
   const columnVisibilityControl = {
     value: columnVisibility,
     onChange: setColumnVisibility,
+    // This is the list of column ids that will be included in the column visibility control
+    includeIds:["newEnrollments", "scheduledMeetings", "attendanceRate", "completedClasses"],
   }
+
   return (
     <div>
       <AdvancedTable
@@ -62,4 +62,4 @@ const AdvancedTableColumnVisibility = (props) => {
   )
 }
 
-export default AdvancedTableColumnVisibility
+export default AdvancedTableColumnVisibilityCustom

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_custom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_custom.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React from "react"
 import AdvancedTable from '../../pb_advanced_table/_advanced_table'
 import MOCK_DATA from "./advanced_table_mock_data.json"
 
@@ -42,10 +42,7 @@ const AdvancedTableColumnVisibilityCustom = (props) => {
     },
   ]
 
-  const [columnVisibility, setColumnVisibility] = useState()
   const columnVisibilityControl = {
-    value: columnVisibility,
-    onChange: setColumnVisibility,
     // This is the list of column ids that will be included in the column visibility control
     includeIds:["newEnrollments", "scheduledMeetings", "attendanceRate", "completedClasses"],
   }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_custom.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_custom.md
@@ -1,0 +1,1 @@
+By using the `includeIds` key/value pair as shown within the `columnVisibilityControl` prop, you can control which columns show up as options in the columnVisibility dropdown.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.jsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableColumnVisibilityMulti = (props) => {
+    const columnDefinitions = [
+        {
+          accessor: "year",
+          label: "Year",
+          id: "year",
+          cellAccessors: ["quarter", "month", "day"],
+        },
+        {
+          label: "Enrollment Data",
+          id: "enrollmentData",
+          columns: [
+            {
+              label: "Enrollment Stats",
+              id: "enrollmentStats",
+              columns: [
+                {
+                  accessor: "newEnrollments",
+                  label: "New Enrollments",
+                  id: "newEnrollments",
+                },
+                {
+                  accessor: "scheduledMeetings",
+                  label: "Scheduled Meetings",
+                  id: "scheduledMeetings",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          label: "Performance Data",
+          id: "performanceData",
+          columns: [
+            {
+              label: "Completion Metrics",
+              id: "completionMetrics",
+              columns: [
+                {
+                  accessor: "completedClasses",
+                  label: "Completed Classes",
+                  id: "completedClasses",
+                },
+                {
+                  accessor: "classCompletionRate",
+                  label: "Class Completion Rate",
+                  id: "classCompletionRate",
+                },
+              ],
+            },
+            {
+              label: "Attendance",
+              id: "attendance",
+              columns: [
+                {
+                  accessor: "attendanceRate",
+                  label: "Attendance Rate",
+                  id: "attendanceRate",
+                },
+                {
+                  accessor: "scheduledMeetings",
+                  label: "Scheduled Meetings",
+                  id: "scheduledMeetings",
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+  const [columnVisibility, setColumnVisibility] = useState()
+
+  const columnVisibilityControl = {
+    value: columnVisibility,
+    onChange: setColumnVisibility,
+  }
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          columnVisibilityControl={columnVisibilityControl}
+          tableData={MOCK_DATA}
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default AdvancedTableColumnVisibilityMulti

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.jsx
@@ -61,11 +61,6 @@ const AdvancedTableColumnVisibilityMulti = (props) => {
                   label: "Attendance Rate",
                   id: "attendanceRate",
                 },
-                {
-                  accessor: "scheduledMeetings",
-                  label: "Scheduled Meetings",
-                  id: "scheduledMeetings",
-                },
               ],
             },
           ],

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React from "react"
 import AdvancedTable from '../../pb_advanced_table/_advanced_table'
 import MOCK_DATA from "./advanced_table_mock_data.json"
 
@@ -67,17 +67,11 @@ const AdvancedTableColumnVisibilityMulti = (props) => {
         },
       ];
 
-  const [columnVisibility, setColumnVisibility] = useState()
-
-  const columnVisibilityControl = {
-    value: columnVisibility,
-    onChange: setColumnVisibility,
-  }
   return (
     <div>
       <AdvancedTable
           columnDefinitions={columnDefinitions}
-          columnVisibilityControl={columnVisibilityControl}
+          columnVisibilityControl={{default: true}}
           tableData={MOCK_DATA}
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_multi.md
@@ -1,0 +1,1 @@
+The `columnVisibilityControl` prop can also be used with multi-header columns as shown.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_with_state.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_with_state.jsx
@@ -1,8 +1,8 @@
-import React from "react"
+import React, { useState } from "react"
 import AdvancedTable from '../../pb_advanced_table/_advanced_table'
 import MOCK_DATA from "./advanced_table_mock_data.json"
 
-const AdvancedTableColumnVisibility = (props) => {
+const AdvancedTableColumnVisibilityWithState = (props) => {
   const columnDefinitions = [
     {
       accessor: "year",
@@ -42,11 +42,19 @@ const AdvancedTableColumnVisibility = (props) => {
     },
   ]
 
+  const [columnVisibility, setColumnVisibility] = useState({
+    newEnrollments: false 
+  })
+
+  const columnVisibilityControl = {
+    value: columnVisibility,
+    onChange: setColumnVisibility,
+  }
   return (
     <div>
       <AdvancedTable
           columnDefinitions={columnDefinitions}
-          columnVisibilityControl={{default: true}}
+          columnVisibilityControl={columnVisibilityControl}
           tableData={MOCK_DATA}
           {...props}
       />
@@ -54,4 +62,4 @@ const AdvancedTableColumnVisibility = (props) => {
   )
 }
 
-export default AdvancedTableColumnVisibility
+export default AdvancedTableColumnVisibilityWithState

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_with_state.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_visibility_with_state.md
@@ -1,0 +1,1 @@
+The `columnVisibilityControl` prop also allows for greater control over the columnVisibility state. Devs can manage state themselves by passing in `value` and `onChange` as shown.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -17,36 +17,36 @@ examples:
   - advanced_table_selectable_rows_no_subrows_rails: Selectable Rows (No Subrows)
 
   react:
-  - advanced_table_default: Default (Required Props)
-  - advanced_table_loading: Loading State
-  - advanced_table_sort: Enable Sorting
-  - advanced_table_sort_control: Sort Control
-  - advanced_table_expanded_control: Expanded Control
-  - advanced_table_expand_by_depth: Expand by Depth
-  - advanced_table_subrow_headers: SubRow Headers
-  - advanced_table_collapsible_trail: Collapsible Trail
-  - advanced_table_table_options: Table Options
-  - advanced_table_table_props: Table Props
-  - advanced_table_sticky_header: Sticky Header
-  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  - advanced_table_sticky_columns: Sticky Columns
-  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  - advanced_table_inline_row_loading: Inline Row Loading
-  - advanced_table_responsive: Responsive Tables
-  - advanced_table_custom_cell: Custom Components for Cells
-  - advanced_table_pagination: Pagination
-  - advanced_table_pagination_with_props: Pagination Props
-  - advanced_table_column_headers: Multi-Header Columns
-  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  - advanced_table_column_border_color: Column Group Border Color
-  # - advanced_table_no_subrows: Table with No Subrows
-  - advanced_table_selectable_rows: Selectable Rows
-  - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
-  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  - advanced_table_inline_editing: Inline Cell Editing
-  - advanced_table_fullscreen: Fullscreen
+  # - advanced_table_default: Default (Required Props)
+  # - advanced_table_loading: Loading State
+  # - advanced_table_sort: Enable Sorting
+  # - advanced_table_sort_control: Sort Control
+  # - advanced_table_expanded_control: Expanded Control
+  # - advanced_table_expand_by_depth: Expand by Depth
+  # - advanced_table_subrow_headers: SubRow Headers
+  # - advanced_table_collapsible_trail: Collapsible Trail
+  # - advanced_table_table_options: Table Options
+  # - advanced_table_table_props: Table Props
+  # - advanced_table_sticky_header: Sticky Header
+  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  # - advanced_table_sticky_columns: Sticky Columns
+  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  # - advanced_table_inline_row_loading: Inline Row Loading
+  # - advanced_table_responsive: Responsive Tables
+  # - advanced_table_custom_cell: Custom Components for Cells
+  # - advanced_table_pagination: Pagination
+  # - advanced_table_pagination_with_props: Pagination Props
+  # - advanced_table_column_headers: Multi-Header Columns
+  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  # - advanced_table_column_border_color: Column Group Border Color
+  # # - advanced_table_no_subrows: Table with No Subrows
+  # - advanced_table_selectable_rows: Selectable Rows
+  # - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
+  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  # - advanced_table_inline_editing: Inline Cell Editing
+  # - advanced_table_fullscreen: Fullscreen
   - advanced_table_column_visibility: Column Visibility Control
   - advanced_table_column_visibility_with_state: Column Visibility Control With State
   - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -48,5 +48,6 @@ examples:
   # - advanced_table_inline_editing: Inline Cell Editing
   # - advanced_table_fullscreen: Fullscreen
   - advanced_table_column_visibility: Column Visibility Control
+  - advanced_table_column_visibility_with_state: Column Visibility Control With State
   - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
   - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -47,3 +47,4 @@ examples:
   - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
   - advanced_table_inline_editing: Inline Cell Editing
   - advanced_table_fullscreen: Fullscreen
+  - advanced_table_column_visibility: Column Visibility Control

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -18,35 +18,35 @@ examples:
 
   react:
   - advanced_table_default: Default (Required Props)
-  # - advanced_table_loading: Loading State
-  # - advanced_table_sort: Enable Sorting
-  # - advanced_table_sort_control: Sort Control
-  # - advanced_table_expanded_control: Expanded Control
-  # - advanced_table_expand_by_depth: Expand by Depth
-  # - advanced_table_subrow_headers: SubRow Headers
-  # - advanced_table_collapsible_trail: Collapsible Trail
-  # - advanced_table_table_options: Table Options
-  # - advanced_table_table_props: Table Props
-  # - advanced_table_sticky_header: Sticky Header
-  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  # - advanced_table_sticky_columns: Sticky Columns
-  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  # - advanced_table_inline_row_loading: Inline Row Loading
-  # - advanced_table_responsive: Responsive Tables
-  # - advanced_table_custom_cell: Custom Components for Cells
-  # - advanced_table_pagination: Pagination
-  # - advanced_table_pagination_with_props: Pagination Props
-  # - advanced_table_column_headers: Multi-Header Columns
-  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  # - advanced_table_column_border_color: Column Group Border Color
-  # # - advanced_table_no_subrows: Table with No Subrows
+  - advanced_table_loading: Loading State
+  - advanced_table_sort: Enable Sorting
+  - advanced_table_sort_control: Sort Control
+  - advanced_table_expanded_control: Expanded Control
+  - advanced_table_expand_by_depth: Expand by Depth
+  - advanced_table_subrow_headers: SubRow Headers
+  - advanced_table_collapsible_trail: Collapsible Trail
+  - advanced_table_table_options: Table Options
+  - advanced_table_table_props: Table Props
+  - advanced_table_sticky_header: Sticky Header
+  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  - advanced_table_sticky_columns: Sticky Columns
+  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  - advanced_table_inline_row_loading: Inline Row Loading
+  - advanced_table_responsive: Responsive Tables
+  - advanced_table_custom_cell: Custom Components for Cells
+  - advanced_table_pagination: Pagination
+  - advanced_table_pagination_with_props: Pagination Props
+  - advanced_table_column_headers: Multi-Header Columns
+  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  - advanced_table_column_border_color: Column Group Border Color
+  # - advanced_table_no_subrows: Table with No Subrows
   - advanced_table_selectable_rows: Selectable Rows
   - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
   - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
   - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  # - advanced_table_inline_editing: Inline Cell Editing
-  # - advanced_table_fullscreen: Fullscreen
+  - advanced_table_inline_editing: Inline Cell Editing
+  - advanced_table_fullscreen: Fullscreen
   - advanced_table_column_visibility: Column Visibility Control
   - advanced_table_column_visibility_with_state: Column Visibility Control With State
   - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -17,36 +17,36 @@ examples:
   - advanced_table_selectable_rows_no_subrows_rails: Selectable Rows (No Subrows)
 
   react:
-  # - advanced_table_default: Default (Required Props)
-  # - advanced_table_loading: Loading State
-  # - advanced_table_sort: Enable Sorting
-  # - advanced_table_sort_control: Sort Control
-  # - advanced_table_expanded_control: Expanded Control
-  # - advanced_table_expand_by_depth: Expand by Depth
-  # - advanced_table_subrow_headers: SubRow Headers
-  # - advanced_table_collapsible_trail: Collapsible Trail
-  # - advanced_table_table_options: Table Options
-  # - advanced_table_table_props: Table Props
-  # - advanced_table_sticky_header: Sticky Header
-  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  # - advanced_table_sticky_columns: Sticky Columns
-  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  # - advanced_table_inline_row_loading: Inline Row Loading
-  # - advanced_table_responsive: Responsive Tables
-  # - advanced_table_custom_cell: Custom Components for Cells
-  # - advanced_table_pagination: Pagination
-  # - advanced_table_pagination_with_props: Pagination Props
-  # - advanced_table_column_headers: Multi-Header Columns
-  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  # - advanced_table_column_border_color: Column Group Border Color
-  # # - advanced_table_no_subrows: Table with No Subrows
-  # - advanced_table_selectable_rows: Selectable Rows
-  # - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
-  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  # - advanced_table_inline_editing: Inline Cell Editing
-  # - advanced_table_fullscreen: Fullscreen
+  - advanced_table_default: Default (Required Props)
+  - advanced_table_loading: Loading State
+  - advanced_table_sort: Enable Sorting
+  - advanced_table_sort_control: Sort Control
+  - advanced_table_expanded_control: Expanded Control
+  - advanced_table_expand_by_depth: Expand by Depth
+  - advanced_table_subrow_headers: SubRow Headers
+  - advanced_table_collapsible_trail: Collapsible Trail
+  - advanced_table_table_options: Table Options
+  - advanced_table_table_props: Table Props
+  - advanced_table_sticky_header: Sticky Header
+  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  - advanced_table_sticky_columns: Sticky Columns
+  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  - advanced_table_inline_row_loading: Inline Row Loading
+  - advanced_table_responsive: Responsive Tables
+  - advanced_table_custom_cell: Custom Components for Cells
+  - advanced_table_pagination: Pagination
+  - advanced_table_pagination_with_props: Pagination Props
+  - advanced_table_column_headers: Multi-Header Columns
+  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  - advanced_table_column_border_color: Column Group Border Color
+  # - advanced_table_no_subrows: Table with No Subrows
+  - advanced_table_selectable_rows: Selectable Rows
+  - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
+  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  - advanced_table_inline_editing: Inline Cell Editing
+  - advanced_table_fullscreen: Fullscreen
   - advanced_table_column_visibility: Column Visibility Control
   - advanced_table_column_visibility_with_state: Column Visibility Control With State
   - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -18,33 +18,35 @@ examples:
 
   react:
   - advanced_table_default: Default (Required Props)
-  - advanced_table_loading: Loading State
-  - advanced_table_sort: Enable Sorting
-  - advanced_table_sort_control: Sort Control
-  - advanced_table_expanded_control: Expanded Control
-  - advanced_table_expand_by_depth: Expand by Depth
-  - advanced_table_subrow_headers: SubRow Headers
-  - advanced_table_collapsible_trail: Collapsible Trail
-  - advanced_table_table_options: Table Options
-  - advanced_table_table_props: Table Props
-  - advanced_table_sticky_header: Sticky Header
-  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  - advanced_table_sticky_columns: Sticky Columns
-  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  - advanced_table_inline_row_loading: Inline Row Loading
-  - advanced_table_responsive: Responsive Tables
-  - advanced_table_custom_cell: Custom Components for Cells
-  - advanced_table_pagination: Pagination
-  - advanced_table_pagination_with_props: Pagination Props
-  - advanced_table_column_headers: Multi-Header Columns
-  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  - advanced_table_column_border_color: Column Group Border Color
-  # - advanced_table_no_subrows: Table with No Subrows
-  - advanced_table_selectable_rows: Selectable Rows
-  - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
-  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  - advanced_table_inline_editing: Inline Cell Editing
-  - advanced_table_fullscreen: Fullscreen
+  # - advanced_table_loading: Loading State
+  # - advanced_table_sort: Enable Sorting
+  # - advanced_table_sort_control: Sort Control
+  # - advanced_table_expanded_control: Expanded Control
+  # - advanced_table_expand_by_depth: Expand by Depth
+  # - advanced_table_subrow_headers: SubRow Headers
+  # - advanced_table_collapsible_trail: Collapsible Trail
+  # - advanced_table_table_options: Table Options
+  # - advanced_table_table_props: Table Props
+  # - advanced_table_sticky_header: Sticky Header
+  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  # - advanced_table_sticky_columns: Sticky Columns
+  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  # - advanced_table_inline_row_loading: Inline Row Loading
+  # - advanced_table_responsive: Responsive Tables
+  # - advanced_table_custom_cell: Custom Components for Cells
+  # - advanced_table_pagination: Pagination
+  # - advanced_table_pagination_with_props: Pagination Props
+  # - advanced_table_column_headers: Multi-Header Columns
+  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  # - advanced_table_column_border_color: Column Group Border Color
+  # # - advanced_table_no_subrows: Table with No Subrows
+  # - advanced_table_selectable_rows: Selectable Rows
+  # - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
+  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  # - advanced_table_inline_editing: Inline Cell Editing
+  # - advanced_table_fullscreen: Fullscreen
   - advanced_table_column_visibility: Column Visibility Control
+  - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
+  - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -41,10 +41,10 @@ examples:
   # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
   # - advanced_table_column_border_color: Column Group Border Color
   # # - advanced_table_no_subrows: Table with No Subrows
-  # - advanced_table_selectable_rows: Selectable Rows
-  # - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
-  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  - advanced_table_selectable_rows: Selectable Rows
+  - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
+  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
   # - advanced_table_inline_editing: Inline Cell Editing
   # - advanced_table_fullscreen: Fullscreen
   - advanced_table_column_visibility: Column Visibility Control

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -28,3 +28,4 @@ export { default as AdvancedTableStickyHeader } from './_advanced_table_sticky_h
 export { default as AdvancedTableStickyColumnsAndHeader } from './_advanced_table_sticky_columns_and_header.jsx'
 export { default as AdvancedTableExpandByDepth } from './_advanced_table_expand_by_depth.jsx'
 export { default as AdvancedTableColumnBorderColor} from './_advanced_table_column_border_color.jsx'
+export { default as AdvancedTableColumnVisibility } from './_advanced_table_column_visibility.jsx'

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -31,3 +31,4 @@ export { default as AdvancedTableColumnBorderColor} from './_advanced_table_colu
 export { default as AdvancedTableColumnVisibility } from './_advanced_table_column_visibility.jsx'
 export { default as AdvancedTableColumnVisibilityCustom } from './_advanced_table_column_visibility_custom.jsx'
 export { default as AdvancedTableColumnVisibilityMulti } from './_advanced_table_column_visibility_multi.jsx'
+export { default as AdvancedTableColumnVisibilityWithState } from './_advanced_table_column_visibility_with_state.jsx'

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -29,3 +29,5 @@ export { default as AdvancedTableStickyColumnsAndHeader } from './_advanced_tabl
 export { default as AdvancedTableExpandByDepth } from './_advanced_table_expand_by_depth.jsx'
 export { default as AdvancedTableColumnBorderColor} from './_advanced_table_column_border_color.jsx'
 export { default as AdvancedTableColumnVisibility } from './_advanced_table_column_visibility.jsx'
+export { default as AdvancedTableColumnVisibilityCustom } from './_advanced_table_column_visibility_custom.jsx'
+export { default as AdvancedTableColumnVisibilityMulti } from './_advanced_table_column_visibility_multi.jsx'

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/scss_partials/advanced_table_sticky_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/scss_partials/advanced_table_sticky_mixin.scss
@@ -77,6 +77,7 @@
     top: 0;
     left: 0;
     border-radius: unset;
+    z-index: 5;
   }
 
   .checkbox-cell {

--- a/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownContainer.tsx
@@ -6,7 +6,7 @@ import {
   buildDataProps,
   buildHtmlProps
 } from "../../utilities/props";
-import { globalProps } from "../../utilities/globalProps";
+import { globalProps, GlobalProps } from "../../utilities/globalProps";
 
 import DropdownContext from "../context";
 
@@ -24,7 +24,7 @@ type DropdownContainerProps = {
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string;
   searchbar?: boolean;
-};
+} & GlobalProps;
 
 const DropdownContainer = (props: DropdownContainerProps) => {
   const {

--- a/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/_section_separator.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
-import { globalProps, globalInlineProps } from '../utilities/globalProps'
+import { globalProps, globalInlineProps, GlobalProps } from '../utilities/globalProps'
 
 import Caption from '../pb_caption/_caption'
 
@@ -19,7 +19,7 @@ type SectionSeparatorProps = {
   orientation?: "horizontal" | "vertical",
   text?: string,
   variant?: "card" | "background",
-}
+} & GlobalProps
 
 const SectionSeparator = (props: SectionSeparatorProps): React.ReactElement => {
   const {


### PR DESCRIPTION
**What does this PR do?** 
[PLAY-2129](https://runway.powerhrg.com/backlog_items/PLAY-2129)

**This PR covers the following:**
Adds `columnVisibilityControl` prop that allows you to toggle visibility of different columns off and on.
Allows devs to manage state for this control if they want so they can set an initial state, etc
allows devs to customize which columns to show as options within the dropdown so they can have a smaller dropdown if they want
Allows for visibility control to work with multi-header columns
For this one, the dropdown shows hierarchy of columns
unchecking and checking cascades up and down similar to MLS

 **To be covered in a follow up:**
With the responsiveness set to true, the dropdown is clipped at the bottom where the table ends on smaller screen sizes (only an issue if dropdown exceeds table height)
This is due the way overflow is set up, and will need to be looked at separately

**Screenshots:**

![Screenshot 2025-05-08 at 11 50 37 AM](https://github.com/user-attachments/assets/bf415c63-ec4e-43fc-8968-d87fcfe0826e)

![Screenshot 2025-05-08 at 11 50 27 AM](https://github.com/user-attachments/assets/43d2ef72-5c3a-4031-8640-8519b1262ec7)


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.