### PR TITLE
[GOG-1042] Grant GoG secrets access

### DIFF
--- a/playbook-website/config/deploy/production/secrets.yaml
+++ b/playbook-website/config/deploy/production/secrets.yaml
@@ -35,8 +35,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-23T17:00:12Z"
-    mac: ENC[AES256_GCM,data:1c0jrxXg2CJpl4Z4mC+I/vL/yJo0gZDVFPNqwk4nYX2iRiCXJL+N+V+ti07Ml1W+4ZoHsGZSC9dF78VZ6Josok3QL2Xtthp7PySkvLZyAqhWY0m5dv6DNaBGKkqVTqcPEp0AgMlK9+1a7DnhOpSZX/R2RsiuxHsJ8LkNsyroPWM=,iv:wRR+AsB11L2r0zPi92QPE6j19GkkrpcMOv7KsbMM5s4=,tag:dScA92dGzuuzRJ64ciXzrQ==,type:str]
+    lastmodified: "2025-06-04T13:11:15Z"
+    mac: ENC[AES256_GCM,data:Vxb4OGUeSC8X0F0zi4RtaW5sbZQ8RWl7hJkDNlpMnF1803FlQ8rGxu/mVbmnhE4P4FA0tVFBZ6Z0x909HxHNx5GRuLeM86hxJuAoH7xJsqaaElR/VsbWFQ7j/NmlsCXDbPP82MlI4+SJuXioRlV/1jNf+YGZGE/95XqG7Cc27FQ=,iv:H/4GAe1uXCnJ0dKp2/GXp7HNOLGBRdGViWCnNRzCiPE=,tag:CVjYATNlkJsJUCTpQERlsg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.1

--- a/playbook-website/config/deploy/prs/secrets.yaml
+++ b/playbook-website/config/deploy/prs/secrets.yaml
@@ -35,8 +35,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-23T17:00:27Z"
-    mac: ENC[AES256_GCM,data:iaQDM4Pzl/nUcwMy07k3qbrupwR2rAiQH+N060upYycShO2hKTeuBXIMrI13HSu+zmi/Bfttw/1LC/hHa3O7vDXw6SEUrRVsAyS4BneO53WmSiJZei7ilBAIgCIdUMdfAtw+S3m7Tb4pdOow+vU1vrq5NDFxU1qNwhza86OlpDc=,iv:4g1EfhnEy6QSv5bGvHUKtXQWePiuzg6ytnp+DyoUaWw=,tag:0MGrT0vgI4zhSgFRfAx6xw==,type:str]
+    lastmodified: "2025-06-04T13:10:52Z"
+    mac: ENC[AES256_GCM,data:osXslUkrnKsU9FDGyLQ4tfYi+2cmlwHx45dG93KqMcB8WcJhbZeHC72cqUqKjCO+XnhnJC4TBO0lBeXgkSY09MAIftW/Y5vabh0UjqCdZKm5x9Cq2Td9oOYx4Ld/YaszvHK3JKplMQj1o/jPiq89E9m8bEH1ixCIPwJOniMyssU=,iv:A6jOstDQynt/izavUg4XxSg0sWbdBv4JOA6wprdpey8=,tag:+bW6428ov+nEI4DMkQpr5g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.1

--- a/playbook-website/config/deploy/staging/secrets.yaml
+++ b/playbook-website/config/deploy/staging/secrets.yaml
@@ -35,8 +35,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-23T17:00:43Z"
-    mac: ENC[AES256_GCM,data:BAUFJMNvJ7ZpY+W4LIAZFA48icyvyClqDFgh9b/uVoRppoU4x87AvD5WX7nSJm7Dn6Dy7ru+BbE36MFZMQMozmVtpxOwdWvxk+WckIzPpIIiB3IFCBhFz01Ql1/kYC56XVGFGTZ/nhGm0Vm3swbroPF/bf6LPHwXGyS6gcAKX9M=,iv:MATRiWYznGMAvu+hukaFJJa92txGq/CFj/B2sX5NaXg=,tag:U80RXtROcr5AcEM7zXvmnA==,type:str]
+    lastmodified: "2025-06-04T13:11:03Z"
+    mac: ENC[AES256_GCM,data:mcTjDgNNZldGWzgrt2YsAnaPiuclruHjdeoYQNyIGDT7Bv4mlgUq35BYWDyiPb73MAkspGuIEMkENw3P6gXh9+4Exo9h3o8jNWamODMs7VW2wnDanu+i2mRJ3xOfV8AjuLd98iIm52vF0idkvIK9C8ti+55iiwFqErYTlqQFXyM=,iv:RajyWX8A9qHhc62gptPpjeRzQohi7HlhywhV3tXPO0Q=,tag:jWBsHYgOwxdHQ5ATBr8GYw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.1


### PR DESCRIPTION
Part of: https://runway.powerhrg.com/backlog_items/GOG-1042

Ensure Guardians of the Galaxy has access to all of the application
secrets that Forever People currently manage So that we can ensure
continuity of access / support as we merge the teams.