### PR TITLE
[PLAY-2303] WebpackerReact Config for Playbook kits to come from Playbook

### DIFF
--- a/playbook/app/entrypoints/playbook-rails-react-bindings.js
+++ b/playbook/app/entrypoints/playbook-rails-react-bindings.js
@@ -37,7 +37,19 @@ WebpackerReact.registerComponents({
   PhoneNumberInput
 })
 
-ujs.setup(
-  () => WebpackerReact.mountComponents(),
-  () => WebpackerReact.unmountComponents()
-)
+//export mount/unmount functions for use if needed
+export const mountPlaybookReactKits = () => {
+  WebpackerReact.mountComponents()
+}
+
+export const unmountPlaybookReactKits = () => {
+  WebpackerReact.unmountComponents()
+}
+
+ujs.setup(mountPlaybookReactKits, unmountPlaybookReactKits)
+
+const observer = new MutationObserver(() => {
+  mountPlaybookReactKits()
+})
+
+observer.observe(document.body, { childList: true, subtree: true })


### PR DESCRIPTION
**What does this PR do?**
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2303)

Currently, when we render Playbook kits via ajax (or Turbo) sometimes we need to call WebpackerReact.mountComponents() to initialize the Playbook kits. This seems to be an issue with all kits listed within [this file](https://github.com/powerhome/playbook/blob/master/playbook/app/entrypoints/playbook-rails-react-bindings.js), most notable being the Typeahead since it is used everywhere.

This workaround of having to call WebpackerReact.mountComponents() has existed for a long time, but with the Vite migration work we want to try and find a better solution for the problem of rendering react rendered rails kits.

The [webpack cleanup work ](https://github.com/powerhome/nitro-web/pull/49189/files) cleaned up the repeated script tags in many files that were calling WebpackerReact.mountComponents() individually since [this code here](https://github.com/powerhome/nitro-web/blob/master/components/nitro_react/renderer/index.tsx#L86-L87) does that at a more macro level.

This Playbook change allows us to remove that call to WebpackerReact.mountComponents() from the renderer/index in nitro_react 

**Screenshots:** 


**How to test?** Steps to confirm the desired behavior:
1. Smoke Test website, especially for Rails Typeahead, MultilevelSelect and highchart Kits
2. [Nitro Alpha here](https://github.com/powerhome/nitro-web/pull/49916)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.