### PR TITLE
[PLAY-2112] Table kit: Styling Issue For One Column Table

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/styles/_table-card.scss
+++ b/playbook/app/pb_kits/playbook/pb_table/styles/_table-card.scss
@@ -22,6 +22,10 @@
               border-radius: 0 4px 0 0;
               border-width: 1px 1px 1px 0;
             }
+            &:only-child {
+              border-radius: 4px 4px 0 0;
+              border-width: 1px 1px 1px 1px;
+            }
           }
         }
       }
@@ -39,6 +43,9 @@
             &:last-child {
               border-width: 0 1px 1px 0;
             }
+            &:only-child {
+              border-width: 0 1px 1px 1px;
+            }
           }
 
           &:last-child {
@@ -52,6 +59,10 @@
               &:last-child {
                 border-radius: 0 0 4px 0;
                 border-width: 0 1px 1px 0;
+              }
+              &:only-child {
+                border-radius: 0 0 4px 4px;
+                border-width: 0 1px 1px 1px;
               }
             }
           }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2112](https://runway.powerhrg.com/backlog_items/PLAY-2112) addresses some styling issues that appeared for a one column table. The initial ticket mentioned the one header cell issue, but there is actually one for when there is one table cell in the body as well. Adding the only-child pseudoclass in addition to first-child and last-child in table-card.scss accounts for these situations. 
One column tables will now have: 
- a left border on the table header (currently there is a gap without a border in the header)
- a curved bottom left corner border radius for the last row (currently a right angle)

Compare and contrast: 
[CSB Reproducing Issue](https://codesandbox.io/p/sandbox/elastic-matan-dkzxnc)
CSB with Alpha

**Screenshots:** Screenshots to visualize your addition/change
<img width="1383" alt="doc ex pre" src="https://github.com/user-attachments/assets/2ea3847b-7af2-4c76-ac52-d228c916cdc1" />
<img width="1388" alt="doc ex with solution" src="https://github.com/user-attachments/assets/ef1455d8-bb2b-42a7-9485-f09e43e0b08f" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the [CSB Reproducing Issue](https://codesandbox.io/p/sandbox/elastic-matan-dkzxnc). See missing header border and right angle border radius for last row. The two- and three- column tables look as expected.
2. Go to the CSB with alpha. See resolution of those two issues in the two one column table examples without any visual change to the control tables (two- and three- column tables).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.