### PR TITLE
[PLAY-2909] Typeahead: createable prop for rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -516,18 +516,18 @@ const resolvedLoadOptions =
       }
 
       // Reset form submitted state when a selection is made (this is all for react rendered rails kit)
-      if (action === "select-option") {
+      if (action === "select-option" || action === "create-option") {
         setFormSubmitted(false)
         // Mark that user has made a selection to disable default value focus behavior
         setHasUserSelected(true)
       }
 
-      // If a value is selected and we're preserving input on blur, clear the input
-      if (action === "select-option" && preserveSearchInput) {
+      // If a value is selected/created and we're preserving input on blur, clear the input
+      if ((action === "select-option" || action === "create-option") && preserveSearchInput) {
         setInputValue("")
       }
 
-      if (action === "select-option") {
+      if (action === "select-option" || action === "create-option") {
         if (selectProps.onMultiValueClick && option)
           selectProps.onMultiValueClick(option)
         const multiValueClearEvent = new CustomEvent(

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_createable.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_createable.html.erb
@@ -1,0 +1,29 @@
+<%
+  options = [
+    { label: 'Orange', value: '#FFA500' },
+    { label: 'Red', value: '#FF0000' },
+    { label: 'Green', value: '#00FF00' },
+    { label: 'Blue', value: '#0000FF' },
+  ]
+%>
+
+<%= pb_rails("typeahead", props: {
+    id: "typeahead-creatable",
+    placeholder: "All Colors",
+    options: options,
+    label: "Colors",
+    name: :foo,
+    createable: true,
+    pills: true,
+  })
+%>
+
+<%= javascript_tag defer: "defer" do %>
+  document.addEventListener("pb-typeahead-kit-typeahead-creatable-result-option-select", function(event) {
+    console.log('Single Option selected')
+    console.dir(event.detail)
+  })
+  document.addEventListener("pb-typeahead-kit-typeahead-creatable-result-clear", function() {
+    console.log('All options cleared')
+  })
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_createable.md
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_createable.md
@@ -1,0 +1,1 @@
+The `createable` prop allows users to create new options by typing a value that doesn't exist in the options list. 

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/example.yml
@@ -11,6 +11,7 @@ examples:
     - typeahead_with_pills_async_users: With Pills (Async Data w/ Users)
     - typeahead_inline: Inline
     - typeahead_multi_kit: Multi Kit Options
+    - typeahead_createable: Createable
     - typeahead_error_state: Error State
     - typeahead_margin_bottom: Margin Bottom
     - typeahead_with_pills_color: With Pills (Custom Color)

--- a/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
@@ -24,8 +24,10 @@
     "createable": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "disabled": {
       "type": "boolean",

--- a/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -62,6 +62,8 @@ module Playbook
                                    default: false
       prop :required_indicator, type: Playbook::Props::Boolean,
                                 default: false
+      prop :createable, type: Playbook::Props::Boolean,
+                        default: false
       def classname
         default_margin_bottom = margin_bottom.present? ? "" : " mb_sm"
         generate_classname("pb_typeahead_kit") + default_margin_bottom
@@ -115,6 +117,7 @@ module Playbook
           clearOnContextChange: clear_on_context_change,
           disabled: disabled,
           preserveSearchInput: preserve_search_input,
+          createable: createable,
         }
 
         base_options[:getOptionLabel] = get_option_label if get_option_label.present?

--- a/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/typeahead.rb
@@ -85,7 +85,7 @@ module Playbook
       end
 
       def is_react?
-        pills || !is_multi || wrapped || input_display == "none"
+        pills || !is_multi || wrapped || input_display == "none" || createable
       end
 
       def typeahead_react_options


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Create the createable prop for rails to match the react

**Screenshots:** Screenshots to visualize your addition/change
<img width="1155" height="337" alt="Screenshot 2026-04-08 at 9 04 21 AM" src="https://github.com/user-attachments/assets/ba4b8b4a-cd56-42b5-8f55-55fba0c1583b" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.