### PR TITLE
[PLAY-2152] Multi-Level Select: Single variant with selectedIds are rendering value and not label

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -195,8 +195,8 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>((pr
           if (!selectedItem.length) {
             setSingleSelectedItem({ id: [], value: "", item: [] });
           } else {
-            const { id, value } = selectedItem[0];
-            setSingleSelectedItem({ id: [id], value, item: selectedItem });
+            const { id, label } = selectedItem[0];
+            setSingleSelectedItem({ id: [id], value: label, item: selectedItem });
           }
         }
       }

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_color.html.erb
@@ -1,62 +1,62 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_color.jsx
@@ -4,63 +4,63 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_default.html.erb
@@ -1,62 +1,62 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "business Affairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_default.jsx
@@ -4,63 +4,63 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled.html.erb
@@ -1,62 +1,62 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled.jsx
@@ -4,63 +4,63 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
     {
         label: "Power Home Remodeling",
-        value: "Power Home Remodeling",
+        value: "powerHomeRemodeling",
         id: "powerhome1",
         expanded: true,
         children: [
             {
                 label: "People",
-                value: "People",
+                value: "people",
                 id: "people1",
                 expanded: true,
                 children: [
                     {
                         label: "Talent Acquisition",
-                        value: "Talent Acquisition",
+                        value: "talentAcquisition",
                         id: "talent1",
                     },
                     {
                         label: "Business Affairs",
-                        value: "Business Affairs",
+                        value: "businessAffairs",
                         id: "business1",
                         children: [
                             {
                                 label: "Initiatives",
-                                value: "Initiatives",
+                                value: "initiatives",
                                 id: "initiative1",
                             },
                             {
                                 label: "Learning & Development",
-                                value: "Learning & Development",
+                                value: "learningAndDevelopment",
                                 id: "development1",
                             },
                         ],
                     },
                     {
                         label: "People Experience",
-                        value: "People Experience",
+                        value: "peopleExperience",
                         id: "experience1",
                     },
                 ],
             },
             {
                 label: "Contact Center",
-                value: "Contact Center",
+                value: "contactCenter",
                 id: "contact1",
                 children: [
                     {
                         label: "Appointment Management",
-                        value: "Appointment Management",
+                        value: "appointmentManagement",
                         id: "appointment1",
                     },
                     {
                         label: "Customer Service",
-                        value: "Customer Service",
+                        value: "customerService",
                         id: "customer1",
                     },
                     {
                         label: "Energy",
-                        value: "Energy",
+                        value: "energy",
                         id: "energy1",
                     },
                 ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.html.erb
@@ -1,65 +1,65 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
             disabled: true,
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
                 disabled: true,
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
             disabled: true,
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options.jsx
@@ -4,66 +4,66 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
             disabled: true,
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
                 disabled: true,
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
             disabled: true,
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.html.erb
@@ -1,65 +1,65 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
             disabled: true,
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
                 disabled: true,
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
             disabled: true,
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_default.jsx
@@ -4,66 +4,66 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
             disabled: true,
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
                 disabled: true,
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
             disabled: true,
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.html.erb
@@ -1,64 +1,64 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             expanded: true,
             disabled: true,
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent.jsx
@@ -4,65 +4,65 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             expanded: true,
             disabled: true,
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.html.erb
@@ -1,64 +1,64 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             expanded: true,
             disabled: true,
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_disabled_options_parent_default.jsx
@@ -4,65 +4,65 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             expanded: true,
             disabled: true,
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_error.html.erb
@@ -1,62 +1,62 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_error.jsx
@@ -4,63 +4,63 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_label.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_label.html.erb
@@ -1,62 +1,62 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_label.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_label.jsx
@@ -4,63 +4,63 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_react_hook.jsx
@@ -5,63 +5,63 @@ import { useForm } from "react-hook-form"
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_reset.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_reset.html.erb
@@ -1,62 +1,62 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         expanded: true,
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_return_all_selected.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_return_all_selected.html.erb
@@ -1,61 +1,61 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_return_all_selected.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_return_all_selected.jsx
@@ -4,62 +4,62 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids.html.erb
@@ -1,61 +1,61 @@
 <% treeData = [{
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "100",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "101",
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "102",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "103",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "104",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "105",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "106",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "107",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "108",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "109",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "110",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids.md
@@ -3,3 +3,5 @@
 Items that include `checked:true` on the treeData itself will also be selected on page load, even without being passed to `selectedIds`.
 
 When an item is marked as checked on page load by any means, the dropdown will expand to show the checked items for easier accessibility. 
+
+When using `selected_ids` and `variant: "single"` together (see [single select doc examples](https://playbook.powerapp.cloud/kits/multi_level_select#single-select)), the `selected_ids` array should contain only one id, because only one item can be selected and displayed at a time. If the `selected_ids` array has multiple ids in it, the first id in the array will be the treeData node checked upon page load.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.jsx
@@ -4,62 +4,62 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
               },
             ],
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.md
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_selected_ids_react.md
@@ -2,4 +2,6 @@
 
 Items that include `checked:true` on the treeData itself will also be selected on page load, even without being passed to `selectedIds`.
 
-When an item is marked as checked on page load by any means, the dropdown will expand to show the checked items for easier accessibility. 
+When an item is marked as checked on page load by any means, the dropdown will expand to show the checked items for easier accessibility.
+
+When using `selectedIds` and `variant="single"` together (see [single select doc examples](https://playbook.powerapp.cloud/kits/multi_level_select/react#single-select)), the `selectedIds` array should contain only one id, because only one item can be selected and displayed at a time. If the `selectedIds` array has multiple ids in it, the first id in the array will be the treeData node checked upon page load.

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single.html.erb
@@ -1,76 +1,76 @@
 <% treeData = [
   {
     label: "HQ",
-    value: "HQ",
+    value: "hQ",
     id: "hq",
   },
   {
     label: "Philadelphia",
-    value: "Philadelphia",
+    value: "philadelphia",
     id: "phl",
     children: [
       {
         label: "Marketing & Sales PHL",
-        value: "Marketing & Sales PHL",
+        value: "marketingAndSalesPhl",
         id: "marketingPHL",
       },
       {
         label: "Installation Office PHL",
-        value: "Installation Office PHL",
+        value: "installationOfficePhl",
         id: "installationPHL",
       },
       {
         label: "Warehouse PHL",
-        value: "Warehouse PHL",
+        value: "warehousePhl",
         id: "warehousePHL",
       },
     ]
   },
   {
     label: "New Jersey",
-    value: "New Jersey",
+    value: "newJersey",
     id: "nj",
     children: [
       {
         label: "New Jersey",
-        value: "New Jersey",
+        value: "newJersey",
         id: "nj1",
         children: [
           {
             label: "Marketing & Sales NJ",
-            value: "Marketing & Sales NJ",
+            value: "marketingAndSalesNj",
             id: "marketingNJ",
           },
           {
             label: "Installation Office NJ",
-            value: "Installation Office NJ",
+            value: "installationOfficeNj",
             id: "installationNJ",
           },
           {
             label: "Warehouse NJ",
-            value: "Warehouse NJ",
+            value: "warehouseNj",
             id: "warehouseNJ",
           },
         ],
       },
       {
         label: "Princeton",
-        value: "Princeton",
+        value: "princeton",
         id: "princeton",
         children: [
           {
             label: "Marketing & Sales Princeton",
-            value: "Marketing & Sales Princeton",
+            value: "marketingAndSalesPrinceton",
             id: "marketingPR",
           },
           {
             label: "Installation Office Princeton",
-            value: "Installation Office Princeton",
+            value: "installationOfficePrinceton",
             id: "installationPR",
           },
           {
             label: "Warehouse Princeton",
-            value: "Warehouse Princeton",
+            value: "warehousePrinceton",
             id: "warehousePR",
           },
         ]
@@ -79,44 +79,44 @@
   },
   {
     label: "Maryland",
-    value: "Maryland",
+    value: "maryland",
     id: "MD",
     children: [
       {
         label: "Marketing & Sales MD",
-        value: "Marketing & Sales MD",
+        value: "marketingAndSalesMd",
         id: "marketingMD",
       },
       {
         label: "Installation Office MD",
-        value: "Installation Office MD",
+        value: "installationOfficeMd",
         id: "installationMD",
       },
       {
         label: "Warehouse MD",
-        value: "Warehouse MD",
+        value: "warehouseMd",
         id: "warehouseMD",
       },
     ]
   },
   {
     label: "Connecticut",
-    value: "Connecticut",
+    value: "connecticut",
     id: "CT",
     children: [
       {
         label: "Marketing & Sales CT",
-        value: "Marketing & Sales CT",
+        value: "marketingAndSalesCt",
         id: "marketingCT",
       },
       {
         label: "Installation Office CT",
-        value: "Installation Office CT",
+        value: "installationOfficeCt",
         id: "installationCT",
       },
       {
         label: "Warehouse CT",
-        value: "Warehouse CT",
+        value: "warehouseCt",
         id: "warehouseCT",
       },
     ]

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single.jsx
@@ -4,76 +4,76 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "HQ",
-    value: "HQ",
+    value: "hQ",
     id: "hq",
   },
   {
     label: "Philadelphia",
-    value: "Philadelphia",
+    value: "philadelphia",
     id: "phl",
     children: [
       {
         label: "Marketing & Sales PHL",
-        value: "Marketing & Sales PHL",
+        value: "marketingAndSalesPhl",
         id: "marketingPHL",
       },
       {
         label: "Installation Office PHL",
-        value: "Installation Office PHL",
+        value: "installationOfficePhl",
         id: "installationPHL",
       },
       {
         label: "Warehouse PHL",
-        value: "Warehouse PHL",
+        value: "warehousePhl",
         id: "warehousePHL",
       },
     ]
   },
   {
     label: "New Jersey",
-    value: "New Jersey",
+    value: "newJersey",
     id: "nj",
     children: [
       {
         label: "New Jersey",
-        value: "New Jersey",
+        value: "newJersey",
         id: "nj1",
         children: [
           {
             label: "Marketing & Sales NJ",
-            value: "Marketing & Sales NJ",
+            value: "marketingAndSalesNj",
             id: "marketingNJ",
           },
           {
             label: "Installation Office NJ",
-            value: "Installation Office NJ",
+            value: "installationOfficeNj",
             id: "installationNJ",
           },
           {
             label: "Warehouse NJ",
-            value: "Warehouse NJ",
+            value: "warehouseNj",
             id: "warehouseNJ",
           },
         ],
       },
       {
         label: "Princeton",
-        value: "Princeton",
+        value: "princeton",
         id: "princeton",
         children: [
           {
             label: "Marketing & Sales Princeton",
-            value: "Marketing & Sales Princeton",
+            value: "marketingAndSalesPrinceton",
             id: "marketingPR",
           },
           {
             label: "Installation Office Princeton",
-            value: "Installation Office Princeton",
+            value: "installationOfficePrinceton",
             id: "installationPR",
           },
           {
             label: "Warehouse Princeton",
-            value: "Warehouse Princeton",
+            value: "warehousePrinceton",
             id: "warehousePR",
           },
         ]
@@ -82,44 +82,44 @@ const treeData = [
   },
   {
     label: "Maryland",
-    value: "Maryland",
+    value: "maryland",
     id: "MD",
     children: [
       {
         label: "Marketing & Sales MD",
-        value: "Marketing & Sales MD",
+        value: "marketingAndSalesMd",
         id: "marketingMD",
       },
       {
         label: "Installation Office MD",
-        value: "Installation Office MD",
+        value: "installationOfficeMd",
         id: "installationMD",
       },
       {
         label: "Warehouse MD",
-        value: "Warehouse MD",
+        value: "warehouseMd",
         id: "warehouseMD",
       },
     ]
   },
   {
     label: "Connecticut",
-    value: "Connecticut",
+    value: "connecticut",
     id: "CT",
     children: [
       {
         label: "Marketing & Sales CT",
-        value: "Marketing & Sales CT",
+        value: "marketingAndSalesCt",
         id: "marketingCT",
       },
       {
         label: "Installation Office CT",
-        value: "Installation Office CT",
+        value: "installationOfficeCt",
         id: "installationCT",
       },
       {
         label: "Warehouse CT",
-        value: "Warehouse CT",
+        value: "warehouseCt",
         id: "warehouseCT",
       },
     ]

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single_children_only.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single_children_only.html.erb
@@ -1,80 +1,80 @@
 <% treeData = [
   {
     label: "HQ",
-    value: "HQ",
+    value: "hQ",
     id: "hq1",
   },
   {
     label: "Philadelphia",
-    value: "Philadelphia",
+    value: "philadelphia",
     id: "phl1",
     hideRadio: true,
     children: [
       {
         label: "Marketing & Sales PHL",
-        value: "Marketing & Sales PHL",
+        value: "marketingAndSalesPhl",
         id: "marketingPHL1",
       },
       {
         label: "Installation Office PHL",
-        value: "Installation Office PHL",
+        value: "installationOfficePhl",
         id: "installationPHL1",
       },
       {
         label: "Warehouse PHL",
-        value: "Warehouse PHL",
+        value: "warehousePHL",
         id: "warehousePHL1",
       },
     ]
   },
   {
     label: "New Jersey",
-    value: "New Jersey",
+    value: "newJersey",
     id: "nj2",
     hideRadio: true,
     children: [
       {
         label: "New Jersey",
-        value: "New Jersey",
+        value: "newJersey",
         id: "nj3",
         hideRadio: true,
         children: [
           {
             label: "Marketing & Sales NJ",
-            value: "Marketing & Sales NJ",
+            value: "marketingAndSalesNj",
             id: "marketingNJ1",
           },
           {
             label: "Installation Office NJ",
-            value: "Installation Office NJ",
+            value: "installationOfficeNj",
             id: "installationNJ1",
           },
           {
             label: "Warehouse NJ",
-            value: "Warehouse NJ",
+            value: "warehouseNj",
             id: "warehouseNJ1",
           },
         ],
       },
       {
         label: "Princeton",
-        value: "Princeton",
+        value: "princeton",
         id: "princeton1",
         hideRadio: true,
         children: [
           {
             label: "Marketing & Sales Princeton",
-            value: "Marketing & Sales Princeton",
+            value: "marketingAndSalesPrinceton",
             id: "marketingPR1",
           },
           {
             label: "Installation Office Princeton",
-            value: "Installation Office Princeton",
+            value: "installationOfficePrinceton",
             id: "installationPR1",
           },
           {
             label: "Warehouse Princeton",
-            value: "Warehouse Princeton",
+            value: "warehousePrinceton",
             id: "warehousePR1",
           },
         ]
@@ -83,46 +83,46 @@
   },
   {
     label: "Maryland",
-    value: "Maryland",
+    value: "maryland",
     id: "MD1",
     hideRadio: true,
     children: [
       {
         label: "Marketing & Sales MD",
-        value: "Marketing & Sales MD",
+        value: "marketingAndSalesMd",
         id: "marketingMD1",
       },
       {
         label: "Installation Office MD",
-        value: "Installation Office MD",
+        value: "installationOfficeMd",
         id: "installationMD1",
       },
       {
         label: "Warehouse MD",
-        value: "Warehouse MD",
+        value: "warehouseMd",
         id: "warehouseMD1",
       },
     ]
   },
   {
     label: "Connecticut",
-    value: "Connecticut",
+    value: "connecticut",
     id: "CT1",
     hideRadio: true,
     children: [
       {
         label: "Marketing & Sales CT",
-        value: "Marketing & Sales CT",
+        value: "marketingAndSalesCt",
         id: "marketingCT1",
       },
       {
         label: "Installation Office CT",
-        value: "Installation Office CT",
+        value: "installationOfficeCt",
         id: "installationCT1",
       },
       {
         label: "Warehouse CT",
-        value: "Warehouse CT",
+        value: "warehouseCt",
         id: "warehouseCT1",
       },
     ]

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single_children_only.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_single_children_only.jsx
@@ -4,80 +4,80 @@ import MultiLevelSelect from "../_multi_level_select";
 const treeData = [
   {
     label: "HQ",
-    value: "HQ",
+    value: "hQ",
     id: "hq1",
   },
   {
     label: "Philadelphia",
-    value: "Philadelphia",
+    value: "philadelphia",
     id: "phl1",
     hideRadio: true,
     children: [
       {
         label: "Marketing & Sales PHL",
-        value: "Marketing & Sales PHL",
+        value: "marketingAndSalesPhl",
         id: "marketingPHL1",
       },
       {
         label: "Installation Office PHL",
-        value: "Installation Office PHL",
+        value: "installationOfficePhl",
         id: "installationPHL1",
       },
       {
         label: "Warehouse PHL",
-        value: "Warehouse PHL",
+        value: "warehousePhl",
         id: "warehousePHL1",
       },
     ]
   },
   {
     label: "New Jersey",
-    value: "New Jersey",
+    value: "newJersey",
     id: "nj2",
     hideRadio: true,
     children: [
       {
         label: "New Jersey",
-        value: "New Jersey",
+        value: "newJersey",
         id: "nj3",
         hideRadio: true,
         children: [
           {
             label: "Marketing & Sales NJ",
-            value: "Marketing & Sales NJ",
+            value: "marketingAndSalesNj",
             id: "marketingNJ1",
           },
           {
             label: "Installation Office NJ",
-            value: "Installation Office NJ",
+            value: "installationOfficeNj",
             id: "installationNJ1",
           },
           {
             label: "Warehouse NJ",
-            value: "Warehouse NJ",
+            value: "warehouseNj",
             id: "warehouseNJ1",
           },
         ],
       },
       {
         label: "Princeton",
-        value: "Princeton",
+        value: "princeton",
         id: "princeton1",
         hideRadio: true,
         children: [
           {
             label: "Marketing & Sales Princeton",
-            value: "Marketing & Sales Princeton",
+            value: "marketingAndSalesPrinceton",
             id: "marketingPR1",
           },
           {
             label: "Installation Office Princeton",
-            value: "Installation Office Princeton",
+            value: "installationOfficePrinceton",
             id: "installationPR1",
           },
           {
             label: "Warehouse Princeton",
-            value: "Warehouse Princeton",
+            value: "warehousePrinceton",
             id: "warehousePR1",
           },
         ]
@@ -86,46 +86,46 @@ const treeData = [
   },
   {
     label: "Maryland",
-    value: "Maryland",
+    value: "maryland",
     id: "MD1",
     hideRadio: true,
     children: [
       {
         label: "Marketing & Sales MD",
-        value: "Marketing & Sales MD",
+        value: "marketingAndSalesMd",
         id: "marketingMD1",
       },
       {
         label: "Installation Office MD",
-        value: "Installation Office MD",
+        value: "installationOfficeMd",
         id: "installationMD1",
       },
       {
         label: "Warehouse MD",
-        value: "Warehouse MD",
+        value: "warehouseMd",
         id: "warehouseMD1",
       },
     ]
   },
   {
     label: "Connecticut",
-    value: "Connecticut",
+    value: "connecticut",
     id: "CT1",
     hideRadio: true,
     children: [
       {
         label: "Marketing & Sales CT",
-        value: "Marketing & Sales CT",
+        value: "marketingAndSalesCt",
         id: "marketingCT1",
       },
       {
         label: "Installation Office CT",
-        value: "Installation Office CT",
+        value: "installationOfficeCt",
         id: "installationCT1",
       },
       {
         label: "Warehouse CT",
-        value: "Warehouse CT",
+        value: "warehouseCt",
         id: "warehouseCT1",
       },
     ]

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_with_children.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_with_children.jsx
@@ -5,25 +5,25 @@ import Badge from "../../pb_badge/_badge";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         status: "active",
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             status: "active",
             variant: "primary",
@@ -31,12 +31,12 @@ const treeData = [
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
                 status: "Inactive",
               },
@@ -44,31 +44,31 @@ const treeData = [
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         status: "Inactive",
         variant: "error",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_with_children_with_radios.jsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_with_children_with_radios.jsx
@@ -5,25 +5,25 @@ import Badge from "../../pb_badge/_badge";
 const treeData = [
   {
     label: "Power Home Remodeling",
-    value: "Power Home Remodeling",
+    value: "powerHomeRemodeling",
     id: "powerhome1",
     expanded: true,
     children: [
       {
         label: "People",
-        value: "People",
+        value: "people",
         id: "people1",
         expanded: true,
         status: "active",
         children: [
           {
             label: "Talent Acquisition",
-            value: "Talent Acquisition",
+            value: "talentAcquisition",
             id: "talent1",
           },
           {
             label: "Business Affairs",
-            value: "Business Affairs",
+            value: "businessAffairs",
             id: "business1",
             status: "active",
             variant: "primary",
@@ -31,12 +31,12 @@ const treeData = [
             children: [
               {
                 label: "Initiatives",
-                value: "Initiatives",
+                value: "initiatives",
                 id: "initiative1",
               },
               {
                 label: "Learning & Development",
-                value: "Learning & Development",
+                value: "learningAndDevelopment",
                 id: "development1",
                 status: "Inactive",
               },
@@ -44,31 +44,31 @@ const treeData = [
           },
           {
             label: "People Experience",
-            value: "People Experience",
+            value: "peopleExperience",
             id: "experience1",
           },
         ],
       },
       {
         label: "Contact Center",
-        value: "Contact Center",
+        value: "contactCenter",
         id: "contact1",
         status: "Inactive",
         variant: "error",
         children: [
           {
             label: "Appointment Management",
-            value: "Appointment Management",
+            value: "appointmentManagement",
             id: "appointment1",
           },
           {
             label: "Customer Service",
-            value: "Customer Service",
+            value: "customerService",
             id: "customer1",
           },
           {
             label: "Energy",
-            value: "Energy",
+            value: "energy",
             id: "energy1",
           },
         ],

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_with_form.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_multi_level_select_with_form.html.erb
@@ -2,62 +2,62 @@
 
   <% treeData = [{
   label: "Power Home Remodeling",
-  value: "Power Home Remodeling",
+  value: "powerHomeRemodeling",
   id: "powerhome1",
   expanded: true,
   children: [
     {
       label: "People",
-      value: "People",
+      value: "people",
       id: "people1",
       children: [
         {
           label: "Talent Acquisition",
-          value: "Talent Acquisition",
+          value: "talentAcquisition",
           id: "talent1",
         },
         {
           label: "Business Affairs",
-          value: "Business Affairs",
+          value: "businessAffairs",
           id: "business1",
           children: [
             {
               label: "Initiatives",
-              value: "Initiatives",
+              value: "initiatives",
               id: "initiative1",
             },
             {
               label: "Learning & Development",
-              value: "Learning & Development",
+              value: "learningAndDevelopment",
               id: "development1",
             },
           ],
         },
         {
           label: "People Experience",
-          value: "People Experience",
+          value: "peopleExperience",
           id: "experience1",
         },
       ],
     },
     {
       label: "Contact Center",
-      value: "Contact Center",
+      value: "contactCenter",
       id: "contact1",
       children: [
         {
           label: "Appointment Management",
-          value: "Appointment Management",
+          value: "appointmentManagement",
           id: "appointment1",
         },
         {
           label: "Customer Service",
-          value: "Customer Service",
+          value: "customerService",
           id: "customer1",
         },
         {
           label: "Energy",
-          value: "Energy",
+          value: "energy",
           id: "energy1",
         },
       ],


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2152](https://runway.powerhrg.com/backlog_items/PLAY-2152) aims to fix a bug in the MultiLevelSelect kit noticed when using two props together - the `selectedIds` array of IDs to prepopulate an input with preselected nodes from the given treeData and the `variant="single"` version of the kit which only allows for one item to be selected at a time. 

There are no doc examples demonstrating these two props together (it's not exactly an edge case, but not a pattern that requires its own doc example), so this PR:

-  educates by updating the selectedIds doc example markdown (rails and react) to say that when using these two props together, the selectedIds array should only have one id in it because single select only selects one thing (if more in the array, it will display the first aka `selectedIds[0]`).
- uses these CSBs to demonstrate that the initial data populating the input is the Label from the treeData not the Value.
-- [CSB reproducing issue](https://codesandbox.io/p/devbox/wild-dew-z2x3f9)
-- [CSB with alpha](https://codesandbox.io/p/devbox/suspicious-davinci-wyf3kr)
- in an effort to make our MLS docs clearer overall, this PR also changes the value content of each MLS doc example's tree data to camelCase, to make it more visually distinct from the label content (31 doc ex total)
```
    label: "Power Home Remodeling",
    value: "Power Home Remodeling",
    id: "powerhome1",
```
is now
```
    label: "Power Home Remodeling",
    value: "powerHomeRemodeling",
    id: "powerhome1",
```

**Screenshots:** Screenshots to visualize your addition/change
The bug: upon page load, the preselected node displays the value (camelCase)
<img width="312" alt="rails PR demonstrate issue in selected id single doc ex" src="https://github.com/user-attachments/assets/668cac62-407e-4f56-acf0-47a9f28e3dc6" />
The fix: upon page load, the preselected node displays the label (Title Case)
<img width="429" alt="react PR selected id single doc ex" src="https://github.com/user-attachments/assets/61ccc53a-ce9d-4ac6-aea8-44e5d2fa4711" />
Markdown added:
<img width="1415" alt="markdown" src="https://github.com/user-attachments/assets/4c221141-233b-4fe0-bf04-534971c955c4" />



**How to test?** Steps to confirm the desired behavior:
1. Go to the [CSB demonstrating this bug](https://codesandbox.io/p/devbox/wild-dew-z2x3f9) - see the camelCase value populate the top MLS upon page render. Compare to the selectedIds and single variant MLSes in the CSB.
2. Compare/contrast to the [CSB with alpha](https://codesandbox.io/p/devbox/suspicious-davinci-wyf3kr) - see the Title Case label now populates the top MLS upon page render.
3. Overall MLS function in the review env ([rails](https://pr4623.playbook.beta.hq.powerapp.cloud/kits/multi_level_select/rails), [react](https://pr4623.playbook.beta.hq.powerapp.cloud/kits/multi_level_select/react)) should not be affected by this code update.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.