### PR TITLE
[PLAY-2373] Update Playbook Icons

### DIFF
--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "0.0.1-alpha.39",
-    "@powerhome/playbook-icons-react": "0.0.1-alpha.39",
+    "@powerhome/playbook-icons": "0.0.1-alpha.40",
+    "@powerhome/playbook-icons-react": "0.0.1-alpha.40",
     "@powerhome/power-fonts": "0.0.1",
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,15 +3161,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@0.0.1-alpha.39":
-  version "0.0.1-alpha.39"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/5b1aad98ce9d9f1907429f2d803023107419771b#5b1aad98ce9d9f1907429f2d803023107419771b"
-  integrity sha512-ks/llk7xmhaE6GQRpajddRnC9dssjDFnpbJz/LMkZ+FIby1QYaa+urk4cscLfgNAEJszYZCrKF9gAzuuCTouew==
+"@powerhome/playbook-icons-react@0.0.1-alpha.40":
+  version "0.0.1-alpha.40"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/30ee3e9d71fb277ad60e73623bcac89254eacd41#30ee3e9d71fb277ad60e73623bcac89254eacd41"
+  integrity sha512-p9qpHln94xWZsab9onOUUiP6simre5wPdm2ipsroDNRXmfcSUwuSpEwUJBBz7G/ceBVgVFYWrguf5p0cmTzzxQ==
 
-"@powerhome/playbook-icons@0.0.1-alpha.39":
-  version "0.0.1-alpha.39"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/8b1f1dcc58253e96aa73395c21b973b54c783bff#8b1f1dcc58253e96aa73395c21b973b54c783bff"
-  integrity sha512-8XzPAYi0DZuYzhnWlpGpgjTlxlf5/uCXLDij+t3pqmZSuaZX9diuFWApDFB2gHm/tdWaM1dP6Z9UcvEDI4N53Q==
+"@powerhome/playbook-icons@0.0.1-alpha.40":
+  version "0.0.1-alpha.40"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/de910f5f223a55027212a4911b0e5681f3ef4d6e#de910f5f223a55027212a4911b0e5681f3ef4d6e"
+  integrity sha512-5OC8VuVPBNzKgVkb12kYnm6ZcL1n5ogLJYFX6d+GHLO45l7LvvluCo/PG2QDgcFIC+Sff/DIGDT8fPpd7XFfOQ==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2373](https://runway.powerhrg.com/backlog_items/PLAY-2373) adds the Playbook Icon to the playbook-icons repo (woohoo!). This PR is a version bump.

[Playbook-icons PR](https://github.com/powerhome/playbook-icons/pull/43)


**Screenshots:** Screenshots to visualize your addition/change
<img width="1122" height="414" alt="playbook icon in PB repo" src="https://github.com/user-attachments/assets/d4885b8e-3d03-460b-b39d-cfce83883e15" />


**How to test?** Steps to confirm the desired behavior:
1. Icon="Playbook" now works with our Icon kit (React or Rails). See "pb_custom_icon" class in screenshot.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.