### PR TITLE
[PLAY-2182] Form Group Kit: Fix Select and Passphrase Inputs Error Misalignment

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/_error_state_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_form_group/_error_state_mixin.scss
@@ -23,7 +23,7 @@
 @mixin error-state-right-side-select-kit {
   &:has(.pb_text_input_kit:not(.error)):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper.error),
   &:has(.pb_text_input_kit.error):has(.pb_text_input_kit_label):has(.pb_select_kit_wrapper) {
-    &:not(:has(.pb_phone_number_input)) {
+    &:not(:has(.pb_phone_number_input)):not(:has(.passphrase-text-input)) {
       align-items: flex-start;
 
       .pb_select_kit_wrapper {
@@ -49,7 +49,7 @@
 
 @mixin error-state-left-side-select-kit {
   &:has(.pb_select_kit_label):has(.pb_select_kit_wrapper):has(.pb_text_input_kit.error) {
-    &:not(:has(.pb_phone_number_input)) {
+    &:not(:has(.pb_phone_number_input)):not(:has(.passphrase-text-input)) {
       align-items: flex-start;
 
       .pb_text_input_kit.error {


### PR DESCRIPTION
**What does this PR do?**
It fixes SCSS in the Form Group Kit where a Select input would affect a Passphrase input's error because it would add extra padding. 
We made another fix to Phone Number Input with [PLAY-2107](https://runway.powerhrg.com/backlog_items/PLAY-2107)

https://runway.powerhrg.com/backlog_items/PLAY-2182

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-05-15 at 4 59 36 PM](https://github.com/user-attachments/assets/6f5c78a2-ec48-4488-bf48-5680e510c2bf)
is fixed:
![Screenshot 2025-05-15 at 4 51 03 PM](https://github.com/user-attachments/assets/169c181a-34f6-4012-a929-540821bf035b)

**How to test?** Steps to confirm the desired behavior:
1. Go to Credit app and make sure an error doesn't misalign the form group.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.