### PR TITLE
Update memory values to 1Gi

### DIFF
--- a/playbook-website/config/deploy/production/values.yaml
+++ b/playbook-website/config/deploy/production/values.yaml
@@ -3,7 +3,7 @@ ingress:
 resourceAllocation:
   playbook:
     limits:
-      memory: 512Mi
+      memory: 1Gi
     requests:
       cpu: 0.5
-      memory: 512Mi
+      memory: 1Gi


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR doubles the memory request and limit for the web pods from 512Mi to 1Gi.

This aims to reduce the web pod restarts and subsequent web service failures when accessing the [rails advanced table](https://playbook.powerapp.cloud/kit_category/advanced_table?type=rails) that appears to tax the web pods when rendering.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.