### PR TITLE
[PLAY-2360] CircleIconButton Fails to Trigger Remove Dialog Load

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
@@ -1,5 +1,5 @@
 <%= pb_content_tag do %>
-  <%= pb_rails("button", props: {type: object.type, loading: object.loading, link: object.link, new_window:object.new_window, variant: object.variant, target: object.target, disabled: object.disabled, dark: object.dark}) do %>
+  <%= pb_rails("button", props: {type: object.type, loading: object.loading, link: object.link, new_window:object.new_window, variant: object.variant, target: object.target, disabled: object.disabled, dark: object.dark, data: object.data}) do %>
     <%= pb_rails("icon", props: {icon: object.icon, fixed_width: true, dark: object.dark}) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2360](https://runway.powerhrg.com/backlog_items/PLAY-2360) concerns an issue with the Rails circle_icon_button not loading content from an AJAX call in the same manner the regular button does. The bug reports that the default circle_icon_button is not buggy, but in my local testing (pre-fix) I cannot get it to work with any of the circle_icon_button variants.
Solution Attempt 1: adding data prop to internal button (current data sits on the circle_icon_button div wrapper which does not have the same button/a role change the internal button does). Undergoing alpha testing.

_**WIP**_

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.