### PR TITLE
[PLAY-2308] Website Search Bug - after Advanced Table Restructuring

### DIFF
--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -142,7 +142,7 @@ module ApplicationHelper
              elsif @type == "swift"
                "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}/swift"
              else
-               "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}#{kit == 'advanced_table' && '?type=rails'}"
+               "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}#{kit == 'advanced_table' ? '?type=rails' : ''}"
              end,
     }
   end

--- a/playbook-website/app/views/pages/playbook_icons.html.erb
+++ b/playbook-website/app/views/pages/playbook_icons.html.erb
@@ -11,77 +11,79 @@
   <% end %>
 
   <div class="content-wrapper">
-    <%= pb_rails("flex", props: { justify: "evenly", gap: "md" }) do %>
-      <%= pb_rails("flex", props: { gap: "md", max_width: "lg", orientation: "column"}) do %>
-        <%= pb_rails("title", props: { size: { xs: "3", sm: "2", md: "1", lg: "1", xl: "1" }, text: "Icons" }) %>
-        <%= pb_rails("flex", props: { classname: "description-default", orientation: "column" }) do %>
-          <%= pb_rails("body", props: {
-            padding_bottom: "sm",
-            text: "Icons are a core part of Playbook’s visual language. Our custom icon set is designed to support clear, consistent, and accessible interfaces. Use them to enhance navigation, reinforce meaning, and improve communication across all digital products."
-          }) %>
-          <%= pb_rails("link", props: {
-            href: "https://playbook.powerapp.cloud/kits/icon/react",
-            target: "child",
-            text: "To use them in your project, check out our Icon kit."
-          }) %>
-        <% end %>
-        <%= pb_rails("flex", props: { classname: "description-mobile", orientation: "column" }) do %>
-          <%= pb_rails("detail", props: {
-            color: "default",
-            padding_bottom: "xs",
-            text: "Icons are a core part of Playbook’s visual language. Our custom icon set is designed to support clear, consistent, and accessible interfaces. Use them to enhance navigation, reinforce meaning, and improve communication across all digital products."
-          }) %>
-          <%= pb_rails("detail") do %>
+    <%= pb_rails("flex", props: { gap: "md", justify: "evenly" }) do %>
+      <%= pb_rails("flex", props: { justify: "center", flex: "1" }) do %>
+        <%= pb_rails("flex", props: { gap: "md", max_width: "lg", orientation: "column"}) do %>
+          <%= pb_rails("title", props: { size: { xs: "3", sm: "2", md: "1", lg: "1", xl: "1" }, text: "Icons" }) %>
+          <%= pb_rails("flex", props: { classname: "description-default", orientation: "column" }) do %>
+            <%= pb_rails("body", props: {
+              padding_bottom: "sm",
+              text: "Icons are a core part of Playbook’s visual language. Our custom icon set is designed to support clear, consistent, and accessible interfaces. Use them to enhance navigation, reinforce meaning, and improve communication across all digital products."
+            }) %>
             <%= pb_rails("link", props: {
               href: "https://playbook.powerapp.cloud/kits/icon/react",
               target: "child",
-              text: "To use them in your project, check out our Icon kit.",
+              text: "To use them in your project, check out our Icon kit."
             }) %>
           <% end %>
-        <% end %>
-        <%= pb_rails("dropdown", props: {
-          options: @icon_categories,
-          selected_value: nil,
-          id: "icon-category-dropdown"
-        }) do %>
-          <%= pb_rails("dropdown/dropdown_trigger") do %>
-            <%= pb_rails("button", props: {
-              full_width: true,
-              icon: "sort",
-              icon_right: true,
-              id: "icon-category-trigger-button",
-              variant: "secondary",
-            }) do %>
-              <span id="icon-category-selected-label">Icon Categories</span>
+          <%= pb_rails("flex", props: { classname: "description-mobile", orientation: "column" }) do %>
+            <%= pb_rails("detail", props: {
+              color: "default",
+              padding_bottom: "xs",
+              text: "Icons are a core part of Playbook’s visual language. Our custom icon set is designed to support clear, consistent, and accessible interfaces. Use them to enhance navigation, reinforce meaning, and improve communication across all digital products."
+            }) %>
+            <%= pb_rails("detail") do %>
+              <%= pb_rails("link", props: {
+                href: "https://playbook.powerapp.cloud/kits/icon/react",
+                target: "child",
+                text: "To use them in your project, check out our Icon kit.",
+              }) %>
             <% end %>
           <% end %>
-          <%= pb_rails("dropdown/dropdown_container", props: { max_width: "xs" }) do %>
-            <% @icon_categories.each do |option| %>
-              <%= pb_rails("dropdown/dropdown_option", props: { option: option }) do %>
-                <%= pb_rails("body", props: { text: option[:label], size: "sm" }) %>
+          <%= pb_rails("dropdown", props: {
+            options: @icon_categories,
+            selected_value: nil,
+            id: "icon-category-dropdown"
+          }) do %>
+            <%= pb_rails("dropdown/dropdown_trigger") do %>
+              <%= pb_rails("button", props: {
+                full_width: true,
+                icon: "sort",
+                icon_right: true,
+                id: "icon-category-trigger-button",
+                variant: "secondary",
+              }) do %>
+                <span id="icon-category-selected-label">Icon Categories</span>
+              <% end %>
+            <% end %>
+            <%= pb_rails("dropdown/dropdown_container", props: { max_width: "xs" }) do %>
+              <% @icon_categories.each do |option| %>
+                <%= pb_rails("dropdown/dropdown_option", props: { option: option }) do %>
+                  <%= pb_rails("body", props: { text: option[:label], size: "sm" }) %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>
-        <% end %>
-        <% @icons_by_category.sort.each do |category, icons| %>
-          <%= pb_rails("flex", props: { align_self: "stretch", gap: "sm", orientation: "column"}) do %>
-            <%= pb_rails("caption", props: {
-              id: category.parameterize,
-              size: "lg",
-              text: category
-            }) %>
-            <%= pb_rails("layout", props: {
-              align_self: "stretch",
-              classname: "icon-grid",
-              layout: "collection"
-            }) do %>
-              <%= pb_rails("layout/body") do %>
-                <% icons.sort_by { |i| i["name"] }.each do |icon| %>
-                  <%= pb_rails("selectable_card_icon", props: {
-                    classname: "icon-card",
-                    icon: icon["name"],
-                    title_text: icon["name"]
-                  }) %>
+          <% @icons_by_category.sort.each do |category, icons| %>
+            <%= pb_rails("flex", props: { align_self: "stretch", gap: "sm", orientation: "column"}) do %>
+              <%= pb_rails("caption", props: {
+                id: category.parameterize,
+                size: "lg",
+                text: category
+              }) %>
+              <%= pb_rails("layout", props: {
+                align_self: "stretch",
+                classname: "icon-grid",
+                layout: "collection"
+              }) do %>
+                <%= pb_rails("layout/body") do %>
+                  <% icons.sort_by { |i| i["name"] }.each do |icon| %>
+                    <%= pb_rails("selectable_card_icon", props: {
+                      classname: "icon-card",
+                      icon: icon["name"],
+                      title_text: icon["name"]
+                    }) %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>
@@ -90,7 +92,7 @@
       <% end %>
 
       <%= pb_rails("section_separator", props: { align_self: "stretch", classname: "icon-categories-section-separator", orientation: "vertical" }) %>
-      <%= pb_rails("flex/flex_item", props: { flex: "1", classname: "icon-categories-sidebar" }) do %>
+      <%= pb_rails("flex/flex_item", props: { flex: "none", classname: "icon-categories-sidebar" }) do %>
         <%= pb_rails("caption", props: { text: "Icon Categories" }) %>
         <%= pb_rails("nav", props: { variant: "subtle" }) do %>
           <% @icon_categories.each do |category| %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2308](https://runway.powerhrg.com/backlog_items/PLAY-2308) addresses a bug with searching on the Playbook website following code changes in the Advanced Table Docs Restructuring story [PLAY-2295](https://runway.powerhrg.com/backlog_items/PLAY-2295). Changing an and operator to a ternary (matching line 141 right above it) solves the search issue.

When a user tried to navigate from a /rails kit page via the search bar, they would be redirected back to the homepage. 

**How to test?** Steps to confirm the desired behavior:
1. Go to the Playbook website in the review env.
2. Navigate to a Rails kit page. 
3. Search for another kit or different page in the search bar. You should successfully navigate to the destination page now. 

BONUS:
This PR also adjusts some flex sizing for the newly unbeta'd playbook icons page (/playbook_icons) - for laptop screensizes/large external monitors, the Icon section is now centered and the icon categories sidebar stays small
How to test? go to https://pr4881.playbook.beta.px.powerapp.cloud/playbook_icons on an external monitor or laptop and see Icon main section centered and the icon category sidebar stays small.

#### Screenshots:
Large sidebar on Icon Page in current prod - external
<img width="2547" height="1328" alt="external icon page" src="https://github.com/user-attachments/assets/2f7af0f4-f4a6-4346-8170-18091353fd3e" />

Icon Page on Laptop screen now
<img width="1582" height="956" alt="icon page flex change laptop 4" src="https://github.com/user-attachments/assets/241043db-7d8b-4641-a7eb-fb91af38c387" />
Icon Page on External screen now
<img width="1770" height="965" alt="icon page flex change external 4" src="https://github.com/user-attachments/assets/8e6778f7-e5fd-4e67-b311-6a5f3febccd6" />


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.