### PR TITLE
[PLAY-2139] Update power-fonts to 0.0.1

### DIFF
--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -11,7 +11,7 @@
     "@mapbox/mapbox-gl-draw": "^1.4.1",
     "@powerhome/playbook-icons": "0.0.1-alpha.38",
     "@powerhome/playbook-icons-react": "0.0.1-alpha.38",
-    "@powerhome/power-fonts": "0.0.1-alpha.6",
+    "@powerhome/power-fonts": "0.0.1",
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^2.4.0",
     "match-sorter": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3159,10 +3159,10 @@
   resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/7336947a1b8e91909a54ad2664cc0ea7e80be352#7336947a1b8e91909a54ad2664cc0ea7e80be352"
   integrity sha512-cKFsJo+hILxbktdjeNLJiNOBc5nSBgWaiH/1nsvb5aeQLcpALyx348GeWja0uBRnr8MzAcVNxCTs1Hqn7H0Geg==
 
-"@powerhome/power-fonts@0.0.1-alpha.6":
-  version "0.0.1-alpha.6"
-  resolved "https://npm.powerapp.cloud/@powerhome/power-fonts/-/aa26f705183fa213bd4488fa53772f2c28bb9edf#aa26f705183fa213bd4488fa53772f2c28bb9edf"
-  integrity sha512-kGv2t8SF8aW5WuRkia8Q0SqbGiJtv34dcy2ckPT0O+a6D4PLrAhtBB5B1sI69/IDZy6CfrjKC/6TIQjDSyx75Q==
+"@powerhome/power-fonts@0.0.1":
+  version "0.0.1"
+  resolved "https://npm.powerapp.cloud/@powerhome/power-fonts/-/866a853e8a3e36bf18b0eddceac6fba492d479d6#866a853e8a3e36bf18b0eddceac6fba492d479d6"
+  integrity sha512-2M2e3c3eNgWMswTyS7yqzHS+SS8iRVfShWfdbpfjoOpuD0xDtqFqraU+/x4ZFELviYECkuy3ZcXKjKBruIBTJg==
 
 "@rails/actioncable@^7.0":
   version "7.1.3"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2139](https://runway.powerhrg.com/backlog_items/PLAY-2139) Bumps [@powerhome/power-fonts](https://github.com/powerhome/power-fonts) from 0.0.1-alpha.6 to 0.0.1 for the Playbook website.

**Screenshots:**
There should be no visual changes - we are just getting off the alpha version of the repo.
<img width="573" alt="playbook local" src="https://github.com/user-attachments/assets/edbd2a8b-191a-4ebb-ba98-55c8ec6538ba" />
<img width="505" alt="computed font family pb" src="https://github.com/user-attachments/assets/26f2e5cb-2062-44ac-a4c7-bf2a75622107" />



**How to test?** Steps to confirm the desired behavior:
1. Go to the [playbook website review env](https://pr4634.playbook.beta.px.powerapp.cloud/).
2. Look at any text/typography. It should still be Power Centra font. Confirm this by: 
 - looking at the lowercase t's (these are very visually distinct in Power Centra)
 - inspect any text/typography kit and look at the computed font-family - the font should be Power Centra


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.