### PR TITLE
[PLAY-2453] Form Kit: Text Field (i.e., Text Input Kit) Attribute Props - Rails

### DIFF
--- a/playbook/lib/playbook/forms/builder/form_field_builder.rb
+++ b/playbook/lib/playbook/forms/builder/form_field_builder.rb
@@ -4,6 +4,15 @@ module Playbook
   module Forms
     class Builder
       class FormFieldBuilder < Module
+        MASK_PATTERNS = {
+          "currency" => '^\$\d{1,3}(?:,\d{3})*(?:\.\d{2})?$',
+          "zip_code" => '\d{5}',
+          "postal_code" => '\d{5}-\d{4}',
+          "ssn" => '\d{3}-\d{2}-\d{4}',
+          "credit_card" => '\d{4} \d{4} \d{4} \d{4}',
+          "cvv" => '\d{3,4}',
+        }.freeze
+
         def initialize(method_name, kit_name:)
           define_method method_name do |name, props: {}, **options, &block|
             props[:label] = @template.label(@object_name, name) if props[:label] == true
@@ -24,6 +33,11 @@ module Playbook
             end
             if props.key?(:autocomplete)
               options[:autocomplete] = props[:autocomplete] == true ? nil : (props[:autocomplete].presence || "off")
+            end
+            if props.key?(:mask)
+              options[:mask] = props[:mask]
+              options[:data] = (options[:data] || {}).merge(pb_input_mask: true)
+              options[:pattern] = MASK_PATTERNS[props[:mask]]
             end
 
             if props.key?(:validation)

--- a/playbook/lib/playbook/forms/builder/form_field_builder.rb
+++ b/playbook/lib/playbook/forms/builder/form_field_builder.rb
@@ -23,7 +23,7 @@ module Playbook
             options[:placeholder] = props[:placeholder] || ""
             options[:type] = props[:type] if props.key?(:type)
             options[:value] = props[:value] if props.key?(:value)
-            options[:disabled] = true if props.key?(:disabled)
+            options[:disabled] = true if props.key?(:disabled) && props[:disabled]
             if props.key?(:disabled)
               cursor_style = props[:disabled] ? "not-allowed" : "pointer"
               existing_style = options[:style] || ""

--- a/playbook/lib/playbook/forms/builder/form_field_builder.rb
+++ b/playbook/lib/playbook/forms/builder/form_field_builder.rb
@@ -12,6 +12,19 @@ module Playbook
             options[:skip_default_ids] = false unless options.key?(:skip_default_ids)
             options[:required] = true if props[:required]
             options[:placeholder] = props[:placeholder] || ""
+            options[:type] = props[:type] if props.key?(:type)
+            options[:value] = props[:value] if props.key?(:value)
+            options[:disabled] = true if props.key?(:disabled)
+            if props.key?(:disabled)
+              cursor_style = props[:disabled] ? "not-allowed" : "pointer"
+              existing_style = options[:style] || ""
+
+              options[:style] =
+                existing_style.empty? ? "cursor: #{cursor_style}" : "#{existing_style}; cursor: #{cursor_style}"
+            end
+            if props.key?(:autocomplete)
+              options[:autocomplete] = props[:autocomplete] == true ? nil : (props[:autocomplete].presence || "off")
+            end
 
             if props.key?(:validation)
               validation = props[:validation]

--- a/playbook/lib/playbook/forms/builder/form_field_builder.rb
+++ b/playbook/lib/playbook/forms/builder/form_field_builder.rb
@@ -34,7 +34,7 @@ module Playbook
             if props.key?(:autocomplete)
               options[:autocomplete] = props[:autocomplete] == true ? nil : (props[:autocomplete].presence || "off")
             end
-            if props.key?(:mask)
+            if props.key?(:mask) && props[:mask].present?
               options[:mask] = props[:mask]
               options[:data] = (options[:data] || {}).merge(pb_input_mask: true)
               options[:pattern] = MASK_PATTERNS[props[:mask]]
@@ -43,7 +43,7 @@ module Playbook
             if props.key?(:validation)
               validation = props[:validation]
               options[:pattern] = validation[:pattern] if validation[:pattern].present?
-              options[:data] = { message: validation[:message] } if validation[:message].present?
+              options[:data] = (options[:data] || {}).merge(message: validation[:message]) if validation[:message].present?
             end
 
             input = super(name, **options, &block)

--- a/playbook/spec/playbook/pb_forms_helper_spec.rb
+++ b/playbook/spec/playbook/pb_forms_helper_spec.rb
@@ -271,6 +271,27 @@ RSpec.describe Playbook::PbFormsHelper, type: :helper do
     end
   end
 
+  context "with mask and validation props combined" do
+    let(:form_body_with_mask_and_validation) do
+      ->(builder) do
+        concat builder.text_field :masked_with_validation, props: {
+          label: true,
+          mask: "currency",
+          validation: { message: "Please enter a valid currency amount" },
+        }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_mask_and_validation) }
+
+    it "preserves both mask and validation data attributes" do
+      expect(subject).to have_tag("input[mask='currency']")
+      expect(subject).to have_tag("input[data-pb-input-mask='true']")
+      expect(subject).to have_tag("input[data-message='Please enter a valid currency amount']")
+      expect(subject).to have_tag("input[pattern]")
+    end
+  end
+
   context "with multiple props combined" do
     let(:form_body_with_multiple) do
       ->(builder) do

--- a/playbook/spec/playbook/pb_forms_helper_spec.rb
+++ b/playbook/spec/playbook/pb_forms_helper_spec.rb
@@ -35,4 +35,271 @@ RSpec.describe Playbook::PbFormsHelper, type: :helper do
 
     it { is_expected.to have_tag("form[data-pb-form-validation=false]") }
   end
+
+  context "with autocomplete props" do
+    let(:form_body_with_autocomplete) do
+      ->(builder) do
+        concat builder.text_field :string_autocomplete, props: { label: true, autocomplete: "email" }
+        concat builder.text_field :boolean_true_autocomplete, props: { label: true, autocomplete: true }
+        concat builder.text_field :boolean_false_autocomplete, props: { label: true, autocomplete: false }
+        concat builder.text_field :no_autocomplete, props: { label: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_autocomplete) }
+
+    it "passes through string autocomplete values" do
+      expect(subject).to have_tag("input[name='example[string_autocomplete]'][autocomplete='email']")
+    end
+
+    it "sets autocomplete to 'off' when false" do
+      expect(subject).to have_tag("input[name='example[boolean_false_autocomplete]'][autocomplete='off']")
+    end
+
+    it "removes autocomplete attribute when true" do
+      expect(subject).to have_tag("input[name='example[boolean_true_autocomplete]']")
+      expect(subject).not_to have_tag("input[name='example[boolean_true_autocomplete]'][autocomplete]")
+    end
+
+    it "has no autocomplete attribute when not specified" do
+      expect(subject).to have_tag("input[name='example[no_autocomplete]']")
+      expect(subject).not_to have_tag("input[name='example[no_autocomplete]'][autocomplete]")
+    end
+  end
+
+  context "with style props" do
+    let(:form_body_with_styles) do
+      ->(builder) do
+        concat builder.text_field :disabled_with_style, props: { label: true, disabled: true }, style: "border: 1px solid blue;"
+        concat builder.text_field :enabled_with_style, props: { label: true, disabled: false }, style: "border: 1px solid blue;"
+        concat builder.text_field :no_style_field, props: { label: true, disabled: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_styles) }
+
+    it "combines existing styles with cursor style for disabled fields" do
+      expect(subject).to have_tag("input[name='example[disabled_with_style]'][style*='border: 1px solid blue'][style*='cursor: not-allowed']")
+    end
+
+    it "combines existing styles with cursor style for enabled fields" do
+      expect(subject).to have_tag("input[name='example[enabled_with_style]'][style*='border: 1px solid blue'][style*='cursor: pointer']")
+    end
+
+    it "only adds cursor style when no existing styles" do
+      expect(subject).to have_tag("input[name='example[no_style_field]'][style='cursor: not-allowed']")
+    end
+  end
+
+  context "with mask props" do
+    let(:form_body_with_mask) do
+      ->(builder) do
+        concat builder.text_field :currency_field, props: { label: true, mask: "currency" }
+        concat builder.text_field :inline_field, props: { label: true, inline: true }
+        concat builder.text_field :both_field, props: { label: true, mask: "currency", inline: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_mask) }
+
+    it "passes through mask prop to text input" do
+      expect(subject).to have_tag("input[mask='currency'][data-pb-input-mask='true']")
+    end
+
+    it "passes through inline prop to text input" do
+      expect(subject).to have_tag("input[name='example[inline_field]']")
+    end
+
+    it "passes through both mask and inline props" do
+      expect(subject).to have_tag("input[mask='currency'][data-pb-input-mask='true']")
+    end
+
+    it "includes all mask-related attributes for currency" do
+      expect(subject).to have_tag("input[mask='currency']")
+      expect(subject).to have_tag("input[data-pb-input-mask='true']")
+      expect(subject).to have_tag("input[pattern]")
+      expect(subject).to have_tag("input[name='']")
+    end
+  end
+
+  context "with disabled props" do
+    let(:form_body_with_disabled) do
+      ->(builder) do
+        concat builder.text_field :disabled_field, props: { label: true, disabled: true }
+        concat builder.text_field :enabled_field, props: { label: true, disabled: false }
+        concat builder.text_field :no_disabled_prop, props: { label: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_disabled) }
+
+    it "adds disabled attribute when disabled is true" do
+      expect(subject).to have_tag("input[name='example[disabled_field]'][disabled]")
+    end
+
+    it "does not add disabled attribute when disabled is false" do
+      expect(subject).to have_tag("input[name='example[enabled_field]']")
+      expect(subject).not_to have_tag("input[name='example[enabled_field]'][disabled]")
+    end
+
+    it "does not add disabled attribute when not specified" do
+      expect(subject).to have_tag("input[name='example[no_disabled_prop]']")
+      expect(subject).not_to have_tag("input[name='example[no_disabled_prop]'][disabled]")
+    end
+  end
+
+  context "with required props" do
+    let(:form_body_with_required) do
+      ->(builder) do
+        concat builder.text_field :required_field, props: { label: true, required: true }
+        concat builder.text_field :not_required_field, props: { label: true, required: false }
+        concat builder.text_field :no_required_prop, props: { label: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_required) }
+
+    it "adds required attribute when required is true" do
+      expect(subject).to have_tag("input[name='example[required_field]'][required]")
+    end
+
+    it "does not add required attribute when required is false" do
+      expect(subject).to have_tag("input[name='example[not_required_field]']")
+      expect(subject).not_to have_tag("input[name='example[not_required_field]'][required]")
+    end
+
+    it "does not add required attribute when not specified" do
+      expect(subject).to have_tag("input[name='example[no_required_prop]']")
+      expect(subject).not_to have_tag("input[name='example[no_required_prop]'][required]")
+    end
+  end
+
+  context "with placeholder props" do
+    let(:form_body_with_placeholder) do
+      ->(builder) do
+        concat builder.text_field :with_placeholder, props: { label: true, placeholder: "Enter your name" }
+        concat builder.text_field :empty_placeholder, props: { label: true, placeholder: "" }
+        concat builder.text_field :no_placeholder, props: { label: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_placeholder) }
+
+    it "adds placeholder attribute when specified" do
+      expect(subject).to have_tag("input[name='example[with_placeholder]'][placeholder='Enter your name']")
+    end
+
+    it "adds empty placeholder attribute when empty string" do
+      expect(subject).to have_tag("input[name='example[empty_placeholder]'][placeholder='']")
+    end
+
+    it "adds empty placeholder attribute when not specified" do
+      expect(subject).to have_tag("input[name='example[no_placeholder]'][placeholder='']")
+    end
+  end
+
+  context "with type props" do
+    let(:form_body_with_type) do
+      ->(builder) do
+        concat builder.text_field :text_field, props: { label: true, type: "text" }
+        concat builder.text_field :email_field, props: { label: true, type: "email" }
+        concat builder.text_field :no_type, props: { label: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_type) }
+
+    it "adds type attribute when specified" do
+      expect(subject).to have_tag("input[name='example[text_field]'][type='text']")
+      expect(subject).to have_tag("input[name='example[email_field]'][type='email']")
+    end
+
+    it "uses default type when not specified" do
+      expect(subject).to have_tag("input[name='example[no_type]'][type='text']")
+    end
+  end
+
+  context "with value props" do
+    let(:form_body_with_value) do
+      ->(builder) do
+        concat builder.text_field :with_value, props: { label: true, value: "Hello World" }
+        concat builder.text_field :empty_value, props: { label: true, value: "" }
+        concat builder.text_field :no_value, props: { label: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_value) }
+
+    it "adds value attribute when specified" do
+      expect(subject).to have_tag("input[name='example[with_value]'][value='Hello World']")
+    end
+
+    it "adds empty value attribute when empty string" do
+      expect(subject).to have_tag("input[name='example[empty_value]'][value='']")
+    end
+
+    it "does not add value attribute when not specified" do
+      expect(subject).to have_tag("input[name='example[no_value]']")
+      expect(subject).not_to have_tag("input[name='example[no_value]'][value]")
+    end
+  end
+
+  context "with validation props" do
+    let(:form_body_with_validation) do
+      ->(builder) do
+        concat builder.text_field :with_pattern, props: { label: true, validation: { pattern: "\\d{3}-\\d{3}-\\d{4}", message: "Please enter a valid phone number" } }
+        concat builder.text_field :with_message_only, props: { label: true, validation: { message: "This field is required" } }
+        concat builder.text_field :no_validation, props: { label: true }
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_validation) }
+
+    it "adds pattern and data-message attributes when validation is specified" do
+      expect(subject).to have_tag("input[name='example[with_pattern]'][pattern]")
+      expect(subject).to have_tag("input[name='example[with_pattern]'][data-message='Please enter a valid phone number']")
+    end
+
+    it "adds only data-message attribute when only message is specified" do
+      expect(subject).to have_tag("input[name='example[with_message_only]'][data-message='This field is required']")
+      expect(subject).not_to have_tag("input[name='example[with_message_only]'][pattern]")
+    end
+
+    it "does not add validation attributes when not specified" do
+      expect(subject).to have_tag("input[name='example[no_validation]']")
+      expect(subject).not_to have_tag("input[name='example[no_validation]'][pattern]")
+      expect(subject).not_to have_tag("input[name='example[no_validation]'][data-message]")
+    end
+  end
+
+  context "with multiple props combined" do
+    let(:form_body_with_multiple) do
+      ->(builder) do
+        concat builder.text_field :complex_field, props: {
+          label: true,
+          disabled: true,
+          required: true,
+          placeholder: "Enter value",
+          type: "email",
+          value: "test@example.com",
+          autocomplete: "email",
+          validation: { pattern: "\\S+@\\S+\\.\\S+", message: "Invalid email" },
+        }, style: "border: 2px solid red;"
+      end
+    end
+
+    subject { helper.pb_form_with(url: "http://example.org", scope: :example, validate: false, &form_body_with_multiple) }
+
+    it "handles all props correctly when combined" do
+      expect(subject).to have_tag("input[name='example[complex_field]'][disabled]")
+      expect(subject).to have_tag("input[name='example[complex_field]'][required]")
+      expect(subject).to have_tag("input[name='example[complex_field]'][placeholder='Enter value']")
+      expect(subject).to have_tag("input[name='example[complex_field]'][type='email']")
+      expect(subject).to have_tag("input[name='example[complex_field]'][value='test@example.com']")
+      expect(subject).to have_tag("input[name='example[complex_field]'][autocomplete='email']")
+      expect(subject).to have_tag("input[name='example[complex_field]'][pattern]")
+      expect(subject).to have_tag("input[name='example[complex_field]'][data-message='Invalid email']")
+      expect(subject).to have_tag("input[name='example[complex_field]'][style*='border: 2px solid red'][style*='cursor: not-allowed']")
+    end
+  end
 end

--- a/playbook/spec/playbook/pb_forms_helper_spec.rb
+++ b/playbook/spec/playbook/pb_forms_helper_spec.rb
@@ -118,7 +118,6 @@ RSpec.describe Playbook::PbFormsHelper, type: :helper do
       expect(subject).to have_tag("input[mask='currency']")
       expect(subject).to have_tag("input[data-pb-input-mask='true']")
       expect(subject).to have_tag("input[pattern]")
-      expect(subject).to have_tag("input[name='']")
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**

- Add `type`, `value`, `disabled`, `autocomplete`, and `mask` props which change attributes for form field builder. 
  - Unlike text input props like `inline` which change the div wrapper (and don't need to be set in `form_field_builder.rb`, these props need to change the nested text input attributes. This is because if content is present, then it's used instead of input_tag which includes these props:
- Combine data attributes so validation and mask can be used together
- Add tests for form.text_field

```
<% if content.present? %>
  <%= content %>
<% elsif has_add_on? %>
  <%= pb_rails("text_input/add_on", props: object.add_on_props) do %>
    <%= input_tag %>
  <% end %>
<% elsif mask.present? %>
  <%= input_tag %>
  <%= tag(:input, data: "sanitized-pb-input", id: sanitized_id, name: object.name, style: "display: none;") %>
<% else %>
  <%= input_tag %>
<% end %>
```

https://runway.powerhrg.com/backlog_items/PLAY-2453

**Screenshots:** Screenshots to visualize your addition/change
<img width="1928" height="354" alt="Screenshot 2025-09-12 at 9 13 55 AM" src="https://github.com/user-attachments/assets/0455c1d1-925a-458c-91a7-525edf4e554b" />

**How to test?** Steps to confirm the desired behavior:
Test on Nitro to see if these props overlap or change forms in any way. 

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.