### PR TITLE
[PLAY-2480] Upgrade Playbook Icons to 1.0.0

### DIFF
--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "0.0.1-alpha.44",
-    "@powerhome/playbook-icons-react": "0.0.1-alpha.44",
+    "@powerhome/playbook-icons": "1.0.0",
+    "@powerhome/playbook-icons-react": "1.0.0",
     "@powerhome/power-fonts": "0.0.1",
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,15 +3169,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@0.0.1-alpha.44":
-  version "0.0.1-alpha.44"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/f89c992855d62144492f5f0c3f90b8062f4cec31#f89c992855d62144492f5f0c3f90b8062f4cec31"
-  integrity sha512-SQPQuKFHe0PvYhI9o3jWhP5zWZU0YxoR4hj1mOSKYoWoNwWkNCko9wr24z2ps23qc3w/KZbhgwdmr86ao9UN0g==
+"@powerhome/playbook-icons-react@1.0.0":
+  version "1.0.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/6824f102f52c6d973acd32fe872f524c2d7b76f3#6824f102f52c6d973acd32fe872f524c2d7b76f3"
+  integrity sha512-Tasb6JQaLT/Uoovc/71BbS8TY27wOj0iVbZsCpAjtveZK7BDvn/iqu+oc7ku1TWYg7Jz1o+dt7v7QFskT8N1CQ==
 
-"@powerhome/playbook-icons@0.0.1-alpha.44":
-  version "0.0.1-alpha.44"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/90e580b0ff045918699420159d9846b6341b1dcc#90e580b0ff045918699420159d9846b6341b1dcc"
-  integrity sha512-CSzlChexsrzG/sNzygiz+qjQbKprUEhXDltRT9op43mKRhg9C2mUhpgOKX91f92qKQydgFaf19/mhUMsCNEx/A==
+"@powerhome/playbook-icons@1.0.0":
+  version "1.0.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/f33b4bb94b67ce0d63e3b876ecddccec03033ea2#f33b4bb94b67ce0d63e3b876ecddccec03033ea2"
+  integrity sha512-UK6qWrOXJIMKhTsfr4exs9S/NTJLd26yF1nsfXBX+YqfGyQutuzK0sRU8DzEBqsQBj6VKzRhvtOpqxXWykEIog==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2480)
[Playbook Icons PR](https://github.com/powerhome/playbook-icons/pull/47)

- Adds alias "spinner-solid" to "loading-solid" icon
- Adds new icon "envelope-slash" to icon repo
- First full release of Playbook Icons repo (1.0.0)

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.