### PR TITLE
[PLAY-2413] Toggle Kit - Add Focus State

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
@@ -46,7 +46,16 @@ $transition: .2s ease-in-out;
     }
 
     input {
-      display: none;
+      position: absolute;
+      opacity: 0;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+
+      &:focus + .pb_toggle_control {
+        box-shadow: 0px 0px 0px 2px $white, 0px 0px 0px 4px $primary;
+        outline: none;
+      }
 
       &:disabled + .pb_toggle_control {
         cursor: not-allowed;
@@ -61,7 +70,11 @@ $transition: .2s ease-in-out;
     }
 
     input:checked {
-      display: none;
+      position: absolute;
+      opacity: 0;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
 
       &:checked + .pb_toggle_control {
         border: $border_success;
@@ -71,6 +84,11 @@ $transition: .2s ease-in-out;
           left: $width / 2 + 2px;
           background-color: $white;
         }
+      }
+
+      &:checked:focus + .pb_toggle_control {
+        box-shadow: 0px 0px 0px 2px $white, 0px 0px 0px 4px $primary;
+        outline: none;
       }
 
       &:disabled + .pb_toggle_control {

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.scss
@@ -13,6 +13,8 @@ $transition: .2s ease-in-out;
   $border_default: 3px solid $color_checkbox_default;
 
   .pb_toggle_wrapper {
+    position: relative;
+
     .pb_toggle_control {
       cursor: pointer;
       transition: $transition;
@@ -23,6 +25,7 @@ $transition: .2s ease-in-out;
       border: $border_default;
       position: relative;
       box-sizing: content-box;
+      pointer-events: none;
 
       &:after {
         transition: $transition;
@@ -47,12 +50,17 @@ $transition: .2s ease-in-out;
 
     input {
       position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
       opacity: 0;
-      width: 1px;
-      height: 1px;
-      overflow: hidden;
+      z-index: 2;
 
-      &:focus + .pb_toggle_control {
+      &:focus + .pb_toggle_control,
+      &:focus-visible + .pb_toggle_control {
         box-shadow: 0px 0px 0px 2px $white, 0px 0px 0px 4px $primary;
         outline: none;
       }
@@ -70,12 +78,6 @@ $transition: .2s ease-in-out;
     }
 
     input:checked {
-      position: absolute;
-      opacity: 0;
-      width: 1px;
-      height: 1px;
-      overflow: hidden;
-
       &:checked + .pb_toggle_control {
         border: $border_success;
         background-color: $color_checkbox_success;
@@ -86,7 +88,8 @@ $transition: .2s ease-in-out;
         }
       }
 
-      &:checked:focus + .pb_toggle_control {
+      &:focus + .pb_toggle_control,
+      &:focus-visible + .pb_toggle_control {
         box-shadow: 0px 0px 0px 2px $white, 0px 0px 0px 4px $primary;
         outline: none;
       }

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import classnames from 'classnames'
 import type { InputCallback } from '../types'
+import { uniqueId } from '../utilities/object'
 
 import {
   buildAriaProps,
@@ -57,6 +58,9 @@ const Toggle = ({
       }
     ))
 
+const [autoId] = useState(() => uniqueId('toggle-'))
+const inputId = id ? `${id}-input` : `${autoId}-input`
+
   return (
     <div
         {...ariaProps}
@@ -65,7 +69,9 @@ const Toggle = ({
         className={classnames(css, globalProps(props), className)}
         id={id}
     >
-      <label className="pb_toggle_wrapper">
+      <label className="pb_toggle_wrapper" 
+          htmlFor={inputId}
+      >
         {children && children}
 
         {!children &&
@@ -73,6 +79,7 @@ const Toggle = ({
               {...props}
               defaultChecked={checked}
               disabled={disabled}
+              id={inputId}
               name={name}
               onChange={onChange}
               tabIndex={tabIndex}

--- a/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/_toggle.tsx
@@ -23,6 +23,7 @@ type Props = {
   name?: string,
   onChange?: InputCallback<HTMLInputElement>,
   size?: "sm" | "md",
+  tabIndex?: number,
   value?: string,
 } & GlobalProps
 
@@ -40,6 +41,7 @@ const Toggle = ({
   // Function body here
   },
   size = 'sm',
+  tabIndex,
   value,
   ...props
 }: Props): React.ReactElement => {
@@ -73,6 +75,7 @@ const Toggle = ({
               disabled={disabled}
               name={name}
               onChange={onChange}
+              tabIndex={tabIndex}
               type="checkbox"
               value={value}
           />

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_default.html.erb
@@ -1,9 +1,11 @@
 <%= pb_rails("toggle", props: {
-  checked: true
+  checked: true,  
+  input_options: { tabindex: 0 }
 }) %>
 
 <br>
 
 <%= pb_rails("toggle", props: {
-  checked: false
+  checked: false,
+  input_options: { tabindex: 0 }
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_toggle/docs/_toggle_default.jsx
@@ -6,11 +6,12 @@ const ToggleDefault = () => {
     <>
       <Toggle
           checked
+          tabIndex={0}
       />
 
       <br />
 
-      <Toggle />
+      <Toggle tabIndex={0} />
     </>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_toggle/toggle.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_toggle/toggle.html.erb
@@ -1,5 +1,5 @@
 <%= pb_content_tag do %>
-  <label class="pb_toggle_wrapper">
+  <label class="pb_toggle_wrapper" for="<%= object.id %>-input">
     <%= content.presence || object.input %>
     <div class="pb_toggle_control"></div>
   </label>

--- a/playbook/app/pb_kits/playbook/pb_toggle/toggle.rb
+++ b/playbook/app/pb_kits/playbook/pb_toggle/toggle.rb
@@ -22,7 +22,8 @@ module Playbook
       end
 
       def input
-        check_box_tag(name, value, checked, input_options.merge(disabled: disabled))
+        input_id = id.present? ? "#{id}-input" : "pb_toggle_#{SecureRandom.hex(4)}"
+        check_box_tag(name, value, checked, input_options.merge(disabled: disabled, id: input_id))
       end
 
     private


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2413](https://runway.powerhrg.com/backlog_items/PLAY-2413) adds a focus state to the Toggle kit. Modeled off of [previous PR](https://github.com/powerhome/playbook/pull/1354) done to add it to Checkbox and Radio. Part of Aug 2025 Tempo accessibility effort.

**NOTE**: The added code adds a focus state to Playbook/Nitro correctly, but it does not work in Tempo. The internal input is "grayed out" in Tempo (while it is currently grayed out everywhere in prod, these changes make it inspectable for Playbook and Nitro). Because this is not working correctly AND the customer facing Toggle was just removed from the Customer Portal) (and are additional embedded accessibility issues in the Toggle kit) I am putting this on pause. Screenshots in [this huddle doc](https://huddle.powerapp.cloud/projects/647/handoffs/2165) highlighting issues.

**Screenshots:** Screenshots to visualize your addition/change
<img width="273" height="283" alt="toggle focus 1" src="https://github.com/user-attachments/assets/f0fda0b0-64db-4cc5-893c-6f06ed468ea1" />
<img width="268" height="327" alt="toggle focus 2" src="https://github.com/user-attachments/assets/10c677f2-60c3-49b6-b523-89a31db9b06d" />

**How to test?** Steps to confirm the desired behavior:
1. Go to Toggle kit page on Playbook review environment. Tab onto any doc example and as you tab along all (non-disabled) Toggles should get the blue focus state outline. 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.