### PR TITLE
[PLAY-2178] Advanced Table: Row Pinning Logic

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
@@ -32,7 +32,9 @@ export const RegularTableView = ({
     table,
     selectableRows,
     hasAnySubRows,
-    stickyLeftColumn
+    stickyLeftColumn,
+    rowPinning,
+    enableRowPinning,
   } = useContext(AdvancedTableContext)
 
 
@@ -50,9 +52,41 @@ export const RegularTableView = ({
   const columnPinning = table.getState().columnPinning || { left: [] };
   const columnDefinitions = table.options.meta?.columnDefinitions || [];
 
+  // Row pinning
+  const pinnedTopRows = rowPinning?.top || [];
+  const pinnedBottomRows = rowPinning?.bottom || [];
+  
+  const allRows = table.getRowModel().rows;
+
+  const normalRows = allRows.filter((row: Row<GenericObject>) => 
+    !pinnedTopRows.includes(row.id) && !pinnedBottomRows.includes(row.id)
+  );
+
   return (
     <>
-      {table.getRowModel().rows.map((row: Row<GenericObject>) => {
+      {/* Pinned Top Rows */}
+      {pinnedTopRows.length > 0 && pinnedTopRows.map((rowId) => {
+        const row = allRows.find(r => r.id === rowId);
+        if (row) {
+          return (
+            <tr className="pinned-top-row"
+                key={`${row.id}-pinned-top`} 
+            >
+              {row.getVisibleCells().map((cell: Cell<GenericObject, unknown>) => (
+                <td className="pinned-row"
+                    key={cell.id}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          );
+        }
+        return null;
+      })}
+
+      {/* Regular Rows */}
+      {normalRows.map((row: Row<GenericObject>) => {
         const isExpandable = row.getIsExpanded();
         const isFirstChildofSubrow = row.depth > 0 && row.index === 0;
         const rowHasNoChildren = row.original?.children && !row.original.children.length ? true : false;
@@ -99,7 +133,7 @@ export const RegularTableView = ({
                       const last = row.getVisibleCells().at(-1);
                       return last?.column.id === cell.column.id;
                     }
-                  
+
                     const visibleSiblings = parent.columns.filter(col => col.getIsVisible());
                     return visibleSiblings.at(-1)?.id === cell.column.id;
                    })();
@@ -150,8 +184,136 @@ export const RegularTableView = ({
           </React.Fragment>
         );
       })}
+
+      {/* Pinned Bottom Rows */}
+      {pinnedBottomRows.length > 0 && pinnedBottomRows.map((rowId) => {
+        const row = allRows.find(r => r.id === rowId);
+        if (row) {
+          return (
+            <tr className="pinned-bottom-row"
+                key={`${row.id}-pinned-bottom`}
+            >
+              {row.getVisibleCells().map((cell: Cell<GenericObject, unknown>) => (
+                <td className="pinned-row"
+                    key={cell.id}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          );
+        }
+        return null;
+      })}
     </>
   );
 }
 
 export default RegularTableView;
+
+// Original code return down
+//   return (
+//     <>
+//       {table.getRowModel().rows.map((row: Row<GenericObject>) => {
+//         const isExpandable = row.getIsExpanded();
+//         const isFirstChildofSubrow = row.depth > 0 && row.index === 0;
+//         const rowHasNoChildren = row.original?.children && !row.original.children.length ? true : false;
+//         const numberOfColumns = table.getAllFlatColumns().length;
+//         const isDataLoading = isExpandable && (inlineRowLoading && rowHasNoChildren) && (row.depth < columnDefinitions[0]?.cellAccessors?.length);
+//         const rowBackground = isExpandable && ((!inlineRowLoading && row.getCanExpand()) || (inlineRowLoading && rowHasNoChildren));
+//         const rowColor = row.getIsSelected() ? "bg-row-selection" : rowBackground ? "bg-silver" : "bg-white";
+
+//         return (
+//           <React.Fragment key={`${row.index}-${row.id}-${row.depth}-row`}>
+//             {isFirstChildofSubrow && subRowHeaders && (
+//               <SubRowHeaderRow
+//                   collapsibleTrail={collapsibleTrail}
+//                   enableToggleExpansion={enableToggleExpansion}
+//                   onClick={handleExpandOrCollapse}
+//                   row={row}
+//                   subRowHeaders={subRowHeaders}
+//                   table={table}
+//               />
+//             )}
+
+//             <tr
+//                 className={`${rowColor} ${row.depth > 0 ? `depth-sub-row-${row.depth}` : ""}`}
+//                 id={`${row.index}-${row.id}-${row.depth}-row`}
+//             >
+//               {/* Render custom checkbox column when we want selectableRows for non-expanding tables */}
+//               {selectableRows && !hasAnySubRows && (
+//                 <td className="checkbox-cell">
+//                   <Checkbox
+//                       checked={row.getIsSelected()}
+//                       disabled={!row.getCanSelect()}
+//                       indeterminate={row.getIsSomeSelected()}
+//                       name={row.id}
+//                       onChange={row.getToggleSelectedHandler()}
+//                   />
+//                 </td>
+//               )}
+
+//               {row.getVisibleCells().map((cell: Cell<GenericObject, unknown>, i: number) => {
+//                 const isPinnedLeft = columnPinning.left.includes(cell.column.id);
+//                 const isLastCell = (() => {
+//                   const parent = cell.column.parent;
+//                     if (!parent) {
+//                       const last = row.getVisibleCells().at(-1);
+//                       return last?.column.id === cell.column.id;
+//                     }
+                  
+//                     const visibleSiblings = parent.columns.filter(col => col.getIsVisible());
+//                     return visibleSiblings.at(-1)?.id === cell.column.id;
+//                    })();
+
+//                 const { column } = cell;
+//                 return (
+//                   <td
+//                       align="right"
+//                       className={classnames(
+//                         `${cell.id}-cell position_relative`,
+//                         isChrome() ? "chrome-styles" : "",
+//                         isPinnedLeft && 'pinned-left',
+//                         stickyLeftColumn && stickyLeftColumn.length > 0 && isPinnedLeft && 'sticky-left',
+//                         isLastCell && 'last-cell',
+//                       )}
+//                       key={`${cell.id}-data`}
+//                       style={{
+//                         left: isPinnedLeft
+//                           ? i === 1 //Accounting for set min-width for first column
+//                             ? '180px'
+//                             : `${column.getStart("left")}px`
+//                           : undefined,
+//                       }}
+//                   >
+//                     {collapsibleTrail && i === 0 && row.depth > 0 && renderCollapsibleTrail(row.depth)}
+//                     <span id={`${cell.id}-span`}>
+//                       {loading ? (
+//                         <LoadingCell />
+//                       ) : (
+//                         flexRender(cell.column.columnDef.cell, cell.getContext())
+//                       )}
+//                     </span>
+//                   </td>
+//                 );
+//               })}
+//             </tr>
+
+//             {/* Display LoadingInline if Row Data is querying and there are no children already */}
+//             {isDataLoading && (
+//               <tr key={`${row.id}-row`}>
+//                 <td colSpan={numberOfColumns}
+//                     style={{ paddingLeft: `${row.depth === 0 ? 0.5 : (row.depth * 2)}em` }}
+//                 >
+//                   <LoadingInline />
+//                 </td>
+//               </tr>
+//             )}
+//           </React.Fragment>
+//         );
+//       })}
+//     </>
+//   );
+// }
+
+// export default RegularTableView;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Context/AdvancedTableContext.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Context/AdvancedTableContext.tsx
@@ -132,7 +132,13 @@ export const AdvancedTableProvider = ({ children, ...props }: {
     virtualizer: isVirtualized ? virtualizer : null,
     flattenedItems,
     virtualizedRows: isVirtualized,
-    enableVirtualization: isVirtualized
+    enableVirtualization: isVirtualized,
+    rowPinning: props.rowPinning,
+    setRowPinning: props.setRowPinning,
+    enableRowPinning: props.enableRowPinning,
+    keepPinnedRows: props.keepPinnedRows,
+    // includeLeafRows: props.includeLeafRows,
+    // includeParentRows: props.includeParentRows
   };
 
   return (

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableActions.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableActions.ts
@@ -57,9 +57,33 @@ export function useTableActions({
     }
   }, [table.getState().rowSelection, onRowSelectionChange]);
 
+  // Row Pinning
+  const pinRow = useCallback((row: Row<GenericObject>, position: 'top' | 'bottom' = 'top') => {
+    const rowId = row.id;
+    table.setRowPinning((prev: any) => {
+      const top = (prev.top || []).filter((id: string) => id !== rowId);
+      const bottom = (prev.bottom || []).filter((id: string) => id !== rowId);
+  
+      return {
+        top: position === 'top' ? [...top, rowId] : top,
+        bottom: position === 'bottom' ? [...bottom, rowId] : bottom,
+      };
+    });
+  }, [table]);
+  
+  const unpinRow = useCallback((row: Row<GenericObject>) => {
+    const rowId = row.id;
+    table.setRowPinning((prev: any) => ({
+      top: (prev.top || []).filter((id: string) => id !== rowId),
+      bottom: (prev.bottom || []).filter((id: string) => id !== rowId),
+    }));
+  }, [table]);
+
   return {
     handleExpandOrCollapse,
     onPageChange,
-    fetchMoreOnBottomReached
+    fetchMoreOnBottomReached,
+    pinRow,
+    unpinRow,
   };
 }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -13,6 +13,31 @@
 .pb_advanced_table {
   $border-color: 1px solid $border_light;
 
+  // scss classes w/ background for testing Row Pinning
+  .pinned-row {
+    background-color: red !important;
+  }
+  
+  .pinned-top-row {
+    background-color: blue !important;
+  }
+  
+  .pinned-bottom-row {
+    background-color: green !important;
+  }
+  
+  .bg-pinned-top {
+    background-color: orange !important;
+  }
+  
+  .bg-pinned-bottom {
+    background-color: yellow !important;
+  }
+  
+  .pinned-row:hover {
+    background-color: pink !important;
+  }
+
   // Base vertical border color variable setup
   --column-border-color: #{$border_light};
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useState, useCallback } from "react";
 import classnames from "classnames";
 
 import { GenericObject } from "../types";
-import { Row, RowSelectionState } from "@tanstack/react-table";
+import { Row, RowSelectionState, RowPinning, RowPinningState, RowPinningPosition } from "@tanstack/react-table";
 
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from "../utilities/props";
 import { globalProps, GlobalProps } from "../utilities/globalProps";
@@ -27,6 +27,13 @@ type FullscreenControls = {
   toggleFullscreen: () => void;
   isFullscreen: boolean;
 };
+
+// type RowPinningPosition = false | 'top' | 'bottom';
+
+// type RowPinningState = {
+//   top?: string[];
+//   bottom?: string[];
+// };
 
 type AdvancedTableProps = {
   aria?: { [key: string]: string }
@@ -64,6 +71,15 @@ type AdvancedTableProps = {
   virtualizedRows?: boolean
   allowFullScreen?: boolean
   fullScreenControl?: (controls: FullscreenControls) => void
+  enableRowPinning?: boolean | ((row: Row<GenericObject>) => boolean);
+  keepPinnedRows?: boolean;
+  rowPinningControl?: {
+    value: RowPinningState;
+    onChange: (updater: RowPinningState) => void;
+  };
+  includeLeafRows?: boolean;
+  includeParentRows?: boolean;
+  // showRowPinningControls?: boolean;
 } & GlobalProps;
 
 const AdvancedTable = (props: AdvancedTableProps) => {
@@ -104,6 +120,12 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     virtualizedRows = false,
     allowFullScreen = false,
     fullScreenControl,
+    enableRowPinning = false,
+    keepPinnedRows = true,
+    rowPinningControl,
+    includeLeafRows = true,
+    includeParentRows = false,
+    // showRowPinningControls = true,
   } = props;
 
   // Component refs
@@ -136,6 +158,9 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     tableOptions,
     onRowSelectionChange,
     columnVisibilityControl,
+    enableRowPinning,
+    keepPinnedRows,
+    rowPinningControl,
   });
 
   // Initialize table actions
@@ -241,7 +266,8 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     maxHeight ? `advanced-table-max-height-${maxHeight}` : '',
     {
       'advanced-table-fullscreen': isFullscreen,
-      'advanced-table-allow-fullscreen': allowFullScreen
+      'advanced-table-allow-fullscreen': allowFullScreen,
+      'advanced-table-row-pinning-enabled': enableRowPinning,
     },
     {'advanced-table-sticky-left-columns': stickyLeftColumn && stickyLeftColumn.length > 0},
     columnGroupBorderColor ? `column-group-border-${columnGroupBorderColor}` : '',
@@ -290,6 +316,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             columnDefinitions={columnDefinitions}
             columnGroupBorderColor={columnGroupBorderColor}
             columnVisibilityControl={columnVisibilityControl}
+            enableRowPinning={enableRowPinning}
             enableToggleExpansion={enableToggleExpansion}
             enableVirtualization={virtualizedRows}
             expandByDepth={expandByDepth}
@@ -297,15 +324,21 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             expandedControl={expandedControl}
             handleExpandOrCollapse={handleExpandOrCollapse}
             hasAnySubRows={hasAnySubRows}
+            // includeLeafRows={includeLeafRows}
+            // includeParentRows={includeParentRows}
             inlineRowLoading={inlineRowLoading}
             isActionBarVisible={isActionBarVisible}
             isFullscreen={isFullscreen}
+            keepPinnedRows={keepPinnedRows}
             loading={loading}
             onExpandByDepthClick={onExpandByDepthClick}
             responsive={responsive}
+            // rowPinning={rowPinning}
             selectableRows={selectableRows}
             setExpanded={setExpanded}
+            // setRowPinning={setRowPinning}
             showActionsBar={showActionsBar}
+            // showRowPinningControls={showRowPinningControls}
             sortControl={sortControl}
             stickyLeftColumn={stickyLeftColumn}
             subRowHeaders={tableOptions?.subRowHeaders}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_pinning.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_pinning.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react"
+import AdvancedTable from '../_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data_with_id.json"
+
+const AdvancedTableRowPinning = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance Rate",
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed Classes",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Class Completion Rate",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated Students",
+    },
+  ]
+
+  // const [rowPinning, setRowPinning] = useState<RowPinningState>({
+  //   top: ["1"],
+  //   bottom: [],
+  //  // bottom: ["5"]
+  // })
+
+  const [rowPinning, setRowPinning] = useState({
+    top: ["1"],
+    // top: ["0-0-0-row"],
+    bottom: []
+  })
+
+  // const handleRowPinningChange = (newPinningState) => {
+  //   setRowPinning(newPinningState)
+  //   console.log("Row pinning changed:", newPinningState)
+  // }
+
+  // const handleRowPinningChange = (newPinningState) => {
+  //   if (typeof newPinningState === 'function') {
+  //     setRowPinning(prev => newPinningState(prev));
+  //   } else {
+  //     setRowPinning(newPinningState);
+  //   }
+  //   console.log("Row pinning changed:", newPinningState);
+  // };
+
+
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          enableRowPinning
+          keepPinnedRows
+          // rowPinning={["1"]}
+          rowPinning={rowPinning}
+          // rowPinningControl={{
+          //   value: rowPinning,
+          //   onChange: handleRowPinningChange
+          // }}
+          setRowPinning={setRowPinning}
+          // setRowPinning={handleRowPinningChange}
+          tableData={MOCK_DATA}
+          {...props}
+      >
+        <AdvancedTable.Header enableSorting />
+        <AdvancedTable.Body />
+      </AdvancedTable>
+    </div>
+  )
+}
+
+export default AdvancedTableRowPinning

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -51,3 +51,4 @@ examples:
   - advanced_table_column_visibility_with_state: Column Visibility Control With State
   - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
   - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns
+  - advanced_table_row_pinning: Row Pinning

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -32,3 +32,4 @@ export { default as AdvancedTableColumnVisibility } from './_advanced_table_colu
 export { default as AdvancedTableColumnVisibilityCustom } from './_advanced_table_column_visibility_custom.jsx'
 export { default as AdvancedTableColumnVisibilityMulti } from './_advanced_table_column_visibility_multi.jsx'
 export { default as AdvancedTableColumnVisibilityWithState } from './_advanced_table_column_visibility_with_state.jsx'
+export { default as AdvancedTableRowPinning } from './_advanced_table_row_pinning.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2178](https://runway.powerhrg.com/backlog_items/PLAY-2178) aims to add Row Pinning logic from Tanstack to the React Advanced Table.

_**WIP PR**_

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.