### PR TITLE
[PLAY-2126] Phone Number Kit: strictMode Prop Accept Numbers and Max Length

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -38,6 +38,7 @@ type PhoneNumberInputProps = {
   required?: boolean,
   value?: string,
   formatAsYouType?: boolean,
+  strictMode?: boolean,
   countrySearch?: boolean,
 }
 
@@ -94,6 +95,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.Ref<unknown>
     preferredCountries = [],
     value = "",
     formatAsYouType = false,
+    strictMode = false,
     countrySearch = false,
   } = props
 
@@ -256,6 +258,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.Ref<unknown>
       countrySearch: countrySearch,
       fixDropdownWidth: false,
       formatAsYouType: formatAsYouType,
+      strictMode: strictMode,
       hiddenInput: hiddenInputs ? () => ({
         phone: `${name}_full`,
         country: `${name}_country_code`,

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_strict_mode.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_strict_mode.html.erb
@@ -1,0 +1,10 @@
+<%= pb_rails("phone_number_input", props: {
+    strict_mode: true,
+}) %>
+
+<%= pb_rails("body", props: { text: "With format_as_you_type" }) %>
+
+<%= pb_rails("phone_number_input", props: {
+    strict_mode: true,
+    format_as_you_type: true,
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_strict_mode.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_strict_mode.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import Body from '../../pb_body/_body'
+import PhoneNumberInput from '../../pb_phone_number_input/_phone_number_input'
+
+const PhoneNumberInputStrictMode = (props) => {
+
+    return (
+        <>
+            <PhoneNumberInput
+                id="strict"
+                strictMode
+                {...props}
+            />
+            <Body>With formatAsYouType</Body>
+            <PhoneNumberInput
+                formatAsYouType
+                id="strict"
+                strictMode
+                {...props}
+            />
+        </>
+    );
+};
+
+export default PhoneNumberInputStrictMode;

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_strict_mode.md
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_strict_mode.md
@@ -1,0 +1,3 @@
+Ignore any irrelevant characters and cap the length at the maximum valid number length.
+
+This can be combined with `format_as_you_type` / `formatAsYouType`. 

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/example.yml
@@ -10,6 +10,7 @@ examples:
   - phone_number_input_clear_field: Clearing the Input Field
   - phone_number_input_access_input_element: Accessing the Input Element
   - phone_number_input_format: Format as You Type
+  - phone_number_input_strict_mode: Strict Mode
   - phone_number_input_country_search: Country Search
 
   rails:
@@ -20,5 +21,6 @@ examples:
   - phone_number_input_exclude_countries: Exclude Countries
   - phone_number_input_validation: Form Validation
   - phone_number_input_format: Format as You Type
+  - phone_number_input_strict_mode: Strict Mode
   - phone_number_input_hidden_inputs: Hidden Inputs
   - phone_number_input_country_search: Country Search

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/index.js
@@ -7,4 +7,5 @@ export { default as PhoneNumberInputValidation } from './_phone_number_input_val
 export { default as PhoneNumberInputClearField } from './_phone_number_input_clear_field'
 export { default as PhoneNumberInputAccessInputElement } from './_phone_number_input_access_input_element'
 export { default as PhoneNumberInputFormat } from './_phone_number_input_format'
+export { default as PhoneNumberInputStrictMode } from './_phone_number_input_strict_mode'
 export { default as PhoneNumberInputCountrySearch } from './_phone_number_input_country_search'

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/phone_number_input.rb
@@ -25,6 +25,8 @@ module Playbook
                    default: ""
       prop :format_as_you_type, type: Playbook::Props::Boolean,
                                 default: false
+      prop :strict_mode, type: Playbook::Props::Boolean,
+                         default: false
       prop :hidden_inputs, type: Playbook::Props::Boolean,
                            default: false
       prop :country_search, type: Playbook::Props::Boolean,
@@ -41,6 +43,7 @@ module Playbook
           disabled: disabled,
           error: error,
           formatAsYouType: format_as_you_type,
+          strictMode: strict_mode,
           hiddenInputs: hidden_inputs,
           initialCountry: initial_country,
           label: label,

--- a/playbook/spec/pb_kits/playbook/kits/phone_number_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/phone_number_input_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Playbook::PbPhoneNumberInput do
   it { is_expected.to define_prop(:error).with_default("") }
   it { is_expected.to define_prop(:value).with_default("") }
   it { is_expected.to define_boolean_prop(:format_as_you_type).with_default(false) }
+  it { is_expected.to define_boolean_prop(:strict_mode).with_default(false) }
   it { is_expected.to define_boolean_prop(:country_search).with_default(false) }
 
   describe "#classname" do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Add strictMode prop which only accepts numbers and caps the input at a max length.
This resulted from an exploration into formatAsYouType not working as expected.

https://runway.powerhrg.com/backlog_items/PLAY-2126

**Screenshots:** Screenshots to visualize your addition/change
<img width="654" height="367" alt="Screenshot 2025-07-16 at 11 32 06 AM" src="https://github.com/user-attachments/assets/5f2b9d9a-97e9-421e-b737-16febb13b980" />

**How to test?** Steps to confirm the desired behavior:
1. Go to kits/phone_number_input/react#format-as-you-type
2. Go to rails


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.