### PR TITLE
[PLAY-2113] Typeahead Kit: Fix Clear All Docs - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
@@ -7,7 +7,7 @@
   ]
 %>
 
-<%= pb_rails("typeahead", props: { id: "typeahead-pills-example1", default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
+<%= pb_rails("typeahead", props: { id: "typeahead-pills-example1", default_options: [options.first], options: options, label: "Products", name: :foo, pills: true }) %>
 
 <%= pb_rails("button", props: {id: "clear-pills", text: "Clear All Options", variant: "secondary"}) %>
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.jsx
@@ -13,7 +13,7 @@ const TypeaheadWithPills = (props) => {
     <>
       <Typeahead
           isMulti
-          label="Colors"
+          label="Products"
           options={options}
           placeholder=""
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.html.erb
@@ -7,25 +7,25 @@
   ]
 %>
 
-<%= pb_rails("typeahead", props: { id: "typeahead-pills-example1", pill_color: "neutral", default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
+<%= pb_rails("typeahead", props: { id: "typeahead-pills-example2", pill_color: "neutral", default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
 
-<%= pb_rails("button", props: {id: "clear-pills", text: "Clear All Options", variant: "secondary"}) %>
+<%= pb_rails("button", props: {id: "clear-pills-color", text: "Clear All Options", variant: "secondary"}) %>
 
 <!-- This section is an example of the available JavaScript event hooks -->
 <%= javascript_tag defer: "defer" do %>
-  document.addEventListener("pb-typeahead-kit-typeahead-pills-example1-result-option-select", function(event) {
+  document.addEventListener("pb-typeahead-kit-typeahead-pills-example2-result-option-select", function(event) {
     console.log('Option selected')
     console.dir(event.detail)
   })
-  document.addEventListener("pb-typeahead-kit-typeahead-pills-example1-result-option-remove", function(event) {
+  document.addEventListener("pb-typeahead-kit-typeahead-pills-example2-result-option-remove", function(event) {
     console.log('Option removed')
     console.dir(event.detail)
   })
-  document.addEventListener("pb-typeahead-kit-typeahead-pills-example1-result-clear", function() {
+  document.addEventListener("pb-typeahead-kit-typeahead-pills-example2-result-clear", function() {
     console.log('All options cleared')
   })
 
-  document.querySelector('#clear-pills').addEventListener('click', function() {
-    document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example1:clear'))
+  document.querySelector('#clear-pills-color').addEventListener('click', function() {
+    document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example2:clear'))
   })
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.html.erb
@@ -7,25 +7,4 @@
   ]
 %>
 
-<%= pb_rails("typeahead", props: { id: "typeahead-pills-example2", pill_color: "neutral", default_options: [options.first], options: options, label: "Products", name: :foo, pills: true }) %>
-
-<%= pb_rails("button", props: {id: "clear-pills-color", text: "Clear All Options", variant: "secondary"}) %>
-
-<!-- This section is an example of the available JavaScript event hooks -->
-<%= javascript_tag defer: "defer" do %>
-  document.addEventListener("pb-typeahead-kit-typeahead-pills-example2-result-option-select", function(event) {
-    console.log('Option selected')
-    console.dir(event.detail)
-  })
-  document.addEventListener("pb-typeahead-kit-typeahead-pills-example2-result-option-remove", function(event) {
-    console.log('Option removed')
-    console.dir(event.detail)
-  })
-  document.addEventListener("pb-typeahead-kit-typeahead-pills-example2-result-clear", function() {
-    console.log('All options cleared')
-  })
-
-  document.querySelector('#clear-pills-color').addEventListener('click', function() {
-    document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example2:clear'))
-  })
-<% end %>
+<%= pb_rails("typeahead", props: { id: "typeahead-pills-example2", pill_color: "neutral", options: options, label: "Products", name: :foo, pills: true }) %>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.html.erb
@@ -7,7 +7,7 @@
   ]
 %>
 
-<%= pb_rails("typeahead", props: { id: "typeahead-pills-example2", pill_color: "neutral", default_options: [options.first], options: options, label: "Colors", name: :foo, pills: true }) %>
+<%= pb_rails("typeahead", props: { id: "typeahead-pills-example2", pill_color: "neutral", default_options: [options.first], options: options, label: "Products", name: :foo, pills: true }) %>
 
 <%= pb_rails("button", props: {id: "clear-pills-color", text: "Clear All Options", variant: "secondary"}) %>
 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills_color.jsx
@@ -13,7 +13,7 @@ const TypeaheadWithPills = (props) => {
     <>
       <Typeahead
           isMulti
-          label="Colors"
+          label="Products"
           options={options}
           pillColor="neutral"
           placeholder=""

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_without_pills.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_without_pills.html.erb
@@ -9,9 +9,9 @@
 
 <%= pb_rails("typeahead", props: {
     id: "typeahead-without-pills-example1",
-    placeholder: "All Colors",
+    placeholder: "All Products",
     options: options, 
-    label: "Colors",
+    label: "Products",
     name: :foo,
     is_multi: false
   })


### PR DESCRIPTION
**What does this PR do?**
- Match Rails "With Pills (Custom Color)" doc to React's
- Off-topic: Change label to Products (fka. Colors) for Product Typeaheads

https://runway.powerhrg.com/backlog_items/PLAY-2113

**Screenshots:** Screenshots to visualize your addition/change
<img width="1311" height="134" alt="Screenshot 2025-09-03 at 1 35 32 PM" src="https://github.com/user-attachments/assets/edb25fc1-8794-4019-a9a4-eb893425afa5" />

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/typeahead/rails#with-pills-custom-color
2. It should match /kits/typeahead/react#with-pills-custom-color


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.