### PR TITLE
[PLAY-2239] Advanced Table: Fixes for Cell Alignment when No Subrows

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/CustomCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/CustomCell.tsx
@@ -47,7 +47,7 @@ export const CustomCell = ({
       <Flex 
           alignItems="center" 
           columnGap="xs"
-          justify={!hasAnySubRows && !inlineRowLoading ? "end" : "start"}
+          justify={"start"}
           orientation="row"
       >
         {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -128,7 +128,7 @@ const isToggleExpansionEnabled =
 
   let justifyHeader:justifyTypes;
 
-  if (header?.index === 0 && hasAnySubRows || (header?.index === 0 && inlineRowLoading)) {
+  if (header?.index === 0 && hasAnySubRows || (header?.index === 0 && inlineRowLoading) || (header?.index === 0 && isToggleExpansionEnabled)) {
     justifyHeader = enableSorting ? "between" : "start";
   } else {
     justifyHeader = isLeafColumn ? "end" : "center";

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_no_subrows.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_no_subrows.html.erb
@@ -1,9 +1,4 @@
-import React from "react"
-import AdvancedTable from '../../pb_advanced_table/_advanced_table'
-import MOCK_DATA from "./advanced_table_mock_data_no_subrows.json"
-
-const AdvancedTableNoSubrows = (props) => {
-  const columnDefinitions = [
+<% column_definitions = [
     {
       accessor: "year",
       label: "Year",
@@ -32,18 +27,7 @@ const AdvancedTableNoSubrows = (props) => {
     {
       accessor: "graduatedStudents",
       label: "Graduated Students",
-    },
-  ]
+    }
+] %>
 
-  return (
-    <div>
-      <AdvancedTable
-          columnDefinitions={columnDefinitions}
-          tableData={MOCK_DATA}
-          {...props}
-      />
-    </div>
-  )
-}
-
-export default AdvancedTableNoSubrows
+<%= pb_rails("advanced_table", props: { id: "table-no-children", enable_toggle_expansion: "none", table_data: @table_data_no_subrows, column_definitions: column_definitions }) %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -42,7 +42,7 @@ examples:
   - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
   - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
   - advanced_table_column_border_color: Column Group Border Color
-  # - advanced_table_no_subrows: Table with No Subrows
+  - advanced_table_no_subrows: Table with No Subrows or Expansion
   - advanced_table_selectable_rows: Selectable Rows
   - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
   - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -13,6 +13,7 @@ examples:
   - advanced_table_column_headers: Multi-Header Columns
   - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
   - advanced_table_column_border_color_rails: Column Group Border Color
+  - advanced_table_no_subrows: Table with No Subrows or Expansion
   - advanced_table_selectable_rows_rails: Selectable Rows
   - advanced_table_selectable_rows_no_subrows_rails: Selectable Rows (No Subrows)
   - advanced_table_selectable_rows_actions_rails: Selectable Rows (With Actions)


### PR DESCRIPTION
**What does this PR do?** 
- [Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2239)
- Cell content i n first column should stay left aligned irrespective of whether there are child rows or not

**Screenshots:**

<img width="1174" alt="Screenshot 2025-06-02 at 10 23 56 AM" src="https://github.com/user-attachments/assets/b683d51a-1482-4422-bb46-f2fd45eaa303" />


**How to test?** Steps to confirm the desired behavior:
1. Navigate to /kits/advanced_table/react#table-with-no-subrows-or-expansion on milano


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.