### PR TITLE
[PLAY-2246] Hover Prop: Updated Visible Hover Prop - React and Rails

### DIFF
--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Hover.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Hover.tsx
@@ -43,8 +43,8 @@ const Hover = () => {
         <VisualGuideExample text="Shadow" hoverProp={{ shadow: "deep" }} />
         <VisualGuideExample text="Scale" hoverProp={{ scale: "md" }} />
         <VisualGuideExample
-          text="Visibility"
-          hoverProp={{ visibility: "false" }}
+          text="Visible"
+          hoverProp={{ visible: "true" }}
         />
         <VisualGuideExample
           text="Underline"
@@ -134,12 +134,12 @@ const Hover = () => {
             <ExampleCodeCard text="boolean" copyIcon={false} />,
             <ValuesCards values={["true", "false"]} />,
             <ExampleCodeCard
-              id="hover-visibility-rails"
-              text="hover: { visibility: 'true' }"
+              id="hover-visible-rails"
+              text="hover: { visible: 'true' }"
             />,
             <ExampleCodeCard
-              id="hover-visibility-react"
-              text="hover={{ visibility: 'true' }}"
+              id="hover-visible-react"
+              text="hover={{ visible: 'true' }}"
             />,
           ],
           [

--- a/playbook-website/app/javascript/components/VisualGuidelines/Examples/GroupHover.tsx
+++ b/playbook-website/app/javascript/components/VisualGuidelines/Examples/GroupHover.tsx
@@ -56,7 +56,7 @@ const GroupHover = ({ example }: {example: string}) => (
             background="product_4_highlight"
             borderRadius="rounded"
             borderNone
-            hover={{ visibility: true }}
+            hover={{ visible: true }}
             padding="xs"
             groupHover
         >

--- a/playbook-website/app/views/pages/code_snippets/group_hover_jsx.txt
+++ b/playbook-website/app/views/pages/code_snippets/group_hover_jsx.txt
@@ -30,7 +30,7 @@
         background="product_4_highlight"
         borderRadius="rounded"
         borderNone
-        hover={{ visibility: true }}
+        hover={{ visible: true }}
         padding="xs"
         groupHover
     >

--- a/playbook/app/pb_kits/playbook/pb_card/docs/_card_light.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/docs/_card_light.html.erb
@@ -1,4 +1,4 @@
-<%= pb_rails("card", props: {
+<%= pb_rails("card", props: {hover: { visible: true }
 })  do %>
   Card content
 <% end %>

--- a/playbook/app/pb_kits/playbook/utilities/_hover.scss
+++ b/playbook/app/pb_kits/playbook/utilities/_hover.scss
@@ -60,7 +60,7 @@
   @include hover-color-classes($text_colors);
   @include hover-color-classes($category_colors);
 
-.hover_visibility {
+.hover_visible_true {
   opacity: 0;
   transition: opacity $transition-speed ease;
 
@@ -70,7 +70,7 @@
 }
 
 .group_hover:hover {
-  .group_hover.hover_visibility {
+  .group_hover.hover_visible_true {
     opacity: 1;
   }
 }

--- a/playbook/app/pb_kits/playbook/utilities/globalProps.ts
+++ b/playbook/app/pb_kits/playbook/utilities/globalProps.ts
@@ -65,7 +65,7 @@ type Hover = Shadow & {
   color?: string,
   scale?: "sm" | "md" | "lg",
   underline?: boolean,
-  visibility?: boolean,
+  visible?: boolean,
 }
 
 type GroupHover  = {
@@ -252,7 +252,7 @@ const PROP_CATEGORIES: {[key:string]: (props: {[key: string]: any}) => string} =
       css += hover.underline ? `hover_underline ` : '';
       css += hover.scale ? `hover_scale_${hover.scale} ` : '';
       css += hover.color ? `hover_color-${hover.color } ` : '';
-      css += hover.visibility ? `hover_visibility` : '';
+      css += hover.visible ? `hover_visible_true` : '';
       return css;
   },
 

--- a/playbook/lib/playbook/hover.rb
+++ b/playbook/lib/playbook/hover.rb
@@ -33,12 +33,16 @@ module Playbook
       [true, false]
     end
 
+    def hover_visible_values
+      %w[true false]
+    end
+
     def hover_values
       hover_options.keys.select { |sk| try(sk) }
     end
 
     def hover_attributes
-      %w[background shadow scale color underline]
+      %w[background shadow scale color underline visible]
     end
 
     def hover_props

--- a/playbook/spec/playbook/global_props/hover_spec.rb
+++ b/playbook/spec/playbook/global_props/hover_spec.rb
@@ -31,12 +31,16 @@ RSpec.describe Playbook::PbBody::Body do
       instance = subject.new({ hover: { underline: false } })
       expect(instance.classname).not_to include("hover_underline")
 
+      instance = subject.new({ hover: { visible: true } })
+      expect(instance.classname).to include("hover_visible_true")
+
       hover_props = {
         shadow: "deep",
         scale: "sm",
         background: "red",
         color: "blue",
         underline: true,
+        visible: true,
       }
       instance = subject.new({ hover: hover_props })
       expect(instance.classname).to include("hover_shadow_deep")
@@ -44,6 +48,7 @@ RSpec.describe Playbook::PbBody::Body do
       expect(instance.classname).to include("hover_background-red")
       expect(instance.classname).to include("hover_color-blue")
       expect(instance.classname).to include("hover_underline")
+      expect(instance.classname).to include("hover_visible_true")
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** 

[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2246)

This PR: 
- Changes the name of the visibility prop to 'visible' for clarity
- visible:true make the item visible on hover, visible:false does nothing
- Makes fixes to the Rails side so the global prop works on rails side as well
- Makes fixes to the beta global_props/hover page, the visual_guidelines/group_hover page + copy on both to account for the change from visibility to visible
- Added spec tests for visible hover prop
- **NOTE** visible true added to default card doc for review purposes, will be backed out once approved.


**Screenshots:** Screenshots to visualize your addition/change

https://github.com/user-attachments/assets/4ff096d5-739d-42e0-99d3-0071b82b0280

**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/card/rails and hover over first doc example

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.