### PR TITLE
[PLAY-2162] Select kit: Doc Examples Demonstrating Non-selectable Subheaders Separating Selectable Options

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_custom_select_subheaders.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_custom_select_subheaders.html.erb
@@ -1,0 +1,12 @@
+<%= pb_rails("select", props: { label: "Favorite Animal" }) do %>
+  <select name="animal" id="animal">
+    <optgroup label="Mammal">
+      <option value="1">Cat</option>
+      <option value="2">Dog</option>
+    </optgroup>
+    <optgroup label="Amphibian">
+      <option value="3">Frog</option>
+      <option value="4">Salamander</option>
+    </optgroup>
+  </select>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_custom_select_subheaders.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_custom_select_subheaders.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import Select from '../_select'
+
+const SelectCustomSelectSubheaders = (props) => {
+  return (
+    <div>
+      <Select
+          label="Favorite Animal"
+          {...props}
+      >
+        <select
+            id="animal"
+            name="animal"
+            {...props}
+        >
+          <optgroup label="Mammal">
+            <option value="1">{'Cat'}</option>
+            <option value="2">{'Dog'}</option>
+          </optgroup>
+          <optgroup label="Amphibian">
+            <option value="3">{'Frog'}</option>
+            <option value="4">{'Salamander'}</option>
+          </optgroup>
+        </select>
+      </Select>
+    </div>
+  )
+}
+
+export default SelectCustomSelectSubheaders

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_custom_select_subheaders.md
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_custom_select_subheaders.md
@@ -1,0 +1,1 @@
+To create a select with non-selectable subheaders, use a Custom Select component to render a native `<select>` containing `<optgroup>` elements. The [optgroup HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/optgroup) groups related options under a non-selectable label in the dropdown.

--- a/playbook/app/pb_kits/playbook/pb_select/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/example.yml
@@ -8,6 +8,7 @@ examples:
   - select_required: Required Select Field
   - select_value_text_same: Equal option value and value text
   - select_custom_select: Custom Select
+  - select_custom_select_subheaders: Custom Select Subheaders
   - select_error: Select w/ Error
   - select_inline: Select Inline
   - select_inline_show_arrow: Select Inline (Always Show Arrow)
@@ -25,6 +26,7 @@ examples:
   - select_required: Required Select Field
   - select_value_text_same: Equal option value and value text
   - select_custom_select: Custom Select
+  - select_custom_select_subheaders: Custom Select Subheaders
   - select_error: Select w/ Error
   - select_inline: Select Inline
   - select_inline_show_arrow: Select Inline (Always Show Arrow)

--- a/playbook/app/pb_kits/playbook/pb_select/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/index.js
@@ -11,3 +11,4 @@ export { default as SelectInlineShowArrow } from './_select_inline_show_arrow.js
 export { default as SelectInlineCompact } from './_select_inline_compact.jsx'
 export { default as SelectMultiple } from './_select_multiple.jsx'
 export { default as SelectReactHook } from './_select_react_hook.jsx'
+export { default as SelectCustomSelectSubheaders } from './_select_custom_select_subheaders.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2162](https://runway.powerhrg.com/backlog_items/PLAY-2162) adds docs to demonstrate how to use the Custom Select + Optgroup element to create a Select with non-selectable subheaders.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1365" alt="react PR" src="https://github.com/user-attachments/assets/fc825e06-79a3-4c32-8032-85d68ba3742b" />
<img width="1366" alt="rails PR" src="https://github.com/user-attachments/assets/71e5351f-3045-4784-8694-c08ebdd815a0" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Select kit "Custom Select Subheaders" doc example in the review environment (rails / react links to come). See the doc examples in action.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.