### PR TITLE
[PLAY-1972] Phone Number Kit: Validate Missing Area Code and Repeat Country Code

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/_phone_number_input.tsx
@@ -197,7 +197,7 @@ const PhoneNumberInput = (props: PhoneNumberInputProps, ref?: React.Ref<unknown>
   }
 
   const validateMissingAreaCode = (itiInit: any) => {
-    if (!required || !itiInit) return
+    if (!itiInit) return
     if (itiInit.getValidationError() === ValidationError.MissingAreaCode) {
       showFormattedError('missing area code')
       return true


### PR DESCRIPTION
**What does this PR do?** 
Add more validation rules:
1. Validate missing area codes (e.g., 555-5555) even without the prop `required`
2. Validate repeat country codes (e.g. US +1 is selected and you write 1-555-555-5555)

https://runway.powerhrg.com/backlog_items/PLAY-1972

**Screenshots:** Screenshots to visualize your addition/change
<img width="1297" height="600" alt="Screenshot 2025-08-06 at 11 17 25 AM" src="https://github.com/user-attachments/assets/983daab0-8392-43db-9164-efd2c0776e68" />

**How to test?** Steps to confirm the desired behavior:
1. Go to phone number kit docs
2. Pick US as country
3. Type 7 digits, it should say "missing area code"
4. Type 15555555555, it should say "repeat country code"
5. Make sure everything works as expected


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.