### PR TITLE
[PLAY-2004] Add Semver and Inactive RC to GitHub PR Checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,5 @@
 - [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
 - [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
 - [ ] **TESTS** I have added test coverage to my code.
+- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
+- [ ] **RC** I have added an `inactive RC` label if not an active RC.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2004](https://runway.powerhrg.com/backlog_items/PLAY-2004) adds two additional items to our PR checklist. The first is a reminder to add a Semver label (minor, major, or patch) and the second is a reminder to add an Inactive RC label if the PR is being merged as inactive.


**Screenshots:** Screenshots to visualize your addition/change
<img width="1200" alt="checklist in github" src="https://github.com/user-attachments/assets/15922e59-6d3a-42be-b378-4c7e7c431bf7" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the PULL_REQUEST_TEMPLATE.md [file on this branch](https://github.com/powerhome/playbook/blob/PLAY-2004-update-PR-template-checklist/.github/PULL_REQUEST_TEMPLATE.md) (PLAY-2004-update-PR-template-checklist).
2. See additional items in checklist in that file.
3. They do not appear on this checklist below ⬇️ yet but will appear there once this PR is merged.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~