### PR TITLE
[PLAY-1973] Form Pill kit: Icon and Avatar sizing is off

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_pill/_form_pill.scss
@@ -20,8 +20,11 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
   margin-bottom: 2px;
   margin-top: 2px;
   cursor: pointer;
-  .pb_form_pill_text, .pb_form_pill_close, .pb_form_pill_tag{
+  .pb_form_pill_text, .pb_form_pill_tag {
     font-size: $font_small !important;
+  }
+  .pb_form_pill_close {
+    font-size: 17px;
   }
 
   &[class*=wrapped] {
@@ -96,7 +99,9 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
         display: flex;
         align-items: center;
         height: 17px;
-        border-radius: calc(50%);
+        width: 17px;
+        justify-content: center;
+        border-radius: 50%;
         cursor: pointer;
         @if ($color_name == "neutral") {
           color: $text_lt_default;
@@ -146,8 +151,7 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
     outline-offset: -1px;
   }
   .pb_form_pill_icon {
-    height: 12px !important;
-    width: 12px !important;
+    height: 0.875em;
     padding-right: $space_xs;
     + .pb_form_pill_text, + .pb_form_pill_tag,
     + .pb_tooltip_kit .pb_form_pill_text, + .pb_tooltip_kit .pb_form_pill_tag,
@@ -158,7 +162,7 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
   &.small {
     height: 17px;
     padding: 0 $space-xs;
-    .pb_form_pill_text, .pb_form_pill_close, .pb_form_pill_tag {
+    .pb_form_pill_text, .pb_form_pill_tag {
       font-size: $font_smallest !important;
     }
     .pb_form_pill_text, .pb_form_pill_tag {
@@ -166,17 +170,20 @@ $form_pill_colors: map-merge($status_color_text, map-merge($data_colors, $produc
       padding: 0 $space_xxs;
     }
     .pb_form_pill_close {
-      height: 10px;
-      border-radius: calc(50%);
+      height: 14px;
+      width: 14px;
+      font-size: 15px;
+      border-radius: 50%;
     }
     [class^=pb_avatar_kit] .avatar_wrapper {
-      flex-basis: 16px;
-      height: 16px;
-      margin-top: 2px;
-      width: 16px;
-      &::before { line-height: 16.5px; }
+      flex-basis: 14px;
+      height: 14px;
+      margin-top: 3px;
+      width: 14px;
+      &::before { line-height: 15px; }
     }
     .pb_form_pill_icon {
+      height: 0.75em;
       padding-right: $space_xxs;
       + .pb_form_pill_text, + .pb_form_pill_tag,
       + .pb_tooltip_kit .pb_form_pill_text, + .pb_tooltip_kit .pb_form_pill_tag,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-1973](https://runway.powerhrg.com/backlog_items/PLAY-1973) requests some adjustments to the size of the Icon,  Avatar, and Close Icon inside the Form Pill kit for the regular size and small size Form Pill. Changes can be compared between [this CSB](https://codesandbox.io/p/sandbox/9qgyfz) from a previous story on Form Pills which has a bunch of different Form Pill permutations and [this CSB](https://codesandbox.io/p/devbox/pbntr-416-form-pill-3-of-5-size-alpha-forked-9jmvms) with alpha from this PR showing size changes.

This PR handles the following:
- Avatar circle is smaller for small Form Pills
- Icon size is larger for default Form Pills
- Close Icon size is larger for default and small Form Pills
- Adding a width along with the new height and font-size for the Close Icon code allowed for `border-radius: 50%` to work instead of a more convoluted calc method (see prior convo about this in the comments of a [previous Form Pill PR](https://github.com/powerhome/playbook/pull/3607))


**Screenshots:** Screenshots to visualize your addition/change
<img width="492" alt="all examples rails" src="https://github.com/user-attachments/assets/75b7dd35-14ef-46b6-9f19-2b4f89c1d1e9" />
<img width="474" alt="all examples react" src="https://github.com/user-attachments/assets/26643d1a-ce84-4165-9d0c-14415ee8968e" />
<img width="401" alt="typeahead side by side" src="https://github.com/user-attachments/assets/9c20994e-683b-4021-9b99-1b6e6956bcd8" />
<img width="391" alt="typeahead small pill side by side" src="https://github.com/user-attachments/assets/76879159-4cea-419e-984b-8d83810e756d" />
<img width="830" alt="mls doc ex side by side" src="https://github.com/user-attachments/assets/822af2f4-9390-4765-842d-44a825205ba1" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Form Pill kit page in review env ([rails](https://pr4620.playbook.beta.px.powerapp.cloud/kits/form_pill), [react](https://pr4620.playbook.beta.px.powerapp.cloud/kits/form_pill/react)) to see changes. Can compare to current pages production.
2. Go to Typeahead and MultiLevelSelect kit pages in review env (Typeahead: [rails](https://pr4620.playbook.beta.px.powerapp.cloud/kits/typeahead), [react](https://pr4620.playbook.beta.px.powerapp.cloud/kits/typeahead/react); MultiLevelSelect: [rails](https://pr4620.playbook.beta.px.powerapp.cloud/kits/multi_level_select), [react](https://pr4620.playbook.beta.px.powerapp.cloud/kits/multi_level_select/react)) to see changes within other kits. For Typeahead check the "With Pills" and "Small Pills" doc examples.
3. Compare the two CSBs for a side by side of every Form Pill permutation + within Typeahead and MLS. CSB from prior story (aka matches current prod) [here](https://codesandbox.io/p/sandbox/9qgyfz); [CSB with alpha here](https://codesandbox.io/p/devbox/pbntr-416-form-pill-3-of-5-size-alpha-forked-9jmvms).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.