### PR TITLE
[PLAY-1968] Typeahead kit: Option to Preserve Search Input on Click POC - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -29,6 +29,7 @@ import { GenericObject, Noop } from '../types'
  * @prop {boolean} async - whether Typeahead should fetch data from
  * a remote location to populate the options
  * @prop {string} label - the text for the optional typeahead input label
+ * @prop {boolean} preserveSearchInput - whether Typeahed should preserve input when the field loses focus
  */
 
 type TypeaheadProps = {
@@ -54,6 +55,7 @@ type TypeaheadProps = {
   optionsByContext?: Record<string, Array<{ label: string; value?: string }>>
   searchContextSelector?: string,
   clearOnContextChange?: boolean,
+  preserveSearchInput?: boolean,
 } & GlobalProps
 
 export type SelectValueType = {
@@ -93,8 +95,12 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
   optionsByContext = {},
   searchContextSelector,
   clearOnContextChange = false,
+  preserveSearchInput = false,
   ...props
 }: TypeaheadProps) => {
+  // State to manage input value for preserveSearchInput prop
+  const [inputValue, setInputValue] = useState("")
+
   const selectProps = {
     cacheOptions: true,
     components: {
@@ -127,7 +133,54 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
     ...props,
   }
 
+  // If preserveSearchInput is true, manage the input value
+  if (preserveSearchInput) {
+    selectProps.inputValue = inputValue
+    selectProps.onInputChange = (newValue: string, actionMeta: {action: string}) => {
+      // Only update the input value for certain actions
+      if (actionMeta.action === 'input-change') {
+        setInputValue(newValue)
+      } else if (actionMeta.action === 'menu-close' && !props.value) {
+        // Don't clear the input when the menu closes without a selection
+        // unless the component is controlled and has a value
+      } else if (actionMeta.action === 'set-value') {
+        // When an option is selected, clear the input
+        setInputValue('')
+      }
+
+      // If the original onInputChange was provided, call it too
+      if (props.onInputChange) {
+        return props.onInputChange(newValue, actionMeta)
+      }
+      return newValue
+    }
+
+    // Handle blur events
+    const originalOnBlur = props.onBlur
+    selectProps.onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+      // Do not clear input on blur - the value is preserved in our state
+      if (originalOnBlur) {
+        originalOnBlur(event)
+      }
+    }
+  }
+
   const [contextValue, setContextValue] = useState("")
+
+  // Add listener for clearing
+  useEffect(() => {
+    const handleClear = () => {
+      if (preserveSearchInput) {
+        setInputValue('')
+      }
+    }
+
+    document.addEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, handleClear)
+
+    return () => {
+      document.removeEventListener(`pb-typeahead-kit-${selectProps.id}:clear`, handleClear)
+    }
+  }, [selectProps.id, preserveSearchInput])
 
   useEffect(() => {
     if (searchContextSelector) {
@@ -137,7 +190,12 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
       const handleContextChange = (e: Event) => {
         const target = e.target as HTMLInputElement;
         setContextValue(target.value);
-        if (clearOnContextChange) document.dispatchEvent(new CustomEvent(`pb-typeahead-kit-${selectProps.id}:clear`))
+        if (clearOnContextChange) {
+          document.dispatchEvent(new CustomEvent(`pb-typeahead-kit-${selectProps.id}:clear`))
+          if (preserveSearchInput) {
+            setInputValue('')
+          }
+        }
       }
 
       if (searchContextElement) searchContextElement.addEventListener('change', handleContextChange)
@@ -146,7 +204,7 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
         if (searchContextElement) searchContextElement.removeEventListener('change', handleContextChange)
       }
     }
-  }, [searchContextSelector])
+  }, [searchContextSelector, clearOnContextChange, selectProps.id, preserveSearchInput])
 
   const contextArray = optionsByContext[contextValue]
   if (Array.isArray(contextArray) && contextArray.length > 0) {
@@ -168,7 +226,12 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
         onChange(_data)
       }
     }
-    
+
+    // If a value is selected and we're preserving input on blur, clear the input
+    if (action === 'select-option' && preserveSearchInput) {
+      setInputValue('')
+    }
+
     if (action === 'select-option') {
       if (selectProps.onMultiValueClick) selectProps.onMultiValueClick(option)
       const multiValueClearEvent = new CustomEvent(`pb-typeahead-kit-${selectProps.id}-result-option-select`, { detail: option ? option : _data })
@@ -181,6 +244,10 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(({
     if (action === 'clear') {
       const multiValueClearEvent = new CustomEvent(`pb-typeahead-kit-${selectProps.id}-result-clear`)
       document.dispatchEvent(multiValueClearEvent)
+      // If preserving input on blur, also clear input on explicit clear
+      if (preserveSearchInput) {
+        setInputValue('')
+      }
     }
   }
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_preserve_input.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_preserve_input.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import Typeahead from '../_typeahead'
+
+const options = [
+  { label: 'Orange', value: '#FFA500' },
+  { label: 'Red', value: '#FF0000' },
+  { label: 'Green', value: '#00FF00' },
+  { label: 'Blue', value: '#0000FF' },
+]
+
+const TypeaheadPreserveInput = (props) => {
+  return (
+    <Typeahead
+        label="Colors"
+        options={options}
+        preserveSearchInput
+        {...props}
+    />
+  )
+}
+
+export default TypeaheadPreserveInput

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_preserve_input.md
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_preserve_input.md
@@ -1,0 +1,1 @@
+By default, text is not preserved in the typeahead kit when you click off of the input field. You can utilize the `preserveSearchInput` prop in order to prevent text from being cleared when the field loses focus

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
@@ -34,3 +34,4 @@ examples:
     - typeahead_with_pills_color: With Pills (Custom Color)
     - typeahead_truncated_text: Truncated Text
     - typeahead_disabled: Disabled
+    - typeahead_preserve_input: Preserve Search Input

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/index.js
@@ -15,3 +15,4 @@ export { default as TypeaheadWithPillsColor } from './_typeahead_with_pills_colo
 export { default as TypeaheadTruncatedText } from './_typeahead_truncated_text.jsx'
 export { default as TypeaheadReactHook } from './_typeahead_react_hook.jsx'
 export { default as TypeaheadDisabled } from './_typeahead_disabled.jsx'
+export { default as TypeaheadPreserveInput } from './_typeahead_preserve_input.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-1968)

**Screenshots:** Screenshots to visualize your addition/change
<img width="1326" alt="Screenshot 2025-05-19 at 1 15 25 PM" src="https://github.com/user-attachments/assets/8065cbc6-1b46-4833-b60f-01fa19fff967" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.