### PR TITLE
[PLAY-2295] PB Website: Advanced Table as own Menu Item in Sidebar

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -258,6 +258,8 @@ private
       group_components.push(kit["components"].map do |component|
         {
           name: component["name"],
+          parent: component["parent"],
+          kit_section: component["kit_section"] || [],
           status: component["status"],
           icons_used: component["icons_used"],
           react_rendered: component["react_rendered"],
@@ -274,8 +276,8 @@ private
 
   def set_category
     @category = params[:category]
-    if categories.include?(@category) && helpers.category_has_kits?(category_kits: kit_categories, type: params[:type])
-      @category_kits = kit_categories
+    if categories.include?(@category) && helpers.category_has_kits?(category_kits: @category === "advanced_table" ? ["advanced_table"] : kit_categories, type: params[:type])
+      @category_kits = @category === "advanced_table" ? ["advanced_table"] : kit_categories
       @kits = params[:name]
     else
       redirect_to root_path, flash: { error: "That kit does not exist" }
@@ -297,6 +299,8 @@ private
 
     if matching_kit
       @kit = matching_kit[:name]
+      @kit_parent = matching_kit[:parent]
+      @kit_section = matching_kit[:kit_section]
       @kit_status = matching_kit[:status]
       @icons_used = matching_kit[:icons_used]
       @react_rendered = matching_kit[:react_rendered]

--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -295,7 +295,15 @@ private
   end
 
   def set_kit
-    matching_kit = all_kits.find { |kit| kit[:name] == params[:name] }
+    matching_kit = if params[:section].present?
+                     all_kits.find do |kit|
+                       kit[:parent] == params[:name] && kit[:name] == params[:section]
+                     end
+                   else
+                     all_kits.find do |kit|
+                       kit[:name] == params[:name] || kit[:parent] == params[:name]
+                     end
+                   end
 
     if matching_kit
       @kit = matching_kit[:name]

--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -148,9 +148,9 @@ class PagesController < ApplicationController
   def kit_show_rails
     @type = "rails"
     @users = Array.new(9) { Faker::Name.name }.paginate(page: params[:page], per_page: 2)
-    @table_data = advanced_table_mock_data if @kit == "advanced_table"
-    @table_data_with_id = advanced_table_mock_data_with_id if @kit == "advanced_table"
-    @table_data_no_subrows = advanced_table_mock_data_no_subrows if @kit == "advanced_table"
+    @table_data = advanced_table_mock_data if @kit == "advanced_table" || @kit_parent == "advanced_table"
+    @table_data_with_id = advanced_table_mock_data_with_id if @kit == "advanced_table" || @kit_parent == "advanced_table"
+    @table_data_no_subrows = advanced_table_mock_data_no_subrows if @kit == "advanced_table" || @kit_parent == "advanced_table"
     render "pages/kit_show"
   end
 

--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -138,9 +138,11 @@ module ApplicationHelper
     {
       label: kit.to_s.titleize,
       value: if @type == "react" || @type.nil?
-               "/kits/#{kit}/react"
+               "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}#{kit == 'advanced_table' ? '?type=react' : '/react'}"
+             elsif @type == "swift"
+               "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}/swift"
              else
-               @type == "swift" ? "/kits/#{kit}/swift" : "/kits/#{kit}"
+               "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}"
              end,
     }
   end
@@ -150,8 +152,8 @@ module ApplicationHelper
 
     MENU["kits"].each do |kit|
       kit_category = kit["category"]
-      # Modify this line to include both name and status in the components array
-      components = kit["components"].map { |c| { name: c["name"], status: c["status"] } }
+      # Modify this line to include name, status and parent in the components array
+      components = kit["components"].map { |c| { name: c["name"], status: c["status"], parent: c["parent"] } }
 
       all_kits << { kit_category => components }
     end
@@ -167,13 +169,15 @@ module ApplicationHelper
       if kit.is_a? Hash
         _kit_category, components = kit.first
         components.each do |component|
-          all_kits.push(component[:name]) if component[:status] != "beta"
+          name_or_parent = component[:parent].presence || component[:name]
+          all_kits.push(name_or_parent) if component[:status] != "beta"
         end
       else
         all_kits.push(kit)
       end
     end
 
+    all_kits.uniq!
     all_kits.sort!
 
     all_kits.each do |sorted_kit|

--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -142,7 +142,7 @@ module ApplicationHelper
              elsif @type == "swift"
                "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}/swift"
              else
-               "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}"
+               "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}#{kit == 'advanced_table' && '?type=rails'}"
              end,
     }
   end

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -27,7 +27,6 @@ const combineKitsandVisualGuidelines = (
 }
 
 const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
-  console.log(kits)
   const kitsAndGuidelines = combineKitsandVisualGuidelines(kits, VisualGuidelinesItems)
 
   const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -27,6 +27,7 @@ const combineKitsandVisualGuidelines = (
 }
 
 const KitSearch = ({ classname, id, kits }: KitSearchProps) => {
+  console.log(kits)
   const kitsAndGuidelines = combineKitsandVisualGuidelines(kits, VisualGuidelinesItems)
 
   const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)

--- a/playbook-website/app/javascript/components/MainSidebar/NavComponents/KitsNavComponent.tsx
+++ b/playbook-website/app/javascript/components/MainSidebar/NavComponents/KitsNavComponent.tsx
@@ -80,8 +80,14 @@ export const KitsNavItem = ({
 
   const generateLink = (categoryKey, sublink, type) => {
     if (sublink) {
+      if (categoryKey === "advanced_table") {
+        // Special case for advanced_table
+        const link = `/kits/advanced_table/${sublink}/${kitsType(type)}`;
+        return currentURL === link ? "" : link;
+      } else {
       const link = `/kits/${sublink}/${kitsType(type)}`;
       return currentURL === link ? "" : link;
+      }
     } else {
       const link = `/kit_category/${categoryKey}?type=${kitsType(type)}`;
       return currentURL === link ? "" : link;

--- a/playbook-website/app/javascript/components/MainSidebar/index.tsx
+++ b/playbook-website/app/javascript/components/MainSidebar/index.tsx
@@ -45,6 +45,7 @@ const MainSidebar = ({
   kits.map((obj: {[key: string]: string[]}) => {
   
     const key = Object.keys(obj)[0];
+    if (key === "advanced_table") return
     const orderedArray = obj[key].sort((a, b) => a.localeCompare(b));
     return { [key]: orderedArray };
   });

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -93,27 +93,27 @@
 </div>
 <div class="kit-show-wrapper">
   <div class="pb--kit-type-nav">
-
+    <% kit_value = @kit_parent.presence || @kit %>
     <%= pb_rails("nav", props: { orientation: "horizontal" }) do %>
-      <% if pb_doc_has_kit_type?(@kit, "rails") %>
-        <%= pb_rails("nav/item", props: { text: "Rails", link: kit_show_rails_path(@kit), active: action_name == 'kit_show_rails' }) %>
+      <% if pb_doc_has_kit_type?(kit_value, "rails") %>
+        <%= pb_rails("nav/item", props: { text: "Rails", link: kit_show_rails_path(kit_value), active: action_name == 'kit_show_rails' }) %>
       <% end %>
-      <% if pb_doc_has_kit_type?(@kit, "react") %>
-        <%= pb_rails("nav/item", props: { text: "React", link: kit_show_reacts_path(@kit), active: action_name == 'kit_show_react' }) %>
+      <% if pb_doc_has_kit_type?(kit_value, "react") %>
+        <%= pb_rails("nav/item", props: { text: "React", link: kit_show_reacts_path(kit_value), active: action_name == 'kit_show_react' }) %>
       <% end %>
-      <% if pb_doc_has_kit_type?(@kit, "swift") %>
-          <%= pb_rails("nav/item", props: { text: "Swift", link: kit_show_swift_path(@kit), active: action_name == 'kit_show_swift' }) %>
+      <% if pb_doc_has_kit_type?(kit_value, "swift") %>
+          <%= pb_rails("nav/item", props: { text: "Swift", link: kit_show_swift_path(kit_value), active: action_name == 'kit_show_swift' }) %>
       <% end %>
     <% end %>
 
     <%= pb_rails("section_separator") %>
   </div>
   <% if (action_name == "kit_show_rails") %>
-    <%= pb_kit(kit: @kit, dark_mode: dark_mode?) %>
+    <%= pb_kit(kit: kit_value, dark_mode: dark_mode?) %>
   <% elsif (action_name == "kit_show_react") %>
-    <%= pb_kit(kit: @kit, type: "react", dark_mode: dark_mode?) %>
+    <%= pb_kit(kit: kit_value, type: "react", dark_mode: dark_mode?, kit_section: @kit_section) %>
   <% elsif (action_name == "kit_show_swift") %>
-    <%= pb_kit(kit: @kit, type: "swift", dark_mode: dark_mode?, show_code: false) %>
+    <%= pb_kit(kit: kit_value, type: "swift", dark_mode: dark_mode?, show_code: false) %>
   <% end %>
 
   <% unless (action_name == "kit_show_swift") %>
@@ -123,15 +123,4 @@
     </div>
   <% end %>
 
-    <% if (action_name == "kit_show_rails") %>
-      <br>
-      <%= pb_rails("docs/kit_api", props: { kit: @kit, dark: dark_mode? }) %>
-    <% elsif (action_name == "kit_show_react") %>
-      <div data-action="toggle" data-togglable="prop_example" class="pb--propsTable">
-        <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm", margin_top: "sm" }) %>
-        <%= react_component("AvailableProps",
-          availableProps: Playbook::PbDocs::KitExample.new(kit: @kit, example_title: "Default", example_key: @kit, type: "react").available_props )
-        %>
-      </div>
-    <% end %>
 </div>

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -109,7 +109,7 @@
     <%= pb_rails("section_separator") %>
   </div>
   <% if (action_name == "kit_show_rails") %>
-    <%= pb_kit(kit: kit_value, dark_mode: dark_mode?) %>
+    <%= pb_kit(kit: kit_value, dark_mode: dark_mode?, kit_section: @kit_section) %>
   <% elsif (action_name == "kit_show_react") %>
     <%= pb_kit(kit: kit_value, type: "react", dark_mode: dark_mode?, kit_section: @kit_section) %>
   <% elsif (action_name == "kit_show_swift") %>

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -4,10 +4,14 @@
       <%= react_component("DarkModeToggle", initMode: cookies[:dark_mode] )%>
     </div>
   <% end %>
+    <% kit_value = @kit_parent.presence || @kit %>
     <%= pb_rails("flex", props: { justify: "between", align_items: "start" }) do %>
     <%= pb_rails("flex/flex_item", props: { flex: "9"}) do %>
       <%= pb_rails("flex", props: { orientation: "column"}) do %>
-        <%= pb_rails("title", props: { text: pb_kit_title(@kit), tag: "h1", size: 1, margin_top: "xl" }) %>
+        <%= pb_rails("title", props: { text: pb_kit_title(kit_value), tag: "h1", size: 1, margin_top: "xl" }) %>
+        <% if @kit_parent.present? %>
+            <%= pb_rails("title", props: { text: pb_kit_title(@kit), size: 3, margin_top: "xs", bold: false }) %>
+        <% end %>
         <% if @kit_status === "beta" %>
           <%= pb_rails("card", props: {highlight: {position: "side", color:"primary", shadow:"deep"}, margin_y: "md", padding: "sm"}) do %>
             <%= pb_rails("flex", props:{ align: "center" }) do %>
@@ -93,7 +97,6 @@
 </div>
 <div class="kit-show-wrapper">
   <div class="pb--kit-type-nav">
-    <% kit_value = @kit_parent.presence || @kit %>
     <%= pb_rails("nav", props: { orientation: "horizontal" }) do %>
       <% if pb_doc_has_kit_type?(kit_value, "rails") %>
         <%= pb_rails("nav/item", props: { text: "Rails", link: kit_show_rails_path(@kit), active: action_name == 'kit_show_rails' }) %>

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -96,13 +96,13 @@
     <% kit_value = @kit_parent.presence || @kit %>
     <%= pb_rails("nav", props: { orientation: "horizontal" }) do %>
       <% if pb_doc_has_kit_type?(kit_value, "rails") %>
-        <%= pb_rails("nav/item", props: { text: "Rails", link: kit_show_rails_path(kit_value), active: action_name == 'kit_show_rails' }) %>
+        <%= pb_rails("nav/item", props: { text: "Rails", link: kit_show_rails_path(@kit), active: action_name == 'kit_show_rails' }) %>
       <% end %>
       <% if pb_doc_has_kit_type?(kit_value, "react") %>
-        <%= pb_rails("nav/item", props: { text: "React", link: kit_show_reacts_path(kit_value), active: action_name == 'kit_show_react' }) %>
+        <%= pb_rails("nav/item", props: { text: "React", link: kit_show_reacts_path(@kit), active: action_name == 'kit_show_react' }) %>
       <% end %>
       <% if pb_doc_has_kit_type?(kit_value, "swift") %>
-          <%= pb_rails("nav/item", props: { text: "Swift", link: kit_show_swift_path(kit_value), active: action_name == 'kit_show_swift' }) %>
+          <%= pb_rails("nav/item", props: { text: "Swift", link: kit_show_swift_path(@kit), active: action_name == 'kit_show_swift' }) %>
       <% end %>
     <% end %>
 

--- a/playbook-website/app/views/pages/kit_show.html.erb
+++ b/playbook-website/app/views/pages/kit_show.html.erb
@@ -123,4 +123,15 @@
     </div>
   <% end %>
 
+    <% if (action_name == "kit_show_rails") %>
+      <br>
+      <%= pb_rails("docs/kit_api", props: { kit: kit_value, dark: dark_mode? }) %>
+    <% elsif (action_name == "kit_show_react") %>
+      <div data-action="toggle" data-togglable="prop_example" class="pb--propsTable">
+        <%= pb_rails("title", props: { text: "Available Props", size: 3, margin_bottom: "sm", margin_top: "sm" }) %>
+        <%= react_component("AvailableProps",
+          availableProps: Playbook::PbDocs::KitExample.new(kit: kit_value, example_title: "Default", example_key: kit_value, type: "react").available_props )
+        %>
+      </div>
+    <% end %>
 </div>

--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -19,6 +19,74 @@ react_only: &2
 swift_only:
 - swift
 kits:
+- category: advanced_table
+  description: The Advanced Table can be used to display complex, nested data in
+      a way that allows for expansion and/or sorting.
+  components:
+  - name: default
+    parent: advanced_table
+    kit_section: ["Default (Required Props)", "Table Options", "Table Props", "Table with No Subrows or Expansion" ]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
+  - name: sorting
+    parent: advanced_table
+    kit_section: ["Enable Sorting", "Sort Control", "Custom Sort"]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
+  - name: pagination_&_data_states
+    parent: advanced_table
+    kit_section: ["Pagination", "Pagination Props", "Loading State", "Inline Row Loading", "Infinite Scroll"]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
+  - name: row_interaction
+    parent: advanced_table
+    kit_section: ["Expanded Control", "Expand by Depth", "SubRow Headers", "Pinned Rows", "Selectable Rows", "Selectable Rows (No Subrows)", "Selectable Rows (With Actions)", "Selectable Rows (No Actions Bar)"]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
+  - name: column_configuration
+    parent: advanced_table
+    kit_section: ["Column Visibility Control", "Column Visibility Control With State", "Column Visibility Control with Custom Dropdown", "Column Visibility Control with Multi-Header Columns", "Multi-Header Columns", "Multi-Header Columns (Multiple Levels)", "Multi-Header Columns with Custom Cells"]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
+  - name: cell_behavior
+    parent: advanced_table
+    kit_section: ["Custom Components for Cells", "Custom Header Cell", "Inline Cell Editing"]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
+  - name: layout_&_positioning
+    parent: advanced_table
+    kit_section: ["Sticky Header", "Sticky Header for Responsive Table", "Sticky Columns", "Sticky Columns with Sticky Header", "Responsive Tables", "Fullscreen", "Advanced Table Scrollbar None"]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
+  - name: styling
+    parent: advanced_table
+    kit_section: ["Collapsible Trail","Row Styling", "Column Styling", "Column Styling with Multiple Headers", "Column Group Border Color"]
+    platforms: *1
+    status: stable
+    icons_used: true
+    react_rendered: false
+    enhanced_element_used: true
 - category: alerts_and_dialogs
   description:
   components:
@@ -116,14 +184,6 @@ kits:
       the ability to sort, filter, and paginate data.
     status: stable
     icons_used: false
-    react_rendered: false
-    enhanced_element_used: true
-  - name: advanced_table
-    platforms: *1
-    description: The Advanced Table can be used to display complex, nested data in
-      a way that allows for expansion and/or sorting.
-    status: stable
-    icons_used: true
     react_rendered: false
     enhanced_element_used: true
   - name: list

--- a/playbook-website/config/routes.rb
+++ b/playbook-website/config/routes.rb
@@ -26,6 +26,12 @@ Rails.application.routes.draw do
   get "kits/:name/rails",           to: "pages#kit_show_rails",           as: "kit_show_rails"
   get "kits/:name/react",           to: "pages#kit_show_react",           as: "kit_show_reacts"
   get "kits/:name/swift",           to: "pages#kit_show_swift",           as: "kit_show_swift"
+
+  ## Kits with section
+  get "kits/:name/:section/react",  to: "pages#kit_show_react",  as: "kit_show_react_section"
+  get "kits/:name/:section/rails",  to: "pages#kit_show_rails",  as: "kit_show_rails_section"
+  get "kits/:name/:section/swift",  to: "pages#kit_show_swift",  as: "kit_show_swift_section"
+
   get "kit_category/:category",         to: "pages#kit_category_show_rails",  as: "kit_category_show"
   get "kit_category/:category/rails",   to: "pages#kit_category_show_rails",  as: "kit_category_show_rails"
   get "kit_category/:category/react",   to: "pages#kit_category_show_react",  as: "kit_category_show_reacts"

--- a/playbook-website/lib/pb_doc_helper.rb
+++ b/playbook-website/lib/pb_doc_helper.rb
@@ -6,9 +6,16 @@ module PlaybookWebsite
       title.remove("pb_").titleize.tr("_", " ")
     end
 
-    def pb_kit(kit: "", type: "rails", show_code: true, limit_examples: false, dark_mode: false, variants: [])
-      examples = pb_doc_kit_examples(kit, type)
+    def pb_kit(kit: "", type: "rails", show_code: true, limit_examples: false, dark_mode: false, variants: [], kit_section: [])
+      examples = pb_doc_kit_examples(kit, type) || []
       examples.select! { |elem| variants.any? { |variant| elem.key?(variant) } } unless variants.empty?
+      unless kit_section.empty?
+        examples.select! do |example|
+          example_title = example.values.first
+          kit_section.any? { |title| example_title.include?(title) }
+        end
+      end
+
       examples = examples.first(1) if limit_examples
       examples.map do |example|
         pb_rails "docs/kit_example", props: {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -12,7 +12,6 @@ examples:
   - advanced_table_custom_cell_rails: Custom Components for Cells
   - advanced_table_column_headers: Multi-Header Columns
   - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
-  - advanced_table_column_border_color_rails: Column Group Border Color
   - advanced_table_no_subrows: Table with No Subrows or Expansion
   - advanced_table_selectable_rows_rails: Selectable Rows
   - advanced_table_selectable_rows_no_subrows_rails: Selectable Rows (No Subrows)
@@ -21,10 +20,11 @@ examples:
   - advanced_table_scrollbar_none: Advanced Table Scrollbar None
   - advanced_table_column_styling_rails: Column Styling
   - advanced_table_column_styling_column_headers_rails: Column Styling with Multiple Headers
+  - advanced_table_column_border_color_rails: Column Group Border Color
+
 
   react:
   - advanced_table_default: Default (Required Props)
-  - advanced_table_loading: Loading State
   - advanced_table_sort: Enable Sorting
   - advanced_table_sort_control: Sort Control
   - advanced_table_custom_sort: Custom Sort
@@ -38,30 +38,31 @@ examples:
   - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
   - advanced_table_sticky_columns: Sticky Columns
   - advanced_table_sticky_columns_and_header: Sticky Columns with Sticky Header
-  - advanced_table_inline_row_loading: Inline Row Loading
   - advanced_table_responsive: Responsive Tables
   - advanced_table_custom_cell: Custom Components for Cells
   - advanced_table_with_custom_header: Custom Header Cell
   - advanced_table_pagination: Pagination
   - advanced_table_pagination_with_props: Pagination Props
+  - advanced_table_loading: Loading State
+  - advanced_table_inline_row_loading: Inline Row Loading
   - advanced_table_column_headers: Multi-Header Columns
   - advanced_table_column_headers_multiple: Multi-Header Columns (Multiple Levels)
   - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
-  - advanced_table_column_border_color: Column Group Border Color
   - advanced_table_no_subrows: Table with No Subrows or Expansion
+  - advanced_table_pinned_rows: Pinned Rows
   - advanced_table_selectable_rows: Selectable Rows
   - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
   - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)
   - advanced_table_selectable_rows_header: Selectable Rows (No Actions Bar)
   - advanced_table_inline_editing: Inline Cell Editing
-  - advanced_table_fullscreen: Fullscreen
   - advanced_table_column_visibility: Column Visibility Control
   - advanced_table_column_visibility_with_state: Column Visibility Control With State
   - advanced_table_column_visibility_custom: Column Visibility Control with Custom Dropdown
   - advanced_table_column_visibility_multi: Column Visibility Control with Multi-Header Columns
-  - advanced_table_pinned_rows: Pinned Rows
   - advanced_table_scrollbar_none: Advanced Table Scrollbar None
   - advanced_table_row_styling: Row Styling
   - advanced_table_column_styling: Column Styling
   - advanced_table_column_styling_column_headers: Column Styling with Multiple Headers
+  - advanced_table_column_border_color: Column Group Border Color
+  - advanced_table_fullscreen: Fullscreen
   - advanced_table_infinite_scroll: Infinite Scroll


### PR DESCRIPTION
**What does this PR do?** 

[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2295)

Covered in this story:

- ✅ Advanced Table as its own menu item (category)
- ✅ sub menu items as per handoff
- ✅ each submenu item to contain required docs only
- ✅ Advanced Table to still show up in search bar
- ✅ clicking on searchbar item will direct to category page for advanced table
- ✅ dark mode toggle to work
- ✅ rails side: table data to work
- ✅ rails side: sections to contain correct docs
- ✅ routes to be advanced_table/section

**Screenshots:** Screenshots to visualize your addition/change

![Screenshot 2025-07-07 at 4 09 45 PM](https://github.com/user-attachments/assets/83d732bf-b356-4b5c-b221-f71b072bc505)

![Screenshot 2025-07-07 at 4 10 48 PM](https://github.com/user-attachments/assets/22ccf38e-10b2-491b-aaa1-4dcb60c81a3f)


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.