### PR TITLE
[PLAY-2511] Update Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -584,6 +584,10 @@
     "category": "Communication"
   },
   {
+    "name": "envelope-slash",
+    "category": "Communication"
+  },
+  {
     "name": "envelope",
     "category": "Communication"
   },
@@ -1161,10 +1165,6 @@
   },
   {
     "name": "spinner",
-    "category": "Interface Core"
-  },
-   {
-    "name": "spinner-solid",
     "category": "Interface Core"
   },
   {

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "0.0.1-alpha.44",
-    "@powerhome/playbook-icons-react": "0.0.1-alpha.44",
+    "@powerhome/playbook-icons": "1.0.1",
+    "@powerhome/playbook-icons-react": "1.0.1",
     "@powerhome/power-fonts": "0.0.1",
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^2.4.0",

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/_loading_inline.tsx
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/_loading_inline.tsx
@@ -56,7 +56,7 @@ const LoadingInline = (props: LoadingInlineProps) => {
         <Icon
             aria={{ label: 'loading icon' }}
             fixedWidth
-            icon={variant === 'dotted' ? 'spinner' : variant === 'solid' ? 'spinner-solid' : undefined}
+            icon={variant === 'dotted' ? 'spinner' : variant === 'solid' ? 'circle-notch' : undefined}
             pulse
         />
         {text}

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.rb
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/loading_inline.rb
@@ -20,7 +20,7 @@ module Playbook
         if variant == "dotted"
           "spinner"
         elsif variant == "solid"
-          "spinner-solid"
+          "circle-notch"
         end
       end
     end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,15 +3169,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@0.0.1-alpha.44":
-  version "0.0.1-alpha.44"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/f89c992855d62144492f5f0c3f90b8062f4cec31#f89c992855d62144492f5f0c3f90b8062f4cec31"
-  integrity sha512-SQPQuKFHe0PvYhI9o3jWhP5zWZU0YxoR4hj1mOSKYoWoNwWkNCko9wr24z2ps23qc3w/KZbhgwdmr86ao9UN0g==
+"@powerhome/playbook-icons-react@1.0.1":
+  version "1.0.1"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/efb3907ba5df93c5af387d8bbb4d4d965a382fa3#efb3907ba5df93c5af387d8bbb4d4d965a382fa3"
+  integrity sha512-zQi/4Q2SPfW0rgFYXgn7LoAZbmo1ogvrL9J4tli/qwUr8xvpIY0Guyw5BU2gNv1OMiI7CrAVOm64vnswMKe/qw==
 
-"@powerhome/playbook-icons@0.0.1-alpha.44":
-  version "0.0.1-alpha.44"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/90e580b0ff045918699420159d9846b6341b1dcc#90e580b0ff045918699420159d9846b6341b1dcc"
-  integrity sha512-CSzlChexsrzG/sNzygiz+qjQbKprUEhXDltRT9op43mKRhg9C2mUhpgOKX91f92qKQydgFaf19/mhUMsCNEx/A==
+"@powerhome/playbook-icons@1.0.1":
+  version "1.0.1"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/b216cac1375fa3354c45c1bb0c901473529299ce#b216cac1375fa3354c45c1bb0c901473529299ce"
+  integrity sha512-gSxwrnMaAJ3P//gxEdukVzLqdGqLss8VdnG/jB/sbdm7c0LYMTEbzNv+7SYIzQYgOlJcctCq6pHKIxbcD6ItjA==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2511](https://runway.powerhrg.com/backlog_items/PLAY-2511) updates the Playbook Icon Repo 
[Playbook-Icons PR here](https://github.com/powerhome/playbook-icons/pull/48). Adds an alias (more on that below) and a new icon (envelope-slash).

This PR also the internal icon used for the solid variant of [LoadingInline]https://playbook.powerapp.cloud/kits/loading_inline/react#variant) to the spinner-solid's new alias circle-notch to ensure the FA icon appears as a fallback when Playbook Icons are not available. Please reference [this CSB with an alpha of this PR](https://codesandbox.io/p/devbox/amazing-turing-y39z46) showing the particular circumstances we are accounting for with this.

**Screenshots:** Screenshots to visualize your addition/change
<img width="846" height="297" alt="csb testing screenshot" src="https://github.com/user-attachments/assets/2ebd05d2-269d-4f2b-9629-cb92730d320c" />
<img width="497" height="426" alt="envelope slash added" src="https://github.com/user-attachments/assets/eade453a-0efe-436f-b583-78ac278e52c4" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /playbook_icons page - see envelope slash.
2. Go to CSB or pull down locally - can see circle-notch displaying solid-spinner as an alias in env with playbook-icons or as itself in env without playbook-icons.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
~~- [ ] **RC** I have added an `inactive RC` label if not an active RC.~~