### PR TITLE
[PLAY-2537] Add display: block To The Text Input Kit

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -3,6 +3,9 @@
 @import "../tokens/colors";
 
 .pb_text_input_kit {
+  label {
+    display: block !important;
+  }
   .pb_text_input_kit_label {
     margin-bottom: $space_xs;
     display: block;


### PR DESCRIPTION
[PLAY-2537](https://runway.powerhrg.com/backlog_items/PLAY-2537)

This PR adds display: block to the text input kit.


**How to test?** Steps to confirm the desired behavior:
1. Make sure styles still looks correct.


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.