### PR TITLE
[PLAY-2402] Playbook Website: Add Missing icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -172,6 +172,10 @@
     "category": "Arrows"
   },
   {
+    "name": "arrows-left-right-through-line",
+    "category": "Arrows"
+  },
+  {
     "name": "arrows-left-right-to-line",
     "category": "Arrows"
   },
@@ -185,6 +189,14 @@
   },
   {
     "name": "arrows-up-down-left-right",
+    "category": "Arrows"
+  },
+  {
+    "name": "arrows-up-down-through-line",
+    "category": "Arrows"
+  },
+  {
+    "name": "arrows-up-down-to-line",
     "category": "Arrows"
   },
   {
@@ -976,6 +988,10 @@
     "category": "Interface Core"
   },
   {
+    "name": "corner",
+    "category": "Interface Core"
+  },
+  {
     "name": "crop",
     "category": "Interface Core"
   },
@@ -1028,6 +1044,10 @@
     "category": "Interface Core"
   },
   {
+    "name": "gap",
+    "category": "Interface Core"
+  },
+  {
     "name": "grid-2",
     "category": "Interface Core"
   },
@@ -1040,7 +1060,15 @@
     "category": "Interface Core"
   },
   {
+    "name": "layer-group",
+    "category": "Interface Core"
+  },
+  {
     "name": "layer-plus",
+    "category": "Interface Core"
+  },
+  {
+    "name": "letter-spacing",
     "category": "Interface Core"
   },
   {
@@ -1061,6 +1089,14 @@
   },
   {
     "name": "object-exclude",
+    "category": "Interface Core"
+  },
+  {
+    "name": "objects-align-center-vertical",
+    "category": "Interface Core"
+  },
+  {
+    "name": "objects-align-left",
     "category": "Interface Core"
   },
   {
@@ -1092,6 +1128,10 @@
     "category": "Interface Core"
   },
   {
+    "name": "rectangle-wide",
+    "category": "Interface Core"
+  },
+  {
     "name": "refresh",
     "category": "Interface Core"
   },
@@ -1104,7 +1144,15 @@
     "category": "Interface Core"
   },
   {
+    "name": "shadow",
+    "category": "Interface Core"
+  },
+  {
     "name": "sliders-h",
+    "category": "Interface Core"
+  },
+  {
+    "name": "spinner-solid",
     "category": "Interface Core"
   },
   {
@@ -1521,6 +1569,10 @@
   },
   {
     "name": "nitro-n",
+    "category": "Power Tooling"
+  },
+  {
+    "name": "playbook",
     "category": "Power Tooling"
   },
   {

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "0.0.1-alpha.40",
-    "@powerhome/playbook-icons-react": "0.0.1-alpha.40",
+    "@powerhome/playbook-icons": "0.0.1-alpha.44",
+    "@powerhome/playbook-icons-react": "0.0.1-alpha.44",
     "@powerhome/power-fonts": "0.0.1",
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,15 +3156,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@0.0.1-alpha.40":
-  version "0.0.1-alpha.40"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/30ee3e9d71fb277ad60e73623bcac89254eacd41#30ee3e9d71fb277ad60e73623bcac89254eacd41"
-  integrity sha512-p9qpHln94xWZsab9onOUUiP6simre5wPdm2ipsroDNRXmfcSUwuSpEwUJBBz7G/ceBVgVFYWrguf5p0cmTzzxQ==
+"@powerhome/playbook-icons-react@0.0.1-alpha.44":
+  version "0.0.1-alpha.44"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/f89c992855d62144492f5f0c3f90b8062f4cec31#f89c992855d62144492f5f0c3f90b8062f4cec31"
+  integrity sha512-SQPQuKFHe0PvYhI9o3jWhP5zWZU0YxoR4hj1mOSKYoWoNwWkNCko9wr24z2ps23qc3w/KZbhgwdmr86ao9UN0g==
 
-"@powerhome/playbook-icons@0.0.1-alpha.40":
-  version "0.0.1-alpha.40"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/de910f5f223a55027212a4911b0e5681f3ef4d6e#de910f5f223a55027212a4911b0e5681f3ef4d6e"
-  integrity sha512-5OC8VuVPBNzKgVkb12kYnm6ZcL1n5ogLJYFX6d+GHLO45l7LvvluCo/PG2QDgcFIC+Sff/DIGDT8fPpd7XFfOQ==
+"@powerhome/playbook-icons@0.0.1-alpha.44":
+  version "0.0.1-alpha.44"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/90e580b0ff045918699420159d9846b6341b1dcc#90e580b0ff045918699420159d9846b6341b1dcc"
+  integrity sha512-CSzlChexsrzG/sNzygiz+qjQbKprUEhXDltRT9op43mKRhg9C2mUhpgOKX91f92qKQydgFaf19/mhUMsCNEx/A==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Add new icons from 0.0.1-alpha.44

https://runway.powerhrg.com/backlog_items/PLAY-2402

**Screenshots:** Screenshots to visualize your addition/change
<img width="1015" height="314" alt="Screenshot 2025-08-29 at 3 09 53 PM" src="https://github.com/user-attachments/assets/f96b6b85-eb53-466a-b81e-499c3ffe2c43" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /playbook_icons


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.