### PR TITLE
[PLAY-2466] Dialog Kit: Fixes for global props and classname not working - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
@@ -74,7 +74,7 @@ const Dialog = (props: DialogProps): React.ReactElement => {
    const dataProps = buildDataProps(data)
    const htmlProps = buildHtmlProps(htmlOptions);
   const dialogClassNames = {
-    base: classnames("pb_dialog", buildCss("pb_dialog", size, placement)),
+    base: classnames("pb_dialog", buildCss("pb_dialog", size, placement), globalProps(props), className),
     afterOpen: "pb_dialog_after_open",
     beforeClose: "pb_dialog_before_close",
   };
@@ -95,8 +95,6 @@ const Dialog = (props: DialogProps): React.ReactElement => {
 
   const classes = classnames(
     buildCss("pb_dialog_wrapper"),
-    globalProps(props),
-    className
   );
 
   const [triggerOpened, setTriggerOpened] = useState(false),


### PR DESCRIPTION
**What does this PR do?** 
[Runway story](https://runway.powerhrg.com/backlog_items/PLAY-2466)

- Fixes for global props and classname not working as expected for react it
- global props and classnames were being applied to the wrong div.


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.