### PR TITLE
[PLAY-2425] TextInput Accessibility

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.tsx
@@ -138,10 +138,14 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
     formattedValue = value
   }
 
+  const errorId = error ? `${id}-error` : undefined
+
   const textInput = (
     childInput ? React.cloneElement(children, { className: "text_input" }) :
     (<input
         {...domSafeProps(props)}
+        aria-describedby={errorId}
+        aria-invalid={!!error}
         className="text_input"
         disabled={disabled}
         id={id}
@@ -199,16 +203,20 @@ const TextInput = (props: TextInputProps, ref: React.LegacyRef<HTMLInputElement>
         {...htmlProps}
         className={css}
     >
-      {label &&
-        <Caption
-            className="pb_text_input_kit_label"
-            text={label}
-        />
-      }
+      {label && (
+        <label htmlFor={id}>
+          <Caption className="pb_text_input_kit_label" 
+              text={label} 
+          />
+        </label>
+      )}
       <div className={`${addOnCss} text_input_wrapper`}>
         {render}
 
         {error && <Body
+            aria={{ atomic: "true", live: "polite" }}
+            htmlOptions={{ role: "alert" }}
+            id={errorId}
             status="negative"
             text={error}
             variant={null}

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.html.erb
@@ -9,23 +9,27 @@
 
 <%= pb_rails("text_input", props: {
   label: "Last Name",
-  placeholder: "Enter last name"
+  placeholder: "Enter last name",
+  id: "last-name"
 }) %>
 
 <%= pb_rails("text_input", props: {
     label: "Phone Number",
     type: "phone",
-    placeholder: "Enter phone number"
+    placeholder: "Enter phone number",
+    id: "phone"
 }) %>
 
 <%= pb_rails("text_input", props: {
     label: "Email Address",
     type: "email",
-    placeholder: "Enter email address"
+    placeholder: "Enter email address",
+    id: "email"
 }) %>
 
 <%= pb_rails("text_input", props: {
     label: "Zip Code",
     type: "number",
-    placeholder: "Enter zip code"
+    placeholder: "Enter zip code",
+    id: "zip"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.jsx
@@ -38,6 +38,7 @@ const TextInputDefault = (props) => {
           {...props}
       />
       <TextInput
+          id="last-name"
           label="Last Name"
           name="lastName"
           onChange={handleOnChangeFormField}
@@ -46,6 +47,7 @@ const TextInputDefault = (props) => {
           {...props}
       />
       <TextInput
+          id="phone"
           label="Phone Number"
           name="phone"
           onChange={handleOnChangeFormField}
@@ -55,6 +57,7 @@ const TextInputDefault = (props) => {
           {...props}
       />
       <TextInput
+          id="email"
           label="Email Address"
           name="email"
           onChange={handleOnChangeFormField}
@@ -64,6 +67,7 @@ const TextInputDefault = (props) => {
           {...props}
       />
       <TextInput
+          id="zip"
           label="Zip Code"
           name="zip"
           onChange={handleOnChangeFormField}
@@ -84,6 +88,7 @@ const TextInputDefault = (props) => {
       <br />
 
       <TextInput
+          id="first-name"
           label="First Name"
           onChange={handleOnChangeFirstName}
           placeholder="Enter first name"

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.md
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_default.md
@@ -1,0 +1,1 @@
+Add an `id` to your Text Input so that clicking the label will move focus directly to the input.

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.html.erb
@@ -1,6 +1,8 @@
 <%= pb_content_tag(:div, id: nil ) do  %>
   <% if object.label.present? %>
+  <label for="<%= object.input_options[:id] || object.id %>" >
     <%= pb_rails("caption", props: { text: object.label, dark: object.dark, classname: "pb_text_input_kit_label" }) %>
+  </label>
   <% end %>
   <%= content_tag(:div, class: "#{add_on_class} text_input_wrapper") do %>
     <% if content.present? %>
@@ -15,7 +17,7 @@
     <% else %>
       <%= input_tag %>
     <% end %>
-    <%= pb_rails("body", props: {dark: object.dark, status: "negative", text: object.error}) if object.error %>
+    <%= pb_rails("body", props: {dark: object.dark, status: "negative", text: object.error, id: object.error_id, aria: { atomic: "true", live: "polite" }, html_options: { role: "alert" }}) if object.error %>
   <% end %>
 <% end %>
 

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -65,10 +65,16 @@ module Playbook
         "#{object.id}-sanitized" if id.present?
       end
 
+      def error_id
+        "#{id}-error" if error.present?
+      end
+
     private
 
       def all_input_options
         {
+          'aria-describedby': error.present? ? error_id : nil,
+          'aria-invalid': error.present?,
           autocomplete: autocomplete ? nil : "off",
           class: "text_input #{input_options.dig(:classname) || ''}",
           data: validation_data,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2425](https://runway.powerhrg.com/backlog_items/PLAY-2425) addresses some accessibility issues on the TextInput kit. 

This PR achieves the following for React and Rails:
- Labels: now when a Text Input has an id, the label will act like the ones on the form dot inputs do and direct focus to the input itself. I've updated the default doc examples to reflect this and included markdown to share this info. This resolves the yellow warning Firefox accessibility "text inputs should have a visible label". This type of update should be done for all of our input kits.
- Errors: when errors pop into the page (like after a failed submit), they should be live announced by a screen reader program. See this CSB as an example for React (Rails is less dynamic so harder to demo in this context, but when using AJAX/Stimulus etc. to make dynamic errors appear the same thing should happen).

**Screenshots:** Screenshots to visualize your addition/change
Accessibility Warning
<img width="1586" height="641" alt="rails text input label error" src="https://github.com/user-attachments/assets/77799ce6-a8e0-4ee0-b331-7b845c63e6bf" />
Warning Resolved
<img width="1615" height="709" alt="rails warning gone" src="https://github.com/user-attachments/assets/77f9570e-96c8-4c0c-96be-201173f619e5" />
Clicking Labels Brings Focus to Input
<img width="143" height="83" alt="Screenshot 2025-08-25 at 8 58 50 AM" src="https://github.com/user-attachments/assets/a92ffa83-a3be-4960-8cae-747cda49bf3e" />

**How to test?** Steps to confirm the desired behavior:
1. Go to the Text Input default doc examples in the review env. Click the labels of each input and see the cursor appear and blue focus outline on each corresponding text input.
2. Go to this CSB and test out a dynamically appearing error message with VoiceOver program on. The error will be live announced as it pops into the page (for easiest testing wait to toggle the button until the VoiceOver program has finished its current statement, the program is not super intuitive).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.