### PR TITLE
[PLAY-2204] Advanced Table: Support Custom headers with Multi-Header Columns

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -65,7 +65,7 @@ kits:
     enhanced_element_used: true
   - name: cell_behavior
     parent: advanced_table
-    kit_section: ["Custom Components for Cells", "Custom Header Cell", "Custom Header Cell with Multi-Header Columns", "Inline Cell Editing"]
+    kit_section: ["Custom Components for Cells", "Custom Header Cell", "Custom Header with Multiple Headers", "Inline Cell Editing"]
     platforms: *1
     status: stable
     icons_used: true

--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -65,7 +65,7 @@ kits:
     enhanced_element_used: true
   - name: cell_behavior
     parent: advanced_table
-    kit_section: ["Custom Components for Cells", "Custom Header Cell", "Inline Cell Editing"]
+    kit_section: ["Custom Components for Cells", "Custom Header Cell", "Custom Header Cell with Multi-Header Columns", "Inline Cell Editing"]
     platforms: *1
     status: stable
     icons_used: true

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -101,7 +101,6 @@ export const TableHeaderCell = ({
     if (!header) return false;
   
     if (header.colSpan > 1 && header.column.parent !== undefined) return true;
-  
     const parent = header.column.parent;
   
     if (!parent) {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -83,11 +83,11 @@ export function useTableState({
   const buildColumns = useCallback((columnDefinitions: GenericObject[], isRoot = true): any[] => {
     return columnDefinitions?.map((column, index) => {
       const isFirstColumn = isRoot && index === 0;
-
       // Handle grouped columns
       if (column.columns && column.columns.length > 0) {
         return {
-          header: column.header || column.label || "",
+          header: column.header ?? column.label ?? "",
+          id: column.id ?? column.label ?? `group-${index}`,
           columns: buildColumns(column.columns, false),
         };
       }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.jsx
@@ -22,7 +22,7 @@ const columnDefinitions = [
         <Flex alignItems="center" 
             justifyContent="center"
         >
-          <Caption marginRight="xs">New Enrollments</Caption>
+          <Caption marginRight="xs">Enrollments Data</Caption>
           <Tooltip placement="top" 
               text="Whoa. I'm a Tooltip" 
               zIndex={10}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.jsx
@@ -8,82 +8,90 @@ import MOCK_DATA from "./advanced_table_mock_data.json"
 
 const AdvancedTableWithCustomHeaderMultiHeader = (props) => {
 
-  const columnDefinitions = [
-        {
-          accessor: "year",
-          label: "Year",
-          id: "year",
-          cellAccessors: ["quarter", "month", "day"],
-        },
-        {
-          label: "Enrollment Data",
-          id: "enrollmentData",
-          header: () => (
-          <Flex alignItems="center" 
-              justifyContent="center"
+const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      id: "year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      label: "Enrollment Data",
+      id: "enrollmentData",
+      header: () => (
+        <Flex alignItems="center" 
+            justifyContent="center"
+        >
+          <Caption marginRight="xs">New Enrollments</Caption>
+          <Tooltip placement="top" 
+              text="Whoa. I'm a Tooltip" 
+              zIndex={10}
           >
-            <Caption marginRight="xs">Enrollment Data</Caption>
-            <Tooltip placement="top" 
-                text="Whoa. I'm a Tooltip" 
-                zIndex={10}
-            >
-              <Icon cursor="pointer" 
-                  icon="info"
-                  size="xs" 
-              />
-            </Tooltip>
-          </Flex>
-        ),
+            <Icon cursor="pointer" 
+                icon="info"
+                size="xs" 
+            />
+          </Tooltip>
+        </Flex>
+      ),
+      columns: [
+        {
+          label: "Enrollment Stats",
+          id: "enrollmentStats",
           columns: [
             {
-              label: "Enrollment Stats",
-              id: "enrollmentStats",
-              columns: [
-                {
-                  accessor: "newEnrollments",
-                  label: "New Enrollments",
-                  id: "newEnrollments",
-                  header: () => (<div>Testings</div>),
-                },
-
-              ],
+              accessor: "newEnrollments",
+              id: "newEnrollments",
+              label: "New Enrollments",
+            },
+            {
+              accessor: "scheduledMeetings",
+              id: "scheduledMeetings",
+              label: "Scheduled Meetings",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Performance Data",
+      id: "performanceData",
+      columns: [
+        {
+          label: "Completion Metrics",
+          id: "completionMetrics",
+          columns: [
+            {
+              accessor: "completedClasses",
+              label: "Completed Classes",
+              id: "completedClasses",
+            },
+            {
+              accessor: "classCompletionRate",
+              label: "Class Completion Rate",
+              id: "classCompletionRate",
             },
           ],
         },
         {
-          label: "Performance Data",
-          id: "performanceData",
+          label: "Attendance",
+          id: "attendance",
           columns: [
             {
-              label: "Completion Metrics",
-              id: "completionMetrics",
-              columns: [
-                {
-                  accessor: "completedClasses",
-                  label: "Completed Classes",
-                  id: "completedClasses",
-                },
-                {
-                  accessor: "classCompletionRate",
-                  label: "Class Completion Rate",
-                  id: "classCompletionRate",
-                },
-              ],
+              accessor: "attendanceRate",
+              label: "Attendance Rate",
+              id: "attendanceRate",
             },
             {
-              label: "Attendance",
-              id: "attendance",
-              columns: [
-                {
-                  accessor: "attendanceRate",
-                  label: "Attendance Rate",
-                  id: "attendanceRate",
-                },
-              ],
+              accessor: "scheduledMeetings",
+              label: "Scheduled Meetings",
+              id: "scheduledMeetings",
             },
           ],
         },
-      ];
+      ],
+    },
+  ];
 
   return (
     <div>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.jsx
@@ -1,0 +1,99 @@
+import React from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import Icon from "../../pb_icon/_icon"
+import Flex from "../../pb_flex/_flex"
+import Caption from "../../pb_caption/_caption"
+import Tooltip from "../../pb_tooltip/_tooltip"
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableWithCustomHeaderMultiHeader = (props) => {
+
+  const columnDefinitions = [
+        {
+          accessor: "year",
+          label: "Year",
+          id: "year",
+          cellAccessors: ["quarter", "month", "day"],
+        },
+        {
+          label: "Enrollment Data",
+          id: "enrollmentData",
+          header: () => (
+          <Flex alignItems="center" 
+              justifyContent="center"
+          >
+            <Caption marginRight="xs">Enrollment Data</Caption>
+            <Tooltip placement="top" 
+                text="Whoa. I'm a Tooltip" 
+                zIndex={10}
+            >
+              <Icon cursor="pointer" 
+                  icon="info"
+                  size="xs" 
+              />
+            </Tooltip>
+          </Flex>
+        ),
+          columns: [
+            {
+              label: "Enrollment Stats",
+              id: "enrollmentStats",
+              columns: [
+                {
+                  accessor: "newEnrollments",
+                  label: "New Enrollments",
+                  id: "newEnrollments",
+                  header: () => (<div>Testings</div>),
+                },
+
+              ],
+            },
+          ],
+        },
+        {
+          label: "Performance Data",
+          id: "performanceData",
+          columns: [
+            {
+              label: "Completion Metrics",
+              id: "completionMetrics",
+              columns: [
+                {
+                  accessor: "completedClasses",
+                  label: "Completed Classes",
+                  id: "completedClasses",
+                },
+                {
+                  accessor: "classCompletionRate",
+                  label: "Class Completion Rate",
+                  id: "classCompletionRate",
+                },
+              ],
+            },
+            {
+              label: "Attendance",
+              id: "attendance",
+              columns: [
+                {
+                  accessor: "attendanceRate",
+                  label: "Attendance Rate",
+                  id: "attendanceRate",
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          tableData={MOCK_DATA}
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default AdvancedTableWithCustomHeaderMultiHeader;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_with_custom_header_multi_header.md
@@ -1,0 +1,1 @@
+The optional `header` key/value pair within `columnDefinitions` can also be used with multi headers as seen here. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -41,6 +41,7 @@ examples:
   - advanced_table_responsive: Responsive Tables
   - advanced_table_custom_cell: Custom Components for Cells
   - advanced_table_with_custom_header: Custom Header Cell
+  - advanced_table_with_custom_header_multi_header: Custom Header Cell with Multi-Header Columns
   - advanced_table_pagination: Pagination
   - advanced_table_pagination_with_props: Pagination Props
   - advanced_table_loading: Loading State

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -41,7 +41,7 @@ examples:
   - advanced_table_responsive: Responsive Tables
   - advanced_table_custom_cell: Custom Components for Cells
   - advanced_table_with_custom_header: Custom Header Cell
-  - advanced_table_with_custom_header_multi_header: Custom Header Cell with Multi-Header Columns
+  - advanced_table_with_custom_header_multi_header: Custom Header with Multiple Headers
   - advanced_table_pagination: Pagination
   - advanced_table_pagination_with_props: Pagination Props
   - advanced_table_loading: Loading State

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -40,3 +40,4 @@ export { default as AdvancedTableColumnStylingColumnHeaders } from './_advanced_
 export { default as AdvancedTableInfiniteScroll} from './_advanced_table_infinite_scroll.jsx'
 export {default as AdvancedTableWithCustomHeader} from './_advanced_table_with_custom_header.jsx'
 export { default as AdvancedTableCustomSort } from './_advanced_table_custom_sort.jsx'
+export { default as AdvancedTableWithCustomHeaderMultiHeader } from './_advanced_table_with_custom_header_multi_header.jsx'


### PR DESCRIPTION
**What does this PR do?** 
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2204)

Custom Header support for multi header tables. 

**Screenshots:**

<img width="984" height="469" alt="Screenshot 2025-07-17 at 10 39 03 AM" src="https://github.com/user-attachments/assets/c06d934e-fd8a-41f4-a09d-0ca8c652b707" />


**How to test?** 
1. Go to cell behavior tab in the Advanced Table menu to see docs


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.