### PR TITLE
[PLAY-2343] Add @tiptap/react to External Dependencies in vite.config.ts

### DIFF
--- a/playbook/vite.config.ts
+++ b/playbook/vite.config.ts
@@ -10,6 +10,9 @@ import { env } from 'process';
 const isProduction = env.NODE_ENV === 'production'
 
 export default defineConfig({
+  optimizeDeps: {
+    exclude: ['tiptap/react'],
+  },
   build: {
     minify: isProduction ? 'terser' : false,
     terserOptions: {
@@ -56,6 +59,7 @@ export default defineConfig({
         'trix',
         'react-trix',
         'webpacker-react',
+        'tiptap/react',
       ],
     },
   },


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2343](https://runway.powerhrg.com/backlog_items/PLAY-2343) excludes @tiptap/react from Vite's dependency optimization so it is treated as an external dependency during the build. This PR adds it to optimizeDeps.exclude and build.rollupOptions.external in the vite.config.ts. The RichTextEditor kit should function as it currently does on Playbook and in satellite apps with this change.

**How to test?** Steps to confirm the desired behavior:
1. Go to the React RichTextEditor kit page. All doc examples should act the same as they do currently.
2. Go to the RichTextEditor locations in Nitro (in alpha review env) - RTEs in those locations should act the same as they do currently.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.