### PR TITLE
[PLAY-1985] Pagination Kit: Show Only with Multiple Pages - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_pagination/_pagination.tsx
+++ b/playbook/app/pb_kits/playbook/pb_pagination/_pagination.tsx
@@ -134,6 +134,10 @@ const Pagination = ( props: PaginationProps) => {
     className
   )
 
+  if (total <= 1) {
+    return null;
+  }
+
   return (
     <div 
         {...ariaProps}

--- a/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default_rails.md
@@ -4,3 +4,5 @@ Our Pagination kit depends on the <a href="https://github.com/mislav/will_pagina
 Once you have perfomed the paginated query in your controller file you can use our kit (see code example below) instead of `<%= will_paginate @users %>` in your view file.
 
 You need to add: <code>require "playbook/pagination_renderer"</code> in your apps controller file.
+
+Note: If the total page count is 0 or 1, the Pagination kit will not be displayed as there aren't multiple pages to navigate.

--- a/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default_react.md
+++ b/playbook/app/pb_kits/playbook/pb_pagination/docs/_pagination_default_react.md
@@ -1,1 +1,3 @@
 The `range` prop determines how many pages to display in the Pagination component. Regardless of this value, the first two and last two pages are always visible to facilitate navigation to the beginning and end of the pagination. If these always-visible pages fall within the specified range, they are included in the display. If they fall outside the range, the pagination will show additional pages up to the number defined by the `range` prop.
+
+Note: If the `total` pages prop is 0 or 1, the Pagination component will not be displayed, as there aren't multiple pages to navigate.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Show the React Pagination Kit only if there are multiple pages to navigate.
- Add note in Rails and React docs. 
  - "Note: If the total page count is 0 or 1, the Pagination kit will not be displayed as there aren't multiple pages to navigate."

https://runway.powerhrg.com/backlog_items/PLAY-1985

**How to test?** Steps to confirm the desired behavior:
1. Make sure the descriptions for both React and Rails pagination kits are updated
2. Review the code sandbox attached to the Runway story.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.