### PR TITLE
Advanced Table: Reduced Opacity on Scrollbar when overflow-y is auto

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -33,6 +33,16 @@
     }
   }
 
+  @mixin scrollbar-styling {
+     &::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      -ms-overflow-style: none !important;
+      scrollbar-width: thin !important;
+      scrollbar-color: rgb(0 0 0 / .20) transparent;
+  }
+
   [id$="-span"] {
     word-wrap: normal;
   }
@@ -226,30 +236,37 @@
   &.advanced-table-max-height-xs {
     max-height: 320px;
     overflow-y: auto;
+    @include scrollbar-styling;
   }
   &.advanced-table-max-height-sm {
     max-height: 480px;
     overflow-y: auto;
+    @include scrollbar-styling;
   }
   &.advanced-table-max-height-md {
     max-height: 768px;
     overflow-y: auto;
+    @include scrollbar-styling;
   }
   &.advanced-table-max-height-lg {
     max-height: 1024px;
     overflow-y: auto;
+    @include scrollbar-styling;
   }
   &.advanced-table-max-height-xl {
     max-height: 1280px;
     overflow-y: auto;
+    @include scrollbar-styling;
   }
   &.advanced-table-max-height-xxl {
     max-height: 1440px;
     overflow-y: auto;
+    @include scrollbar-styling;
   }
   &.advanced-table-max-height-xxxl {
     max-height: 1920px;
     overflow-y: auto;
+    @include scrollbar-styling;
   }
 
   // Fullscreen


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Testing reducing scrollbar opacity for better visibility

**Screenshots:** Screenshots to visualize your addition/change



https://github.com/user-attachments/assets/4f19025f-6a9d-46f0-b38c-f585b58fd801


**How to test?** Steps to confirm the desired behavior:
1. Go to do example for sticky header and responsive and expand rows to trigger scroll

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.