### PR TITLE
[PLAY-2161] Dropdown Kit: Display 'no option' with no results in autocomplete - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/index.js
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/index.js
@@ -115,6 +115,7 @@ export default class PbDropdown extends PbEnhancedElement {
 
   handleSearch(term = "") {
     const lcTerm = term.toLowerCase();
+    let hasMatch = false
     this.element.querySelectorAll(OPTION_SELECTOR).forEach((opt) => {
       //make it so that if the option is selected, it will not show up in the search results
       if (this.isMultiSelect && this.selectedOptions.has(opt.dataset.dropdownOptionLabel)) {
@@ -128,9 +129,32 @@ export default class PbDropdown extends PbEnhancedElement {
       // hide or show option
       const match = label.includes(lcTerm);
       opt.style.display = match ? "" : "none";
+      if (match) hasMatch = true
     });
 
     this.adjustDropdownHeight();
+
+    this.removeNoOptionsMessage()
+    if (!hasMatch) {
+      this.showNoOptionsMessage()
+    }
+  }
+
+  showNoOptionsMessage() {
+    if (this.element.querySelector(".dropdown_no_options")) return;
+
+    const noOptionElement = document.createElement("div");
+    noOptionElement.className = "pb_body_kit_light dropdown_no_options pb_item_kit p_xs display_flex justify_content_center";
+    noOptionElement.textContent = "no option";
+
+    this.target.appendChild(noOptionElement);
+  }
+
+  removeNoOptionsMessage() {
+    const existing = this.element.querySelector(".dropdown_no_options");
+    if (existing) {
+      existing.remove();
+    }
   }
 
   handleOptionClick(event) {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
- Show 'no option' in Rails dropdown like in React for autocomplete
- Add a div with the same classes, `pb_body_kit_light dropdown_no_options pb_item_kit p_xs display_flex justify_content_center`

https://runway.powerhrg.com/backlog_items/PLAY-2161

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-05-29 at 9 36 14 AM](https://github.com/user-attachments/assets/c90a3efb-1e41-4d9b-8873-ea005467be20)

**How to test?** Steps to confirm the desired behavior:
1. Go to /dropdown/rails
2. Test all the autocomplete docs

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.