### PR TITLE
[PLAY-2241] Table Kit: Use data-sticky-id's instead of repeated id's - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.html.erb
@@ -1,7 +1,7 @@
 <%= pb_rails("table", props: { size: "md", responsive: "scroll", sticky_left_column: ["a"], sticky_right_column: ["b"] }) do %>
   <thead>
     <tr>
-      <th id="a">Column 1</th>
+      <th data-sticky-id="a">Column 1</th>
       <th>Column 2</th>
       <th>Column 3</th>
       <th>Column 4</th>
@@ -15,12 +15,12 @@
       <th>Column 12</th>
       <th>Column 13</th>
       <th>Column 14</th>
-      <th id="b">Column 15</th>
+      <th data-sticky-id="b">Column 15</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td id="a">Value 1</td>
+      <td data-sticky-id="a">Value 1</td>
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
@@ -34,10 +34,10 @@
       <td>Value 12</td>
       <td>Value 13</td>
       <td>Value 14</td>
-      <td id="b">Value 15</td>
+      <td data-sticky-id="b">Value 15</td>
     </tr>
     <tr>
-      <td id="a">Value 1</td>
+      <td data-sticky-id="a">Value 1</td>
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
@@ -51,10 +51,10 @@
       <td>Value 12</td>
       <td>Value 13</td>
       <td>Value 14</td>
-      <td id="b">Value 15</td>
+      <td data-sticky-id="b">Value 15</td>
     </tr>
     <tr>
-      <td id="a">Value 1</td>
+      <td data-sticky-id="a">Value 1</td>
       <td>Value 2</td>
       <td>Value 3</td>
       <td>Value 4</td>
@@ -68,7 +68,7 @@
       <td>Value 12</td>
       <td>Value 13</td>
       <td>Value 14</td>
-      <td id="b">Value 15</td>
+      <td data-sticky-id="b">Value 15</td>
     </tr>
   </tbody>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns_rails.md
@@ -1,3 +1,3 @@
 The `sticky_left_column` and `sticky_right_column` props can be used together on the same table as needed.
 
-Please ensure that unique ids are used for all columns across multiple tables. Using the same columns ids on multiple tables can lead to issues when using props.
+Please ensure that unique `data-sticky-id`s are used for all columns across multiple tables. Using the same columns `data-sticky-id`s on multiple tables can lead to issues when using props.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns.html.erb
@@ -1,9 +1,9 @@
 <%= pb_rails("table", props: { size: "md", responsive: "scroll", sticky_left_column: ["1", "2", "3"] }) do %>
   <thead>
     <tr>
-      <th id="1">Column 1</th>
-      <th id="2">Column 2</th>
-      <th id="3">Column 3</th>
+      <th data-sticky-id="1">Column 1</th>
+      <th data-sticky-id="2">Column 2</th>
+      <th data-sticky-id="3">Column 3</th>
       <th>Column 4</th>
       <th>Column 5</th>
       <th>Column 6</th>
@@ -20,9 +20,9 @@
   </thead>
   <tbody>
     <tr>
-      <td id="1">Value 1</td>
-      <td id="2">Value 2</td>
-      <td id="3">Value 3</td>
+      <td data-sticky-id="1">Value 1</td>
+      <td data-sticky-id="2">Value 2</td>
+      <td data-sticky-id="3">Value 3</td>
       <td>Value 4</td>
       <td>Value 5</td>
       <td>Value 6</td>
@@ -38,9 +38,9 @@
 
     </tr>
     <tr>
-      <td id="1">Value 1</td>
-      <td id="2">Value 2</td>
-      <td id="3">Value 3</td>
+      <td data-sticky-id="1">Value 1</td>
+      <td data-sticky-id="2">Value 2</td>
+      <td data-sticky-id="3">Value 3</td>
       <td>Value 4</td>
       <td>Value 5</td>
       <td>Value 6</td>
@@ -56,9 +56,9 @@
 
     </tr>
     <tr>
-      <td id="1">Value 1</td>
-      <td id="2">Value 2</td>
-      <td id="3">Value 3</td>
+      <td data-sticky-id="1">Value 1</td>
+      <td data-sticky-id="2">Value 2</td>
+      <td data-sticky-id="3">Value 3</td>
       <td>Value 4</td>
       <td>Value 5</td>
       <td>Value 6</td>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns_rails.md
@@ -1,3 +1,3 @@
-The `sticky_left_column` prop expects an array of the column ids you want to be sticky. Make sure to add the corresponding id to the `<th>` and `<td>`.
+The `sticky_left_column` prop expects an array of the column `data-sticky-id`s you want to be sticky. Make sure to add the corresponding `data-sticky-id` to the `<th>` and `<td>`.
 
-Please ensure that unique ids are used for all columns across multiple tables. Using the same columns ids on multiple tables can lead to issues when using the `sticky_left_column`.
+Please ensure that unique `data-sticky-id`s are used for all columns across multiple tables. Using the same columns `data-sticky-id`s on multiple tables can lead to issues when using the `sticky_left_column`.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.html.erb
@@ -13,9 +13,9 @@
       <th>Column 10</th>
       <th>Column 11</th>
       <th>Column 12</th>
-      <th id="13">Column 13</th>
-      <th id="14">Column 14</th>
-      <th id="15">Column 15</th>
+      <th data-sticky-id="13">Column 13</th>
+      <th data-sticky-id="14">Column 14</th>
+      <th data-sticky-id="15">Column 15</th>
     </tr>
   </thead>
   <tbody>
@@ -32,9 +32,9 @@
       <td>Value 10</td>
       <td>Value 11</td>
       <td>Value 12</td>
-      <td id="13">Value 13</td>
-      <td id="14">Value 14</td>
-      <td id="15">Value 15</td>
+      <td data-sticky-id="13">Value 13</td>
+      <td data-sticky-id="14">Value 14</td>
+      <td data-sticky-id="15">Value 15</td>
     </tr>
     <tr>
       <td>Value 1</td>
@@ -49,9 +49,9 @@
       <td>Value 10</td>
       <td>Value 11</td>
       <td>Value 12</td>
-      <td id="13">Value 13</td>
-      <td id="14">Value 14</td>
-      <td id="15">Value 15</td>
+      <td data-sticky-id="13">Value 13</td>
+      <td data-sticky-id="14">Value 14</td>
+      <td data-sticky-id="15">Value 15</td>
     </tr>
     <tr>
       <td>Value 1</td>
@@ -66,9 +66,9 @@
       <td>Value 10</td>
       <td>Value 11</td>
       <td>Value 12</td>
-      <td id="13">Value 13</td>
-      <td id="14">Value 14</td>
-      <td id="15">Value 15</td>
+      <td data-sticky-id="13">Value 13</td>
+      <td data-sticky-id="14">Value 14</td>
+      <td data-sticky-id="15">Value 15</td>
     </tr>
   </tbody>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns_rails.md
@@ -1,3 +1,3 @@
-The `sticky_right_column` prop works in the same way as the above `sticky_left_column` prop. It expects an array of the column ids you want to be sticky. Make sure to add the corresponding id to the `<th>` and `<td>`.
+The `sticky_right_column` prop works in the same way as the above `sticky_left_column` prop. It expects an array of the column `data-sticky-id`s you want to be sticky. Make sure to add the corresponding `data-sticky-id` to the `<th>` and `<td>`.
 
-Please ensure that unique ids are used for all columns across multiple tables. Using the same columns ids on multiple tables can lead to issues when using the `sticky_right_column` prop.
+Please ensure that unique `data-sticky-id`s are used for all columns across multiple tables. Using the same columns `data-sticky-id`s on multiple tables can lead to issues when using the `sticky_right_column` prop.

--- a/playbook/app/pb_kits/playbook/pb_table/index.ts
+++ b/playbook/app/pb_kits/playbook/pb_table/index.ts
@@ -64,8 +64,8 @@ export default class PbTable extends PbEnhancedElement {
 
     this.stickyLeftColumns.forEach((colId, index) => {
       const isLastColumn = index === this.stickyLeftColumns.length - 1;
-      const header = this.element.querySelector(`th[id="${colId}"]`);
-      const cells = this.element.querySelectorAll(`td[id="${colId}"]`);
+      const header = this.element.querySelector(`th[data-sticky-id="${colId}"]`);
+      const cells = this.element.querySelectorAll(`td[data-sticky-id="${colId}"]`);
 
       if (header) {
         header.classList.add('sticky');
@@ -125,8 +125,8 @@ export default class PbTable extends PbEnhancedElement {
 
     this.stickyRightColumnsReversed.forEach((colId, index) => {
       const isLastColumn = index === this.stickyRightColumns.length - 1;
-      const header = this.element.querySelector(`th[id="${colId}"]`);
-      const cells = this.element.querySelectorAll(`td[id="${colId}"]`);
+      const header = this.element.querySelector(`th[data-sticky-id="${colId}"]`);
+      const cells = this.element.querySelectorAll(`td[data-sticky-id="${colId}"]`);
 
       if (header) {
         header.classList.add('sticky');


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Use data-sticky-id's instead of repeated id's for left and right sticky columns.

https://runway.powerhrg.com/backlog_items/PLAY-2241

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-06-11 at 1 44 38 PM](https://github.com/user-attachments/assets/3864081e-e23a-4031-98e4-f233c03b11ee)

**How to test?** Steps to confirm the desired behavior:
1. Test the rails table sticky columns docs

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.