### PR TITLE
[PLAY-2206] Advanced Table: Fix for border when StickyLeftColumn, Sticky Header and ColumnBorderColor used together

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -555,9 +555,6 @@
       box-shadow: $shadow_deep;
     }
 
-    // Apply border colors for sticky columns
-    @include apply-sticky-colors("light");
-
     @include advanced-table-sticky-mixin(
       $border_light,
       $white,

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -554,14 +554,15 @@
       background-color: $white;
       box-shadow: $shadow_deep;
     }
+
+    // Apply border colors for sticky columns
+    @include apply-sticky-colors("light");
+
     @include advanced-table-sticky-mixin(
       $border_light,
       $white,
       lighten($silver, $opacity_7)
     );
-
-    // Apply border colors for sticky columns
-    @include apply-sticky-colors("light");
   }
 
   // Responsive Styles


### PR DESCRIPTION
**What does this PR do?**

Fixes for bug when StickyLeftColumn, Sticky Header and ColumnBorderColor used together, style from the ColumnBorderColor overrode the table container box-shadow

**Screenshots:**
![Screenshot 2025-05-20 at 1 27 57 PM](https://github.com/user-attachments/assets/fd3a006c-c57f-45cc-ac04-f1228cf50afc)


**How to test?** 
[csb with fix](https://codesandbox.io/p/devbox/advanced-table-multi-column-sticky-forked-52kcyd)


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.