### PR TITLE
[PLAY-2148] Select Kit: Classnames Spaces Fix - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/select.rb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.rb
@@ -24,7 +24,9 @@ module Playbook
       prop :validation_message, type: Playbook::Props::String, default: ""
 
       def classnames
-        classname + inline_class + compact_class + show_arrow_class
+        ([classname] + [inline_class, compact_class, show_arrow_class])
+          .reject(&:empty?)
+          .join(" ")
       end
 
       def all_attributes
@@ -44,7 +46,7 @@ module Playbook
       end
 
       def inline_class
-        inline ? " inline " : " "
+        inline ? "inline" : ""
       end
 
       def compact_class

--- a/playbook/spec/pb_kits/playbook/kits/select_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/select_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe Playbook::PbSelect::Select do
   it { is_expected.to define_string_prop(:name) }
   it { is_expected.to define_string_prop(:onchange) }
   it { is_expected.to define_boolean_prop(:required).with_default(false) }
+  it { is_expected.to define_boolean_prop(:inline).with_default(false) }
+  it { is_expected.to define_boolean_prop(:compact).with_default(false) }
+  it { is_expected.to define_boolean_prop(:show_arrow).with_default(false) }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
@@ -22,6 +25,9 @@ RSpec.describe Playbook::PbSelect::Select do
       expect(subject.new(dark: true).classname).to eq "pb_select mb_sm dark"
       expect(subject.new(margin: "lg").classname).to eq "pb_select m_lg"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_select mb_sm additional_class"
+      expect(subject.new(compact: true).classnames).to eq "pb_select mb_sm compact"
+      expect(subject.new(inline: true, show_arrow: true).classnames).to eq "pb_select mb_sm inline show_arrow"
+      expect(subject.new(inline: true, compact: true, show_arrow: true).classnames).to eq "pb_select mb_sm inline compact show_arrow"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Fix Select classnames bug by making sure there is a single space between all additional classes (inline, compact, show_arrow).

https://runway.powerhrg.com/backlog_items/PLAY-2148

**Screenshots:** Screenshots to visualize your addition/change
<img width="1584" height="60" alt="Screenshot 2025-07-22 at 9 05 56 AM" src="https://github.com/user-attachments/assets/75ddf589-3ade-414c-9003-16ed1de05dff" />

**How to test?** Steps to confirm the desired behavior:
1. Go to kits/select/rails and compare to prod


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.