### PR TITLE
[PLAY-2125] Phone Number Input: Fix the Error Styles for Country Search - Rails & React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.scss
@@ -42,7 +42,7 @@ $flag-min-resolution: 192dpi;
   .iti__country-list {
     min-width: $dropdown-min-width;
   }
-  // iti-spacer-horizontal's default is 8px, or $space_xs 
+  // iti-spacer-horizontal's default is 8px, or $space_xs
   .iti__country-list .iti__flag, .iti__country-name {
     margin-right: $space_xs;
   }
@@ -60,7 +60,7 @@ $flag-min-resolution: 192dpi;
     color: $focus_input_light;
   }
 
-  .dropdown_open {
+  .dropdown_open:not(.error) {
     .text_input {
       border-color: $primary !important;
     }
@@ -76,7 +76,7 @@ $flag-min-resolution: 192dpi;
   }
 
   .iti__divider {
-    border-bottom: 1px solid $border_light !important;  
+    border-bottom: 1px solid $border_light !important;
   }
 
   .iti__selected-country-primary {
@@ -96,7 +96,7 @@ $flag-min-resolution: 192dpi;
     justify-content: center;
     align-items: center;
     border-width: 0;
-    border-radius: $space_xxs; 
+    border-radius: $space_xxs;
 
     &[aria-expanded="true"] {
       color: $primary_action;
@@ -199,7 +199,7 @@ $flag-min-resolution: 192dpi;
   }
 
   .iti__dropdown-content {
-    border-radius: $space_xs; 
+    border-radius: $space_xs;
     border: 1px solid $border_light !important;
     position: absolute;
     top: 100%;
@@ -228,13 +228,13 @@ $flag-min-resolution: 192dpi;
     }
 
     .iti__dropdown-content {
-      border-radius: $space_xs; 
+      border-radius: $space_xs;
       border: 1px solid $border_dark !important;
       .iti__search-input {
         background-color: $bg_dark_card;
         &:hover {
           background-color: $bg_dark_card;
-        }      
+        }
         &:active,
         &:focus {
           background-color: $card_dark;
@@ -243,7 +243,7 @@ $flag-min-resolution: 192dpi;
     }
 
     .iti__divider {
-      border-bottom: 1px solid $border_dark !important;  
+      border-bottom: 1px solid $border_dark !important;
     }
 
     .iti__country-list {
@@ -278,7 +278,7 @@ $flag-min-resolution: 192dpi;
       color: $white;
     }
   }
-  
+
   @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: $flag-min-resolution) {
     .iti__flag {
       background-image: url("https://unpkg.com/intl-tel-input@24.6.0/build/img/flags@2x.png");

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -71,7 +71,7 @@
     }
     &.error {
       .text_input_wrapper {
-        input,
+        input:not(.iti__search-input),
         .text_input {
           border-color: $error_dark;
         }
@@ -102,7 +102,7 @@
       [class*="pb_body_kit"] {
         margin-top: $space_xs / 2;
       }
-      input,
+      input:not(.iti__search-input),
       .text_input {
         border-color: $error;
       }

--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -71,6 +71,7 @@
     }
     &.error {
       .text_input_wrapper {
+        // The `:not` here prevents error styling from affecting the country search input in the Phone Number Input Kit.
         input:not(.iti__search-input),
         .text_input {
           border-color: $error_dark;
@@ -102,6 +103,7 @@
       [class*="pb_body_kit"] {
         margin-top: $space_xs / 2;
       }
+      // The `:not` here prevents error styling from affecting the country search input in the Phone Number Input Kit.
       input:not(.iti__search-input),
       .text_input {
         border-color: $error;


### PR DESCRIPTION
[PLAY-2125](https://runway.powerhrg.com/backlog_items/PLAY-2125)
[Review ENV](https://pr4610.playbook.beta.px.powerapp.cloud/kits/phone_number_input/react#country-search-1)

This fixes the error styling on the phone input for the country search. 

Here's an example of how it currently looks: [Production](https://playbook.powerapp.cloud/kits/phone_number_input/react)
and the fixed version: [Review ENV](https://pr4610.playbook.beta.px.powerapp.cloud/kits/phone_number_input/react#country-search-1)