### PR TITLE
[PLAY-2145] All Kits: Fix `html_options style` without Inline Styles Bug - Rails

### DIFF
--- a/playbook/lib/playbook/kit_base.rb
+++ b/playbook/lib/playbook/kit_base.rb
@@ -129,9 +129,9 @@ module Playbook
       end
 
       inline_styles = dynamic_inline_props
-      merged[:style] = if inline_styles.present?
-                         merged[:style].present? ? "#{merged[:style]}; #{inline_styles}" : inline_styles
-                       end
+      if inline_styles.present?
+        merged[:style] = merged[:style].present? ? "#{merged[:style]}; #{inline_styles}" : inline_styles
+      end
 
       merged.deep_merge(data_attributes)
     end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fix bug where style would be set to nil if inline styles (e.g., height) weren't present

https://runway.powerhrg.com/backlog_items/PLAY-2145

**How to test?** Steps to confirm the desired behavior:
1. Go to /kit_playground_rails
2. Paste the following:
3. `<%= pb_rails("title", props: { text: "Welcome to Playbook", size: 1, html_options: { style: "background-color: blue;" } }) %>
<%= pb_rails("title", props: { text: "Welcome to Playbook", size: 1, height: "50px", html_options: { style: "background-color: blue;" } }) %>`
4. Both should be blue
5. The second should have a height of 50px

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.