### PR TITLE
Advanced Table: Scrollbar none scss fixes

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -39,7 +39,7 @@
       }
 
       -ms-overflow-style: none !important;
-      scrollbar-width: thin !important;
+      scrollbar-width: thin;
       scrollbar-color: #00000033 transparent !important;
   }
 


### PR DESCRIPTION
**What does this PR do?** 

The scrollbar styling scss was overriding the scrollbar none scss, this fixes that.


**Screenshots:** 




**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.