### PR TITLE
[PLAY-2257] Draggable Kit: Dragging Between Drag Containers to not Break Page

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_draggable/context/types.ts
+++ b/playbook/app/pb_kits/playbook/pb_draggable/context/types.ts
@@ -6,14 +6,16 @@ export interface ItemType {
 
 export interface InitialStateType {
   items: ItemType[];
-  dragData: { id: string; initialGroup: string };
+  dragData: { id: string; initialGroup: string, originId?: string };
   isDragging: string;
   activeContainer: string;
 }
 
 export type ActionType =
   | { type: 'SET_ITEMS'; payload: ItemType[] }
-  | { type: 'SET_DRAG_DATA'; payload: { id: string; initialGroup: string } }
+  | { type: 'SET_DRAG_DATA'; payload: {
+    originId: string; id: string; initialGroup: string 
+} }
   | { type: 'SET_IS_DRAGGING'; payload: string }
   | { type: 'SET_ACTIVE_CONTAINER'; payload: string }
   | { type: 'CHANGE_CATEGORY'; payload: { itemId: string; container: string } }
@@ -35,4 +37,5 @@ export type ActionType =
     onDrop?: (container: string) => void;
     onDragOver?: (e: Event, container: string) => void;
     dropZone?: DropZoneConfig | string; // Can accept string for backward compatibility
+    providerId?: string;
   }


### PR DESCRIPTION
**What does this PR do?** 
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2257)

- Dragging drag items between doc examples should not break docs

**Screenshots:** 

https://github.com/user-attachments/assets/41386bc9-c68d-466e-bf65-4468d942e5ad


**How to test?** Steps to confirm the desired behavior:
1. Go to React docs for draggable kit and try dragging between doc examples

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.