### PR TITLE
[PLAY-2395] Playbook Website: Create Text Align, Opacity and Screen Sizes token pages

### DIFF
--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Opacity.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Opacity.tsx
@@ -1,0 +1,33 @@
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+
+const Opacity = () => {
+  return (
+    <>
+      <ShowPage
+        pageType="tokens"
+        title="Opacity"
+        description="Opacity tokens control the transparency of elements. Commonly used for visual states like disabled, hover, or layering effects."
+      >
+        <PropsExamplesTable
+          headers={["Tokens", "Value", "SASS Example"]}
+          rows={[
+            ["$opacity_1", ".1", <ExampleCodeCard id="opacity-1" text="opacity: $opacity_1;" />],
+            ["$opacity_2", ".2", <ExampleCodeCard id="opacity-2" text="opacity: $opacity_2;" />],
+            ["$opacity_3", ".3", <ExampleCodeCard id="opacity-3" text="opacity: $opacity_3;" />],
+            ["$opacity_4", ".4", <ExampleCodeCard id="opacity-4" text="opacity: $opacity_4;" />],
+            ["$opacity_5", ".5", <ExampleCodeCard id="opacity-5" text="opacity: $opacity_5;" />],
+            ["$opacity_6", ".6", <ExampleCodeCard id="opacity-6" text="opacity: $opacity_6;" />],
+            ["$opacity_7", ".7", <ExampleCodeCard id="opacity-7" text="opacity: $opacity_7;" />],
+            ["$opacity_8", ".8", <ExampleCodeCard id="opacity-8" text="opacity: $opacity_8;" />],
+            ["$opacity_9", ".9", <ExampleCodeCard id="opacity-9" text="opacity: $opacity_9;" />],
+            ["$opacity_10", "1", <ExampleCodeCard id="opacity-10" text="opacity: $opacity_10;" />],
+          ]}
+        />
+      </ShowPage>
+    </>
+  );
+};
+
+export default Opacity;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/ScreenSizes.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/ScreenSizes.tsx
@@ -1,0 +1,123 @@
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+
+const ScreenSizes = () => {
+  return (
+    <>
+      <ShowPage
+        pageType="tokens"
+        title="Screen Sizes"
+        description="Screen Size tokens define responsive breakpoints used in media queries. Tokens represent common device widths, enabling adaptive layout changes across screen sizes."
+      >
+        <PropsExamplesTable
+          headers={["Tokens", "Value", "SASS Example"]}
+          rows={[
+            [
+              "$screen-xs-min",
+              "575px",
+              <ExampleCodeCard
+                id="screen-xs-min"
+                text={`@media screen and (min-width: $screen-xs-min) {
+                  padding: 16px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-xs-max",
+              "$screen-xs-min - 1",
+              <ExampleCodeCard
+                id="screen-xs-max"
+                text={`@media screen and (max-width: $screen-xs-max) {
+                  padding: 16px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-sm-min",
+              "576px",
+              <ExampleCodeCard
+                id="screen-sm-min"
+                text={`@media screen and (min-width: $screen-sm-min) {
+                  padding: 24px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-sm-max",
+              "$screen-sm-min - 1",
+              <ExampleCodeCard
+                id="screen-sm-max"
+                text={`@media screen and (max-width: $screen-sm-max) {
+                  padding: 24px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-md-min",
+              "768px",
+              <ExampleCodeCard
+                id="screen-md-min"
+                text={`@media screen and (min-width: $screen-md-min) {
+                  padding: 32px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-md-max",
+              "$screen-md-min - 1",
+              <ExampleCodeCard
+                id="screen-md-max"
+                text={`@media screen and (max-width: $screen-md-max) {
+                  padding: 32px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-lg-min",
+              "992px",
+              <ExampleCodeCard
+                id="screen-lg-min"
+                text={`@media screen and (min-width: $screen-lg-min) {
+                  padding:40px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-lg-max",
+              "$screen-lg-min - 1",
+              <ExampleCodeCard
+                id="screen-lg-max"
+                text={`@media screen and (max-width: $screen-lg-max) {
+                  padding: 40px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-xl-min",
+              "1200px",
+              <ExampleCodeCard
+                id="screen-xl-min"
+                text={`@media screen and (min-width: $screen-xl-min) {
+                  min-height: 64px;
+                }`}
+              />,
+            ],
+            [
+              "$screen-xl-max",
+              "$screen-xl-min - 1",
+              <ExampleCodeCard
+                id="screen-xl-max"
+                text={`@media screen and (max-width: $screen-xl-max) {
+                  padding: 64px;
+                }`}
+              />,
+            ],
+          ]}
+        />
+      </ShowPage>
+    </>
+  );
+};
+
+export default ScreenSizes;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/TextAlign.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/TextAlign.tsx
@@ -1,0 +1,31 @@
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+
+const TextAlign = () => {
+  return (
+    <>
+      <ShowPage
+        pageType="tokens"
+        title="Text Align"
+        description="Text-Align tokens control the horizontal alignment of inline content. Values map directly to CSS text-align properties."
+      >
+        <PropsExamplesTable
+          headers={["Tokens", "Value", "SASS Example"]}
+          rows={[
+            ["$text_align_start", "start", <ExampleCodeCard id="text-align-start" text="text-align: $text_align_start;" />],
+            ["$text_align_end", "end", <ExampleCodeCard id="text-align-end" text="text-align: $text_align_end;" />],
+            ["$text_align_left", "left", <ExampleCodeCard id="text-align-left" text="text-align: $text_align_left;" />],
+            ["$text_align_right", "right", <ExampleCodeCard id="text-align-right" text="text-align: $text_align_right;" />],
+            ["$text_align_center", "center", <ExampleCodeCard id="text-align-center" text="text-align: $text_align_center;" />],
+            ["$text_align_justify", "justify", <ExampleCodeCard id="text-align-justify" text="text-align: $text_align_justify;" />],
+            ["$text_align_justify_all", "justify-all", <ExampleCodeCard id="text-align-justify_all" text="text-align: $text_align_justify-all;" />],
+            ["$text_align_match_parent", "match-parent", <ExampleCodeCard id="text-align-match_parent" text="text-align: $text_align_match_parent;" />],
+          ]}
+        />
+      </ShowPage>
+    </>
+  );
+};
+
+export default TextAlign;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
@@ -2,12 +2,18 @@ import { Background } from "playbook-ui";
 import Display from "./Examples/Display";
 import Animation from "./Examples/Animation";
 import VerticalAlign from "./Examples/VerticalAlign";
+import Opacity from "./Examples/Opacity";
+import ScreenSizes from "./Examples/ScreenSizes";
+import TextAlign from "./Examples/TextAlign";
 
 
 const COMPONENT_MAP = {
   animation: Animation,
   display: Display,
   vertical_align: VerticalAlign,
+  opacity: Opacity,
+  screen_sizes: ScreenSizes,
+  text_align: TextAlign,
 };
 
 const TokensExamples = () => {

--- a/playbook-website/config/global_props_and_tokens.yml
+++ b/playbook-website/config/global_props_and_tokens.yml
@@ -9,3 +9,6 @@ tokens:
   - animation
   - display
   - vertical_align
+  - opacity
+  - screen_sizes
+  - text_align


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-2395

This PR adds pages for [Text Align](https://pr5123.playbook.beta.hq.powerapp.cloud/tokens/text_align), [Opacity](https://pr5123.playbook.beta.hq.powerapp.cloud/tokens/opacity) and [Screen Sizes](https://pr5123.playbook.beta.hq.powerapp.cloud/tokens/screen_sizes) tokens on Playbook.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to /tokens
2. Navigate to the new tokens pages
3. Compare to mockup 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.