### PR TITLE
[PLAY-2899] Form Custom Validations Consistency + Select validation_message Broken

### DIFF
--- a/playbook/app/entrypoints/playbook-rails.js
+++ b/playbook/app/entrypoints/playbook-rails.js
@@ -28,6 +28,7 @@ import PbMultiLevelSelect from 'kits/pb_multi_level_select'
 import PbCheckbox from 'kits/pb_checkbox'
 import PbButton from 'kits/pb_button'
 import PbTimePicker from 'kits/pb_time_picker'
+import PbFormValidation from 'kits/pb_form/pb_form_validation'
 
 // Register all kits with the global registry
 // Please note: the order of this array determines the order of kit initialization, which can be important for kits that depend on others (e.g., a kit that enhances a text input should be registered after PbTextInput)
@@ -56,6 +57,7 @@ const kits = [
   PbCheckbox,
   PbButton,
   PbTimePicker,
+  PbFormValidation,
 ]
 
 // Register all kits (this just stores them, doesn't initialize yet)
@@ -72,8 +74,9 @@ PbKitRegistry.start()
 // Copy Button
 addCopyEventListeners()
 
-// Form utilities
-import 'kits/pb_form/pb_form_validation'
+// Form utilities - PbFormValidation is registered with PbKitRegistry above
+// so it starts automatically. We also expose it on window for legacy support.
+window.PbFormValidation = PbFormValidation
 import formHelper from 'kits/pb_form/formHelper'
 window.formHelper = formHelper
 

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -31,6 +31,7 @@
       name: object.name,
       placeholder: object.placeholder,
       required: object.required,
+      validation: object.validation_message.present? ? { message: object.validation_message } : {},
     }) %>
     <% end %>
     <% if object.selection_type == "quickpick" %>

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validate.html.erb
@@ -97,8 +97,8 @@
 }] %>
 
 <%= pb_form_with(scope: :example, method: :get, url: "", validate: true) do |form| %>
-  <%= form.typeahead :example_typeahead_validation, props: { data: { typeahead_example2: true, user: {} }, label: true, placeholder: "Search for a user", required: true, validation: { message: "Please select a user." } } %>
-  <%= form.typeahead :example_typeahead_validation_react, props: { options: example_typeahead_options, pills: true, label: "Example Typeahead (React Rendered)", placeholder: "Search for a user", required: true, validation: { message: "Please select a color." } } %>
+  <%= form.typeahead :example_typeahead_validation, props: { data: { typeahead_example2: true, user: {} }, label: true, placeholder: "Search for a user", required: true } %>
+  <%= form.typeahead :example_typeahead_validation_react, props: { options: example_typeahead_options, pills: true, label: "Example Typeahead (React Rendered)", placeholder: "Search for a user", required: true } %>
   <%= form.typeahead :example_typeahead_validation_react_2, props: { options: example_typeahead_options, pills: true, label: "Example Typeahead 2 (React Rendered)", placeholder: "Search for a user", required: true } %>
   <%= form.text_field :example_text_field_validation, props: { label: true, required: true } %>
   <%= form.phone_number_field :example_phone_number_field_validation, props: { label: "Example phone field", hidden_inputs: true, required: true } %>
@@ -110,14 +110,14 @@
   <%= form.text_area :example_text_area_validation, props: { label: true, required: true } %>
   <%= form.dropdown_field :example_dropdown_validation, props: { label: true, options: example_dropdown_options, required: true } %>
   <%= form.dropdown_field :example_dropdown_validation_multi, props: { label: true, options: example_dropdown_options, multi_select: true, required: true } %>
-  <%= form.select :example_select_validation, [ ["Yes", 1], ["No", 2] ], props: { label: true, blank_selection: "Select One...", required: true, validation_message: "Please, select an option." } %>
+  <%= form.select :example_select_validation, [ ["Yes", 1], ["No", 2] ], props: { label: true, blank_selection: "Select One...", required: true } %>
   <%= form.collection_select :example_collection_select_validation, example_collection, :value, :name, props: { label: true, blank_selection: "Select One...", required: true } %>
   <%= form.check_box :example_checkbox_validation, props: { text: "Example Checkbox Validation", label: true, required: true }, checked_value: "1", unchecked_value: "0" %>
-  <%= form.date_picker :example_date_picker_2, props: { label: true, required: true, validation_message: "Please, select a date.", allow_input: true } %>
+  <%= form.date_picker :example_date_picker_2, props: { label: true, required: true, allow_input: true } %>
   <%= form.star_rating_field :example_star_rating_validation, props: { variant: "interactive", label: true, required: true } %>
   <%= form.time_zone_select_field :example_time_zone_select, ActiveSupport::TimeZone.us_zones, { default: "Eastern Time (US & Canada)" }, props: { label: true, blank_selection: "Select a Time Zone...", required: true } %>
   <%= form.multi_level_select :example_multi_level_select, props: { id: "multi-level-select-form", tree_data: treeData, margin_bottom: "sm", required: true, label: "Example Multi Level Select field" } %>
-  <%= form.time_picker :example_time_picker_validation, props: { label: true, required: true, validation_message: "Please select a time." } %>
+  <%= form.time_picker :example_time_picker_validation, props: { label: true, required: true } %>
  
   <%= form.actions do |action| %>
     <%= action.submit %>

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validation_msg.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validation_msg.html.erb
@@ -1,0 +1,90 @@
+<%
+  example_collection = [
+    OpenStruct.new(name: "Alabama", value: 1),
+    OpenStruct.new(name: "Alaska", value: 2),
+    OpenStruct.new(name: "Arizona", value: 3),
+    OpenStruct.new(name: "Arkansas", value: 4),
+    OpenStruct.new(name: "California", value: 5),
+    OpenStruct.new(name: "Colorado", value: 6),
+    OpenStruct.new(name: "Connecticut", value: 7),
+    OpenStruct.new(name: "Delaware", value: 8),
+    OpenStruct.new(name: "Florida", value: 9),
+    OpenStruct.new(name: "Georgia", value: 10),
+  ]
+%>
+
+
+<%
+  example_typeahead_options = [
+    { label: 'Orange', value: '#FFA500' },
+    { label: 'Red', value: '#FF0000' },
+    { label: 'Green', value: '#00FF00' },
+    { label: 'Blue', value: '#0000FF' },
+  ]
+%>
+
+
+<%= pb_form_with(scope: :example, method: :get, url: "", validate: true) do |form| %>
+  <%= form.text_field :example_text_field_validation_msg, props: { label: "Text Field With Validation Message", required: true, validation: { message: "I am a custom validation message for text field." } } %>
+  <%= form.typeahead :example_typeahead_validation_msg, props: { data: { typeahead_example_msg: true, user: {} }, label: "Typeahead With Validation Message", placeholder: "Search for a user", required: true, validation: { message: "I am a custom validation message for typeahead." } } %>
+  <%= form.typeahead :example_typeahead_validation_react_msg, props: { options: example_typeahead_options, pills: true, label: "Typeahead With Validation Message (React Rendered)", placeholder: "Search for a color", required: true, validation: { message: "I am a custom validation message for React typeahead." } } %>
+  <%= form.select :example_select_validation_msg, [ ["Yes", 1], ["No", 2] ], props: { label: true, blank_selection: "Select One...", required: true, validation_message: "I am a custom validation message for select." } %>
+  <%= form.collection_select :example_collection_select_validation_msg, example_collection, :value, :name, props: { label: "Collection Select With Validation Message", blank_selection: "Select a State...", required: true, validation_message: "I am a custom validation message for collection select." } %>
+  <%= form.date_picker :example_date_picker_validation_msg, props: { label: "Date Picker With Validation Message", required: true, validation_message: "I am a custom validation message for date picker.", allow_input: true } %>
+  <%= form.time_picker :example_time_picker_validation_msg, props: { label: "Time Picker With Validation Message", required: true, validation_message: "I am a custom validation message for time picker." } %>
+
+  <%= form.actions do |action| %>
+    <%= action.submit %>
+    <%= action.button props: { type: "reset", text: "Cancel", variant: "secondary" } %>
+  <% end %>
+<% end %>
+
+<!-- form.typeahead user results example template -->
+<template data-typeahead-example-result-option>
+  <%= pb_rails("user", props: {
+    name: tag(:slot, name: "name"),
+    orientation: "horizontal",
+    align: "left",
+    avatar_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGP6zwAAAgcBApocMXEAAAAASUVORK5CYII=",
+    avatar: true
+    }) %>
+</template>
+
+<!-- form.typeahead JS example implementation -->
+<%= javascript_tag defer: "defer" do %>
+  document.addEventListener("pb-typeahead-kit-search", function(event) {
+    if (!event.target.dataset || !event.target.dataset.typeaheadExampleMsg) return
+
+    fetch(`https://api.github.com/search/users?q=${encodeURIComponent(event.detail.searchingFor)}`)
+      .then(response => response.json())
+      .then((result) => {
+        const resultOptionTemplate = document.querySelector("[data-typeahead-example-result-option]")
+
+        event.detail.setResults((result.items || []).map((user) => {
+          const wrapper = resultOptionTemplate.content.cloneNode(true)
+          wrapper.children[0].dataset.user = JSON.stringify(user)
+          wrapper.querySelector('slot[name="name"]').replaceWith(user.login)
+          wrapper.querySelector('img').dataset.src = user.avatar_url
+          return wrapper
+        }))
+      })
+  })
+
+
+  document.addEventListener("pb-typeahead-kit-result-option-selected", function(event) {
+    if (!event.target.dataset.typeaheadExampleMsg) return
+
+    const selectedUserJSON = event.detail.selected.firstElementChild.dataset.user
+    const selectedUserData = JSON.parse(selectedUserJSON)
+
+    // set the input field's value
+    event.target.querySelector('input[name=example_typeahead_validation_msg]').value = selectedUserData.login
+
+    // log the selected option's dataset
+    console.log('The selected user data:')
+    console.dir(selectedUserData)
+
+    // do even more with the data later - TBD
+    event.target.dataset.user = selectedUserJSON
+  })
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validation_msg.md
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_validation_msg.md
@@ -1,0 +1,13 @@
+Custom validation messages allow you to override the browser's default validation text with your own messaging. This provides a better user experience by giving specific, actionable feedback.
+
+**Text-based inputs** (TextInput, Typeahead) use the `validation` prop with a `message` key:
+```ruby
+validation: { message: "Please enter a valid email address." }
+```
+
+**Selection-based inputs** (Select, DatePicker, TimePicker) use the `validation_message` prop:
+```ruby
+validation_message: "Please select an option."
+```
+
+When a required field is left empty or fails validation, your custom message will display instead of the generic browser default.

--- a/playbook/app/pb_kits/playbook/pb_form/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/example.yml
@@ -3,5 +3,6 @@ examples:
   rails:
   - form_form_with: Default
   - form_form_with_validate: Default + Validation
+  - form_form_with_validation_msg: Validation + Custom Validation Message
   - form_form_with_loading: Default + Loading
   - form_with_required_indicator: With Optional Required Indicator

--- a/playbook/app/pb_kits/playbook/pb_form/pb_form_validation.js
+++ b/playbook/app/pb_kits/playbook/pb_form/pb_form_validation.js
@@ -122,3 +122,5 @@ class PbFormValidation extends PbEnhancedElement {
 }
 
 window.PbFormValidation = PbFormValidation
+
+export default PbFormValidation

--- a/playbook/app/pb_kits/playbook/pb_select/select.rb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.rb
@@ -43,7 +43,14 @@ module Playbook
           multiple: multiple,
           onchange: onchange,
           include_blank: include_blank,
+          data: validation_data,
         }.merge(attributes).merge(input_options)
+      end
+
+      def validation_data
+        fields = input_options[:data] || {}
+        fields[:message] = validation_message unless validation_message.blank?
+        fields
       end
 
       # Same resolved id as the native +<select>+ (+all_attributes[:id]+) for label +for+.

--- a/playbook/lib/playbook/forms/builder/collection_select_field.rb
+++ b/playbook/lib/playbook/forms/builder/collection_select_field.rb
@@ -21,6 +21,7 @@ module Playbook
         html_options[:id] = props[:input_options][:id]
         html_options[:class] = props[:input_options][:class] if props[:input_options][:class]
         html_options[:data] = (html_options[:data] || {}).merge(props[:input_options][:data] || {})
+        html_options[:data][:message] = props[:validation_message] if props[:validation_message].present?
 
         input = super(name, collection, value_method, text_method, options, html_options)
 

--- a/playbook/lib/playbook/forms/builder/date_picker_field.rb
+++ b/playbook/lib/playbook/forms/builder/date_picker_field.rb
@@ -31,6 +31,7 @@ module Playbook
             label: nil,
             placeholder: props[:placeholder],
             required: props[:required],
+            validation: props[:validation_message].present? ? { message: props[:validation_message] } : {},
           }
         )
 

--- a/playbook/lib/playbook/forms/builder/select_field.rb
+++ b/playbook/lib/playbook/forms/builder/select_field.rb
@@ -21,6 +21,7 @@ module Playbook
         html_options[:id] = props[:input_options][:id]
         html_options[:class] = props[:input_options][:class] if props[:input_options][:class]
         html_options[:data] = (html_options[:data] || {}).merge(props[:input_options][:data] || {})
+        html_options[:data][:message] = props[:validation_message] if props[:validation_message].present?
 
         input = super(name, choices, options, html_options, &block)
 

--- a/playbook/lib/playbook/forms/builder/time_zone_select_field.rb
+++ b/playbook/lib/playbook/forms/builder/time_zone_select_field.rb
@@ -21,6 +21,7 @@ module Playbook
         html_options[:id] = props[:input_options][:id]
         html_options[:class] = props[:input_options][:class] if props[:input_options][:class]
         html_options[:data] = (html_options[:data] || {}).merge(props[:input_options][:data] || {})
+        html_options[:data][:message] = props[:validation_message] if props[:validation_message].present?
 
         input = @template.time_zone_select(@object_name, name, choices, options, html_options)
 

--- a/playbook/lib/playbook/pb_forms_helper.rb
+++ b/playbook/lib/playbook/pb_forms_helper.rb
@@ -47,8 +47,30 @@ module Playbook
       capture do
         concat form_with(**options, &block)
         concat javascript_tag(<<~JS)
-          window.addEventListener("DOMContentLoaded", function() { PbFormValidation.start() })
-          window.addEventListener("DOMContentLoaded", () => formHelper())
+          (function() {
+            // PbFormValidation is now registered with PbKitRegistry and starts automatically
+            // when the playbook-rails bundle loads. This script provides a fallback for edge
+            // cases and ensures formHelper is called
+            var startValidation = function() {
+              if (typeof PbFormValidation !== 'undefined' && PbFormValidation.start) {
+                PbFormValidation.start();
+              }
+              if (typeof formHelper === 'function') {
+                formHelper();
+              }
+            };
+
+            // Try immediately in case bundle already loaded
+            if (document.readyState !== 'loading') {
+              startValidation();
+            } else {
+              document.addEventListener('DOMContentLoaded', startValidation);
+            }
+
+            // Turbo support for dynamically loaded forms
+            document.addEventListener('turbo:load', startValidation);
+            document.addEventListener('turbo:frame-load', startValidation);
+          })();
         JS
       end
     end

--- a/playbook/lib/playbook/pb_forms_helper.rb
+++ b/playbook/lib/playbook/pb_forms_helper.rb
@@ -48,28 +48,21 @@ module Playbook
         concat form_with(**options, &block)
         concat javascript_tag(<<~JS)
           (function() {
-            // PbFormValidation is now registered with PbKitRegistry and starts automatically
-            // when the playbook-rails bundle loads. This script provides a fallback for edge
-            // cases and ensures formHelper is called
-            var startValidation = function() {
-              if (typeof PbFormValidation !== 'undefined' && PbFormValidation.start) {
-                PbFormValidation.start();
-              }
+            // PbFormValidation is registered with PbKitRegistry and starts automatically
+            // when the playbook-rails bundle loads. The MutationObserver in PbKitRegistry
+            // handles dynamically added forms (including Turbo navigations).
+            // This inline script ensures formHelper runs for this form.
+            var initForm = function() {
               if (typeof formHelper === 'function') {
                 formHelper();
               }
             };
 
-            // Try immediately in case bundle already loaded
-            if (document.readyState !== 'loading') {
-              startValidation();
+            if (document.readyState === 'loading') {
+              document.addEventListener('DOMContentLoaded', initForm, { once: true });
             } else {
-              document.addEventListener('DOMContentLoaded', startValidation);
+              initForm();
             }
-
-            // Turbo support for dynamically loaded forms
-            document.addEventListener('turbo:load', startValidation);
-            document.addEventListener('turbo:frame-load', startValidation);
           })();
         JS
       end

--- a/playbook/spec/pb_kits/playbook/kits/select_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/select_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Playbook::PbSelect::Select do
   it { is_expected.to define_boolean_prop(:show_arrow).with_default(false) }
   it { is_expected.to define_hash_prop(:input_options).with_default({}) }
   it { is_expected.to define_boolean_prop(:required_indicator).with_default(false) }
+  it { is_expected.to define_string_prop(:validation_message).with_default("") }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
@@ -53,6 +54,50 @@ RSpec.describe Playbook::PbSelect::Select do
       select = subject.new(id: "default-id", input_options: {})
 
       expect(select.all_attributes[:id]).to eq "default-id"
+    end
+
+    it "includes validation_message as data-message attribute" do
+      select = subject.new(validation_message: "Please select an option")
+
+      expect(select.all_attributes[:data]).to eq({ message: "Please select an option" })
+    end
+
+    it "merges validation_message with existing input_options data" do
+      select = subject.new(
+        validation_message: "Required",
+        input_options: { data: { controller: "select" } }
+      )
+
+      expect(select.all_attributes[:data]).to eq({ controller: "select", message: "Required" })
+    end
+
+    it "does not include data-message when validation_message is blank" do
+      select = subject.new(validation_message: "")
+
+      expect(select.all_attributes[:data]).to eq({})
+    end
+  end
+
+  describe "#validation_data" do
+    it "returns hash with message when validation_message is present" do
+      select = subject.new(validation_message: "This field is required")
+
+      expect(select.validation_data).to eq({ message: "This field is required" })
+    end
+
+    it "returns empty hash when validation_message is blank" do
+      select = subject.new(validation_message: "")
+
+      expect(select.validation_data).to eq({})
+    end
+
+    it "merges with existing input_options data" do
+      select = subject.new(
+        validation_message: "Required",
+        input_options: { data: { custom: "value" } }
+      )
+
+      expect(select.validation_data).to eq({ custom: "value", message: "Required" })
     end
   end
 

--- a/playbook/spec/playbook/pb_forms_helper_spec.rb
+++ b/playbook/spec/playbook/pb_forms_helper_spec.rb
@@ -23,10 +23,9 @@ RSpec.describe Playbook::PbFormsHelper, type: :helper do
 
     it { is_expected.to have_tag("form[data-pb-form-validation=true]") }
 
-    it "includes form validation initialization script" do
-      expect(subject).to match(/PbFormValidation\.start\(\)/)
-      expect(subject).to match(/turbo:load/)
-      expect(subject).to match(/turbo:frame-load/)
+    it "includes form helper initialization script" do
+      expect(subject).to match(/formHelper\(\)/)
+      expect(subject).to match(/DOMContentLoaded/)
     end
   end
 

--- a/playbook/spec/playbook/pb_forms_helper_spec.rb
+++ b/playbook/spec/playbook/pb_forms_helper_spec.rb
@@ -23,7 +23,11 @@ RSpec.describe Playbook::PbFormsHelper, type: :helper do
 
     it { is_expected.to have_tag("form[data-pb-form-validation=true]") }
 
-    it { is_expected.to match(/window.addEventListener\("DOMContentLoaded", function\(\) \{ PbFormValidation.start\(\) \}\)/) }
+    it "includes form validation initialization script" do
+      expect(subject).to match(/PbFormValidation\.start\(\)/)
+      expect(subject).to match(/turbo:load/)
+      expect(subject).to match(/turbo:frame-load/)
+    end
   end
 
   context "without validations" do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-2899?from=active_sprint)

This PR fixes form validation issues where custom validation messages (validation_message / validation props) were not working reliably in consumer apps (Nitro/Tempo) and specifically fixes Select validation which was broken even in Playbook docs.

#### Issues
**Issue 1**: Select validation_message broken

- The validation_message prop was defined but never passed to the actual <select> element
- Form builder methods created the <select> via Rails helpers but didn't include the validation data attribute

**Issue 2**: Form validation unreliable in consumer apps

- PbFormValidation was initialized via inline script on DOMContentLoaded only
- If the Playbook bundle loaded with defer (common in modern Rails), DOMContentLoaded could fire before PbFormValidation was defined
- No Turbo support for dynamically loaded forms

#### Changes
**Core Fixes**
- pb_form_validation.js
    - Added export default so it can be properly imported and registered with PbKitRegistry
- playbook-rails.js
   - Registered PbFormValidation with PbKitRegistry for automatic initialization via MutationObserver
   - Ensures validation starts reliably regardless of bundle load timing
- pb_forms_helper.rb
   - Made inline script defensive (checks if PbFormValidation exists before calling)

**Form Builder Fixes**
- select_field.rb, collection_select_field.rb, time_zone_select_field.rb
   - Added `html_options[:data][:message] = props[:validation_message]` to pass validation message to the `<select> `element
- date_picker_field.rb
   - Added validation prop to inner text_field call so validation message flows through

**Kit Fixes**
- pb_select/select.rb
    - Added validation_data method and included it in all_attributes for direct kit usage

- pb_date_picker/date_picker.html.erb
   - Added validation prop to inner text_input for direct kit usage

**Documentation**
- Added _form_form_with_validation_msg.html.erb for all kits supporting custom validation: TextInput, Typeahead, Select, Collection Select, DatePicker, TimePicker


**Test Updates**
- pb_forms_helper_spec.rb


**Screenshots:** Screenshots to visualize your addition/change
<img width="1280" height="911" alt="Screenshot 2026-04-07 at 11 57 21 AM" src="https://github.com/user-attachments/assets/3f7908f7-aa43-4b31-8d72-beee9ab79dfd" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.