### PR TITLE
[PLAY-404] Advanced Table: Selectable Rows Color Opacity

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -56,7 +56,7 @@
   }
 
   .bg-row-selection {
-    background-color: $info_subtle;
+    background-color: #E5EEFA;
   }
 
   .full-width {
@@ -227,7 +227,7 @@
 
       &.bg-row-selection {
         td:first-child {
-          background-color: $info_subtle;
+          background-color: #E5EEFA;
         }
       }
     }
@@ -888,6 +888,18 @@
           th.sticky-left,
           td.sticky-left {
             border-right: 1px solid $border_dark !important;
+          }
+        }
+      }
+    }
+    .bg-row-selection {
+      background-color: #202850;
+    }
+    .pb_advanced_table_body {
+      tr.virtualized-table-row {
+        &.bg-row-selection {
+          td:first-child {
+            background-color: #202850;
           }
         }
       }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/scss_partials/advanced_table_sticky_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/scss_partials/advanced_table_sticky_mixin.scss
@@ -2,7 +2,8 @@
   $border-color,
   $bg-main,
   $bg-secondary,
-  $highlight: $info_subtle
+  $highlight: #E5EEFA,
+  $highlight-dark: #202850,
 ) {
   border-radius: 4px;
   box-shadow: 1px 0 0 0px $border-color, -1px 0 0 0px $border-color;
@@ -93,6 +94,20 @@
 
     .pb_advanced_table_header {
       box-shadow: none !important;
+    }
+  }
+
+  &.dark {
+    .bg-row-selection {
+      td:first-child,
+      .sticky-left {
+        background-color: $highlight-dark;
+      }
+    }
+    .virtualized-table-row {
+      &.bg-row-selection td:first-child {
+        background-color: $highlight-dark;
+      }
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-404](https://runway.powerhrg.com/backlog_items/PLAY-404) updates the color for selected rows in Advanced Tables to one that does not have opacity. The previous color changed the first column to a more transparent variant of $info_subtle when in a responsive  set up such that the content underneath the first column was visible. The new color token does not have any opacity and avoids this issue. I have also added a separate dark mode color for selectable rows.

**Screenshots:** Screenshots to visualize your addition/change
Light Mode
<img width="1140" alt="rails light default" src="https://github.com/user-attachments/assets/77dfc5c9-f264-472c-93aa-85c71ea53f33" />
<img width="617" alt="react light responsive" src="https://github.com/user-attachments/assets/fe46a8b5-78d0-4472-bd1f-f380303eb093" />
Dark Mode
<img width="1326" alt="react dark default" src="https://github.com/user-attachments/assets/1749403c-05f1-4d0e-b791-279df553b11c" />
<img width="589" alt="rails dark responsive" src="https://github.com/user-attachments/assets/72c9d4d1-49e8-481d-8053-684153072431" />
Infinite Scroll + Selectable Rows set up (not a standard doc example just a screenshot from testing showing looks as expected now)
<img width="1384" alt="react light default and infinite scroll" src="https://github.com/user-attachments/assets/7164a7c3-0bb8-44d8-af34-d93daa836b7d" />
<img width="575" alt="react dark responsive infinite scroll" src="https://github.com/user-attachments/assets/aa84d065-020f-4fdc-ab0d-9d0b4530e80a" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the 4 Selectable Rows doc examples in the review env (rails + react): "Selectable Rows", "Selectable Rows (No Subrows)", "Selectable Rows (With Actions)", "Selectable Rows (No Actions Bar)"
2. Test each doc example: see the new color when a row is selected, resize the window to trigger a responsive table and see that the first column remains opaque when columns are scrolled horizontally, check dark mode and see the same thing there.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.