### PR TITLE
[PLAY-2437] Global Props: Create Text Align, Position and Z-Index pages

### DIFF
--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/PositionGlobalProps.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/PositionGlobalProps.tsx
@@ -1,0 +1,171 @@
+import { Image, Flex, Card, Body } from "playbook-ui";
+
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+import HeaderWithIcon from "../../Templates/Subcomponents/HeaderWithIcon";
+import ValueCardWithTooltip from "../../Templates/Subcomponents/ValueCardWithTooltip";
+
+const Position = () => {
+  const VisualGuideExample = ({ imageUrl, position }: any) => {
+    return (
+      <>
+        <Flex orientation="column" alignItems="center" gap="xs">
+            <Image
+              alt="picture of a misty forest"
+              size="lg"
+              url={imageUrl}
+            />
+            <Body text={position} />
+        </Flex>
+      </>
+    )
+  }
+
+  const PositionCard = () => {
+      return (
+        <Flex width="100%" justify="around" wrap>
+          <VisualGuideExample imageUrl="https://unsplash.it/500/400/?image=634" position="Static" />
+          <VisualGuideExample imageUrl="https://unsplash.it/500/400/?image=634" position="Relative" />
+          <VisualGuideExample imageUrl="https://unsplash.it/500/400/?image=634" position="Absolute" />
+          <VisualGuideExample imageUrl="https://unsplash.it/500/400/?image=634" position="Fixed" />
+          <VisualGuideExample imageUrl="https://unsplash.it/500/400/?image=634" position="Sticky" />
+        </Flex>
+      );
+  };
+
+  const PositionValues = [
+    "relative",
+    "absolute",
+    "fixed",
+    "sticky",
+    "static",
+  ];
+
+  const SpacingValues = [
+    { name: "0"},
+    { name: "xxs", value: "4px" },
+    { name: "xs", value: "8px" },
+    { name: "sm", value: "16px" },
+    { name: "md", value: "24px" },
+    { name: "lg", value: "32px" },
+    { name: "xl", value: "40px" },
+  ];
+
+  const PositionValuesCards = () => {
+    return (
+      <Flex gap="xs" wrap>
+        {PositionValues.map((value) => (
+          <ExampleCodeCard text={value} copyIcon={false} />
+        ))}
+      </Flex>
+    );
+  };
+
+  const SpacingValuesCards = () => {
+    return (
+      <Flex gap="xs" wrap>
+        {SpacingValues.map((spacing) => (
+          <ValueCardWithTooltip
+            key={spacing.name}
+            text={spacing.name}
+            tooltipText={spacing.value}
+          />
+        ))}
+      </Flex>
+    );
+  };
+
+  return (
+    <ShowPage
+      title="Position"
+      description={
+        <>
+          The Position prop controls how an element is placed on a page and
+          how it interacts with other elements within the viewport or layout.
+          For more information on Position prop controls, refer to the{" "}
+          <a
+            href="https://developer.mozilla.org/en-US/docs/Web/CSS/position"
+            target="_blank"
+          >
+            MDN document found here.
+          </a>
+        </>
+      }
+      VisualGuideCard={PositionCard()}
+    >
+      <PropsExamplesTable
+        headers={[
+          "Prop",
+          "Type",
+          <HeaderWithIcon />,
+          "Rails Example",
+          "React Example",
+        ]}
+        rows={[
+          [
+            "Position",
+            <ExampleCodeCard text="union" copyIcon={false} />,
+            <PositionValuesCards />,
+            <ExampleCodeCard id="position-rails" text="position: 'absolute'" />,
+            <ExampleCodeCard id="position-react" text="position= 'absolute" />,
+          ],
+          [
+            "Top",
+            <ExampleCodeCard text="union" copyIcon={false} />,
+            <SpacingValuesCards />,
+            <ExampleCodeCard
+              id="top-rails"
+              text="top: 'sm'"
+            />,
+            <ExampleCodeCard
+              id="top-react"
+              text="top= 'sm'"
+            />,
+          ],
+          [
+            "Bottom",
+            <ExampleCodeCard text="union" copyIcon={false} />,
+            <SpacingValuesCards />,
+            <ExampleCodeCard
+              id="bottom-rails"
+              text="bottom: 'sm'"
+            />,
+            <ExampleCodeCard
+              id="bottom-react"
+              text="bottom= 'sm'"
+            />,
+          ],
+          [
+            "Left",
+            <ExampleCodeCard text="union" copyIcon={false} />,
+            <SpacingValuesCards />,
+            <ExampleCodeCard
+              id="left-rails"
+              text="left: 'sm'"
+            />,
+            <ExampleCodeCard
+              id="left-react"
+              text="left= 'sm'"
+            />,
+          ],
+          [
+            "Right",
+            <ExampleCodeCard text="union" copyIcon={false} />,
+            <SpacingValuesCards />,
+            <ExampleCodeCard
+              id="right-rails"
+              text="right: 'sm'"
+            />,
+            <ExampleCodeCard
+              id="right-react"
+              text="right= 'sm'"
+            />,
+          ],
+        ]}
+      />
+    </ShowPage>
+  );
+};
+
+export default Position;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/TextAlignGlobalProps.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/TextAlignGlobalProps.tsx
@@ -1,0 +1,181 @@
+import React from "react";
+import { Flex, Card, Body, Caption } from "playbook-ui";
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+import ResponsivenessSection from "../../Templates/Subcomponents/ResponsivenessSection";
+
+const TextAlign = () => {
+
+    const VisualGuideExample = ({ text, textAlign }: any) => {
+        return (
+      <>
+        <Flex orientation="column" alignItems="center" gap="xs">
+            <Card
+              className="visual_guide_card_text_align"
+              alignItems="center"
+              justifyContent="center"
+              padding="sm"
+              background="light"
+              textAlign={textAlign}
+            >
+              {text}
+            </Card>
+            <Body text={textAlign} />
+        </Flex>
+      </>
+      )
+     }
+
+    const TextAlignCard = () => {
+        return (
+          <Flex gap="sm">
+            <VisualGuideExample text="The quick brown fox jumps over 17 lazy dogs." textAlign="left" />
+            <VisualGuideExample text="The quick brown fox jumps over 17 lazy dogs." textAlign="right" />
+            <VisualGuideExample text="The quick brown fox jumps over 17 lazy dogs." textAlign="center" />
+            <VisualGuideExample text="The quick brown fox jumps over 17 lazy dogs." textAlign="justify" />
+            <VisualGuideExample text="The quick brown fox jumps over 17 lazy dogs." textAlign="start" />
+            <VisualGuideExample text="The quick brown fox jumps over 17 lazy dogs." textAlign="end" />
+          </Flex>
+        );
+    };
+
+
+    const values = [
+      "left",
+      "right",
+      "center",
+      "justify",
+      "justify-all",
+      "start",
+      "end",
+      "match-parent",
+      "initial",
+      "inherit",
+    ];
+
+    const ValuesCards = () => {
+      return (
+        <Flex gap="xs" wrap>
+          {values.map((value) => (
+            <ExampleCodeCard text={value} copyIcon={false} />
+          ))}
+        </Flex>
+      );
+    };
+
+    const ResponsiveExamples = () => {
+      return (
+        <>
+          <Flex alignItems="center" gap="sm">
+            <Caption text="Rails" />
+            <ExampleCodeCard
+              id="responsive-rails"
+              text="text_align: { xs: 'justify', sm: 'justify', md: 'left', lg: 'left', xl: 'left', default: 'left' }"
+            />
+          </Flex>
+          <Flex alignItems="center" gap="sm">
+            <Caption text="React" />
+            <ExampleCodeCard
+              id="responsive-react"
+              text="textAlign= {{ xs: 'justify', sm: 'justify', md: 'left', lg: 'left', xl: 'left', default: 'left' }}"
+            />
+          </Flex>
+        </>
+      );
+    };
+
+
+  return (
+    <>
+      <ShowPage
+        title="Text Align"
+        description={
+          <>
+            The Text Align prop controls the horizontal alignment of inline-level
+            content within a block-level container. It can affect the alignment
+            of text, inline elements, inline-blocks, and images. Text Align is
+            commonly used to align text to the left, right, center, or justify it
+            across the full width of a container. For more information on Text
+            Align prop controls, refer to the{" "}
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/CSS/text-align"
+              target="_blank"
+            >
+              MDN document found here.
+            </a>
+          </>
+        }
+        VisualGuideCard={TextAlignCard()}
+      >
+        <PropsExamplesTable
+          headers={[
+            "Text Align",
+            "Type",
+            "Values",
+            "Rails Example",
+            "React Example",
+          ]}
+            rows={
+              [
+                [
+                  "Text Align",
+                  <ExampleCodeCard text="union" copyIcon={false} />,
+                  <ValuesCards />,
+                  <ExampleCodeCard text={`text_align:"right"`} />,
+                  <ExampleCodeCard text={`textAlign="right"`} />
+                ]
+              ]
+            }
+        />
+
+        <ResponsivenessSection
+          exampleSection={<ResponsiveExamples />}
+        >
+          <PropsExamplesTable
+            firstColumnBold={false}
+            headers={[
+              "Breakpoints",
+              "Value",
+              "Description",
+            ]}
+            rows={[
+              [
+                "xs",
+                "max-width: 575px",
+                "Extra small screens"
+              ],
+              [
+                "sm",
+                "min-width: 576px, max-width: 767px",
+                "Small screens"
+              ],
+              [
+                "md",
+                "min-width: 768px, max-width: 991px",
+                "Medium screens"
+              ],
+              [
+                "lg",
+                "min-width: 992px, max-width: 1199px",
+                "Large screens"
+              ],
+              [
+                "xl",
+                "min-width: 1200px",
+                "Extra large screens"
+              ],
+              [
+                "default",
+                "All sizes",
+                "Default is used as a final fallback and is not tied to a specific screen size."
+              ]
+            ]}
+          />
+        </ResponsivenessSection>
+      </ShowPage>
+    </>
+  )
+}
+
+export default TextAlign;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Z-IndexGlobalProps.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/Z-IndexGlobalProps.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { Flex, FlexItem, Card, Title, Caption } from "playbook-ui";
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+import ResponsivenessSection from "../../Templates/Subcomponents/ResponsivenessSection";
+import ValueCardWithTooltip from "../../Templates/Subcomponents/ValueCardWithTooltip";
+
+const ZIndex = () => {
+    const values = [
+      { name: "1", value: "100"},
+      { name: "2", value: "200" },
+      { name: "3", value: "300" },
+      { name: "4", value: "400" },
+      { name: "5", value: "500" },
+      { name: "6", value: "600" },
+      { name: "7", value: "700" },
+      { name: "8", value: "800"},
+      { name: "9", value: "900"},
+      { name: "10", value: "1000"},
+    ];
+
+    const cardIndexes = ["2", "3", "4", "5", "6", "7", "8", "9", "10"]
+
+    const ZIndexCard = () => {
+        return (
+          <Flex maxWidth="100%">
+            <Card
+              borderRadius="none"
+              padding="xl"
+              background="light"
+              zIndex="1"
+            >
+              <Title bold={false}
+                     size={2}
+                     tag='h2'
+                     text="1"
+              />
+            </Card>
+            {cardIndexes.map((index) => (
+              <Card
+                borderRadius="none"
+                shadow="deeper"
+                padding="xl"
+                background="light"
+                zIndex={index}
+                htmlOptions={{style: {wordWrap: "normal"}}}
+              >
+                <Title bold={false}
+                       size={2}
+                       tag='h2'
+                       text={index}
+                />
+              </Card>
+            ))}
+          </Flex>
+        );
+    };
+
+    const ValuesCards = () => {
+      return (
+        <Flex gap="xs" wrap>
+          {values.map((value) => (
+            <ValueCardWithTooltip
+              key={value.name}
+              text={value.name}
+              tooltipText={value.value}
+            />
+          ))}
+        </Flex>
+      );
+    };
+
+    const ResponsiveExamples = () => {
+      return (
+        <>
+          <Flex alignItems="center" gap="sm">
+            <Caption text="Rails" />
+            <ExampleCodeCard
+              id="responsive-rails"
+              text="z_index: { xs: '1', sm: '2', md: '3', lg: '4', xl: '5', default: '6' }"
+            />
+          </Flex>
+          <Flex alignItems="center" gap="sm">
+            <Caption text="React" />
+            <ExampleCodeCard
+              id="responsive-react"
+              text="textAlign= {{ xs: '1', sm: '2', md: '3', lg: '4', xl: '5', default: '6' }}"
+            />
+          </Flex>
+        </>
+      );
+    };
+
+
+  return (
+    <>
+      <ShowPage
+        title="Text Align"
+        description={
+          <>
+            The Z-Index prop controls the stack order of components along the z-axis,
+            determining which elements appear in front of or behind others. It is
+            commonly used for overlays, modals, tooltips, and other layered UI elements.
+            When used improperly, z-index can lead to stacking conflicts or unpredictable
+            visual results, particularly for deeply nested layouts. For more information
+            on Z-Index prop controls, refer to the{" "}
+            <a
+              href="https://developer.mozilla.org/en-US/docs/Web/CSS/z-index"
+              target="_blank"
+            >
+              MDN document found here.
+            </a>
+          </>
+        }
+        VisualGuideCard={ZIndexCard()}
+      >
+        <PropsExamplesTable
+          headers={[
+            "Z-Index",
+            "Type",
+            "Values",
+            "Rails Example",
+            "React Example",
+          ]}
+            rows={
+              [
+                [
+                  "Z-Index",
+                  <ExampleCodeCard text="union" copyIcon={false} />,
+                  <ValuesCards />,
+                  <ExampleCodeCard text={`z_index:"5"`} />,
+                  <ExampleCodeCard text={`zIndex="5"`} />
+                ]
+              ]
+            }
+        />
+
+        <ResponsivenessSection
+          exampleSection={<ResponsiveExamples />}
+        >
+          <PropsExamplesTable
+            firstColumnBold={false}
+            headers={[
+              "Breakpoints",
+              "Value",
+              "Description",
+            ]}
+            rows={[
+              [
+                "xs",
+                "max-width: 575px",
+                "Extra small screens"
+              ],
+              [
+                "sm",
+                "min-width: 576px, max-width: 767px",
+                "Small screens"
+              ],
+              [
+                "md",
+                "min-width: 768px, max-width: 991px",
+                "Medium screens"
+              ],
+              [
+                "lg",
+                "min-width: 992px, max-width: 1199px",
+                "Large screens"
+              ],
+              [
+                "xl",
+                "min-width: 1200px",
+                "Extra large screens"
+              ],
+              [
+                "default",
+                "All sizes",
+                "Default is used as a final fallback and is not tied to a specific screen size."
+              ]
+            ]}
+          />
+        </ResponsivenessSection>
+      </ShowPage>
+    </>
+  )
+}
+
+export default ZIndex;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex.tsx
@@ -9,7 +9,10 @@ import LineHeight from "./Examples/LineHeightGlobalProps";
 import Display from "./Examples/DisplayGlobalProps";
 import MaxWidth from "./Examples/MaxWidth";
 import MinWidth from "./Examples/MinWidth";
+import Position from "./Examples/PositionGlobalProps";
+import TextAlign from "./Examples/TextAlignGlobalProps";
 import Width from "./Examples/Width";
+import ZIndex from "./Examples/Z-IndexGlobalProps";
 
 const COMPONENT_MAP = {
   cursor: Cursor,
@@ -21,7 +24,10 @@ const COMPONENT_MAP = {
   display: Display,
   max_width: MaxWidth,
   min_width: MinWidth,
+  position: Position,
+  text_align: TextAlign,
   width: Width,
+  z_index: ZIndex,
 };
 
 const GlobalPropsExamples = () => {

--- a/playbook-website/config/global_props_and_tokens.yml
+++ b/playbook-website/config/global_props_and_tokens.yml
@@ -8,7 +8,10 @@ global_props:
   - display
   - max_width
   - min_width
+  - position
+  - text_align
   - width
+  - z_index
 
 
 tokens:


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2437)

This PR adds the following to our Global Props pages:
* /global_props/position
* /global_props/text_align
* /global_props/z_index

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.