### PR TITLE
[PLAY-2512] Button Kit: Ability to Dynamically Toggle Disabled State in Rails

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -134,7 +134,7 @@ kits:
     status: stable
     icons_used: true
     react_rendered: false
-    enhanced_element_used: false
+    enhanced_element_used: true
   - name: button_toolbar
     platforms: *1
     description: This kit should primarily hold the most commonly used buttons.

--- a/playbook/app/entrypoints/playbook-rails.js
+++ b/playbook/app/entrypoints/playbook-rails.js
@@ -79,6 +79,9 @@ PbMultiLevelSelect.start()
 import PbCheckbox from 'kits/pb_checkbox'
 PbCheckbox.start()
 
+import PbButton from 'kits/pb_button'
+PbButton.start()
+
 import 'flatpickr'
 
 // React-Rendered Rails Kits =====

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.html.erb
@@ -1,28 +1,30 @@
-<br/>
-  <%= pb_rails("button", props: { text: "Disable Buttons", variant: "link", id: "toggle-disabled-demo" }) %>
-  <%= pb_rails("button", props: { text: "Enable Buttons", variant: "link", id: "toggle-enabled-demo" }) %>
-<br/>
-<%= pb_rails("button", props: { text: "I am a Normal Button", id: "normal_managed_button", data:{pb_button_managed: true}, margin_bottom: "lg" }) %>
-<br/>
-<%= pb_rails("button", props: { text: "I am an <a> Button", id: "a_tag_managed_button", tag:"a", data:{pb_button_managed: true}, link: "http://google.com", margin_right: "lg" }) %>
+  <%= pb_rails("body", props: { text: "Click to disable the Buttons below", id: "toggle-disabled-demo", cursor: "pointer", color:"link", margin_bottom:"sm" }) %>
+  <%= pb_rails("body", props: { text: "Click to enable the Buttons below", id: "toggle-enabled-demo", cursor: "pointer", color:"link", margin_bottom:"sm" }) %>
 
+<%= pb_rails("card", props:{display:"flex", flex_direction:"row", justify_content:"center"}) do %>
+<%= pb_rails("button", props: { text: "I am a Button", id: "normal_managed_button", data:{pb_button_managed: true}, margin_right: "lg" }) %>
+<%= pb_rails("button", props: { text: "I am an <a> Button", id: "a_tag_managed_button", tag:"a", data:{pb_button_managed: true}, link: "http://google.com"}) %>
+<% end %>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     const disableTrigger = document.querySelector('#toggle-disabled-demo')
     const enableTrigger = document.querySelector('#toggle-enabled-demo')
 
-    // Managed Buttons
+    // Find the Buttons you want to 'manage'
     const btn = document.querySelector('#normal_managed_button');
     const link = document.querySelector('#a_tag_managed_button');
 
     disableTrigger.addEventListener('click', (e) => {
-        // Disable both default button and a tag button
+        // Disable default button
         btn.setAttribute('disabled', true)
+        // Disable a tag button
         link.setAttribute('aria-disabled', 'true')
     });
+
     enableTrigger.addEventListener('click', (e) => {
-        // Enable both default button and a tag button
+        // Enable default button
         btn.removeAttribute('disabled')
+        // Enable a tag button
         link.removeAttribute('aria-disabled')
     });
   });

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.html.erb
@@ -1,20 +1,29 @@
-<%= pb_rails("button", props: { text: "Button Primary", id: "button_primary", data:{pb_button_managed: true}, margin_right: "lg" }) %>
-<%= pb_rails("button", props: { text: "A Tag Button", id: "a_tag_button", tag:"a", data:{pb_button_managed: true}, link: "http://google.com", margin_right: "lg" }) %>
-
+<br/>
+  <%= pb_rails("button", props: { text: "Disable Buttons", variant: "link", id: "toggle-disabled-demo" }) %>
+  <%= pb_rails("button", props: { text: "Enable Buttons", variant: "link", id: "toggle-enabled-demo" }) %>
+<br/>
+<%= pb_rails("button", props: { text: "I am a Normal Button", id: "normal_managed_button", data:{pb_button_managed: true}, margin_bottom: "lg" }) %>
+<br/>
+<%= pb_rails("button", props: { text: "I am an <a> Button", id: "a_tag_managed_button", tag:"a", data:{pb_button_managed: true}, link: "http://google.com", margin_right: "lg" }) %>
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    const btn = document.querySelector('#button_primary');
-    btn.setAttribute('disabled', 'disabled')
-    setTimeout(() => {
-      btn.removeAttribute('disabled')
-    }, 6000);
+    const disableTrigger = document.querySelector('#toggle-disabled-demo')
+    const enableTrigger = document.querySelector('#toggle-enabled-demo')
 
+    // Managed Buttons
+    const btn = document.querySelector('#normal_managed_button');
+    const link = document.querySelector('#a_tag_managed_button');
 
-   const link = document.querySelector('#a_tag_button');
-   link.setAttribute('aria-disabled', 'true')
-    setTimeout(() => {
-      link.setAttribute('aria-disabled', 'false')
-    }, 6000);
+    disableTrigger.addEventListener('click', (e) => {
+        // Disable both default button and a tag button
+        btn.setAttribute('disabled', true)
+        link.setAttribute('aria-disabled', 'true')
     });
+    enableTrigger.addEventListener('click', (e) => {
+        // Enable both default button and a tag button
+        btn.removeAttribute('disabled')
+        link.removeAttribute('aria-disabled')
+    });
+  });
 </script>

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.html.erb
@@ -1,0 +1,20 @@
+<%= pb_rails("button", props: { text: "Button Primary", id: "button_primary", data:{pb_button_managed: true}, margin_right: "lg" }) %>
+<%= pb_rails("button", props: { text: "A Tag Button", id: "a_tag_button", tag:"a", data:{pb_button_managed: true}, link: "http://google.com", margin_right: "lg" }) %>
+
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const btn = document.querySelector('#button_primary');
+    btn.setAttribute('disabled', 'disabled')
+    setTimeout(() => {
+      btn.removeAttribute('disabled')
+    }, 6000);
+
+
+   const link = document.querySelector('#a_tag_button');
+   link.setAttribute('aria-disabled', 'true')
+    setTimeout(() => {
+      link.setAttribute('aria-disabled', 'false')
+    }, 6000);
+    });
+</script>

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
@@ -1,7 +1,5 @@
 If needing to toggle the disabled state of the Button dynmically, you can now do so in rails using the `pb-button-managed` data attribute. 
 
-If your button has `data:{ pb-button-managed: true }`  on it, you can then toggle state via attributes: for buttons set/remove disabled, for links set/remove aria-disabled="true". This will handle disabling the button, preventing clicks as well as all style changes so yuo don't have to.  
+If your button has `data:{ pb-button-managed: true }`  on it, you can then toggle state via attributes: for buttons set/remove disabled, for links set/remove aria-disabled="true". This will handle disabling the button, preventing clicks as well as all style changes so you don't have to.  
 
-View the code snippet below to see this in action.
-
-For demo purposes, we are disabling the buttons and then enabling after a timeout. You can disable/enable based on whatever logic you need. 
+Click to enable or disable the buttons above and view the code snippet below for details!

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
@@ -1,0 +1,7 @@
+If needing to toggle the disabled state of the Button dynmically, you can now do so in rails using the `pb-button-managed` data attribute. 
+
+If your button has `data:{ pb-button-managed: true }`  on it, you can then toggle state via attributes: for buttons set/remove disabled, for links set/remove aria-disabled="true". This will handle disabling the button, preventing clicks as well as all style changes so yuo don't have to.  
+
+View the code snippet below to see this in action.
+
+For demo purposes, we are disabling the buttons and then enabling after a timeout. You can disable/enable based on whatever logic you need. 

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
@@ -1,5 +1,7 @@
 If needing to toggle the disabled state of the Button dynmically, you can now do so in rails using the `pb-button-managed` data attribute. 
 
-If your button has `data:{ pb-button-managed: true }`  on it, you can then toggle state via attributes: for buttons set/remove disabled, for links set/remove aria-disabled="true". This will handle disabling the button, preventing clicks as well as all style changes so you don't have to.  
+1) Add the following data attribute to your button kit: `data:{ pb-button-managed: true }`
+
+2) To toggle enabled/disabled state via attributes: for buttons set/remove disabled, for links set/remove aria-disabled="true". This will handle disabling the button, preventing clicks as well as all style changes so you don't have to.  
 
 Click to enable or disable the buttons above and view the code snippet below for details!

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled.md
@@ -1,4 +1,4 @@
-If needing to toggle the disabled state of the Button dynmically, you can now do so in rails using the `pb-button-managed` data attribute. 
+If needing to toggle the disabled state of the Button dynamically (for example, within a Turbo or Stimulus context), you can now do so in rails using the `pb-button-managed` data attribute. 
 
 1) Add the following data attribute to your button kit: `data:{ pb-button-managed: true }`
 

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.html.erb
@@ -1,17 +1,20 @@
-  <%= pb_rails("button", props: { text: "Disable Button", variant: "link", id: "toggle-disabled-demo-with-helper" }) %>
-  <%= pb_rails("button", props: { text: "Enable Button", variant: "link", id: "toggle-enabled-demo-with-helper" }) %>
+  <%= pb_rails("body", props: { text: "Click to disable the Button below", id: "toggle-disabled-demo-with-helper", cursor: "pointer", color:"link", margin_bottom:"sm" }) %>
+  <%= pb_rails("body", props: { text: "Click to enable the Button below", id: "toggle-enabled-demo-with-helper", cursor: "pointer", color:"link", margin_bottom:"sm" }) %>
 <br/>
+<%= pb_rails("card", props:{display:"flex", flex_direction:"row", justify_content:"center"}) do %>
 <%= pb_rails("button", props: { text: "Watch me Change!", id: "managed_button_with_helper", data:{pb_button_managed: true} }) %>
+<% end %>
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    const demoBtn = document.querySelector('#managed_button_with_helper')
-
     const disable = document.querySelector('#toggle-disabled-demo-with-helper')
     const enable = document.querySelector('#toggle-enabled-demo-with-helper')
 
-    disable.addEventListener('click', (e) => {demoBtn._pbButton.disable()});
+    // Find the Button you want to 'manage'
+    const demoBtn = document.querySelector('#managed_button_with_helper')
 
+    // Use the pbButton object created by the kit to call the enable/disable methods
+    disable.addEventListener('click', (e) => {demoBtn._pbButton.disable()});
     enable.addEventListener('click', (e) => {demoBtn._pbButton.enable()});
 
   });

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.html.erb
@@ -1,0 +1,18 @@
+  <%= pb_rails("button", props: { text: "Disable Button", variant: "link", id: "toggle-disabled-demo-with-helper" }) %>
+  <%= pb_rails("button", props: { text: "Enable Button", variant: "link", id: "toggle-enabled-demo-with-helper" }) %>
+<br/>
+<%= pb_rails("button", props: { text: "Watch me Change!", id: "managed_button_with_helper", data:{pb_button_managed: true} }) %>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const demoBtn = document.querySelector('#managed_button_with_helper')
+
+    const disable = document.querySelector('#toggle-disabled-demo-with-helper')
+    const enable = document.querySelector('#toggle-enabled-demo-with-helper')
+
+    disable.addEventListener('click', (e) => {demoBtn._pbButton.disable()});
+
+    enable.addEventListener('click', (e) => {demoBtn._pbButton.enable()});
+
+  });
+</script>

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.md
@@ -1,5 +1,7 @@
 The disabled state for the button can also be toggled via small helpers available through the `pb-button-managed` data attribute. 
 
-If your button has `data:{ pb-button-managed: true }`  on it, you can then toggle state via the provided `_pbButton.disable()` and `_pbButton.enable()` helpers as shoen in the code snippet below.
+1) Add the following data attribute to your button kit: `data:{ pb-button-managed: true }`
 
-Click to enable or disable the buttons above!
+2) Toggle state via the provided `_pbButton.disable()` and `_pbButton.enable()` helpers as shown in the code snippet below.
+
+Click to enable or disable the buttons above to see this in action!

--- a/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.md
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/_button_managed_disabled_helper.md
@@ -1,0 +1,5 @@
+The disabled state for the button can also be toggled via small helpers available through the `pb-button-managed` data attribute. 
+
+If your button has `data:{ pb-button-managed: true }`  on it, you can then toggle state via the provided `_pbButton.disable()` and `_pbButton.enable()` helpers as shoen in the code snippet below.
+
+Click to enable or disable the buttons above!

--- a/playbook/app/pb_kits/playbook/pb_button/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/example.yml
@@ -12,6 +12,7 @@ examples:
   - button_size: Button Size
   - button_form: Button Form Attribute
   - button_managed_disabled: Button Toggle Disabled State
+  - button_managed_disabled_helper: Button Toggle Disabled State Helper
   
   react:
   - button_default: Button Variants

--- a/playbook/app/pb_kits/playbook/pb_button/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_button/docs/example.yml
@@ -11,6 +11,7 @@ examples:
   - button_options: Button Additional Options
   - button_size: Button Size
   - button_form: Button Form Attribute
+  - button_managed_disabled: Button Toggle Disabled State
   
   react:
   - button_default: Button Variants

--- a/playbook/app/pb_kits/playbook/pb_button/index.js
+++ b/playbook/app/pb_kits/playbook/pb_button/index.js
@@ -1,0 +1,97 @@
+import PbEnhancedElement from "../pb_enhanced_element"
+
+const BUTTON_SELECTOR = "[data-pb-button-managed]"
+
+export default class PbButton extends PbEnhancedElement {
+  static get selector() {
+    return BUTTON_SELECTOR
+  }
+
+  connect() {
+    this._attrManaged = this._attributesPresent()
+
+    this._onClick = (e) => {
+      if (this.isDisabled()) {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+      }
+    }
+    this.element.addEventListener("click", this._onClick, true)
+
+    if (this._attrManaged) this._syncClassesFromAttributes()
+
+    this._observer = new MutationObserver(() => {
+      this._attrManaged = true
+      this._syncClassesFromAttributes()
+    })
+    this._observer.observe(this.element, {
+      attributes: true,
+      attributeFilter: ["disabled", "aria-disabled"],
+    })
+  }
+
+  disconnect() {
+    this.element.removeEventListener("click", this._onClick, true)
+    this._observer?.disconnect()
+  }
+
+  disable() { this.setDisabled(true) }
+  enable()  { this.setDisabled(false) }
+
+  setDisabled(state) {
+    if (this._isButton()) {
+      state
+        ? this.element.setAttribute("disabled", "disabled")
+        : this.element.removeAttribute("disabled")
+    } else {
+      state
+        ? this.element.setAttribute("aria-disabled", "true")
+        : this.element.removeAttribute("aria-disabled")
+    }
+    this._attrManaged = true
+    this._applyClassState(state)
+  }
+
+  isDisabled() {
+    if (this._isButton()) {
+      if (this.element.hasAttribute("disabled")) return true
+      if (this._attrManaged && !this.element.hasAttribute("disabled")) return false
+    } else {
+      const aria = this.element.getAttribute("aria-disabled")
+      if (aria === "true") return true
+      if (this._attrManaged && aria !== "true") return false
+    }
+    return this.element.classList.contains("pb_button_disabled")
+  }
+
+  _isButton() {
+    return this.element.tagName === "BUTTON"
+  }
+
+  _attributesPresent() {
+    return this.element.hasAttribute("disabled") || this.element.hasAttribute("aria-disabled")
+  }
+
+  _syncClassesFromAttributes() {
+    const state = this._attrDisabledState()
+    const disabled = (state === null) ? false : state
+    this._applyClassState(disabled)
+  }
+
+  _attrDisabledState() {
+    if (this._isButton()) {
+      return this.element.hasAttribute("disabled") ? true : null
+    } else {
+      const aria = this.element.getAttribute("aria-disabled")
+      if (aria === "true") return true
+      if (aria === "false") return false
+      return this.element.hasAttribute("aria-disabled") ? false : null
+    }
+  }
+
+  _applyClassState(disabled) {
+    this.element.classList.toggle("pb_button_disabled", !!disabled)
+    this.element.classList.toggle("pb_button_enabled", !disabled)
+  }
+}
+

--- a/playbook/app/pb_kits/playbook/pb_button/index.js
+++ b/playbook/app/pb_kits/playbook/pb_button/index.js
@@ -9,6 +9,7 @@ export default class PbButton extends PbEnhancedElement {
 
   connect() {
     this._attrManaged = this._attributesPresent()
+    this.element._pbButton = this 
 
     this._onClick = (e) => {
       if (this.isDisabled()) {
@@ -33,6 +34,7 @@ export default class PbButton extends PbEnhancedElement {
   disconnect() {
     this.element.removeEventListener("click", this._onClick, true)
     this._observer?.disconnect()
+    delete this.element._pbButton
   }
 
   disable() { this.setDisabled(true) }

--- a/playbook/spec/pb_kits/playbook/kits/button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/button_spec.rb
@@ -79,5 +79,81 @@ RSpec.describe Playbook::PbButton::Button do
       expect(subject.new(size: "sm").classname).to eq "pb_button_kit pb_button_primary pb_button_inline pb_button_enabled pb_button_size_sm"
       expect(subject.new(size: "lg").classname).to eq "pb_button_kit pb_button_primary pb_button_inline pb_button_enabled pb_button_size_lg"
     end
+
+    context "when managing enabled/disabled states" do
+      it "correctly toggles between enabled and disabled classes", :aggregate_failures do
+        enabled_button = subject.new(disabled: false)
+        disabled_button = subject.new(disabled: true)
+
+        expect(enabled_button.classname).to include("pb_button_enabled")
+        expect(enabled_button.classname).to_not include("pb_button_disabled")
+
+        expect(disabled_button.classname).to include("pb_button_disabled")
+        expect(disabled_button.classname).to_not include("pb_button_enabled")
+      end
+
+      it "applies disabled state correctly for different variants", :aggregate_failures do
+        %w[primary secondary link danger reaction].each do |variant|
+          enabled_button = subject.new(variant: variant, disabled: false)
+          disabled_button = subject.new(variant: variant, disabled: true)
+
+          expect(enabled_button.classname).to include("pb_button_enabled")
+          expect(disabled_button.classname).to include("pb_button_disabled")
+        end
+      end
+
+      it "maintains disabled state with other modifiers", :aggregate_failures do
+        button_props = {
+          disabled: true,
+          full_width: true,
+          size: "lg",
+          variant: "secondary",
+        }
+        button = subject.new(button_props)
+
+        expect(button.classname).to include("pb_button_disabled")
+        expect(button.classname).to include("pb_button_block")
+        expect(button.classname).to include("pb_button_size_lg")
+        expect(button.classname).to include("pb_button_secondary")
+      end
+    end
+  end
+
+  describe "#options for managed buttons" do
+    context "when button supports JavaScript management" do
+      it "properly handles disabled attribute for button tags", :aggregate_failures do
+        disabled_button = subject.new(disabled: true)
+        enabled_button = subject.new(disabled: false)
+
+        expect(disabled_button.options).to include(disabled: true)
+        expect(enabled_button.options).to_not include(disabled: true)
+      end
+
+      it "supports data attributes for managed functionality" do
+        button_with_data = subject.new({})
+        expect { button_with_data.options }.to_not raise_error
+      end
+    end
+  end
+
+  describe "disabled state behavior for different tag types" do
+    context "when using button tag" do
+      it "uses disabled attribute for button elements", :aggregate_failures do
+        button = subject.new(disabled: true, link: nil)
+
+        expect(button.tag).to eq "button"
+        expect(button.options).to include(disabled: true)
+      end
+    end
+
+    context "when using a tag" do
+      it "prevents link functionality when disabled", :aggregate_failures do
+        disabled_link_button = subject.new(disabled: true, link: "http://example.com")
+        enabled_link_button = subject.new(disabled: false, link: "http://example.com")
+
+        expect(disabled_link_button.tag).to eq "button"
+        expect(enabled_link_button.tag).to eq "a"
+      end
+    end
   end
 end


### PR DESCRIPTION
**What does this PR do?** 

[Runway story](https://runway.powerhrg.com/backlog_items/PLAY-2512)

This PR creates a config for the Button kit in Rails that will allow devs to toggle the enabled and disabled state within turbo frames or stimulus so they do not have to manually toggle classnames or attributes. 

**Screenshots:** 

<img width="909" height="583" alt="Screenshot 2025-09-26 at 9 09 20 AM" src="https://github.com/user-attachments/assets/b4d038ea-2e16-4eb1-8815-809f8e1863e0" />

<img width="911" height="589" alt="Screenshot 2025-09-26 at 9 09 26 AM" src="https://github.com/user-attachments/assets/5d8c342d-0213-4010-a9d3-fdebf465c0ba" />



**How to test?** Steps to confirm the desired behavior:
1. 2 new docs at bottom of Button kit Rails page
2. [Alpha in Nitro](https://github.com/powerhome/nitro-web/pull/52002)

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.