### PR TITLE
[PLAY-2150] Table kit: Expandable/Collapsible not behaving correctly when multiple icons are present

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_collapsible_with_custom_click.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_collapsible_with_custom_click.jsx
@@ -8,7 +8,7 @@ const TableWithCollapsibleWithCustomClick = (props) => {
 
   const Content = () => {
     return (
-      <Card 
+      <Card
           borderNone
           borderRadius="none"
           padding="md"
@@ -37,7 +37,7 @@ return (
 
         </Table.Head>
         <Table.Body>
-          <Table.Row collapsible 
+          <Table.Row collapsible
               collapsibleContent={<Content/>}
               toggleCellId="cell-1"
               {...props}
@@ -46,8 +46,16 @@ return (
             <Table.Cell>{'Value 2'}</Table.Cell>
             <Table.Cell>{'Value 3'}</Table.Cell>
             <Table.Cell>{'Value 4'}</Table.Cell>
-            <Table.Cell>{'Value 5'}</Table.Cell>
-            <Table.Cell cursor="pointer" 
+            <Table.Cell cursor="pointer"
+                id="cell-100"
+            >
+              <Icon
+                  color="primary"
+                  fixedWidth
+                  icon="chevron-down"
+              />
+            </Table.Cell>
+            <Table.Cell cursor="pointer"
                 id="cell-1"
                 textAlign="right"
             >
@@ -59,7 +67,7 @@ return (
             </Table.Cell>
 
           </Table.Row>
-          <Table.Row collapsible 
+          <Table.Row collapsible
               collapsibleContent={<Content/>}
               toggleCellId="cell-2"
               {...props}
@@ -69,7 +77,7 @@ return (
             <Table.Cell>{'Value 3'}</Table.Cell>
             <Table.Cell>{'Value 4'}</Table.Cell>
             <Table.Cell>{'Value 5'}</Table.Cell>
-            <Table.Cell cursor="pointer" 
+            <Table.Cell cursor="pointer"
                 id="cell-2"
                 textAlign="right"
             >
@@ -81,7 +89,7 @@ return (
             </Table.Cell>
 
           </Table.Row>
-          <Table.Row collapsible 
+          <Table.Row collapsible
               collapsibleContent={<Content/>}
               toggleCellId="cell-3"
               {...props}
@@ -91,7 +99,7 @@ return (
             <Table.Cell>{'Value 3'}</Table.Cell>
             <Table.Cell>{'Value 4'}</Table.Cell>
             <Table.Cell>{'Value 5'}</Table.Cell>
-            <Table.Cell cursor="pointer" 
+            <Table.Cell cursor="pointer"
                 id="cell-3"
                 textAlign="right"
             >

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_collapsible_with_custom_click.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_collapsible_with_custom_click.jsx
@@ -46,15 +46,7 @@ return (
             <Table.Cell>{'Value 2'}</Table.Cell>
             <Table.Cell>{'Value 3'}</Table.Cell>
             <Table.Cell>{'Value 4'}</Table.Cell>
-            <Table.Cell cursor="pointer"
-                id="cell-100"
-            >
-              <Icon
-                  color="primary"
-                  fixedWidth
-                  icon="chevron-down"
-              />
-            </Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
             <Table.Cell cursor="pointer"
                 id="cell-1"
                 textAlign="right"

--- a/playbook/app/pb_kits/playbook/pb_table/subcomponents/_table_row.tsx
+++ b/playbook/app/pb_kits/playbook/pb_table/subcomponents/_table_row.tsx
@@ -83,7 +83,7 @@ const TableRow = (props: TableRowPropTypes): React.ReactElement => {
       target instanceof SVGElement &&
       (target.matches("svg.pb_custom_icon") || target.closest("svg.pb_custom_icon"));
 
-        if (clickedCell && isIconClick) {
+        if (clickedCell || (clickedCell && isIconClick)) {
       setIsCollapsed(!isCollapsed);
       }
     } else {

--- a/playbook/app/pb_kits/playbook/pb_table/subcomponents/_table_row.tsx
+++ b/playbook/app/pb_kits/playbook/pb_table/subcomponents/_table_row.tsx
@@ -55,7 +55,7 @@ const TableRow = (props: TableRowPropTypes): React.ReactElement => {
   const htmlProps = buildHtmlProps(htmlOptions);
   const sideHighlightClass =
     sideHighlightColor != "" ? `side_highlight_${sideHighlightColor}` : null;
-  
+
   const [isCollapsed, setIsCollapsed] = useCollapsible(true);
 
   const collapsibleRow = collapsible && isCollapsed === true ? "collapsible_table_row" : null;
@@ -83,14 +83,14 @@ const TableRow = (props: TableRowPropTypes): React.ReactElement => {
       target instanceof SVGElement &&
       (target.matches("svg.pb_custom_icon") || target.closest("svg.pb_custom_icon"));
 
-        if (clickedCell || isIconClick) { 
+        if (clickedCell && isIconClick) {
       setIsCollapsed(!isCollapsed);
       }
     } else {
       setIsCollapsed(!isCollapsed);
     }
   };
-    
+
   return (
     <>
       {collapsible ? (
@@ -116,7 +116,7 @@ const TableRow = (props: TableRowPropTypes): React.ReactElement => {
                   tag="td"
               >
                 <tr/>
-                <Collapsible.Content 
+                <Collapsible.Content
                     className={collapsibleSideHighlight ? `table_collapsible_side_highlight` : ''}
                     dark={dark}
                     margin="none"
@@ -149,7 +149,7 @@ const TableRow = (props: TableRowPropTypes): React.ReactElement => {
                   tag="td"
               >
                 <tr/>
-                <Collapsible.Content 
+                <Collapsible.Content
                     className={collapsibleSideHighlight ? `table_collapsible_side_highlight` : ''}
                     dark={dark}
                     margin="none"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2150)

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to [React Doc Example](https://pr4582.playbook.beta.px.powerapp.cloud/kits/table/react#table-with-collapsible-with-custom-click)
2. Click on far right icon to open/close collapsible
3. Click on icon under column 5. Icon will not affect collapsible.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
