### PR TITLE
[PLAY-2524] MultipleUsersStacked:  scss refactor

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
+++ b/playbook/app/pb_kits/playbook/pb_multiple_users_stacked/_multiple_users_stacked.scss
@@ -89,7 +89,18 @@ $positions: (
   }
 }
 
-[class^=pb_multiple_users_stacked_kit] {
+.pb_multiple_users_stacked_kit,
+.pb_multiple_users_stacked_kit_single,
+.pb_multiple_users_stacked_kit_bubble,
+.pb_multiple_users_stacked_kit_single_bubble,
+.pb_multiple_users_stacked_kit_bubble_size_sm,
+.pb_multiple_users_stacked_kit_bubble_size_md,
+.pb_multiple_users_stacked_kit_bubble_size_lg,
+.pb_multiple_users_stacked_kit_bubble_size_xl,
+.pb_multiple_users_stacked_kit_single_bubble_size_sm,
+.pb_multiple_users_stacked_kit_single_bubble_size_md,
+.pb_multiple_users_stacked_kit_single_bubble_size_lg,
+.pb_multiple_users_stacked_kit_single_bubble_size_xl {
   $container_size: map-get($avatar-sizes, "xs");
   $bubble_container_size: map-get($avatar-sizes, "sm");
   $overlap: -15px;
@@ -103,7 +114,8 @@ $positions: (
   position: relative;
   flex-shrink: 0;
   flex-grow: 0;
-  [class^=pb_avatar_kit].pb_multiple_users_stacked_item {
+  .pb_avatar_kit_size_xs.pb_multiple_users_stacked_item,
+  .pb_avatar_kit_size_md.pb_multiple_users_stacked_item {
     @include avatar-size($stacked_size);
     &.dark {
       .avatar_wrapper {
@@ -117,10 +129,17 @@ $positions: (
       }
     }
   }
-  &[class*=_single] .pb_multiple_users_stacked_item {
+  &.pb_multiple_users_stacked_kit_single .pb_multiple_users_stacked_item,
+  &.pb_multiple_users_stacked_kit_single_bubble .pb_multiple_users_stacked_item,
+  &.pb_multiple_users_stacked_kit_single_bubble_size_sm .pb_multiple_users_stacked_item,
+  &.pb_multiple_users_stacked_kit_single_bubble_size_md .pb_multiple_users_stacked_item,
+  &.pb_multiple_users_stacked_kit_single_bubble_size_lg .pb_multiple_users_stacked_item,
+  &.pb_multiple_users_stacked_kit_single_bubble_size_xl .pb_multiple_users_stacked_item {
     @include avatar-size(28px);
   }
-  [class^=pb_avatar_kit].second_item, [class^=pb_badge_kit].second_item {
+  .pb_avatar_kit_size_xs.second_item,
+  .pb_avatar_kit_size_md.second_item, 
+  .pb_badge_kit_primary_rounded.second_item {
     @include position((bottom: 0, right: 0));
     z-index: 2;
     background: tint($primary, 90%);
@@ -143,7 +162,8 @@ $positions: (
 
   // Iterate over each size to adjust the bubble container only when class contains "_bubble_"
   @each $size_name, $size_value in $avatar-sizes {
-      &[class*=_bubble_][class*=_size_#{$size_name}] {
+      &.pb_multiple_users_stacked_kit_bubble_size_#{$size_name},
+      &.pb_multiple_users_stacked_kit_single_bubble_size_#{$size_name} {
         // Set bubble container size based on the class
         $bubble_container_size: $size_value;
         $container_size: $size_value;
@@ -161,7 +181,8 @@ $positions: (
           background-color: $card_dark;
         }
   
-        [class^=pb_avatar_kit].pb_multiple_users_stacked_item {
+        .pb_avatar_kit_size_xs.pb_multiple_users_stacked_item,
+        .pb_avatar_kit_size_md.pb_multiple_users_stacked_item {
           @include avatar-size($bubble_container_size * 0.45); // Adjust the size of stacked avatars
   
           &.dark {
@@ -175,7 +196,8 @@ $positions: (
           }
         }
   
-        [class^=pb_avatar_kit] {
+        .pb_avatar_kit_size_xs,
+        .pb_avatar_kit_size_md {
           // First Item
           &.first_item {
             @include position(map-get(map-get($positions, 'first-item-double'), $size_name));
@@ -235,8 +257,13 @@ $positions: (
           }
         }
         
-        &[class*=_single_bubble] {
-          [class^=pb_avatar_kit].first_item {
+        &.pb_multiple_users_stacked_kit_single_bubble,
+        &.pb_multiple_users_stacked_kit_single_bubble_size_sm,
+        &.pb_multiple_users_stacked_kit_single_bubble_size_md,
+        &.pb_multiple_users_stacked_kit_single_bubble_size_lg,
+        &.pb_multiple_users_stacked_kit_single_bubble_size_xl {
+          .pb_avatar_kit_size_xs.first_item,
+          .pb_avatar_kit_size_md.first_item {
             @include position((top: 0, left: 0));
             @include avatar-size($bubble_container_size);
           }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[Runway story](https://runway.powerhrg.com/backlog_items/PLAY-2524)

- Refactored SCSS for MultipleUsersStacked to remove partial selectors
- No change to functionality or logic

**Screenshots:** Screenshots to visualize your addition/change

<img width="284" height="683" alt="Screenshot 2025-09-29 at 12 44 49 PM" src="https://github.com/user-attachments/assets/2b0792c0-736e-41f2-b187-689e7baa0773" />

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.