### PR TITLE
[PLAY-2214] Checkbox kit: Add Hidden Input Logic Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -28,9 +28,19 @@ module Playbook
 
       def input
         inputs = []
-        inputs << hidden_field_tag(name, hidden_value || "0") if hidden_input && name.present?
+        effective_name = name || input_options[:name]
+        effective_value = value || input_options[:value] || "1"
+        is_checked = checked || input_options[:checked]
 
-        inputs << check_box_tag(name, value || "1", checked, input_options.merge(disabled: disabled))
+        inputs << hidden_field_tag(effective_name, hidden_value || "0") if hidden_input && effective_name.present?
+
+        inputs << check_box_tag(
+          effective_name,
+          effective_value,
+          is_checked,
+          input_options.merge(disabled: disabled)
+        )
+
         safe_join(inputs)
       end
 

--- a/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -18,13 +18,20 @@ module Playbook
                       default: false
       prop :form_spacing, type: Playbook::Props::Boolean,
                           default: false
+      prop :hidden_input, type: Playbook::Props::Boolean,
+                          default: false
+      prop :hidden_value
 
       def classname
         generate_classname("pb_checkbox_kit", checked_class) + error_class
       end
 
       def input
-        check_box_tag(name, value, checked, input_options.merge(disabled: disabled))
+        inputs = []
+        inputs << hidden_field_tag(name, hidden_value || "0") if hidden_input && name.present?
+
+        inputs << check_box_tag(name, value || "1", checked, input_options.merge(disabled: disabled))
+        safe_join(inputs)
       end
 
       def checkbox_label_status

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_custom.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_custom.html.erb
@@ -1,3 +1,4 @@
 <%= pb_rails("checkbox", props: {text: "Custom Checkbox"}) do%>
+    <input type="hidden" name="custom-name" value="0" />
     <input type="checkbox" name="custom-name" value="custom-value"/>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_custom_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_custom_rails.md
@@ -1,0 +1,1 @@
+When using a custom checkbox wrapped in the Checkbox kit, hidden inputs are not automatically included and cannot be prop enabled. Manually add a hidden input before the checkbox if necessary to submit a value when the checkbox is unchecked (as is standard in Rails forms).

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_form.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_form.html.erb
@@ -1,0 +1,22 @@
+
+<%= pb_form_with(scope: :example, url: "", method: :get) do |form| %>
+  <%=pb_rails("flex", props: { gap: "sm", orientation: "column"}) do %>
+    <%= pb_rails("checkbox" , props: {
+      text: "1. pb_rails(\"checkbox\") Checkbox from kit",
+      value: "checkbox-value",
+      name: "checkbox-name",
+      hidden_input: true
+      }) %>
+    <%= form.check_box :example_checkbox,
+      data: { field1: "value1", field2: "value2" },
+      props: { text: "2. form.check_box Checkbox from Form Builder" },
+      unchecked_value: "no",
+      id: "checkbox-id",
+      name: "checkbox-name",
+      class: "checkbox-class"
+    %>
+    <%= form.actions do |action| %>
+      <%= action.button props: { type: "submit", text: "Submit", variant: "primary" } %>
+    <% end %>   
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_form.md
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_form.md
@@ -1,0 +1,5 @@
+The way to access hidden inputs for form submission depends on which version of the kit being used within the form context.
+
+If using the Rails Checkbox version of the kit, set `hidden_input: true`. Inspect Checkbox #1 in the example above to see the hidden input in the DOM. 
+
+If using the Form Builder version of the kit (reference the [Form kit page](https://playbook.powerapp.cloud/kits/form) for more on these), the hidden input will appear if the input has a set `unchecked_value`. Inspect Checkbox #2 in the example above (and the two checkbox examples on the Form kit page) to see the hidden input in the DOM. See the [Rails check_box FormHelper docs](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-check_box) for more.

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_options.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_options.html.erb
@@ -1,5 +1,6 @@
 <%= pb_rails("checkbox" , props: {
   text: "Checkbox with Options",
+  hidden_input: true,
   input_options: {
     id: "checkbox-id",
     name: "checkbox-name",

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/example.yml
@@ -7,6 +7,7 @@ examples:
     - checkbox_options: Checkbox w/ Options
     - checkbox_indeterminate: Indeterminate Checkbox
     - checkbox_disabled: Disabled Checkbox
+    - checkbox_form: Form and Hidden Input
 
   react:
   - checkbox_default: Default

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
@@ -101,7 +101,7 @@
   <%= form.dropdown_field :example_dropdown_validation_multi, props: { label: true, options: example_dropdown_options, multi_select: true, required: true } %>
   <%= form.select :example_select_validation, [ ["Yes", 1], ["No", 2] ], props: { label: true, blank_selection: "Select One...", required: true, validation_message: "Please, select an option." } %>
   <%= form.collection_select :example_collection_select_validation, example_collection, :value, :name, props: { label: true, blank_selection: "Select One...", required: true } %>
-  <%= form.check_box :example_checkbox, props: { text: "Example Checkbox", label: true, required: true } %>
+  <%= form.check_box :example_checkbox_validation, props: { text: "Example Checkbox Validation", label: true, required: true }, checked_value: "1", unchecked_value: "0" %>
   <%= form.date_picker :example_date_picker_2, props: { label: true, required: true, validation_message: "Please, select a date.", allow_input: true } %>
   <%= form.star_rating_field :example_star_rating_validation, props: { variant: "interactive", label: true, required: true } %>
   <%= form.time_zone_select_field :example_time_zone_select, ActiveSupport::TimeZone.us_zones, { default: "Eastern Time (US & Canada)" }, props: { label: true, blank_selection: "Select a Time Zone...", required: true } %>

--- a/playbook/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Playbook::PbCheckbox::Checkbox do
   it { is_expected.to define_boolean_prop(:indeterminate_main).with_default(false) }
   it { is_expected.to define_prop(:indeterminate_parent) }
   it { is_expected.to define_hash_prop(:input_options).with_default({}) }
+  it { is_expected.to define_boolean_prop(:hidden_input).with_default(false) }
+  it { is_expected.to define_prop(:hidden_value) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
@@ -28,6 +30,57 @@ RSpec.describe Playbook::PbCheckbox::Checkbox do
       expect(subject.new(error: true).classname).to eq "pb_checkbox_kit_off error"
       expect(subject.new(dark: true, error: true).classname).to eq "pb_checkbox_kit_off dark error"
       expect(subject.new(disabled: true).disabled).to eq true
+    end
+  end
+
+  describe "#input" do
+    context "when hidden_input is true" do
+      it "includes a hidden input with the correct name and value" do
+        checkbox = subject.new(
+          hidden_input: true,
+          name: "example_name",
+          value: "1",
+          hidden_value: "0"
+        )
+
+        rendered_input = checkbox.input
+
+        expect(rendered_input).to include('type="hidden"')
+        expect(rendered_input).to include('name="example_name"')
+        expect(rendered_input).to include('value="0"')
+      end
+    end
+
+    context "when name is set in input_options" do
+      it "resolves hidden input name from input_options" do
+        checkbox = subject.new(
+          hidden_input: true,
+          input_options: {
+            name: "option_name",
+            value: "option_value",
+          }
+        )
+
+        rendered_input = checkbox.input
+
+        expect(rendered_input).to include('type="hidden"')
+        expect(rendered_input).to include('name="option_name"')
+        expect(rendered_input).to include('value="0"')
+      end
+    end
+
+    context "when hidden_input is false" do
+      it "does not include a hidden input" do
+        checkbox = subject.new(
+          hidden_input: false,
+          name: "no_hidden"
+        )
+
+        rendered_input = checkbox.input
+
+        expect(rendered_input).not_to include('<input type="hidden"')
+        expect(rendered_input).to include('<input type="checkbox" name="no_hidden"')
+      end
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2214](https://runway.powerhrg.com/backlog_items/PLAY-2214) adds a `hidden_input` boolean prop to the rails Checkbox kit so unchecked values can be properly submitted with our base kit `pb_rails("checkbox")` within the `form`/`pb_form_with` context. The logic is set so that it works whether name, value, and other key attributes are passed directly as props or via the `input_options` hash.

Additionally, this update improves documentation for the Form Builder variant (`form.check_box` / `f.check_box`) on the Checkbox and Form kit pages, clarifying how to enable and use hidden inputs in those contexts (by including an `unchecked_value`).

I've also updated the custom checkbox doc example to highlight that it is not compatible with the prop (hidden inputs must be added manually).

**Screenshots:** Screenshots to visualize your addition/change
New "Form and Hidden Input" doc example
<img width="1322" alt="for PR form and hidden input doc ex" src="https://github.com/user-attachments/assets/66e77a36-e4bd-43af-b122-3ad1dc3be11c" />
Updated "Custom Checkbox" doc example
<img width="1571" alt="for PR custom checkbox doc ex" src="https://github.com/user-attachments/assets/cb91a8f2-1862-4ad6-b941-bd087bf551f7" />
Form kit page Production has an unchecked value in the first doc example only...
<img width="1396" alt="form builder side by side prod" src="https://github.com/user-attachments/assets/7d528848-2fca-4a1c-a355-5a1d174bb0d6" />
...when this is added to the second doc example, a hidden input appears
<img width="1032" alt="for PR updated validation doc ex" src="https://github.com/user-attachments/assets/e3bc3ae0-4fda-4824-8ecf-ef34973ab6e1" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the "[Form and Hidden Input](https://pr4689.playbook.beta.gm.powerapp.cloud/kits/checkbox#form-and-hidden-input)" doc example in the review env. Inspect the DOM to see hidden inputs. The first checkbox is pb_rails("checkbox") and the second is form.check_box.
2. Scroll up to the "[Custom Checkbox](https://pr4689.playbook.beta.gm.powerapp.cloud/kits/checkbox#custom-checkbox)" and "[Checkbox with Options](https://pr4689.playbook.beta.gm.powerapp.cloud/kits/checkbox#checkbox-w-options)" doc examples. Inspect the DOM and look at the code to see hidden inputs.
3. Go to the Form kit page and look at the checkbox examples each of the first two doc examples ("[Default](https://pr4689.playbook.beta.gm.powerapp.cloud/kits/form#default)" and "[Default + Validation](https://pr4689.playbook.beta.gm.powerapp.cloud/kits/form#default-validation)") in the review env. Inspect the DOM to see hidden inputs.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.