### PR TITLE
[PLAY-2312] Advanced Table: Sort Available on All Columns

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -33,7 +33,7 @@ kits:
     enhanced_element_used: true
   - name: sorting
     parent: advanced_table
-    kit_section: ["Enable Sorting", "Sort Control", "Custom Sort"]
+    kit_section: ["Enable Sorting", "Sort Control", "Enable Sort By Column", "Custom Sort"]
     platforms: *1
     status: stable
     icons_used: true

--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -33,7 +33,7 @@ kits:
     enhanced_element_used: true
   - name: sorting
     parent: advanced_table
-    kit_section: ["Enable Sorting", "Sort Control", "Enable Sort By Column", "Custom Sort"]
+    kit_section: ["Enable Sorting", "Sort Control", "Enable Sort By Column", "Enable Sort By Column (Multi-Column)", "Custom Sort"]
     platforms: *1
     status: stable
     icons_used: true

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SortIconButton.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SortIconButton.tsx
@@ -4,51 +4,48 @@ import { Header } from "@tanstack/react-table"
 import { GenericObject } from "../../types"
 
 import Icon from "../../pb_icon/_icon"
-import { getAllIcons } from "../../utilities/icons/allicons"
 
 import { displayIcon } from "../Utilities/IconHelpers"
 
 type SortIconButtonProps = {
   header: Header<GenericObject, unknown>
   sortIcon?: string | string[]
+  enableSortingRemoval?: boolean
 }
 
-export const SortIconButton = ({ header, sortIcon }: SortIconButtonProps) => {
-
-const firstIcon = displayIcon(sortIcon)[0] 
-const secondIcon = displayIcon(sortIcon)[1] 
-const upIcon = getAllIcons()["arrowUpShortWide"].icon as unknown as { [key: string]: SVGElement }
-const downIcon = getAllIcons()["arrowDownShortWide"].icon as unknown as { [key: string]: SVGElement }
+export const SortIconButton = ({ header, sortIcon, enableSortingRemoval }: SortIconButtonProps) => {
+  const firstIcon = displayIcon(sortIcon)[0]
+  const secondIcon = displayIcon(sortIcon)[1]
 
   return (
     <>
-      {header.column.getIsSorted() === "desc" ? (
-        <div className="sort-button-icon" 
+      {header.column.getIsSorted() === "desc" && (
+        <div
+            className="sort-button-icon"
             key={firstIcon}
             style={{ paddingLeft: `${header?.index === 0 ? "2px" : "4px"}` }}
         >
-        { firstIcon === "arrow-up-short-wide" ? (
-          <Icon 
-              className="svg-inline--fa"
-              customIcon={upIcon}
-          /> ) : (
           <Icon icon={firstIcon} />
-        )}
         </div>
-      ) : (
-        <div className="sort-button-icon" 
+      )}
+      {header.column.getIsSorted() === "asc" && (
+        <div
+            className="sort-button-icon"
             key={secondIcon}
-            style={{ paddingLeft: "4px" }}
+            style={{ paddingLeft: `${header?.index === 0 ? "2px" : "4px"}` }}
         >
-        { secondIcon === "arrow-down-short-wide" ? (
-          <Icon 
-              className="svg-inline--fa"
-              customIcon={downIcon}
-          /> ) : (
           <Icon icon={secondIcon} />
-        )}
+        </div>
+      )}
+      {header.column.getIsSorted() === false && (
+        <div
+            className="sort-button-icon"
+            key={enableSortingRemoval ? "arrow-up-arrow-down" : secondIcon}
+            style={{ paddingLeft: `${header?.index === 0 ? "2px" : "4px"}` }}
+        >
+          <Icon icon={enableSortingRemoval ? "arrow-up-arrow-down" : secondIcon} />
         </div>
       )}
     </>
-  )
-}
+  );
+};

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SortIconButton.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/SortIconButton.tsx
@@ -25,6 +25,7 @@ const downIcon = getAllIcons()["arrowDownShortWide"].icon as unknown as { [key: 
       {header.column.getIsSorted() === "desc" ? (
         <div className="sort-button-icon" 
             key={firstIcon}
+            style={{ paddingLeft: `${header?.index === 0 ? "2px" : "4px"}` }}
         >
         { firstIcon === "arrow-up-short-wide" ? (
           <Icon 
@@ -37,6 +38,7 @@ const downIcon = getAllIcons()["arrowDownShortWide"].icon as unknown as { [key: 
       ) : (
         <div className="sort-button-icon" 
             key={secondIcon}
+            style={{ paddingLeft: "4px" }}
         >
         { secondIcon === "arrow-down-short-wide" ? (
           <Icon 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -50,11 +50,10 @@ export const TableHeaderCell = ({
     expanded,
     setExpanded,
     expandByDepth,
+    enableSortingRemoval,
     onExpandByDepthClick,
     toggleExpansionIcon,
     sortControl,
-    firstColumnSort,
-    setFirstColumnSort,
     responsive,
     selectableRows,
     hasAnySubRows,
@@ -284,7 +283,9 @@ const isToggleExpansionEnabled =
               (loading ? (
                 <div className="loading-toggle-icon" />
               ) : (
-                <SortIconButton header={header} 
+                <SortIconButton 
+                    enableSortingRemoval={enableSortingRemoval}
+                    header={header} 
                     sortIcon={sortIcon} 
                 />
               ))}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -53,6 +53,8 @@ export const TableHeaderCell = ({
     onExpandByDepthClick,
     toggleExpansionIcon,
     sortControl,
+    firstColumnSort,
+    setFirstColumnSort,
     responsive,
     selectableRows,
     hasAnySubRows,
@@ -63,6 +65,7 @@ export const TableHeaderCell = ({
   } = useContext(AdvancedTableContext);
 
   type justifyTypes = "none" | "center" | "start" | "end" | "between" | "around" | "evenly"
+  
   
   const toggleSortButton = (event: React.SyntheticEvent) => {
     if (sortControl) {
@@ -110,7 +113,9 @@ export const TableHeaderCell = ({
     const visibleSiblings = parent.columns.filter(columnHasVisibleLeaf);
     return visibleSiblings.at(-1) === header.column;
   })();
- 
+
+enableSorting ? setFirstColumnSort(true) : setFirstColumnSort(false)
+
 const cellClassName = classnames(
   "table-header-cells",
   `${showActionsBar && isActionBarVisible && "header-cells-with-actions"}`,
@@ -256,12 +261,9 @@ const isToggleExpansionEnabled =
             )}
 
           <Flex
-              className={`${header?.index === 0 &&
-                enableSorting &&
-                "header-sort-button pb_th_link"}`}
-              cursor={header?.index === 0 && enableSorting ? "pointer" : "default"}
-              {...(header?.index === 0 &&
-                enableSorting && {
+              className={`${header?.index === 0 && enableSorting && "header-sort-button pb_th_link"} ${header?.column.getCanSort() && "header-sort-secondary-columns"}`}
+              cursor={(header?.column.getCanSort() || (header?.index === 0 && enableSorting) ? "pointer" : "default")}
+              {...((header?.column.getCanSort() || (header?.index === 0 && enableSorting)) && {
                   htmlOptions: {
                     onClick: (event: React.MouseEvent) => toggleSortButton(event),
                     onKeyDown: (event: React.KeyboardEvent) => {
@@ -279,9 +281,7 @@ const isToggleExpansionEnabled =
               {flexRender(header?.column.columnDef.header, header?.getContext())}
             </div>
 
-            {header?.index === 0 &&
-              header.column.getCanSort() &&
-              enableSorting &&
+            {header?.column.getCanSort() &&
               (loading ? (
                 <div className="loading-toggle-icon" />
               ) : (

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -114,7 +114,6 @@ export const TableHeaderCell = ({
     return visibleSiblings.at(-1) === header.column;
   })();
 
-enableSorting ? setFirstColumnSort(true) : setFirstColumnSort(false)
 
 const cellClassName = classnames(
   "table-header-cells",
@@ -261,9 +260,9 @@ const isToggleExpansionEnabled =
             )}
 
           <Flex
-              className={`${header?.index === 0 && enableSorting && "header-sort-button pb_th_link"} ${header?.column.getCanSort() && "header-sort-secondary-columns"}`}
-              cursor={(header?.column.getCanSort() || (header?.index === 0 && enableSorting) ? "pointer" : "default")}
-              {...((header?.column.getCanSort() || (header?.index === 0 && enableSorting)) && {
+              className={`${header?.index === 0 && enableSorting && "header-sort-button pb_th_link"} ${header?.index !== 0 && header?.column.getCanSort() && "header-sort-secondary-columns"}`}
+              cursor={((header?.index !== 0 && header?.column.getCanSort()) || (header?.index === 0 && enableSorting) ? "pointer" : "default")}
+              {...(((header?.index !== 0 && header?.column.getCanSort()) || (header?.index === 0 && enableSorting)) && {
                   htmlOptions: {
                     onClick: (event: React.MouseEvent) => toggleSortButton(event),
                     onKeyDown: (event: React.KeyboardEvent) => {
@@ -281,7 +280,7 @@ const isToggleExpansionEnabled =
               {flexRender(header?.column.columnDef.header, header?.getContext())}
             </div>
 
-            {header?.column.getCanSort() &&
+            {((header?.index !== 0 && header?.column.getCanSort()) || (header?.index === 0 && enableSorting)) &&
               (loading ? (
                 <div className="loading-toggle-icon" />
               ) : (

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -18,6 +18,7 @@ interface UseTableStateProps {
   columnDefinitions: GenericObject[];
   expandedControl?: GenericObject;
   sortControl?: GenericObject;
+  firstColumnSort?: boolean;
   onRowToggleClick?: (arg: Row<GenericObject>) => void;
   selectableRows?: boolean;
   initialLoadingRowsCount?: number;
@@ -40,6 +41,7 @@ export function useTableState({
   columnDefinitions,
   expandedControl,
   sortControl,
+  firstColumnSort,
   onRowToggleClick,
   selectableRows,
   initialLoadingRowsCount = 10,
@@ -91,11 +93,11 @@ export function useTableState({
           columns: buildColumns(column.columns, false),
         };
       }
-
       // Define the base column structure
       const columnStructure = {
         ...columnHelper.accessor(column.accessor, {
           header: column.header ?? column.label ?? "",
+          enableSorting: (isFirstColumn && firstColumnSort) || column.enableSort === true,
         }),
       };
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -41,7 +41,6 @@ export function useTableState({
   columnDefinitions,
   expandedControl,
   sortControl,
-  firstColumnSort,
   onRowToggleClick,
   selectableRows,
   initialLoadingRowsCount = 10,
@@ -97,7 +96,7 @@ export function useTableState({
       const columnStructure = {
         ...columnHelper.accessor(column.accessor, {
           header: column.header ?? column.label ?? "",
-          enableSorting: (isFirstColumn && firstColumnSort) || column.enableSort === true,
+          enableSorting: isFirstColumn || column.enableSort === true,
         }),
       };
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -16,6 +16,7 @@ import { createCellFunction } from "../Utilities/CellRendererUtils";
 interface UseTableStateProps {
   tableData: GenericObject[];
   columnDefinitions: GenericObject[];
+  enableSortingRemoval?: boolean;
   expandedControl?: GenericObject;
   sortControl?: GenericObject;
   firstColumnSort?: boolean;
@@ -39,6 +40,7 @@ interface UseTableStateProps {
 export function useTableState({
   tableData,
   columnDefinitions,
+  enableSortingRemoval,
   expandedControl,
   sortControl,
   onRowToggleClick,
@@ -167,7 +169,7 @@ export function useTableState({
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    enableSortingRemoval: false,
+    enableSortingRemoval: enableSortingRemoval,
     sortDescFirst: true,
     onRowSelectionChange: setRowSelection,
     onRowPinningChange,

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/SubKits/TableHeader.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/SubKits/TableHeader.tsx
@@ -28,7 +28,7 @@ export const TableHeader = ({
   dark = false,
   enableSorting = false,
   id,
-  sortIcon = ["arrow-up-short-wide", "arrow-down-short-wide"],
+  sortIcon = ["arrow-up-wide-short", "arrow-down-short-wide"],
   ...props
 }: TableHeaderProps) => {
   const {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -422,6 +422,15 @@
     padding: 2px;
   }
 
+  .header-sort-secondary-columns {
+    color: $primary !important;
+
+    &:hover {
+      background-color: rgba($primary, 0.03);
+      border-radius: $border_radius_md;
+    }
+  }
+
   .toggle-all-icon {
     @extend .button-icon;
     @extend %primary-color-pseudo;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -122,9 +122,6 @@ const AdvancedTable = (props: AdvancedTableProps) => {
   // Component refs
   const tableWrapperRef = useRef<HTMLDivElement>(null);
 
-  // State to pass to useTableState to mantain backwards compatibility with original sort logic
-  const [firstColumnSort, setFirstColumnSort] = useState(false);
-
   const {
     table,
     expanded,
@@ -140,7 +137,6 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     tableData,
     columnDefinitions,
     expandedControl,
-    firstColumnSort,
     sortControl,
     onRowToggleClick,
     selectableRows,
@@ -341,7 +337,6 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             expandByDepth={expandByDepth}
             expanded={expanded}
             expandedControl={expandedControl}
-            firstColumnSort={firstColumnSort}
             handleExpandOrCollapse={handleExpandOrCollapse}
             hasAnySubRows={hasAnySubRows}
             inlineRowLoading={inlineRowLoading}
@@ -355,7 +350,6 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             rowStyling={rowStyling}
             selectableRows={selectableRows}
             setExpanded={setExpanded}
-            setFirstColumnSort={setFirstColumnSort}
             showActionsBar={showActionsBar}
             sortControl={sortControl}
             stickyLeftColumn={stickyLeftColumn}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -40,6 +40,7 @@ type AdvancedTableProps = {
   dark?: boolean
   data?: { [key: string]: string }
   enableToggleExpansion?: "all" | "header" | "none"
+  enableSortingRemoval?: boolean
   expandedControl?: GenericObject
   expandByDepth?: { [key: string]: string | number }
   onExpandByDepthClick?: (arg: number, arg1: any) => void
@@ -87,6 +88,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     dark = false,
     data = {},
     enableToggleExpansion = "header",
+    enableSortingRemoval = false,
     expandedControl,
     expandByDepth,
     onExpandByDepthClick,
@@ -136,6 +138,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
   } = useTableState({
     tableData,
     columnDefinitions,
+    enableSortingRemoval,
     expandedControl,
     sortControl,
     onRowToggleClick,
@@ -332,6 +335,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             columnGroupBorderColor={columnGroupBorderColor}
             columnVisibilityControl={columnVisibilityControl}
             customSort={customSort}
+            enableSortingRemoval={enableSortingRemoval}
             enableToggleExpansion={enableToggleExpansion}
             enableVirtualization={virtualizedRows}
             expandByDepth={expandByDepth}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx
@@ -122,7 +122,9 @@ const AdvancedTable = (props: AdvancedTableProps) => {
   // Component refs
   const tableWrapperRef = useRef<HTMLDivElement>(null);
 
-  // Initialize table state
+  // State to pass to useTableState to mantain backwards compatibility with original sort logic
+  const [firstColumnSort, setFirstColumnSort] = useState(false);
+
   const {
     table,
     expanded,
@@ -138,6 +140,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
     tableData,
     columnDefinitions,
     expandedControl,
+    firstColumnSort,
     sortControl,
     onRowToggleClick,
     selectableRows,
@@ -338,6 +341,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             expandByDepth={expandByDepth}
             expanded={expanded}
             expandedControl={expandedControl}
+            firstColumnSort={firstColumnSort}
             handleExpandOrCollapse={handleExpandOrCollapse}
             hasAnySubRows={hasAnySubRows}
             inlineRowLoading={inlineRowLoading}
@@ -351,6 +355,7 @@ const AdvancedTable = (props: AdvancedTableProps) => {
             rowStyling={rowStyling}
             selectableRows={selectableRows}
             setExpanded={setExpanded}
+            setFirstColumnSort={setFirstColumnSort}
             showActionsBar={showActionsBar}
             sortControl={sortControl}
             stickyLeftColumn={stickyLeftColumn}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -124,6 +124,23 @@ const columnDefinitions = [
   },
 ]
 
+const columnDefinitionsSort = [
+  {
+    accessor: "year",
+    label: "Year",
+    cellAccessors: ["quarter", "month", "day"],
+  },
+  {
+    accessor: "newEnrollments",
+    label: "New Enrollments",
+    enableSort: true,
+  },
+  {
+    accessor: "scheduledMeetings",
+    label: "Scheduled Meetings",
+  },
+];
+
 const columnDefinitionsCustomRenderer = [
   {
     accessor: "year",
@@ -676,3 +693,20 @@ test("rowStyling prop works as expected", () => {
   const row1 = tableBody.querySelector('tr:nth-child(1)') 
   expect(row1).toHaveStyle({backgroundColor: colors.white, color: colors.black})
 })
+
+test("Sort icon renders with enableSort on individual columns", () => {
+  render(
+    <AdvancedTable
+        columnDefinitions={columnDefinitionsSort}
+        data={{ testid: testId }}
+        tableData={MOCK_DATA}
+    />
+  );
+
+  const kit = screen.getByTestId(testId);
+  const sortIcon = kit.querySelector(".sort-button-icon");
+  expect(sortIcon).toBeInTheDocument();
+  const sortButton = kit.querySelector(".header-sort-secondary-columns");
+  expect(sortButton).toBeInTheDocument();
+});
+

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.jsx
@@ -41,6 +41,7 @@ const AdvancedTableSortPerColumn = (props) => {
     <div>
       <AdvancedTable
           columnDefinitions={columnDefinitions}
+          enableSortingRemoval
           tableData={MOCK_DATA}
           {...props}
       >

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.jsx
@@ -1,0 +1,54 @@
+import React from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableSortPerColumn = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+      enableSort: true,
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance Rate",
+      enableSort: true,
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed Classes",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Class Completion Rate",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated Students",
+    },
+  ]
+
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          tableData={MOCK_DATA}
+          {...props}
+      >
+        <AdvancedTable.Header />
+        <AdvancedTable.Body />
+      </AdvancedTable>
+    </div>
+  )
+}
+
+export default AdvancedTableSortPerColumn;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.md
@@ -1,3 +1,6 @@
 Sorting can now be enabled on any of the columns. To do this, add `enableSort:true` to the columnDefinition of the column you want sorting enabled on. Once enabled, clicking on the header will toggle sort between ascending and descending.
 
+The optional `enableSortingRemoval` prop can also be used in conjunction with sorting functionality. This prop is set to 'false' by default but if set to 'true' sorting order will circle like: 'none' -> 'desc' -> 'asc' -> 'none' -> ...
+It is recommended that `enableSortingRemoval` be set to 'true' when sort is enabled on mutiple columns so that sorting direction is always clear via the sort icon. 
+
 __NOTE:__ For sort on the first column, continue to use the separate `enableSorting` prop on AdvancedTable.Header as [shown here](https://playbook.powerapp.cloud/kits/advanced_table/sorting/react#enable-sorting).

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column.md
@@ -1,0 +1,3 @@
+Sorting can now be enabled on any of the columns. To do this, add `enableSort:true` to the columnDefinition of the column you want sorting enabled on. Once enabled, clicking on the header will toggle sort between ascending and descending.
+
+__NOTE:__ For sort on the first column, continue to use the separate `enableSorting` prop on AdvancedTable.Header as [shown here](https://playbook.powerapp.cloud/kits/advanced_table/sorting/react#enable-sorting).

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.jsx
@@ -69,7 +69,7 @@ const columnDefinitions = [
           tableData={MOCK_DATA}
           {...props}
       >
-        <AdvancedTable.Header />
+        <AdvancedTable.Header enableSorting />
         <AdvancedTable.Body />
       </AdvancedTable>
     </div>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.jsx
@@ -66,6 +66,7 @@ const columnDefinitions = [
     <div>
       <AdvancedTable
           columnDefinitions={columnDefinitions}
+          enableSortingRemoval
           tableData={MOCK_DATA}
           {...props}
       >

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.jsx
@@ -1,0 +1,79 @@
+import React from "react"
+import AdvancedTable from '../../pb_advanced_table/_advanced_table'
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+const AdvancedTableSortPerColumnForMultiColumn = (props) => {
+const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      label: "Enrollment Data",
+      columns: [
+        {
+          label: "Enrollment Stats",
+          columns: [
+            {
+              accessor: "newEnrollments",
+              label: "New Enrollments",
+              enableSort: true,
+            },
+            {
+              accessor: "scheduledMeetings",
+              label: "Scheduled Meetings",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Performance Data",
+      columns: [
+        {
+          label: "Completion Metrics",
+          columns: [
+            {
+              accessor: "completedClasses",
+              label: "Completed Classes",
+              enableSort: true,
+            },
+            {
+              accessor: "classCompletionRate",
+              label: "Class Completion Rate",
+            },
+          ],
+        },
+        {
+          label: "Attendance",
+          columns: [
+            {
+              accessor: "attendanceRate",
+              label: "Attendance Rate",
+            },
+            {
+              accessor: "scheduledMeetings",
+              label: "Scheduled Meetings",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  return (
+    <div>
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          tableData={MOCK_DATA}
+          {...props}
+      >
+        <AdvancedTable.Header />
+        <AdvancedTable.Body />
+      </AdvancedTable>
+    </div>
+  )
+}
+
+export default AdvancedTableSortPerColumnForMultiColumn;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_sort_per_column_for_multi_column.md
@@ -1,0 +1,1 @@
+Sorting on columns can also be applied to columns when using the multi-header variant, however in this case sorting can only be set on leaf columns NOT on parent columns. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -30,6 +30,7 @@ examples:
   - advanced_table_sort: Enable Sorting
   - advanced_table_sort_control: Sort Control
   - advanced_table_sort_per_column: Enable Sort By Column
+  - advanced_table_sort_per_column_for_multi_column: Enable Sort By Column (Multi-Column)
   - advanced_table_custom_sort: Custom Sort
   - advanced_table_expanded_control: Expanded Control
   - advanced_table_expand_by_depth: Expand by Depth

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -29,6 +29,7 @@ examples:
   - advanced_table_default: Default (Required Props)
   - advanced_table_sort: Enable Sorting
   - advanced_table_sort_control: Sort Control
+  - advanced_table_sort_per_column: Enable Sort By Column
   - advanced_table_custom_sort: Custom Sort
   - advanced_table_expanded_control: Expanded Control
   - advanced_table_expand_by_depth: Expand by Depth

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -42,3 +42,4 @@ export {default as AdvancedTableWithCustomHeader} from './_advanced_table_with_c
 export { default as AdvancedTableCustomSort } from './_advanced_table_custom_sort.jsx'
 export { default as AdvancedTableWithCustomHeaderMultiHeader } from './_advanced_table_with_custom_header_multi_header.jsx'
 export { default as AdvancedTableSortPerColumn } from './_advanced_table_sort_per_column.jsx'
+export { default as AdvancedTableSortPerColumnForMultiColumn } from './_advanced_table_sort_per_column_for_multi_column.jsx'

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -41,3 +41,4 @@ export { default as AdvancedTableInfiniteScroll} from './_advanced_table_infinit
 export {default as AdvancedTableWithCustomHeader} from './_advanced_table_with_custom_header.jsx'
 export { default as AdvancedTableCustomSort } from './_advanced_table_custom_sort.jsx'
 export { default as AdvancedTableWithCustomHeaderMultiHeader } from './_advanced_table_with_custom_header_multi_header.jsx'
+export { default as AdvancedTableSortPerColumn } from './_advanced_table_sort_per_column.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2312)

- This PR adds ability to add sort to any column on the table, not just the first one.
- It retains original functionality for adding sort on first column for backward compatibility. 
- Adds an additional `enableSortingRemoval` prop to allow sort to cycle through 'none' -> 'desc' -> 'asc' -> 'none' -> .. as opposed to just asc and desc so sort can be reset as well 

**Screenshots:** Screenshots to visualize your addition/change

<img width="1019" height="581" alt="Screenshot 2025-07-29 at 2 40 44 PM" src="https://github.com/user-attachments/assets/3c255f33-80d6-493a-816f-9eabfe0bb3d0" />

<img width="1016" height="521" alt="Screenshot 2025-07-29 at 2 40 59 PM" src="https://github.com/user-attachments/assets/ff9b76cc-5d88-4e05-9c1b-8f2683b4d0f9" />

**How to test?** Steps to confirm the desired behavior:
[Docs under the 'Sorting' menu item](https://pr4945.playbook.beta.gm.powerapp.cloud/kits/advanced_table/sorting/react)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.