### PR TITLE
[PLAY-2172] Home Address Street Kit: Handle Undefined/Null Values - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
@@ -107,7 +107,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
             {titleize(addressCont)}
           </Title>
           <Body color="light">
-            {`${titleize(city)}, ${uppercaseState} ${zipcode}`}
+            {`${city ? `${titleize(city)}, ` : ''}${uppercaseState}${zipcode ? ` ${zipcode}` : ''}`}
           </Body>
         </div>
       }
@@ -124,13 +124,13 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
                 size={4}
                 tag="span"
             >
-              {`${titleize(city)}, ${uppercaseState}`}
+              {`${city ? `${titleize(city)}, ` : ''}${uppercaseState}`}
             </Title>
             <Body
                 color="light"
                 tag="span"
             >
-              {` ${zipcode}`}
+              {` ${zipcode ?? ''}`}
             </Body>
           </div>
         </div>
@@ -146,7 +146,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
                 color="light"
                 dark={dark}
               >
-            {`${titleize(city)}, ${uppercaseState} ${zipcode}`}
+            {`${city ? `${titleize(city)}, ` : ''}${uppercaseState}${zipcode ? ` ${zipcode}` : ''}`}
           </Body>
           </div>
         </div>

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/_home_address_street.tsx
@@ -81,6 +81,8 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
 
   const formatStreetAdr = (address: string): string => preserveCase ? address : titleize(address)
 
+  const uppercaseState = state?.toUpperCase() ?? ''
+
   return (
     <div
         className={classes(className, dark)}
@@ -105,7 +107,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
             {titleize(addressCont)}
           </Title>
           <Body color="light">
-            {`${titleize(city)}, ${state.toUpperCase()} ${zipcode}`}
+            {`${titleize(city)}, ${uppercaseState} ${zipcode}`}
           </Body>
         </div>
       }
@@ -122,7 +124,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
                 size={4}
                 tag="span"
             >
-              {`${titleize(city)}, ${state.toUpperCase()}`}
+              {`${titleize(city)}, ${uppercaseState}`}
             </Title>
             <Body
                 color="light"
@@ -144,7 +146,7 @@ const HomeAddressStreet = (props: HomeAddressStreetProps): React.ReactElement =>
                 color="light"
                 dark={dark}
               >
-            {`${titleize(city)}, ${state.toUpperCase()} ${zipcode}`}
+            {`${titleize(city)}, ${uppercaseState} ${zipcode}`}
           </Body>
           </div>
         </div>


### PR DESCRIPTION
**What does this PR do?**
- Fix bug where the page would crash because we used `toUpperCase()` even if state was undefined
- Return blank values if props are undefined

https://runway.powerhrg.com/backlog_items/PLAY-2172

**Screenshots:**
If all values are undefined:
![Screenshot 2025-05-13 at 9 46 16 AM](https://github.com/user-attachments/assets/7b97fc7d-725b-4ce3-9746-d7971e5eeeee)


**How to test?** Steps to confirm the desired behavior:
1. Make sure nothing changed with /home_address_street/react
2. In Nitro, search for "402676". The header should stay.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.