### PR TITLE
Bump ci-kubed to v10.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM phusion/passenger-customizable:1.0.19 AS base
 
 RUN --mount=type=cache,id=playbook-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=playbook-apt-lib,target=/var/lib/apt,sharing=locked \
-    apt-get update -y && \
     mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak && \
-    apt update && apt install -y ca-certificates && \
-    mv /etc/apt/sources.list.d.bak /etc/apt/sources.list.d
+    apt-get update -y && \
+    apt-get install -y ca-certificates curl gnupg && \
+    curl -fsSL https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key-2025.txt | gpg --dearmor -o /etc/apt/trusted.gpg.d/phusion-passenger.gpg && \
+    mv /etc/apt/sources.list.d.bak /etc/apt/sources.list.d && \
+    apt-get update -y
 
 RUN bash -lc 'rvm remove all --force && rvm install ruby-3.3.0 && rvm --default use ruby-3.3.0 && gem install bundler -v 2.5.3'
 RUN --mount=type=cache,id=playbook-apt-cache,target=/var/cache/apt,sharing=locked \
@@ -30,7 +32,8 @@ RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/insta
     && npm install -g npm@$NPM_VERSION yarn@$YARN_VERSION
 
 RUN --mount=type=cache,id=playbook-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=playbook-apt-lib,target=/var/lib/apt,sharing=locked \apt-get update -y \
+    --mount=type=cache,id=playbook-apt-lib,target=/var/lib/apt,sharing=locked \
+    apt-get update -y \
     && apt-get install -y shared-mime-info=1.15-1
 
 RUN bundle config --global silence_root_warning 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
 library 'github.com/powerhome/ci-kubed@1c81d877a05417860bca4d369e088bca18fe640b'
 
 app.build(
-  cluster: ['wc-beta-px'],
   buildCacheVolumeSize: '15Gi',
   resources: [
     requestCpu: '2',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'github.com/powerhome/ci-kubed@cddebc2c1fe503c8e25b6bf736a0233df7c66ff3'
+library 'github.com/powerhome/ci-kubed@v10.0.0'
 
 app.build(
   buildCacheVolumeSize: '20Gi',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 library 'github.com/powerhome/ci-kubed@1c81d877a05417860bca4d369e088bca18fe640b'
 
 app.build(
-  buildCacheVolumeSize: '15Gi',
+  buildCacheVolumeSize: '20Gi',
   resources: [
     requestCpu: '2',
     requestMemory: '10Gi',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 library 'github.com/powerhome/ci-kubed@1c81d877a05417860bca4d369e088bca18fe640b'
 
 app.build(
+  buildCacheVolumeSize: '15Gi',
   resources: [
     requestCpu: '2',
     requestMemory: '10Gi',
@@ -15,20 +16,7 @@ app.build(
     files: ["docker-compose.yml", "docker-compose.ci.yml"]
   ) { compose ->
     stage('Image Build') {
-      compose.bake(bakeFiles: ['docker-bake.hcl'], remoteConfig: [
-        resourceQuota: [
-            requests: [
-                cpu: '2',
-                memory: '10Gi',
-            ],
-            limits: [
-                memory: '10Gi',
-            ]
-        ],
-        storageConfig: [
-          size: '15Gi',
-        ],
-      ])
+      compose.bake(bakeFiles: ['docker-bake.hcl'])
     }
 
     stage('Test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@
 library 'github.com/powerhome/ci-kubed@1c81d877a05417860bca4d369e088bca18fe640b'
 
 app.build(
+  cluster: ['wc-beta-px'],
   buildCacheVolumeSize: '15Gi',
   resources: [
     requestCpu: '2',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'github.com/powerhome/ci-kubed@d25a16164118ed059ff2cb7578c53ad4940f952e'
+library 'github.com/powerhome/ci-kubed@1c81d877a05417860bca4d369e088bca18fe640b'
 
 app.build(
   resources: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'github.com/powerhome/ci-kubed@v9.8.0'
+library 'github.com/powerhome/ci-kubed@d25a16164118ed059ff2cb7578c53ad4940f952e'
 
 app.build(
   resources: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'github.com/powerhome/ci-kubed@1c81d877a05417860bca4d369e088bca18fe640b'
+library 'github.com/powerhome/ci-kubed@cddebc2c1fe503c8e25b6bf736a0233df7c66ff3'
 
 app.build(
   buildCacheVolumeSize: '20Gi',


### PR DESCRIPTION

## What's Changed
* Support directly mounting a BuildkitCache volume into the build pod
* Adds `buildCacheVolumeSize`, `buildCacheMaxDisks`, `cacheKey`, `distinctPrCacheKeys` parameters to `app.build`
* Use custom `builder` image combining docker and buildkit
* Deprecates `remoteConfig` in `bake` calls
* Deprecates `useComposeInBake` bake parameter
* Removes PACv1 conditional annotations and commands
