### PR TITLE
[PLAY-2343] CircleIconButton - Ensure Aria Applies to Internal Button

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/_circle_icon_button.tsx
@@ -65,6 +65,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
         id={id}
     >
       <Button
+          aria={aria}
           dark={dark}
           disabled={disabled}
           htmlType={type}
@@ -78,6 +79,7 @@ const CircleIconButton = (props: CircleIconButtonProps): React.ReactElement => {
       >
         <Icon
             fixedWidth
+            htmlOptions={{'aria-hidden': true}}
             icon={icon}
         />
       </Button>

--- a/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_circle_icon_button/circle_icon_button.html.erb
@@ -1,5 +1,6 @@
 <%= pb_content_tag do %>
   <%= pb_rails("button", props: {
+    aria: object.aria,
     type: object.type, 
     loading: object.loading, 
     link: object.link, 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2423](https://runway.powerhrg.com/backlog_items/PLAY-2423) adds the aria prop to the internal Button element wrapped by the main div of the CircleIconButton for Rails and React so that labels apply where browsers/screenreaders/etc actually expects them. It also hides the Icon from aria view for the React kit so this does not throw an additional labeling error constantly. Accessible use of the Circle Icon Button will apply an aria label with the semantic meaning conveyed by the icon of choice to the button itself and the icon does not need its own redundant label. The Rails Icon aria set up is much more complex ([passes aria to svg](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_icon/icon.rb#L113) but needs to allow more than just label) and will need to be handled separately. 

Part of Aug 2025 Tempo accessibility effort.

**Screenshots:** Screenshots to visualize your addition/change
The two errors: 
<img width="1672" height="537" alt="button level error" src="https://github.com/user-attachments/assets/a73ffc7b-a036-4dd9-b6fd-9bbdb12bdaf8" />
<img width="1660" height="563" alt="icon level error" src="https://github.com/user-attachments/assets/41b43ecc-c048-47aa-8f88-374a0352e13f" />
See both errors resolved:
<img width="758" height="461" alt="errors resolved" src="https://github.com/user-attachments/assets/dbadb202-4bdc-459b-870c-de067eaa4953" />
Example code:
```
    <CircleIconButton
        aria={{'label': 'Add Item aria label'}}
        icon="plus"
        variant="primary"
        {...props}
    />
```

**How to test?** Steps to confirm the desired behavior:
1. CSB (link to come)

In Nitro only [two locations](https://github.com/search?q=repo%3Apowerhome%2Fnitro-web+pb_rails%28%22circle_icon_button%22+aria%3A&type=code) use aria with Circle Icon Button this should let it apply properly

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.