### PR TITLE
[PLAY-2467] Contact kit - International Phone Number Compatibility

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_contact/_contact.tsx
+++ b/playbook/app/pb_kits/playbook/pb_contact/_contact.tsx
@@ -17,6 +17,7 @@ const contactTypeMap: { [key: string]: string } = {
   'work': 'phone-office',
   'work-cell': 'phone-laptop',
   'wrong-phone': 'phone-slash',
+  'international': 'globe',
 }
 
 const envelopeIcon = getAllIcons()["envelope"].icon as unknown as { [key: string]: SVGElement }
@@ -24,6 +25,10 @@ const envelopeIcon = getAllIcons()["envelope"].icon as unknown as { [key: string
 const formatContact = (contactString: string, contactType: string) => {
   if (contactType === 'email') return contactString
 
+  // International phone numbers are unformatted
+  if (contactType === 'international') return contactString
+  
+  // Format US numbers
   const cleaned = contactString.replace(/\D/g, '')
   const phoneNumber = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/)
 

--- a/playbook/app/pb_kits/playbook/pb_contact/contact.rb
+++ b/playbook/app/pb_kits/playbook/pb_contact/contact.rb
@@ -29,6 +29,8 @@ module Playbook
           "phone-slash"
         when "extension"
           "phone-plus"
+        when "international"
+          "globe"
         else # "unknown" || "other"
           "phone"
         end
@@ -38,6 +40,8 @@ module Playbook
         if contact_type == "email"
           contact_value
         elsif contact_type == "extension" && contact_value.match(/^\d{4}$/)
+          contact_value
+        elsif contact_type == "international"
           contact_value
         else
           number_to_phone(formatted_value, area_code: true)

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default.html.erb
@@ -13,11 +13,26 @@
 }) %>
 
 <%= pb_rails("contact", props: {
-  contact_type: "wrong number",
+  contact_type: "work",
   contact_value: "3245627482",
 }) %>
 
 <%= pb_rails("contact", props: {
   contact_type: "work-cell",
   contact_value: "349-185-9988",
+}) %>
+
+<%= pb_rails("contact", props: {
+  contact_type: "wrong-phone",
+  contact_value: "2124396666",
+}) %>
+
+<%= pb_rails("contact", props: {
+  contact_type: "extension",
+  contact_value: "1233",
+}) %>
+
+<%= pb_rails("contact", props: {
+  contact_type: "international",
+  contact_value: "+44 7700 900461",
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default.jsx
@@ -28,6 +28,21 @@ const ContactDefault = (props) => {
           contactValue="3245627482"
           {...props}
       />
+      <Contact
+          contactType="wrong-phone"
+          contactValue="2124396666"
+          {...props}
+      />
+      <Contact
+          contactType='extension'
+          contactValue="1234"
+          {...props}
+      />
+      <Contact
+          contactType="international"
+          contactValue="+44 7700 900461"
+          {...props}
+      />
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default.md
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_default.md
@@ -1,0 +1,5 @@
+The Contact kit automatically formats US phone numbers when the `contactType` / `contact_type` is one of: `home` (default), `work`, `cell`, `work-cell`, `wrong-phone`.
+
+- Use `email` to display emails.
+- Use `international` to display International phone numbers exactly as provided (no formatting applied).
+- Use `extension` to display four digit phone extensions.

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail.html.erb
@@ -26,3 +26,9 @@
   contact_value: "1233",
   contact_detail: "Ext",
 }) %>
+
+<%= pb_rails("contact", props: {
+  contact_type: "international",
+  contact_value: "+44 7700 900461",
+  contact_detail: "International",
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail.jsx
+++ b/playbook/app/pb_kits/playbook/pb_contact/docs/_contact_with_detail.jsx
@@ -33,6 +33,12 @@ const ContactDefault = (props) => {
           contactValue="1234"
           {...props}
       />
+      <Contact
+          contactDetail="International"
+          contactType="international"
+          contactValue="+44 7700 900461"
+          {...props}
+      />
     </div>
   )
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2467](https://runway.powerhrg.com/backlog_items/PLAY-2467) adds an "international" `contactType` so that users/devs can add an international phone number. Previously, trying to make an international phone number work with one of the current phone contactTypes would either render it null (React) or weirdly US-formatify a phone number that didn't fit (Rails).

This PR achieves "proposed solution 1" from the ticket. It adds markdown and examples to the default doc examples to fully explain what contactTypes exist (because of the way the kit was built allowing strings but only certain ones, the list does not appear in the Kit Props table) and how they display given data. It also adds an International example to the Detail Indicator doc example.

**Screenshots:** Screenshots to visualize your addition/change
Current Behavior (last example in each screenshot):
<img width="756" height="129" alt="contact kit international rails" src="https://github.com/user-attachments/assets/f870e7a7-65f5-4ae7-ae30-590860bbdece" />
<img width="592" height="121" alt="contact kit international react" src="https://github.com/user-attachments/assets/76968ac7-8d81-4c34-989d-d012ff11570a" />
Updated doc examples:
<img width="1145" height="790" alt="updated doc ex" src="https://github.com/user-attachments/assets/119793ac-3cab-408c-850a-9372222867ea" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Contact kit doc examples and see international phone numbers appearing as given to contactValue prop without US formatting.
2. See this CSB for examples on how it will just preserve whatever formatting given.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.