### PR TITLE
[PLAY-2243] Checkbox Kit: Custom Indeterminate Main Checkbox Labels - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.rb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/checkbox.rb
@@ -6,6 +6,8 @@ module Playbook
       prop :error, type: Playbook::Props::Boolean, default: false
       prop :checked, type: Playbook::Props::Boolean, default: false
       prop :indeterminate_main, type: Playbook::Props::Boolean, default: false
+      prop :indeterminate_main_labels, type: Playbook::Props::Array,
+                                       default: []
       prop :indeterminate_parent
       prop :text
       prop :value
@@ -49,10 +51,19 @@ module Playbook
       end
 
       def data
-        Hash(prop(:data)).merge(
+        base_data = Hash(prop(:data)).merge(
           pb_checkbox_indeterminate_main: indeterminate_main,
           pb_checkbox_indeterminate_parent: indeterminate_parent
         )
+
+        if indeterminate_main && indeterminate_main_labels.size == 2
+          base_data.merge!(
+            pb_checkbox_indeterminate_main_label_check: indeterminate_main_labels[0],
+            pb_checkbox_indeterminate_main_label_uncheck: indeterminate_main_labels[1]
+          )
+        end
+
+        base_data
       end
 
     private

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_indeterminate.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_indeterminate.html.erb
@@ -9,10 +9,10 @@
     <tr>
       <th>
         <%= pb_rails("checkbox", props: {
-          text: "Uncheck All",
           value: "checkbox-value",
           name: "main-checkbox",
           indeterminate_main: true,
+          indeterminate_main_labels: ["Check All Ice Cream", "Uncheck All Ice Cream"],
           id: "indeterminate-checkbox"
         }) %>
       </th>

--- a/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_indeterminate_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/docs/_checkbox_indeterminate_rails.md
@@ -1,1 +1,2 @@
 If you want to use indeterminate, "check/uncheck all" checkboxes, add `indeterminate_main: true` and an `id` to the main checkbox. Then, add an `indeterminate_parent` prop with the main checkbox's `id` to the children checkboxes.
+If you want to customize the main checkbox labels, set an array `indeterminate_main_labels` with "Check All" and "Uncheck All" labels.

--- a/playbook/app/pb_kits/playbook/pb_checkbox/index.js
+++ b/playbook/app/pb_kits/playbook/pb_checkbox/index.js
@@ -23,7 +23,9 @@ export default class PbCheckbox extends PbEnhancedElement {
       mainCheckbox.checked = checkedCount > 0;
 
       // Determine the main checkbox label based on the number of checked checkboxes
-      const text = checkedCount === 0 ? 'Check All' : 'Uncheck All';
+      const checkAllLabel = mainCheckboxWrapper.dataset.pbCheckboxIndeterminateMainLabelCheck ?? 'Check All'
+      const uncheckAllLabel = mainCheckboxWrapper.dataset.pbCheckboxIndeterminateMainLabelUncheck ?? 'Uncheck All'
+      const text = checkedCount === 0 ? checkAllLabel : uncheckAllLabel;
 
       // Determine the icon class to add and remove based on the number of checked checkboxes
       const iconClassToAdd = checkedCount === 0 ? 'pb_checkbox_checkmark' : 'pb_checkbox_indeterminate';

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_selectable_rows.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_selectable_rows.html.erb
@@ -19,6 +19,7 @@
                     value: "checkbox-value",
                     name: "main-checkbox-selectable",
                     indeterminate_main: true,
+                    indeterminate_main_labels: ["", ""],
                     id: "checkbox-selectable"
                 }) %>
             <% end %>

--- a/playbook/spec/pb_kits/playbook/kits/checkbox_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/checkbox_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Playbook::PbCheckbox::Checkbox do
   it { is_expected.to define_prop(:disabled).with_default(false) }
   it { is_expected.to define_boolean_prop(:checked).with_default(false) }
   it { is_expected.to define_boolean_prop(:indeterminate_main).with_default(false) }
+  it { is_expected.to define_array_prop(:indeterminate_main_labels).with_default([]) }
   it { is_expected.to define_prop(:indeterminate_parent) }
   it { is_expected.to define_hash_prop(:input_options).with_default({}) }
   it { is_expected.to define_boolean_prop(:hidden_input).with_default(false) }


### PR DESCRIPTION
**What does this PR do?**

- Add `indeterminate_main_labels` prop which can be set with ["Check All Label", "Uncheck All Label"]
  - If not provided, defaults to "Check All" and "Uncheck All"
  - If ["", ""] is provided, no labels are used
- Update "Table with Selectable Rows" doc to match React- remove labels.

https://runway.powerhrg.com/backlog_items/PLAY-2243

**Screenshots:** Screenshots to visualize your addition/change
<img width="1569" height="450" alt="Screenshot 2025-07-16 at 3 59 33 PM" src="https://github.com/user-attachments/assets/b3cc80d0-bda8-4a4b-8cda-c97feaf8f2c3" />
<img width="400" height="444" alt="Screenshot 2025-07-16 at 3 59 52 PM" src="https://github.com/user-attachments/assets/6127ddf5-9bf6-4bd3-98ed-39182f2b0240" />

**How to test?** Steps to confirm the desired behavior:
1. /kits/checkbox/rails#indeterminate-checkbox-1
2. /kits/table/rails


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.