### PR TITLE
[PLAY-2208] Dropdown Kit: Adding Jest and RSpec Tests

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "../utilities/test-utils"
+import { render, screen, fireEvent } from "../utilities/test-utils"
 
 import { Dropdown, Icon, IconCircle } from 'playbook-ui'
 
@@ -264,3 +264,109 @@ test("searchbar prop to render TextInput in container", () => {
   const searchbar = kit.querySelector('.pb_text_input_kit')
   expect(searchbar).toBeInTheDocument()
 })
+
+test("MultiSelect prop to allow multiple selections + add correct Form Pills", () => {
+  render(
+    <Dropdown 
+        data={{ testid: testId }} 
+        multiSelect 
+        options={options} 
+    />
+ );
+
+  const kit = screen.getByTestId(testId);
+  const option = Array.from(kit.querySelectorAll(".pb_dropdown_option_list"));
+  fireEvent.click(option[0]); // Select first option
+  fireEvent.click(option[1]); // Select second option
+  const formPills = kit.querySelectorAll(".pb_form_pill_kit_primary");
+  expect(formPills.length).toBe(2);
+  expect(formPills[0]).toHaveTextContent("United States");
+  expect(formPills[1]).toHaveTextContent("Canada");
+});
+
+ test("hides each selected option from the dropdown", () => {
+
+    render(
+      <Dropdown 
+          data={{ testid: testId }} 
+          multiSelect 
+          options={options} 
+      />
+    );
+
+  const kit = screen.getByTestId(testId);
+  const option = Array.from(kit.querySelectorAll(".pb_dropdown_option_list"));
+  const firstOpt = options[0].label
+  fireEvent.click(option[0]);
+  const option2 = Array.from(kit.querySelectorAll(".pb_dropdown_option_list"));
+  expect(option2[0]).not.toHaveTextContent(firstOpt)
+  })
+
+test("renders form pills inside trigger", () => {
+      render(
+        <Dropdown 
+            data={{ testid: testId }} 
+            multiSelect 
+            options={options} 
+        />
+      );
+
+  const kit = screen.getByTestId(testId)
+  const option = kit.querySelector('.pb_dropdown_option_list')
+  fireEvent.click(option)
+  const formPill = kit.querySelector(".pb_form_pill_kit_primary")
+  expect(formPill).toBeInTheDocument()
+  })
+
+test("multiSelect and autocomplete to work together", () => {
+  render (
+    <Dropdown
+        autocomplete
+        data={{ testid: testId }}
+        multiSelect
+        options={options}
+    />   
+  )
+
+  const kit = screen.getByTestId(testId)
+  const input = kit.querySelector('.dropdown_input')
+  expect(input).toBeInTheDocument()
+    const option = kit.querySelector('.pb_dropdown_option_list')
+  fireEvent.click(option)
+  const formPill = kit.querySelector(".pb_form_pill_kit_primary")
+  expect(formPill).toBeInTheDocument()
+})
+
+test("renders form pills with size and color", () => {
+      render(
+        <Dropdown 
+            data={{ testid: testId }} 
+            formPillProps={{ size: "small", color: "neutral" }}
+            multiSelect 
+            options={options} 
+        />
+      );
+
+  const kit = screen.getByTestId(testId)
+  const option = kit.querySelector('.pb_dropdown_option_list')
+  fireEvent.click(option)
+  const formPill = kit.querySelector(".pb_form_pill_kit_neutral")
+  expect(formPill).toBeInTheDocument()
+  expect(formPill).toHaveClass("small")
+  })
+
+test("defaultValue works with multiSelect", () => {
+    render(
+      <Dropdown
+          data={{ testid: testId }}
+          defaultValue={[options[0], options[2]]}
+          multiSelect
+          options={options}
+      />
+    )
+    const kit = screen.getByTestId(testId)
+    expect(kit.querySelectorAll(".pb_form_pill_kit_primary")).toHaveLength(2)
+    const option2 = Array.from(kit.querySelectorAll(".pb_dropdown_option_list"));
+    const firstOpt = options[0].label
+    expect(option2[0]).not.toHaveTextContent(firstOpt)
+  })

--- a/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Playbook::PbDropdown::Dropdown do
   it { is_expected.to define_boolean_prop(:autocomplete) }
   it { is_expected.to define_boolean_prop(:searchbar) }
   it { is_expected.to define_boolean_prop(:multi_select).with_default(false) }
+  it { is_expected.to define_hash_prop(:form_pill_props).with_default({}) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do

--- a/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Playbook::PbDropdown::Dropdown do
   it { is_expected.to define_string_prop(:default_value) }
   it { is_expected.to define_boolean_prop(:autocomplete) }
   it { is_expected.to define_boolean_prop(:searchbar) }
+  it { is_expected.to define_boolean_prop(:multi_select).with_default(false) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
@@ -34,6 +35,33 @@ RSpec.describe Playbook::PbDropdown::Dropdown do
     it "does not include blank selection option if blank_selection is not present" do
       dropdown = subject.new(options: [{ id: 1, label: "Option 1", value: "1" }])
       expect(dropdown.send(:options_with_blank)).not_to include({ id: "", value: "", label: "" })
+    end
+  end
+
+  describe "#multi_select" do
+    it "includes pb_dropdown_multi_select when multi_select is true" do
+      dropdown = subject.new(multi_select: true)
+      expect(dropdown.data).to include(pb_dropdown: true, pb_dropdown_multi_select: true)
+    end
+    it "does not include pb_dropdown_multi_select when multi_select is false" do
+      dropdown = subject.new(multi_select: false)
+      expect(dropdown.data).not_to include(pb_dropdown_multi_select: true)
+    end
+    it "includes pb_dropdown_multi_select when multi_select is true and autocomplete is true" do
+      dropdown = subject.new(multi_select: true, autocomplete: true)
+      expect(dropdown.data).to include(pb_dropdown: true, pb_dropdown_multi_select: true)
+    end
+    it "Renders form pill props when form_pills_props used and multi_select is true" do
+      dropdown = subject.new(multi_select: true, form_pill_props: { size: "small" })
+      expect(dropdown.data[:form_pill_props]).to eq("{\"size\":\"small\"}")
+    end
+    it "Renders form pill when multi_select is true" do
+      dropdown = subject.new(multi_select: true)
+      expect(dropdown.data[:form_pill_props]).to eq("{}")
+    end
+    it "Renders default_value when used" do
+      dropdown = subject.new(multi_select: true, default_value: [{ id: 1, label: "Option 1", value: "1" }])
+      expect(dropdown.send(:input_default_value)).to eq("1")
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** 

- Adds Jest tests
- Adds Rspec tests


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
If passes CI, all is well

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.