### PR TITLE
[PLAY-2292] Advanced Table: Pinned Rows - Loading and Filtering

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -66,7 +66,7 @@ export function useTableState({
   const setExpanded = expandedControl ? expandedControl.onChange : setLocalExpanded;
   const columnVisibility = (columnVisibilityControl && columnVisibilityControl.value) ? columnVisibilityControl.value : localColumnVisibility;
   const setColumnVisibility = (columnVisibilityControl && columnVisibilityControl.onChange) ? columnVisibilityControl.onChange : setLocalColumnVisibility;
-  const rowPinning = pinnedRows?.value ?? localRowPinning
+  const rowPinning = loading ? { top: [] } : (pinnedRows?.value ?? localRowPinning);
   const onRowPinningChange = pinnedRows?.onChange ?? setLocalRowPinning
 
   // Virtualized data handling (chunked loading)
@@ -181,7 +181,9 @@ export function useTableState({
   });
 
   // Handle row pinning changes
-    useEffect(() => {
+  useEffect(() => {
+    if (loading) return;
+    
     const topPins = pinnedRows?.value?.top ?? [];
     if (topPins.length === 0) {
       onRowPinningChange({ top: [] });
@@ -198,7 +200,7 @@ export function useTableState({
       }
     });
     onRowPinningChange({ top: allPinned });
-  }, [table, pinnedRows?.value?.top?.join(',')]);
+  }, [table, pinnedRows?.value?.top?.join(','), loading]);
 
   // Check if table has any sub-rows
   const hasAnySubRows = table.getRowModel().rows.some(row => row.subRows && row.subRows.length > 0);


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2292](https://runway.powerhrg.com/backlog_items/PLAY-2292) is an SLA ticket re: the Pinned Rows React prop in the Sales to Closed Dashboard. 

**__WIP PR - for alpha testing__**

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.