### PR TITLE
[PLAY-1556]  React Prop table not working on Kit Collection pages

### DIFF
--- a/playbook-website/app/views/pages/kit_collection.html.erb
+++ b/playbook-website/app/views/pages/kit_collection.html.erb
@@ -9,9 +9,12 @@
   <div class="multi-kits-container">
     <% if @type == "rails" %>
       <%= pb_kit(kit: @selected_kit, dark_mode: dark_mode?, variants: @variants) %>
+      <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
     <% elsif @type == "react" %>
       <%= pb_kit(kit: @selected_kit, type: "react", dark_mode: dark_mode?, variants: @variants) %>
+      <%= react_component("AvailableProps",
+        availableProps: Playbook::PbDocs::KitExample.new(kit: @selected_kit, example_title: "Default", example_key: @selected_kit, type: "react").available_props )
+      %>
     <% end %>
-    <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
   </div>
 <% end %>

--- a/playbook-website/app/views/pages/kit_collection.html.erb
+++ b/playbook-website/app/views/pages/kit_collection.html.erb
@@ -9,9 +9,9 @@
   <div class="multi-kits-container">
     <% if @type == "rails" %>
       <%= pb_kit(kit: @selected_kit, dark_mode: dark_mode?, variants: @variants) %>
-      <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
     <% elsif @type == "react" %>
       <%= pb_kit(kit: @selected_kit, type: "react", dark_mode: dark_mode?, variants: @variants) %>
     <% end %>
+    <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
   </div>
 <% end %>

--- a/playbook-website/app/views/pages/kit_variants_collection.html.erb
+++ b/playbook-website/app/views/pages/kit_variants_collection.html.erb
@@ -25,9 +25,12 @@
   <div class="multi-kits-container">
     <% if @type == "rails" %>
       <%= pb_kit(kit: @selected_kit, dark_mode: dark_mode?, variants: @variants) %>
+      <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
     <% elsif @type == "react" %>
       <%= pb_kit(kit: @selected_kit, type: "react", dark_mode: dark_mode?, variants: @variants) %>
+      <%= react_component("AvailableProps",
+        availableProps: Playbook::PbDocs::KitExample.new(kit: @selected_kit, example_title: "Default", example_key: @selected_kit, type: "react").available_props )
+      %>
     <% end %>
-    <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
   </div>
 <% end %>

--- a/playbook-website/app/views/pages/kit_variants_collection.html.erb
+++ b/playbook-website/app/views/pages/kit_variants_collection.html.erb
@@ -25,9 +25,9 @@
   <div class="multi-kits-container">
     <% if @type == "rails" %>
       <%= pb_kit(kit: @selected_kit, dark_mode: dark_mode?, variants: @variants) %>
-      <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
     <% elsif @type == "react" %>
       <%= pb_kit(kit: @selected_kit, type: "react", dark_mode: dark_mode?, variants: @variants) %>
     <% end %>
+    <%= pb_rails("docs/kit_api", props: { kit: @selected_kit, dark: dark_mode? }) %>
   </div>
 <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1556 Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-1556)

**How to test?** Steps to confirm the desired behavior:
1. Go to https://pr4598.playbook.beta.px.powerapp.cloud/kit_collection/title&card&nav/title/react


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
