### PR TITLE
[PLAY-2167] Advanced Table Horizontal Rows Double when Container True

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -410,7 +410,6 @@
 
   // Make sure all horizontal borders use the default border color
   tr, th, td {
-    border-top-color: $border_light !important;
     border-bottom-color: $border_light !important;
   }
 
@@ -631,7 +630,6 @@
 
     // Make sure all horizontal borders use the default border color in dark mode
     tr, th, td {
-      border-top-color: $border_dark !important;
       border-bottom-color: $border_dark !important;
     }
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2167](https://runway.powerhrg.com/backlog_items/PLAY-2167) is an investigation to figure out why the horizontal rows of the Advanced Table are doubled in Nitro when container is true. 

**Screenshots**
See [Alpha PR](https://github.com/powerhome/nitro-web/pull/48991/) for more screenshots. Compare Headcount over Time borders QA vs. Review env below:
<img width="1536" alt="nitroqa headcount over time" src="https://github.com/user-attachments/assets/9b12fe19-4ea5-4ddf-8bbc-07f03b5a0caf" />
<img width="1554" alt="local headcount over time" src="https://github.com/user-attachments/assets/5d7034a2-e61a-44b4-9ce5-296d117fc5cb" />
Rails example - setting container: true on Rails Advanced Table to demo this as well Pre-Alpha and Post-Alpha:
<img width="1520" alt="local adv table rails temp container true pre alpha" src="https://github.com/user-attachments/assets/3084522f-aca2-4140-9fc6-b43636b3be01" />
<img width="1536" alt="local w alpha container true normal rows" src="https://github.com/user-attachments/assets/be8b703c-5c4a-4345-8120-2f6fecf6c345" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the [Accrual Report page](https://nitroqa.powerhrg.com/marketing/accrual_report?mt=Accrual%20Report) [Headcount Over Time page](https://nitroqa.powerhrg.com/human_resources/headcount_per_month?mt=Headcount+Over+Time), [CD KPIs by Year](https://nitroqa.powerhrg.com/marketing/customer_development_kpi/year), or [Company Plan Tracker]( https://nitroqa.powerhrg.com/company_plans/tracker?mt=Company+Plan+Tracker) in Nitro (which have the advanced tables with `container: true`) in QA and the review env. Compare the thickness of the horizontal row borders between rows in the two environments. The review env's borders will match the thickness of those on the doc examples/Advanced Tables where container is false.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.