### PR TITLE
[PLAY-2320] Advanced Table Kit: Not respecting paginationProps - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -146,8 +146,6 @@ export function useTableState({
 
   // Pagination configuration
   const paginationInitializer = useMemo(() => {
-    if (!pagination) return {};
-
     return {
       getPaginationRowModel: getPaginationRowModel(),
       paginateExpandedRows: false,


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fix pagination when enabled after initial render
Use TanStack Table pagination from start and handle visibility in [React view](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.tsx#L307-L314)

https://runway.powerhrg.com/backlog_items/PLAY-2320

**Screenshots:** Screenshots to visualize your addition/change
<img width="1120" height="314" alt="Screenshot 2025-10-01 at 9 13 47 AM" src="https://github.com/user-attachments/assets/54b0940d-bbf9-4257-88a8-1dccf5fae408" />

**How to test?** Steps to confirm the desired behavior:
1. Go to CSB in runway
2. Compare to older CSB
3. After 5 seconds, pagination with 4 years per page should show. 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.