### PR TITLE
[PLAY-2904] Advanced Table: Adjust Header Alignment Prop for Larger Screens - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.html.erb
@@ -7,7 +7,7 @@
       <% header_row.each_with_index do |cell, cell_index| %>
         <% header_component = object.header_component_info(cell, cell_index, row_index) %>
         <%= pb_rails(header_component[:name], props: header_component[:props]) do %>
-          <%= pb_rails("flex", props: { align: "center", justify: cell_index.zero? ? "start" : row_index === header_rows.size - 1 ? "end" : "center", text_align: (cell[:header_alignment] || "end") }) do %>
+          <%= pb_rails("flex", props: { align: "center", justify: object.header_flex_justify(cell, cell_index, row_index), text_align: object.header_flex_text_align(cell) }) do %>
             <% if cell_index.zero? && row_index === header_rows.size - 1 %>
               <% if object.selectable_rows && object.enable_toggle_expansion != "none" %>
                 <%= pb_rails("flex/flex_item", props: { padding_right: "xs" }) do %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.rb
@@ -192,6 +192,19 @@ module Playbook
         { name: component_name, props: component_props }
       end
 
+      # Flex justify for header cells: column_styling header_alignment when present (otherwisedefault by column/row index)
+      def header_flex_justify(cell, cell_index, row_index)
+        ha = cell[:header_alignment]
+        return header_alignment_to_justify(ha) if ha.present?
+
+        default_header_flex_justify(cell_index, row_index)
+      end
+
+      # Flex text_align from column_styling header_alignment (default is end)
+      def header_flex_text_align(cell)
+        (cell[:header_alignment].presence || "end").to_s
+      end
+
     private
 
       # Find the original column definition for a cell
@@ -349,6 +362,26 @@ module Playbook
           row.children
         elsif row.respond_to?(:[])
           row[:children] || row["children"]
+        end
+      end
+
+      # 2 header alignment helper methods
+      def header_alignment_to_justify(header_alignment)
+        case header_alignment.to_s
+        when "left" then "start"
+        when "center" then "center"
+        when "right" then "end"
+        else "end"
+        end
+      end
+
+      def default_header_flex_justify(cell_index, row_index)
+        if cell_index.zero?
+          "start"
+        elsif row_index == header_rows.size - 1
+          "end"
+        else
+          "center"
         end
       end
     end

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_header_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_header_spec.rb
@@ -368,6 +368,26 @@ RSpec.describe Playbook::PbAdvancedTable::TableHeader do
     end
   end
 
+  describe "#header_flex_justify and #header_flex_text_align" do
+    let(:instance) { subject.new(column_definitions: [{ accessor: "a", label: "A" }, { accessor: "b", label: "B" }]) }
+
+    it "maps header_alignment to flex justify like React (left→start, center→center, right→end)" do
+      expect(instance.header_flex_justify({ header_alignment: "left" }, 1, 0)).to eq "start"
+      expect(instance.header_flex_justify({ header_alignment: "center" }, 1, 0)).to eq "center"
+      expect(instance.header_flex_justify({ header_alignment: "right" }, 1, 0)).to eq "end"
+    end
+
+    it "uses default row/column justify when header_alignment is absent" do
+      expect(instance.header_flex_justify({ label: "A" }, 0, 0)).to eq "start"
+      expect(instance.header_flex_justify({ label: "B" }, 1, 0)).to eq "end"
+    end
+
+    it "sets text_align from header_alignment or end" do
+      expect(instance.header_flex_text_align({ header_alignment: "left" })).to eq "left"
+      expect(instance.header_flex_text_align({ label: "x" })).to eq "end"
+    end
+  end
+
   describe "#has_custom_header_background_color?" do
     it "returns true when header_background_color is present" do
       instance = subject.new({})


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2904](https://runway.powerhrg.com/backlog_items/PLAY-2904?from=active_sprint) addresses a bug with the Rails Advanced Table header_alignment prop. This prop worked on smaller screen sizes not on larger screens. This PR makes it work all the time in a basic Advanced Table or Multi Header context.

**Screenshots:** Screenshots to visualize your addition/change
Current Prod large screen vs. smaller screen:
<img width="1428" height="893" alt="prod no alignment wide screen" src="https://github.com/user-attachments/assets/c5cbda5b-a3ed-420a-87a6-cf513b192ccb" />
<img width="853" height="1015" alt="prod align smaller screen" src="https://github.com/user-attachments/assets/ebe2e0a3-1246-44ec-a5cb-d80870d8cca7" />
With Update large screen = smaller screen:
<img width="1459" height="908" alt="local align wide screen" src="https://github.com/user-attachments/assets/83d00b36-e4cd-4c77-8f0e-fa6894200568" />
<img width="813" height="1022" alt="local align small screen" src="https://github.com/user-attachments/assets/14459275-09e5-4d41-b9b2-81af1e46a5a5" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Rails Advanced Table [styling doc example page](https://pr6038.playbook.wc.beta.hq.powerapp.cloud/kits/styling/rails), Column Styling + Column Styling with Multiple Headers doc examples. Compare the alignment of the Header text for large vs. small screens in the review env vs. production. 
For Column Styling: "New Enrollments" should be left aligned and "Scheduled Meetings" center aligned
For Column Styling with Multiple Headers: "New Enrollments" should be left aligned and "Completed Classes" center aligned


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.