### PR TITLE
[PLAY-2422] FixedConfirmationToast kit - Accessibility

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/_fixed_confirmation_toast.tsx
@@ -35,6 +35,8 @@ type FixedConfirmationToastProps = {
 
 const FixedConfirmationToast = (props: FixedConfirmationToastProps): React.ReactElement => {
   const [showToast, toggleToast] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
+
   const {
     autoClose = 0,
     children,
@@ -84,12 +86,24 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps): React.React
     onClose();
   };
 
+  // prevents Screen Reader from announcing all examples on page load, just dynamic on open
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
   return (
     <>
       {showToast && (
         <div
+            aria-atomic={hydrated && open ? "true" : undefined}
+            aria-live={hydrated && open ? "polite" : undefined} 
             className={css}
             onClick={handleClick}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") handleClick();
+            }}
+            role="status"
+            tabIndex={0}
             {...htmlProps}
         >
           {returnedIcon && icon !== "none" && (
@@ -112,6 +126,7 @@ const FixedConfirmationToast = (props: FixedConfirmationToastProps): React.React
 
           {closeable && (
             <Icon
+                aria={{ "label": "Close Toast" }}
                 className="pb_icon"
                 cursor="pointer"
                 fixedWidth={false}

--- a/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_fixed_confirmation_toast/fixed_confirmation_toast.html.erb
@@ -1,6 +1,6 @@
-<%= pb_content_tag do %>
+<%= pb_content_tag(:div, "aria-atomic": "true", "aria-live": "polite", role: "status", tabindex: 0) do %>
     <% if object.icon_value && object.icon_value != "none" %>
-    <%= pb_rails("icon", props: { icon: object.icon_value, classname: "pb_icon", fixed_width: true }) %>
+    <%= pb_rails("icon", props: { icon: object.icon_value, classname: "pb_icon", fixed_width: true, aria: { "aria-label": "#{object.icon_value} icon" } }) %>
     <% end %>
     <% if content %>
         <%= content %>
@@ -8,5 +8,5 @@
         <%= pb_rails("title", props: { text: object.text, size: 4, flex: "1", classname: "pb_fixed_confirmation_toast_text" }) %>
     <% end %>
 
-    <%= pb_rails("icon", props: { icon: "times", classname: "pb_icon", cursor: "pointer", fixed_width: true }) if object.closeable %>
+    <%= pb_rails("icon", props: { icon: "times", classname: "pb_icon", cursor: "pointer", fixed_width: true, aria: { "aria-label": "Close Toast" } }) if object.closeable %>
 <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2422](https://runway.powerhrg.com/backlog_items/PLAY-2422) addresses some accessibility issues on the Fixed Confirmation Toast kit. Some of the issues are Icon related and require the Icon updates done in [PLAY-2419](https://github.com/powerhome/playbook/pull/5056) to fully work, but these changes have been tested on that branch and will be compatible once they all come together. 

The stretch goal was not fully achievable. The clickable red stop warning has been downgraded to a yellow warning triangle focus semantic labeling warning for both React and Rails and that is a win. They persist as they relate to a much larger issue of divs having onclick events attached directly to them (see similar notes on many other tickets).
Addressing this for FCTs will require a full refactor of how FCT handle the click event (I have some saved code investigating this, involves changing the close icon to an HTML button wrapping the Icon or using an Icon Button and then attaching the click directly to that for closeable toasts) that felt like "too much" for this but can be considered in future.

The PR does achieve the following:
- FCTs have role: status and aria-live/aria-atomic labels ensure that FCTs that dynamically appear on the page will be announced by a screen reader.
- FCTs just hanging out on a page already (like doc examples) will not be live announced. React needed code to prevent against hydration to achieve this, Rails was OK.
- Icons in FCT will have the correct aria labels (once hits prod after PLAY-2419 does, requires those Icon kit updates to fully appreciate).
- Adding tabindex to FCT for both/onKeyDown for React downgrades the red clickable warning to a yellow focusable warning.

**Screenshots:** Screenshots to visualize your addition/change
<img width="790" height="533" alt="closeable react w accessibility warning" src="https://github.com/user-attachments/assets/5b64d871-6f6d-4678-aabf-4ea49bcf378b" />
<img width="1096" height="991" alt="autoclose rails w accessibility warning" src="https://github.com/user-attachments/assets/98230a79-cc8d-4b7f-991e-63bf3f42b632" />
<img width="884" height="717" alt="react fct aria on first icon" src="https://github.com/user-attachments/assets/24214c98-012b-4b5e-aa47-00da0e722b68" />
<img width="346" height="108" alt="close icon aria" src="https://github.com/user-attachments/assets/8271a0de-9aa1-4677-9856-cac2ccb6095a" />

**How to test?** Steps to confirm the desired behavior:
1. Go to the Fixed Confirmation Toast kit on the review env. Everything should look and function as it does currently.
2. Inspect with Firefox accessibility tools to see the "status" role and a decrease in warnings (the Icon warnings will not be resolved in the review env but will just pop into place once merged to prod after PLAY-2419).
3. Test in Safari with Voiceover to hear the live aria announcing in action.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.