### PR TITLE
Date Picker in Dialog Issue

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/docs/_dialog_default.html.erb
@@ -2,10 +2,16 @@
 
 <%= pb_rails("dialog", props: { 
     id:"dialog-1", 
-    size: "sm", 
-    title: "Header Title is the Title Prop", 
-    text: "Hello Body Text, Nice to meet ya.", 
+    size: "md", 
     cancel_button: "Cancel Button", 
     confirm_button: "Okay", 
     confirm_button_id: "confirm-button-1"
-}) %>
+})  do %>
+
+
+  <%= pb_rails("date_picker", props: {
+        label:           "Pick a date",
+        picker_id:       "date-picker-position-element222",
+      }) %>
+
+<% end %>


### PR DESCRIPTION
Can't figure out how to get the calendar popup to be above the dialog 

Spin up the env locally and go to the simple rails date picker example http://localhost:3000/kits/dialog/rails#simple

![Screenshot 2025-06-02 at 11 53 43 AM](https://github.com/user-attachments/assets/271256f8-8cb5-413c-850c-8d86581d7a20)
