### PR TITLE
[PLAY-2213] Advanced Table Kit: Fix Fullscreen Docs

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableActionBar.tsx
@@ -155,6 +155,11 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
     </Tooltip>
   )
 
+  const getPortalTarget = () => {
+    const el = document.fullscreenElement;
+    return el?.id ? `#${el.id}` : 'body';
+  }
+
   return (
     <Card
         borderNone={!isVisible}
@@ -182,6 +187,7 @@ const TableActionBar: React.FC<TableActionBarProps> = ({
           <PbReactPopover
               closeOnClick="outside"
               placement="bottom-end"
+              portal={getPortalTarget()}
               reference={popoverReference}
               shouldClosePopover={handleShouldClose}
               show={showPopover}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_selectable_rows_actions.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_selectable_rows_actions.jsx
@@ -47,14 +47,14 @@ const CustomActions = () => {
       <CircleIconButton
           icon="file-csv"
           onClick={() =>
-            alert(rowIds.length === 0 ? "No Selection Made" : `Row ids ${rowIds.join(", ")} will be exported!`)
+            alert(rowIds.length === 0 ? "No Selection Made" : 'Row ids ' + rowIds.join(", ") + 'will be exported!')
           }
           variant="link"
       />
       <CircleIconButton
           icon="trash-alt"
           onClick={() =>
-            alert(rowIds.length === 0 ? "No Selection Made" : `Row ids ${rowIds.join(", ")} will be deleted!`)
+            alert(rowIds.length === 0 ? "No Selection Made" : 'Row ids ' + rowIds.join(", ") + 'will be deleted!')
           }
           variant="link"
         />

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_selectable_rows_actions_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_selectable_rows_actions_rails.html.erb
@@ -88,10 +88,11 @@ actions = [
     if (!selectedRowIds || selectedRowIds.length === 0) {
       alert('No Selection Made');
     } else {
+      const selectedRowsString = selectedRowIds.join(', ');
       if (actionType === 'export') {
-        alert(`Row ids ${selectedRowIds.join(', ')} will be exported!`);
+        alert('Row ids ' + selectedRowsString + ' will be exported!');
       } else if (actionType === 'delete') {
-        alert(`Row ids ${selectedRowIds.join(', ')} will be deleted!`);
+        alert('Row ids ' + selectedRowsString + ' will be deleted!');
       }
     }
   };


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Fix fullscreen functionality for "Selectable Rows (With Actions)" in React and Rails
  - Template literals `${}` don't work well with html.erb (the fullscreen scripts don't run). Switch out.
- Fix "Column Visibility Control" action bar popover in fullscreen and show
  - Use `portal` prop in Popover kit and use either the fullscreen element or the default `body` if there is no fullscreen element.

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-06-05 at 3 45 29 PM](https://github.com/user-attachments/assets/5cc12589-838e-4ea7-b366-cecb26809b65)

**How to test?** Steps to confirm the desired behavior:
1. Go to "Selectable Rows (With Actions)" in React and Rails
2. You should be able to open these in fullscreen
3. Go to the "Column Visibility Control" docs in React
4. Open them in fullscreen
5. You should be able to see the action bar


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.