### PR TITLE
[PLAY-2288] Advanced Table: Custom Sort

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
@@ -40,7 +40,6 @@ export const SubRowHeaderRow = ({
   const canExpand = inlineRowLoading ? rowHasChildren : row.getCanExpand()
   const hasSubrowsToSort = row.getParentRow()?.subRows
 
-  console.log()
 
   return (
     <tr className="custom-row bg-silver">
@@ -69,7 +68,7 @@ export const SubRowHeaderRow = ({
                   aria-label="Sort this group"
                   className="sort-button-icon"
                   onClick={() => {
-                    console.log(row.getParentRow()?.getIsGrouped(), "parent's subrows");
+                    console.log(row.getParentRow()?.subRows);
                 }}
               >
                 <Icon 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
@@ -53,7 +53,9 @@ export const SubRowHeaderRow = ({
         <div style={{ paddingLeft: `${row.depth * 1.25}em` }}>
           <Flex align="center" 
               columnGap="xs"
-              justifyContent={customSort && hasSubrowsToSort && hasSubrowsToSort.length > 1 && "between"}
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              //@ts-ignore
+              justifyContent={customSort && hasSubrowsToSort && hasSubrowsToSort.length > 1 ? "between" : undefined}
           >
             <Flex columnGap="xs">
               {enableToggleExpansion === "all" && canExpand ? (

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
@@ -33,7 +33,7 @@ export const SubRowHeaderRow = ({
   subRowHeaders,
   table,
 }: SubRowHeaderRowProps & GlobalProps) => {
-  const { inlineRowLoading, customSort } = useContext(AdvancedTableContext)
+  const { inlineRowLoading, customSort, onCustomSortClick } = useContext(AdvancedTableContext)
 
   const numberOfColumns = table.getAllFlatColumns().length
   const rowHasChildren = row.original.children ? true : false
@@ -66,15 +66,13 @@ export const SubRowHeaderRow = ({
             {customSort && hasSubrowsToSort && hasSubrowsToSort.length > 1 && (
               <button
                   aria-label="Sort this group"
-                  className="sort-button-icon"
-                  onClick={() => {
-                    console.log(row.getParentRow()?.subRows);
-                }}
+                  className="sort-button-icon gray-icon"
+                  onClick={() => { onCustomSortClick && onCustomSortClick(row.getParentRow()?.subRows)}}
               >
                 <Icon 
                     cursor="pointer" 
                     fixedWidth 
-                    icon="arrow-up-short-wide" 
+                    icon="sort" 
                 />
               </button>
             )}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
@@ -53,16 +53,19 @@ export const SubRowHeaderRow = ({
         <div style={{ paddingLeft: `${row.depth * 1.25}em` }}>
           <Flex align="center" 
               columnGap="xs"
+              justifyContent={customSort && hasSubrowsToSort && hasSubrowsToSort.length > 1 && "between"}
           >
-            {enableToggleExpansion === "all" && canExpand ? (
-              <ToggleIconButton onClick={onClick} 
-                  row={row} 
+            <Flex columnGap="xs">
+              {enableToggleExpansion === "all" && canExpand ? (
+                <ToggleIconButton onClick={onClick} 
+                    row={row} 
+                />
+              ) : null}
+              <Caption
+                  marginLeft={canExpand ? "none" : "xs"}
+                  text={subRowHeaders[row.depth - 1]}
               />
-            ) : null}
-            <Caption
-                marginLeft={canExpand ? "none" : "xs"}
-                text={subRowHeaders[row.depth - 1]}
-            />
+            </Flex>
             {customSort && hasSubrowsToSort && hasSubrowsToSort.length > 1 && (
               <button
                   aria-label="Sort this group"

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SubRowHeaderRow.tsx
@@ -7,6 +7,7 @@ import { GlobalProps } from "../../utilities/globalProps"
 
 import Flex from "../../pb_flex/_flex"
 import Caption from "../../pb_caption/_caption"
+import Icon from "../../pb_icon/_icon"
 
 import { ToggleIconButton } from "./ToggleIconButton"
 import { renderCollapsibleTrail } from "./CollapsibleTrail"
@@ -32,17 +33,20 @@ export const SubRowHeaderRow = ({
   subRowHeaders,
   table,
 }: SubRowHeaderRowProps & GlobalProps) => {
-  const { inlineRowLoading } = useContext(AdvancedTableContext)
+  const { inlineRowLoading, customSort } = useContext(AdvancedTableContext)
 
   const numberOfColumns = table.getAllFlatColumns().length
   const rowHasChildren = row.original.children ? true : false
   const canExpand = inlineRowLoading ? rowHasChildren : row.getCanExpand()
+  const hasSubrowsToSort = row.getParentRow()?.subRows
+
+  console.log()
 
   return (
     <tr className="custom-row bg-silver">
       <td
           className={`custom-row-first-column ${
-          isChrome() ? "chrome-styles" : ""
+            isChrome() ? "chrome-styles" : ""
           }`}
           colSpan={1}
       >
@@ -53,18 +57,33 @@ export const SubRowHeaderRow = ({
           >
             {enableToggleExpansion === "all" && canExpand ? (
               <ToggleIconButton onClick={onClick} 
-                  row={row}
+                  row={row} 
               />
             ) : null}
             <Caption
                 marginLeft={canExpand ? "none" : "xs"}
                 text={subRowHeaders[row.depth - 1]}
             />
+            {customSort && hasSubrowsToSort && hasSubrowsToSort.length > 1 && (
+              <button
+                  aria-label="Sort this group"
+                  className="sort-button-icon"
+                  onClick={() => {
+                    console.log(row.getParentRow()?.getIsGrouped(), "parent's subrows");
+                }}
+              >
+                <Icon 
+                    cursor="pointer" 
+                    fixedWidth 
+                    icon="arrow-up-short-wide" 
+                />
+              </button>
+            )}
           </Flex>
         </div>
       </td>
 
       <td colSpan={numberOfColumns - 1} />
     </tr>
-  )
+  );
 }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -68,6 +68,7 @@ type AdvancedTableProps = {
   tableProps?: GenericObject
   toggleExpansionIcon?: string | string[]
   onRowSelectionChange?: (arg: RowSelectionState) => void
+  onCustomSortClick?: (arg: GenericObject[]) => void
   virtualizedRows?: boolean
   allowFullScreen?: boolean
   fullScreenControl?: (controls: FullscreenControls) => void
@@ -97,6 +98,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     maxHeight,
     onRowToggleClick,
     onToggleExpansionClick,
+    onCustomSortClick,
     pagination = false,
     paginationProps,
     pinnedRows,
@@ -339,6 +341,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             isActionBarVisible={isActionBarVisible}
             isFullscreen={isFullscreen}
             loading={loading}
+            onCustomSortClick={onCustomSortClick}
             onExpandByDepthClick={onExpandByDepthClick}
             pinnedRows={pinnedRows}
             responsive={responsive}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -36,6 +36,7 @@ type AdvancedTableProps = {
   columnDefinitions: GenericObject[]
   columnGroupBorderColor?: "text_lt_default" | "text_lt_light" | "text_lt_lighter" | "text_dk_default" | "text_dk_light" | "text_dk_lighter"
   columnVisibilityControl?: GenericObject
+  customSort?:boolean;
   dark?: boolean
   data?: { [key: string]: string }
   enableToggleExpansion?: "all" | "header" | "none"
@@ -81,6 +82,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     columnDefinitions,
     columnGroupBorderColor,
     columnVisibilityControl,
+    customSort,
     dark = false,
     data = {},
     enableToggleExpansion = "header",
@@ -325,6 +327,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             columnDefinitions={columnDefinitions}
             columnGroupBorderColor={columnGroupBorderColor}
             columnVisibilityControl={columnVisibilityControl}
+            customSort={customSort}
             enableToggleExpansion={enableToggleExpansion}
             enableVirtualization={virtualizedRows}
             expandByDepth={expandByDepth}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_sort.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_sort.jsx
@@ -1,0 +1,64 @@
+import React from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableCustomSort = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      id: "year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      id: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      id: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+    {
+      accessor: "attendanceRate",
+      id: "attendanceRate",
+      label: "Attendance Rate",
+    },
+    {
+      accessor: "completedClasses",
+      id: "completedClasses",
+      label: "Completed Classes",
+    },
+    {
+      accessor: "classCompletionRate",
+      id: "classCompletionRate",
+      label: "Class Completion Rate",
+    },
+    {
+      accessor: "graduatedStudents",
+      id: "graduatedStudents",
+      label: "Graduated Students",
+    },
+  ]
+
+//Render the subRow header rows
+const subRowHeaders = ["Quarter", "Month", "Day"]
+
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          customSort
+          enableToggleExpansion="all"
+          tableData={MOCK_DATA}
+          {...props}
+      >
+        <AdvancedTable.Header enableSorting />
+        <AdvancedTable.Body subRowHeaders={subRowHeaders} />
+      </AdvancedTable>
+    </div>
+  )
+}
+
+export default AdvancedTableCustomSort

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_sort.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_sort.jsx
@@ -51,6 +51,7 @@ const subRowHeaders = ["Quarter", "Month", "Day"]
           columnDefinitions={columnDefinitions}
           customSort
           enableToggleExpansion="all"
+          onCustomSortClick={(subrows)=>{console.log("Custom sort clicked", subrows)}}
           tableData={MOCK_DATA}
           {...props}
       >

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_sort.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_custom_sort.md
@@ -1,0 +1,5 @@
+The optional `customSort` prop can be used to add a sort button within a subrow header. The button will only appear if that subrowheader has more than one subrow nested within it. This button comes with a callback function called `onCustomSortClick`.
+
+The `onCustomSortClick` provides as an argument an array of all the subrows nested within that level of the table. 
+
+__NOTE__: `customSort` must be used in conjunction with the `subRowHeaders` prop. The `customSort` DOES NOT handle the sort logic, this must be handled on the frontend using the callback provided. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -23,44 +23,44 @@ examples:
   # - advanced_table_column_styling_column_headers_rails: Column Styling with Multiple Headers
 
   react:
-  # - advanced_table_default: Default (Required Props)
-  # - advanced_table_loading: Loading State
+  - advanced_table_default: Default (Required Props)
+  - advanced_table_loading: Loading State
   - advanced_table_sort: Enable Sorting
   - advanced_table_sort_control: Sort Control
   - advanced_table_custom_sort: Custom Sort
-  # - advanced_table_expanded_control: Expanded Control
-  # - advanced_table_expand_by_depth: Expand by Depth
+  - advanced_table_expanded_control: Expanded Control
+  - advanced_table_expand_by_depth: Expand by Depth
   - advanced_table_subrow_headers: SubRow Headers
-  # - advanced_table_collapsible_trail: Collapsible Trail
-  # - advanced_table_table_options: Table Options
-  # - advanced_table_table_props: Table Props
-  # - advanced_table_sticky_header: Sticky Header
-  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  # - advanced_table_sticky_columns: Sticky Columns
-  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  # - advanced_table_inline_row_loading: Inline Row Loading
-  # - advanced_table_responsive: Responsive Tables
-  # - advanced_table_custom_cell: Custom Components for Cells
-  # - advanced_table_pagination: Pagination
-  # - advanced_table_pagination_with_props: Pagination Props
-  # - advanced_table_column_headers: Multi-Header Columns
-  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  # - advanced_table_column_border_color: Column Group Border Color
-  # - advanced_table_no_subrows: Table with No Subrows or Expansion
-  # - advanced_table_selectable_rows: Selectable Rows
-  # - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
-  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  # - advanced_table_inline_editing: Inline Cell Editing
-  # - advanced_table_fullscreen: Fullscreen
-  # - advanced_table_column_visibility: Column Visibility Control
-  # - advanced_table_column_visibility_with_state: Column Visibility Control With State
-  # - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
-  # - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns
-  # - advanced_table_pinned_rows: Pinned Rows
-  # - advanced_table_scrollbar_none: Advanced Table Scrollbar None
-  # - advanced_table_row_styling: Row Styling
-  # - advanced_table_column_styling: Column Styling
-  # - advanced_table_column_styling_column_headers: Column Styling with Multiple Headers
-  # - advanced_table_infinite_scroll: Infinite Scroll
+  - advanced_table_collapsible_trail: Collapsible Trail
+  - advanced_table_table_options: Table Options
+  - advanced_table_table_props: Table Props
+  - advanced_table_sticky_header: Sticky Header
+  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  - advanced_table_sticky_columns: Sticky Columns
+  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  - advanced_table_inline_row_loading: Inline Row Loading
+  - advanced_table_responsive: Responsive Tables
+  - advanced_table_custom_cell: Custom Components for Cells
+  - advanced_table_pagination: Pagination
+  - advanced_table_pagination_with_props: Pagination Props
+  - advanced_table_column_headers: Multi-Header Columns
+  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  - advanced_table_column_border_color: Column Group Border Color
+  - advanced_table_no_subrows: Table with No Subrows or Expansion
+  - advanced_table_selectable_rows: Selectable Rows
+  - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
+  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  - advanced_table_inline_editing: Inline Cell Editing
+  - advanced_table_fullscreen: Fullscreen
+  - advanced_table_column_visibility: Column Visibility Control
+  - advanced_table_column_visibility_with_state: Column Visibility Control With State
+  - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
+  - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns
+  - advanced_table_pinned_rows: Pinned Rows
+  - advanced_table_scrollbar_none: Advanced Table Scrollbar None
+  - advanced_table_row_styling: Row Styling
+  - advanced_table_column_styling: Column Styling
+  - advanced_table_column_styling_column_headers: Column Styling with Multiple Headers
+  - advanced_table_infinite_scroll: Infinite Scroll

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -23,43 +23,44 @@ examples:
   # - advanced_table_column_styling_column_headers_rails: Column Styling with Multiple Headers
 
   react:
-  - advanced_table_default: Default (Required Props)
-  - advanced_table_loading: Loading State
+  # - advanced_table_default: Default (Required Props)
+  # - advanced_table_loading: Loading State
   - advanced_table_sort: Enable Sorting
   - advanced_table_sort_control: Sort Control
-  - advanced_table_expanded_control: Expanded Control
-  - advanced_table_expand_by_depth: Expand by Depth
+  - advanced_table_custom_sort: Custom Sort
+  # - advanced_table_expanded_control: Expanded Control
+  # - advanced_table_expand_by_depth: Expand by Depth
   - advanced_table_subrow_headers: SubRow Headers
-  - advanced_table_collapsible_trail: Collapsible Trail
-  - advanced_table_table_options: Table Options
-  - advanced_table_table_props: Table Props
-  - advanced_table_sticky_header: Sticky Header
-  - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  - advanced_table_sticky_columns: Sticky Columns
-  - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  - advanced_table_inline_row_loading: Inline Row Loading
-  - advanced_table_responsive: Responsive Tables
-  - advanced_table_custom_cell: Custom Components for Cells
-  - advanced_table_pagination: Pagination
-  - advanced_table_pagination_with_props: Pagination Props
-  - advanced_table_column_headers: Multi-Header Columns
-  - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  - advanced_table_column_border_color: Column Group Border Color
-  - advanced_table_no_subrows: Table with No Subrows or Expansion
-  - advanced_table_selectable_rows: Selectable Rows
-  - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
-  - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
-  - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
-  - advanced_table_inline_editing: Inline Cell Editing
-  - advanced_table_fullscreen: Fullscreen
-  - advanced_table_column_visibility: Column Visibility Control
-  - advanced_table_column_visibility_with_state: Column Visibility Control With State
-  - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
-  - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns
-  - advanced_table_pinned_rows: Pinned Rows
-  - advanced_table_scrollbar_none: Advanced Table Scrollbar None
-  - advanced_table_row_styling: Row Styling
-  - advanced_table_column_styling: Column Styling
-  - advanced_table_column_styling_column_headers: Column Styling with Multiple Headers
-  - advanced_table_infinite_scroll: Infinite Scroll
+  # - advanced_table_collapsible_trail: Collapsible Trail
+  # - advanced_table_table_options: Table Options
+  # - advanced_table_table_props: Table Props
+  # - advanced_table_sticky_header: Sticky Header
+  # - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
+  # - advanced_table_sticky_columns: Sticky Columns
+  # - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
+  # - advanced_table_inline_row_loading: Inline Row Loading
+  # - advanced_table_responsive: Responsive Tables
+  # - advanced_table_custom_cell: Custom Components for Cells
+  # - advanced_table_pagination: Pagination
+  # - advanced_table_pagination_with_props: Pagination Props
+  # - advanced_table_column_headers: Multi-Header Columns
+  # - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
+  # - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
+  # - advanced_table_column_border_color: Column Group Border Color
+  # - advanced_table_no_subrows: Table with No Subrows or Expansion
+  # - advanced_table_selectable_rows: Selectable Rows
+  # - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
+  # - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
+  # - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
+  # - advanced_table_inline_editing: Inline Cell Editing
+  # - advanced_table_fullscreen: Fullscreen
+  # - advanced_table_column_visibility: Column Visibility Control
+  # - advanced_table_column_visibility_with_state: Column Visibility Control With State
+  # - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
+  # - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns
+  # - advanced_table_pinned_rows: Pinned Rows
+  # - advanced_table_scrollbar_none: Advanced Table Scrollbar None
+  # - advanced_table_row_styling: Row Styling
+  # - advanced_table_column_styling: Column Styling
+  # - advanced_table_column_styling_column_headers: Column Styling with Multiple Headers
+  # - advanced_table_infinite_scroll: Infinite Scroll

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -38,3 +38,4 @@ export { default as AdvancedTableRowStyling } from './_advanced_table_row_stylin
 export { default as AdvancedTableColumnStyling } from './_advanced_table_column_styling.jsx'
 export { default as AdvancedTableColumnStylingColumnHeaders } from './_advanced_table_column_styling_column_headers.jsx'
 export { default as AdvancedTableInfiniteScroll} from './_advanced_table_infinite_scroll.jsx'
+export { default as AdvancedTableCustomSort } from './_advanced_table_custom_sort.jsx'


### PR DESCRIPTION
**What does this PR do?** 

[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2288)
- POC work down on[ this story](https://runway.powerhrg.com/backlog_items/PLAY-2258)
- Sort on the inner dimension cannot be handled by the kit itself without mutating the data so we are only providing the following:
  - A button that shows up in the subrow header with a callback function attached
  - The callback function will have as an argument an array of the immediate subrows that can be sorted
  - Nitro devs will handle the sort itself from the frontend so nothing needed from us there
  - Use the 'sort' icon for that button + make it aligned to end of cell so it matches the sort button in the header cell.


**Screenshots:** 
![Screenshot 2025-06-23 at 12 49 31 PM](https://github.com/user-attachments/assets/ec89d3e3-b616-429b-82df-92b538e06f61)


**How to test?** Steps to confirm the desired behavior:
doc example [here](https://pr4767.playbook.beta.px.powerapp.cloud/kits/advanced_table/react#custom-sort)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.