### PR TITLE
[PLAY-2180] Playbook Website: Remove Dribble Link from Homepage

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/layouts/Footer.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Footer.tsx
@@ -114,15 +114,6 @@ const Footer = () => {
             </FlexItem>
             <FlexItem>
               <Title dark tag='h4' text='Connect' size={4} marginBottom='md' />
-              <a href='https://dribbble.com/powerhrg'>
-                <Body
-                  text='Dribbble'
-                  dark
-                  color='light'
-                  marginBottom='md'
-                  hover={{ color: "text_dk_default" }}
-                />
-              </a>
               <a href='https://github.com/powerhome/playbook'>
                 <Body
                   text='Github'
@@ -145,7 +136,7 @@ const Footer = () => {
           </Flex>
         </Flex>
         <div className='copyright-tag'>
-          <Caption text='© 2023-24, ALL RIGHTS RESERVED' color='lighter' dark />
+          <Caption text={`© ${new Date().getFullYear()}-${(new Date().getFullYear() + 1).toString().slice(-2)}, ALL RIGHTS RESERVED`} color='lighter' dark />
         </div>
       </div>
     </div>

--- a/playbook-website/app/views/layouts/_footer.html.erb
+++ b/playbook-website/app/views/layouts/_footer.html.erb
@@ -48,9 +48,6 @@
     
         <%= pb_rails("flex/flex_item") do %>
           <%= pb_rails("title", props: { dark: true, tag: "h4", text: "Connect", size: 4, margin_bottom: "md" }) %>
-          <a href="https://dribbble.com/powerhrg">
-            <%= pb_rails("body", props: { text: "Dribbble", dark: true, color: "light", margin_bottom: "md", hover: {color: "text_dk_default"} }) %>
-          </a>
           <a href="https://github.com/powerhome/playbook">
             <%= pb_rails("body", props: { text: "Github", dark: true, color: "light", margin_bottom: "md", hover: {color: "text_dk_default"} }) %>
           </a>
@@ -62,7 +59,7 @@
     <% end %>
 
     <div class="copyright-tag">
-      <%= pb_rails("caption", props: { text: "© 2023-24, ALL RIGHTS RESERVED", color: "lighter", dark: true }) %>
+      <%= pb_rails("caption", props: { text: "© #{Date.current.year}-#{(Date.current.year + 1).to_s.last(2)}, ALL RIGHTS RESERVED", color: "lighter", dark: true }) %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2180]https://runway.powerhrg.com/backlog_items/PLAY-2180) requests some updates to Playbook's footer. I made these changes on our current website footer as well as in the beta react redesign just for completeness/future-proofing it should it go live. The Dribbble link has been removed from the footer and the Copyright year is now dynamic (currently 2025-26 but will update based on current year going forward).

**Screenshots:** Screenshots to visualize your addition/change
<img width="941" height="298" alt="footer for PR" src="https://github.com/user-attachments/assets/6644faaa-7c3d-4995-8afa-f10299cd2dbb" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the review env and scroll down to the footer on any page. The Dribbble link should no longer be present (with the other two items in the Connect Column moving up a space) and the Copyright year should say 2025-26.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.