### PR TITLE
Dialog Kit: Remove Dialog kit from react bindings file

### DIFF
--- a/playbook/app/entrypoints/playbook-rails-react-bindings.js
+++ b/playbook/app/entrypoints/playbook-rails-react-bindings.js
@@ -5,10 +5,6 @@ import ujs from 'webpacker-react/ujs'
 
 import BarGraph from 'kits/pb_bar_graph/_bar_graph'
 import CircleChart from 'kits/pb_circle_chart/_circle_chart'
-import Dialog from 'kits/pb_dialog/_dialog'
-import DialogBody from 'kits/pb_dialog/child_kits/_dialog_body'
-import DialogFooter from 'kits/pb_dialog/child_kits/_dialog_footer'
-import DialogHeader from 'kits/pb_dialog/child_kits/_dialog_header'
 import DistributionBar from 'kits/pb_distribution_bar/_distribution_bar'
 import Gauge from 'kits/pb_gauge/_gauge'
 import Legend from 'kits/pb_legend/_legend'
@@ -22,10 +18,6 @@ import PhoneNumberInput from 'kits/pb_phone_number_input/_phone_number_input'
 WebpackerReact.registerComponents({
   BarGraph,
   CircleChart,
-  Dialog,
-  DialogBody,
-  DialogFooter,
-  DialogHeader,
   DistributionBar,
   MultiLevelSelect,
   Legend,


### PR DESCRIPTION
**What does this PR do?** 
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2307)

The Dialog kit has imports/exports included in this [playbook-rails-react-bindings.js file](https://github.com/powerhome/playbook/blob/master/playbook/app/entrypoints/playbook-rails-react-bindings.js) 
This is a remnant of when this kit was a react rendered rails kit on the rails side. We already did the work to create a Rails only Dialog kit so the imports/exports of Dialog is not longer needed in this bindings file


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** 
Test Dialog kit docs on Rails side.
Alpha test in Nitro


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.