### PR TITLE
[PLAY-2252] Advanced Table: Add Rails Header Alignment Docs Examples

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -19,8 +19,8 @@ examples:
   - advanced_table_selectable_rows_actions_rails: Selectable Rows (With Actions)
   - advanced_table_selectable_rows_header_rails: Selectable Rows (No Actions Bar)
   - advanced_table_scrollbar_none: Advanced Table Scrollbar None
-  # - advanced_table_column_styling_rails: Column Styling
-  # - advanced_table_column_styling_column_headers_rails: Column Styling with Multiple Headers
+  - advanced_table_column_styling_rails: Column Styling
+  - advanced_table_column_styling_column_headers_rails: Column Styling with Multiple Headers
 
   react:
   - advanced_table_default: Default (Required Props)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2252](https://runway.powerhrg.com/backlog_items/PLAY-2252) re-adds two Rails Advanced Table doc examples. These were created in [PLAY-1893](https://runway.powerhrg.com/backlog_items/PLAY-1893) but not publicized then due to issues with the load time of the Rails doc example page. [PLAY-2255](https://runway.powerhrg.com/backlog_items/PLAY-2255) refactored some code to decrease the page's load time.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1369" alt="two column styling rails doc ex on page" src="https://github.com/user-attachments/assets/51e12b89-38cf-4259-b177-e03278ac7617" />


**How to test?** Steps to confirm the desired behavior:
1. Go to [Rails Advanced Table doc example page in the review env](https://pr4786.playbook.beta.px.powerapp.cloud/kits/advanced_table/rails). The page should load. Scroll down to the bottom and see two column styling doc examples, "Column Styling" and "Column Styling with Multiple Headers"


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.