### PR TITLE
HotFix for Scss compiling error in Nitro

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -40,7 +40,7 @@
 
       -ms-overflow-style: none !important;
       scrollbar-width: thin !important;
-      scrollbar-color: rgb(0 0 0 / .20) transparent;
+      scrollbar-color: #00000033 transparent !important;
   }
 
   [id$="-span"] {
@@ -563,6 +563,7 @@
   // Sticky Left Columns Styling
   &[class*="advanced-table-sticky-left-columns"] {
     overflow-x: scroll;
+    @include scrollbar-styling;
     .sticky-left {
       position: sticky !important;
       z-index: 2;
@@ -582,6 +583,7 @@
     &[class*="advanced-table-responsive-scroll"] {
       overflow-x: auto;
       width: 100%;
+      @include scrollbar-styling;
 
       // These are the responsive borders that should NOT inherit the custom color
       @include advanced-table-sticky-mixin(


### PR DESCRIPTION
**What does this PR do?** 

The scss for the scrollbar color works correctly in Playbook but breaks CI in Nitro due to scss compiling errors. 
```
SassC::SyntaxError: Error: Function rgb is missing argument $green. (SassC::SyntaxError)
```

Switching from rgb to a HEX value should fix the issue. 

**Screenshots:**


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.