### PR TITLE
[PLAY-2018] Advanced Table Kit: Add Table Header Borders with Vertical Border and Multi-Header

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/styles/_vertical_border.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_vertical_border.scss
@@ -4,7 +4,7 @@
       border-right: 1px solid $border_light !important;
     }
 
-    thead tr:last-child th {
+    thead tr:not(:first-child) th {
       border-right: 1px solid $border_light !important;
     }
     


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Add 1px right border to table headers that aren't the first row for verticalBorder.

This fixes the "inconsistent" borders in Firefox and Chrome with the verticalBorder prop.
It also adds borders to the last table header row in multi-header with verticalBorder true. 

https://runway.powerhrg.com/backlog_items/PLAY-2018

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-06-10 at 10 25 07 AM](https://github.com/user-attachments/assets/371388f2-09a3-498b-b18b-ffd6d93fedae)

**How to test?** Steps to confirm the desired behavior:
1. Use Firefox **and** Chrome
2. Make sure the docs with the verticalBorder prop look good
3. In Runway- I'm going to make a codesandbox to check out

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.