### PR TITLE
[PLAY-2397] Tokens: Create Letter Spacing, Shadow and Titles token pages

### DIFF
--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/Data/TokenCards.ts
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/Data/TokenCards.ts
@@ -35,6 +35,13 @@ export const TokenCards = [
     link: "/tokens/line_height",
   },
   {
+    title: "Letter Spacing",
+    description:
+      "Controls the spacing between characters in text for fine-tuning typographic tone.",
+    icon: "text-spacing",
+    link: "/tokens/letter_spacing",
+  },
+  {
     title: "Opacity",
     description:
       "Defined transparency levels, ranging from 0% (invisible) to 100% (fully visible).",

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/Data/TokenCards.ts
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/Data/TokenCards.ts
@@ -38,7 +38,7 @@ export const TokenCards = [
     title: "Letter Spacing",
     description:
       "Controls the spacing between characters in text for fine-tuning typographic tone.",
-    icon: "text-spacing",
+    icon: "letter-spacing",
     link: "/tokens/letter_spacing",
   },
   {

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/LetterSpacing.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/LetterSpacing.tsx
@@ -1,0 +1,90 @@
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+
+const LetterSpacing = () => {
+    return (
+        <>
+            <ShowPage
+                pageType="tokens"
+                title="Letter Spacing"
+                description="Letter Spacing tokens control the spacing between characters in text. They are useful for fine-tuning typographic tone in headings, buttons, and labels."
+            >
+                <PropsExamplesTable
+                    headers={["Token", "Value", "SASS Example"]}
+                    rows={[
+                        [
+                            "$lspace_tightest",
+                            "-.1em",
+                            <ExampleCodeCard
+                                id="lspace-tightest"
+                                text="letter-spacing: $lspace_tightest;"
+                            />
+                        ],
+                        [
+                            "$lspace_tighter",
+                            "-.07em",
+                            <ExampleCodeCard
+                                id="lspace-tighter"
+                                text="letter-spacing: $lspace_tighter;"
+                            />
+                        ],
+                        [
+                            "$lspace_tight",
+                            "-.01em",
+                            <ExampleCodeCard
+                                id="lspace-tight"
+                                text="letter-spacing: $lspace_tight;"
+                            />
+                        ],
+                        [
+                            "$lspace_normal",
+                            ".003em",
+                            <ExampleCodeCard
+                                id="lspace_normal"
+                                text="letter-spacing: $lspace_normal;"
+                            />
+                        ],
+                        [
+                            "lspace_loose",
+                            ".03em",
+                            <ExampleCodeCard
+                                id="lspace_loose"
+                                text="letter-spacing: $lspace_loose"
+                            />
+                        ],
+                        [
+                            "lspace_looser",
+                            ".07em",
+                            <ExampleCodeCard
+                                id="lspace_looser"
+                                text="letter-spacing: $lspace_looser;"
+                            />
+                        ],
+                        [
+                            "lspace_loosest",
+                            ".1em",
+                            <ExampleCodeCard
+                                id="lspace_loosest"
+                                text="letter-spacing: $lspace_loosest;"
+                            />
+                        ],
+                        [
+                            "lspace_super_loosest",
+                            ".2em",
+                            <ExampleCodeCard
+                                id="lspace_super_loosest"
+                                text="letter-spacing: $lspace_super_loosest;"
+                            />
+                        ],
+
+                    ]}
+                >
+
+                </PropsExamplesTable>
+            </ShowPage>
+        </>
+    )
+}
+
+export default LetterSpacing;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Shadows.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Shadows.tsx
@@ -1,0 +1,57 @@
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+
+const Shadows = () => {
+    return (
+        <>
+            <ShowPage
+                pageType="tokens"
+                title="Shadow"
+                description="Shadow tokens define box-shadow styles to create depth and visual hierarchy. Commonly used for modals, cards, and elevated UI components."
+            >
+                <PropsExamplesTable
+                    headers={["Token", "Value", "SASS Example"]}
+                    rows={[
+                        [
+                            "$shadow_none",
+                            "0 0 0 0 transparent",
+                            <ExampleCodeCard
+                                id="shadow_none"
+                                text="box-shadow: $shadow_none;"
+                            />
+                        ],
+                          [
+                            "$shadow_deep",
+                            "0 4px 10px 0 rgba($shadow, 0.16)",
+                            <ExampleCodeCard
+                                id="shadow_deep"
+                                text="box-shadow: $shadow_deep;"
+                            />
+                        ],
+                          [
+                            "$shadow_deeper",
+                            "0 12px 28px 0 rgba($shadow, 0.18)",
+                            <ExampleCodeCard
+                                id="shadow_deeper"
+                                text="box-shadow: $shadow_deeper;"
+                            />
+                        ],
+                          [
+                            "$shadow_deepest",
+                            "0 30px 38px 4px $shadow, 0 2px 14px 4px rgba($shadow, 0.1)",
+                            <ExampleCodeCard
+                                id="shadow_deepest"
+                                text="box-shadow: $shadow_deepest;"
+                            />
+                        ],
+                    ]}
+                >
+
+                </PropsExamplesTable>
+            </ShowPage>
+        </>
+    )
+}
+
+export default Shadows;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Titles.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Titles.tsx
@@ -1,0 +1,200 @@
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+
+const Titles = () => {
+    return (
+        <>
+            <ShowPage
+                pageType="tokens"
+                title="Titles"
+                description="Title tokens define typographic styles for headings and page titles. Includes size, weight, and spacing to ensure consistent hierarchy and structure across the UI."
+            >
+                <PropsExamplesTable
+                    headers={["Token", "Value", "SASS Example"]}
+                    rows={[
+                        [
+                            "pb_title",
+                            <>
+                                {`font-size: 44px ($heading_1)
+                                    font-weight: 300 ($lighter)
+                                    line-height: $lh_tighter (from line_height file)
+                                    letter-spacing: -0.01em ($lspace_tight)
+                                    color: $text_lt_default
+                                    font-family: 'Power Centra', 'Helvetica Neue', Helvetica, Arial, sans_serif`
+                                    .split('\n')
+                                    .map((line, idx) => (
+                                        <span key={idx}>
+                                            {line}
+                                            <br />
+                                        </span>
+                                    ))
+                                }
+                            </>,
+                            <>
+                                <ExampleCodeCard
+                                    id="pb_title_example_1"
+                                    text=".class-name { @include pb_title; }"
+                                />
+                                <br />
+                                <ExampleCodeCard
+                                    id="pb_title_example_2"
+                                    text=".class-name { @include pb_title($heading_2, $bolder, 1.4, $lspace_normal); }"
+                                />
+                            </>,
+
+                        ],
+                        [
+                            "pb_title_1",
+                            <>
+                                {`font-size: 44px ($heading_1)
+                                    font-weight: 300 ($lighter)
+                                    line-height: $lh_tighter (from line_height file)
+                                    letter-spacing: -0.01em ($lspace_tight)
+                                    color: $text_lt_default
+                                    font-family: "Power Centra", "Helvetica Neue", Helvetica, Arial, sans_serif`
+                                    .split('\n')
+                                    .map((line, idx) => (
+                                        <span key={idx}>
+                                            {line}
+                                            <br />
+                                        </span>
+                                    ))
+                                }
+                            </>,
+                            <>
+                                <ExampleCodeCard
+                                    id="pb_title_1_example_1"
+                                    text=".class-name { @include pb_title_1; }"
+                                />
+                                <br />
+                                <ExampleCodeCard
+                                    id="pb_title_1_example_2"
+                                    text=".class-name { @include pb_title($heading_1, $lighter, $lh_tighter, $lspace_tight); }"
+                                />
+                            </>,
+                        ],
+                        [
+                            "pb_title_2",
+                            <>
+                                {`font-size: 32px ($heading_2)
+                                    font-weight: 300
+                                    line-height: 0.96
+                                    letter-spacing: -0.01em`
+                                    .split('\n')
+                                    .map((line, idx) => (
+                                        <span key={idx}>
+                                            {line}
+                                            <br />
+                                        </span>
+                                    ))
+                                }
+                            </>,
+                            <>
+                                <ExampleCodeCard
+                                    id="pb_title_2_example_1"
+                                    text=".class-name { @include pb_title_2; }"
+                                />
+                                <br />
+                                <ExampleCodeCard
+                                    id="pb_title_2_example_2"
+                                    text=".class-name { @include pb_title($heading_2, $lighter, 0.96, $lspace_tight); }"
+                                />
+                            </>,
+                        ],
+                        [
+                            "pb_title_3",
+                            <>
+                                {`font-size: 15.5px ($heading_4 = $font_base)
+                                    font-weight: 700 ($bolder)
+                                    letter-spacing: 0.003em ($lspace_normal)`
+                                    .split('\n')
+                                    .map((line, idx) => (
+                                        <span key={idx}>
+                                            {line}
+                                            <br />
+                                        </span>
+                                    ))
+                                }
+                            </>,
+                            <>
+                                <ExampleCodeCard
+                                    id="pb_title_3_example_1"
+                                    text=".class-name { @include pb_title_3; }"
+                                />
+                                <br />
+                                <ExampleCodeCard
+                                    id="pb_title_3_example_2"
+                                    text=".class-name { @include pb_title($heading_3, $lighter, $lh_tighter, $lspace_tight); }"
+                                />
+                            </>,
+                        ],
+                        [
+                            "pb_title_4",
+                            <>
+                                {`font-size: 27px ($heading_3 = $font_larger)
+                                    font-weight: 300 ($lighter)
+                                    line-height: $lh_tighter (from line_height file)
+                                    letter-spacing: -0.01em ($lspace_tight)
+                                    color: $text_lt_default
+                                    font-family: "Power Centra", "Helvetica Neue", Helvetica, Arial, sans_serif`
+                                    .split('\n')
+                                    .map((line, idx) => (
+                                        <span key={idx}>
+                                            {line}
+                                            <br />
+                                        </span>
+                                    ))
+                                }
+                            </>,
+                            <>
+                                <ExampleCodeCard
+                                    id="pb_title_4_example_1"
+                                    text=".class-name { @include pb_title_4; }"
+                                />
+                                <br />
+                                <ExampleCodeCard
+                                    id="pb_title_4_example_2"
+                                    text=".class-name { @include pb_title($heading_4, $bolder, $lh_tighter, $lspace_normal);}"
+                                />
+                            </>,
+                        ],
+                        [
+                            "pb_title_bold",
+                            "font-weight: 700 ($bolder)",
+                            <ExampleCodeCard
+                                id="pb_title_bold_example_1"
+                                text=".class-name { @include pb_title_bold; }"
+                            />
+                        ],
+                        [
+                            "pb_title_thin",
+
+                            <>
+                                {`font-weight: 300 ($lighter)
+                                    letter-spacing: -0.01em ($lspace_tight)`
+                                    .split('\n')
+                                    .map((line, idx) => (
+                                        <span key={idx}>
+                                            {line}
+                                            <br />
+                                        </span>
+                                    ))
+                                }
+                            </>,
+                            <>
+                                <ExampleCodeCard
+                                    id="pb_title_thin_example_1"
+                                    text=".class-name { @include pb_title_thin; }"
+                                />
+                            </>
+                        ],
+                    ]}
+                >
+                </PropsExamplesTable>
+            </ShowPage>
+        </>
+    )
+}
+
+export default Titles;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
@@ -13,7 +13,7 @@ import VerticalAlign from "./Examples/VerticalAlign";
 import ZIndex from "./Examples/Z-Index";
 import LetterSpacing from "./Examples/LetterSpacing";
 import Shadows from "./Examples/Shadows";
-import Titles from "./Examples/titles";
+import Titles from "./Examples/Titles";
 
 
 const COMPONENT_MAP = {

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
@@ -11,19 +11,25 @@ import ScreenSizes from "./Examples/ScreenSizes";
 import TextAlign from "./Examples/TextAlign";
 import VerticalAlign from "./Examples/VerticalAlign";
 import ZIndex from "./Examples/Z-Index";
+import LetterSpacing from "./Examples/LetterSpacing";
+import Shadows from "./Examples/Shadows";
+import Titles from "./Examples/titles";
 
 
 const COMPONENT_MAP = {
   animation: Animation,
   border_radius: BorderRadius,
   display: Display,
+  letter_spacing: LetterSpacing,
   line_height: LineHeight,
   opacity: Opacity,
   overflow: Overflow,
   position: Position,
   scale: Scale,
   screen_sizes: ScreenSizes,
+  shadows: Shadows,
   text_align: TextAlign,
+  titles: Titles,
   vertical_align: VerticalAlign,
   z_index: ZIndex,
 };

--- a/playbook-website/config/global_props_and_tokens.yml
+++ b/playbook-website/config/global_props_and_tokens.yml
@@ -16,11 +16,14 @@ tokens:
   - border_radius
   - display
   - line_height
+  - letter_spacing
   - opacity
   - overflow
   - position
   - scale
   - screen_sizes
+  - shadows
   - text_align
+  - titles
   - vertical_align
   - z_index


### PR DESCRIPTION
[PLAY-2397](https://runway.powerhrg.com/backlog_items/PLAY-2397)

Adds Letter Spacing, Shadow and Titles token docs



**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.