### PR TITLE
Fixes for Card doc example

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_card/docs/_card_light.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_card/docs/_card_light.html.erb
@@ -1,4 +1,4 @@
-<%= pb_rails("card", props: {hover: { visible: true }
+<%= pb_rails("card", props: {
 })  do %>
   Card content
 <% end %>


### PR DESCRIPTION
Accidentally shipped a test for a global prop within the doc example, fixing it here. 
