### PR TITLE
[PLAY-2158] Popover Kit: Transition from popper.js to floating-ui - Rails

### DIFF
--- a/playbook/package.json
+++ b/playbook/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@floating-ui/dom": "^1.6.13",
     "@fortawesome/fontawesome-free": "^6.2.1",
-    "@popperjs/core": "^2.11.8",
     "classnames": "2.5.1",
     "flatpickr": "^4.6.13",
     "highcharts": "^11.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3149,7 +3149,7 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@popperjs/core@^2.11.8", "@popperjs/core@^2.9.0":
+"@popperjs/core@^2.9.0":
   version "2.11.8"
   resolved "https://npm.powerapp.cloud/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==


### PR DESCRIPTION
**What does this PR do?**

- Switch out popper.js for floating-ui for Rails
  - createPopper → computePosition
  - `autoUpdate` replaces Popper’s reactive re-rendering
  - Middleware replaces modifiers
  - Manually set x, y, and position styles like in the tooltip kit
- Remove the `@popperjs/core` ^2.11.8 dependency
  - Note: this is still a dependency for tiptap, so ^2.9.0 is still installed

https://runway.powerhrg.com/backlog_items/PLAY-2158

**Screenshots:** Screenshots to visualize your addition/change
![Screenshot 2025-07-01 at 1 54 06 PM](https://github.com/user-attachments/assets/152fc868-e3d8-42bf-b5f7-7b159b6dabbb)

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/popover/rails
2. Compare to prod


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.