### PR TITLE
[PLAY-2212] Table kit: Sticky Left and Right columns with responsive=none still going into mobile view on small screens

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/styles/_mobile_collapse.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_mobile_collapse.scss
@@ -3,7 +3,7 @@
 @import "../../pb_caption/caption_mixin";
 
 @media only screen and (max-width: $screen-xs-max) {
-  [class^=pb_table] {
+  [class^=pb_table]:not(.table-responsive-scroll) {
     &.table-sm.table-collapse-sm,
     &.table-md.table-collapse-sm,
     &.table-lg.table-collapse-sm {


### PR DESCRIPTION
[PLAY-2212](https://runway.powerhrg.com/backlog_items/PLAY-2212)

Adding `responsive="scroll"` to the Table kit will no longer make it responsive. 

![Screenshot 2025-05-28 at 3 04 38 PM](https://github.com/user-attachments/assets/0be06e05-81ef-4bee-8043-2af71a9a5fcc)


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.