### PR TITLE
[PLAY-2122] Date Picker: Display 'Time Range' Label when selecting a quick pick 

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -17,6 +17,7 @@ type DatePickerProps = {
   customQuickPickDates: { override: boolean, dates: any[] },
   dark?: boolean,
   data?: { [key: string]: string },
+  dateDisplay?: boolean,
   defaultDate?: string,
   disableDate?: number[],
   disableInput?: boolean,
@@ -66,6 +67,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     customQuickPickDates,
     dark = false,
     data = {},
+    dateDisplay = false,
     defaultDate = '',
     disableDate = null,
     disableInput,
@@ -118,6 +120,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     datePickerHelper({
       allowInput,
       customQuickPickDates,
+      dateDisplay,
       defaultDate,
       disableDate,
       disableRange,

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
@@ -9,6 +9,8 @@ module Playbook
                                      default: {}
       prop :dark, type: Playbook::Props::Boolean,
                   default: false
+      prop :date_display, type: Playbook::Props::Boolean,
+                          default: false
       prop :default_date, type: Playbook::Props::String,
                           default: ""
       prop :disable_date, type: Playbook::Props::Array,
@@ -95,6 +97,7 @@ module Playbook
         {
           allowInput: allow_input,
           customQuickPickDates: custom_quick_pick_dates,
+          dateDisplay: date_display,
           defaultDate: default_date,
           disableDate: disable_date,
           disableRange: disable_range,

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -16,6 +16,7 @@ const getPositionElement = (element: string | Element) => {
 type DatePickerConfig = {
   closeOnSelect?: boolean,
   customQuickPickDates: { override: boolean, dates: any[] },
+  dateDisplay?: boolean,
   disableDate?: number[],
   disableRange?: number[],
   disableWeekdays?: number[],
@@ -48,6 +49,7 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
     allowInput,
     closeOnSelect = true,
     customQuickPickDates = { override: true, dates: [] },
+    dateDisplay = false,
     defaultDate,
     disableDate,
     disableRange,
@@ -151,7 +153,7 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
 
     } else if (selectionType === "quickpick") {
       //------- QUICKPICK VARIANT PLUGIN -------------//
-      pluginList.push(quickPickPlugin(thisRangesEndToday, customQuickPickDates, defaultDate as string))
+      pluginList.push(quickPickPlugin(thisRangesEndToday, customQuickPickDates, defaultDate as string, dateDisplay))
     }
 
     // time selection

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_quick_pick_date_display.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_quick_pick_date_display.html.erb
@@ -1,0 +1,13 @@
+<%= pb_rails("date_picker", props: {
+  allow_input: true,
+  date_display: true,
+  end_date_id: "quick-pick-end-date",
+  end_date_name: "quick-pick-end-date",
+  mode: "range",
+  picker_id: "date-picker-quick-pick-date-display",
+  placeholder: "mm/dd/yyyy to mm/dd/yyyy",
+  selection_type: "quickpick",
+  start_date_id: "quick-pick-start-date",
+  start_date_name: "quick-pick-start-date"
+}) %>
+

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_quick_pick_date_display.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_quick_pick_date_display.jsx
@@ -1,0 +1,18 @@
+import React from "react"
+import DatePicker from "../_date_picker"
+
+const DatePickerQuickPickDateDisplay = (props) => (
+  <>
+    <DatePicker
+        allowInput
+        dateDisplay
+        mode="range"
+        pickerId="date-picker-quick-pick-date-display"
+        placeholder="mm/dd/yyyy to mm/dd/yyyy"
+        selectionType="quickpick"
+        {...props}
+    />
+  </>
+)
+
+export default DatePickerQuickPickDateDisplay

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
@@ -48,6 +48,7 @@ examples:
   - date_picker_quick_pick_custom: Custom Quick Pick Dates
   - date_picker_quick_pick_custom_override: Custom Quick Pick Dates (append to defaults)
   - date_picker_quick_pick_default_date: Range (Quick Pick w/ Default Date)
+  - date_picker_quick_pick_date_display: Range (Quick Pick) with Date Display
   - date_picker_range_pattern: Range with 2 Date Pickers and a Quick Pick
   - date_picker_format: Format
   - date_picker_disabled: Disabled Dates

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
@@ -15,6 +15,7 @@ examples:
   - date_picker_quick_pick_custom: Custom Quick Pick Dates
   - date_picker_quick_pick_custom_override: Custom Quick Pick Dates (append to defaults)
   - date_picker_quick_pick_default_date: Range (Quick Pick w/ Default Date)
+  - date_picker_quick_pick_date_display: Range (Quick Pick) with Date Display
   - date_picker_range_pattern_rails: Range with 2 Date Pickers and a Quick Pick
   - date_picker_format: Format
   - date_picker_disabled: Disabled Dates
@@ -48,8 +49,8 @@ examples:
   - date_picker_quick_pick_custom: Custom Quick Pick Dates
   - date_picker_quick_pick_custom_override: Custom Quick Pick Dates (append to defaults)
   - date_picker_quick_pick_default_date: Range (Quick Pick w/ Default Date)
-  - date_picker_quick_pick_date_display: Range (Quick Pick) with Date Display
   - date_picker_range_pattern: Range with 2 Date Pickers and a Quick Pick
+  - date_picker_quick_pick_date_display: Range (Quick Pick) with Date Display
   - date_picker_format: Format
   - date_picker_disabled: Disabled Dates
   - date_picker_min_max: Min Max

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/index.js
@@ -27,3 +27,4 @@ export { default as DatePickerQuickPickCustom } from './_date_picker_quick_pick_
 export { default as DatePickerQuickPickCustomOverride } from './_date_picker_quick_pick_custom_override'
 export { default as DatePickerQuickPickDefaultDate } from './_date_picker_quick_pick_default_date'
 export { default as DatePickerRangePattern } from './_date_picker_range_pattern'
+export { default as DatePickerQuickPickDateDisplay } from './_date_picker_quick_pick_date_display'

--- a/playbook/app/pb_kits/playbook/pb_date_picker/plugins/quickPick.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/plugins/quickPick.tsx
@@ -27,7 +27,6 @@ type customQuickPickDatesType = {
 let activeLabel = ""
 
 const quickPickPlugin = (thisRangesEndToday: boolean, customQuickPickDates: customQuickPickDatesType | undefined, defaultDate: string, dateDisplay: boolean) => {
-  // console.log(thisRangesEndToday)
   return function (fp: FpTypes & any): any {
     const today = new Date()
     const yesterday = DateTime.getYesterdayDate(new Date())

--- a/playbook/app/pb_kits/playbook/pb_date_picker/plugins/quickPick.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/plugins/quickPick.tsx
@@ -26,7 +26,8 @@ type customQuickPickDatesType = {
 
 let activeLabel = ""
 
-const quickPickPlugin = (thisRangesEndToday: boolean, customQuickPickDates: customQuickPickDatesType | undefined, defaultDate: string) => {
+const quickPickPlugin = (thisRangesEndToday: boolean, customQuickPickDates: customQuickPickDatesType | undefined, defaultDate: string, dateDisplay: boolean) => {
+  // console.log(thisRangesEndToday)
   return function (fp: FpTypes & any): any {
     const today = new Date()
     const yesterday = DateTime.getYesterdayDate(new Date())
@@ -82,19 +83,45 @@ const quickPickPlugin = (thisRangesEndToday: boolean, customQuickPickDates: cust
       [key: string]: Date[]
     };
 
-    let ranges: rangesType = {
-      'Today': [today, today],
-      'Yesterday': [yesterday, yesterday],
-      'This week': [thisWeekStartDate, thisWeekEndDate],
-      'This month': [thisMonthStartDate, thisMonthEndDate],
-      'This quarter': [thisQuarterStartDate, thisQuarterEndDate],
-      'This year': [thisYearStartDate, thisYearEndDate],
-      'Last week': [lastWeekStartDate, lastWeekEndDate],
-      'Last month': [lastMonthStartDate, lastMonthEndDate],
-      'Last quarter': [lastQuarterStartDate, lastQuarterEndDate],
-      'Last year': [lastYearStartDate, lastYearEndDate]
+    const formatDate = (date: Date): string => {
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      const year = date.getFullYear();
+      return `${month}/${day}/${year}`;
     };
 
+
+    let ranges: rangesType = {}
+
+    console.log(dateDisplay)
+
+    if (dateDisplay) {
+      ranges = {
+        [formatDate(today)]: [today, today],
+        [formatDate(yesterday)]: [yesterday, yesterday],
+        [`${formatDate(thisWeekStartDate)} to ${formatDate(thisWeekEndDate)}`]: [thisWeekStartDate, thisWeekEndDate],
+        [`${formatDate(thisMonthStartDate)} to ${formatDate(thisMonthEndDate)}`]: [thisMonthStartDate, thisMonthEndDate],
+        [`${formatDate(thisQuarterStartDate)} to ${formatDate(thisQuarterEndDate)}`]: [thisQuarterStartDate, thisQuarterEndDate],
+        [`${formatDate(thisYearStartDate)} to ${formatDate(thisYearEndDate)}`]: [thisYearStartDate, thisYearEndDate],
+        [`${formatDate(lastWeekStartDate)} to ${formatDate(lastWeekEndDate)}`]: [lastWeekStartDate, lastWeekEndDate],
+        [`${formatDate(lastMonthStartDate)} to ${formatDate(lastMonthEndDate)}`]: [lastMonthStartDate, lastMonthEndDate],
+        [`${formatDate(lastQuarterStartDate)} to ${formatDate(lastQuarterEndDate)}`]: [lastQuarterStartDate, lastQuarterEndDate],
+        [`${formatDate(lastYearStartDate)} to ${formatDate(lastYearEndDate)}`]: [lastYearStartDate, lastYearEndDate]
+      }
+    } else {
+      ranges = {
+        'Today': [today, today],
+        'Yesterday': [yesterday, yesterday],
+        'This week': [thisWeekStartDate, thisWeekEndDate],
+        'This month': [thisMonthStartDate, thisMonthEndDate],
+        'This quarter': [thisQuarterStartDate, thisQuarterEndDate],
+        'This year': [thisYearStartDate, thisYearEndDate],
+        'Last week': [lastWeekStartDate, lastWeekEndDate],
+        'Last month': [lastMonthStartDate, lastMonthEndDate],
+        'Last quarter': [lastQuarterStartDate, lastQuarterEndDate],
+        'Last year': [lastYearStartDate, lastYearEndDate]
+      }
+    }
 
     if (customQuickPickDates && Object.keys(customQuickPickDates).length !== 0) {
       if (customQuickPickDates.dates.length && customQuickPickDates.override === false) {
@@ -108,7 +135,7 @@ const quickPickPlugin = (thisRangesEndToday: boolean, customQuickPickDates: cust
             )
           }
         })
-      } else if(customQuickPickDates.dates.length && customQuickPickDates.override !== false) {
+      } else if (customQuickPickDates.dates.length && customQuickPickDates.override !== false) {
         ranges = {}
         customQuickPickDates.dates.forEach((item) => {
           if (Array.isArray(item.value)) {


### PR DESCRIPTION
[PLAY-2122](https://runway.powerhrg.com/backlog_items/PLAY-2122)

This PR adds a `dateDisplay`/`date_display` that will display the range using dates


<img width="613" alt="Screenshot 2025-06-03 at 3 44 11 PM" src="https://github.com/user-attachments/assets/7416280e-1bd2-495f-a796-96a6cfcbb48b" />


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.