### PR TITLE
[PLAY-2907] DatePicker Year Dropdown goes MIA after form submission

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
@@ -3,7 +3,7 @@ import { Button, Dialog, DatePicker } from "playbook-ui";
 
 const DatePickerDialogSubmission = () => {
     const [isOpen, setIsOpen] = useState(false);
-    const [payoffDateFixed, setPayoffDateFixed] = useState("");
+    const [dateFixed, setDateFixed] = useState("");
     const [pickerInstance, setPickerInstance] = useState(0);
 
     const close = () => setIsOpen(false);
@@ -13,7 +13,7 @@ const DatePickerDialogSubmission = () => {
     };
 
     const handleSubmit = () => {
-        if (!payoffDateFixed.trim()) return;
+        if (!dateFixed.trim()) return;
         close();
     };
 
@@ -31,14 +31,13 @@ const DatePickerDialogSubmission = () => {
             >
                 <Dialog.Body>
                     <DatePicker
-                        defaultDate={payoffDateFixed || undefined}
+                        defaultDate={dateFixed || undefined}
                         key={`fixed-${pickerInstance}`}
-                        label="Payoff Date (fixed)"
-                        marginBottom="none"
-                        maxDate="4/17/2026"
+                        label="Date (fixed)"
+                        maxDate="4/12/2026"
                         minDate="3/17/2026"
-                        onChange={(dateStr) => setPayoffDateFixed(dateStr || "")}
-                        pickerId={`payoffStatementDatePickerFixed-${pickerInstance}`}
+                        onChange={(dateStr) => setDateFixed(dateStr || "")}
+                        pickerId={`datePickerFixed-${pickerInstance}`}
                         staticPosition={false}
                     />
                 </Dialog.Body>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
@@ -6,7 +6,11 @@ const DatePickerDialogSubmission = () => {
     const [dateFixed, setDateFixed] = useState("");
     const [pickerInstance, setPickerInstance] = useState(0);
 
-    const close = () => setIsOpen(false);
+    const close = (clearDate = false) => {
+        if (clearDate) setDateFixed("");
+        setIsOpen(false);
+    };
+
     const open = () => {
         setPickerInstance((current) => current + 1);
         setIsOpen(true);
@@ -24,7 +28,7 @@ const DatePickerDialogSubmission = () => {
                 text="Open Dialog" 
             />
             <Dialog
-                onClose={close}
+                onClose={() => close(true)}
                 opened={isOpen}
                 size="md"
                 title="Date Picker: Dialog Submission Example"
@@ -33,7 +37,7 @@ const DatePickerDialogSubmission = () => {
                     <DatePicker
                         defaultDate={dateFixed || undefined}
                         key={`fixed-${pickerInstance}`}
-                        label="Date (fixed)"
+                        label="Date"
                         maxDate="4/12/2026"
                         minDate="3/17/2026"
                         onChange={(dateStr) => setDateFixed(dateStr || "")}
@@ -47,7 +51,7 @@ const DatePickerDialogSubmission = () => {
                         text="Submit"
                     />
                     <Button 
-                        onClick={close} 
+                        onClick={() => close(true)} 
                         text="Cancel" 
                         variant="link" 
                     />

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+import { Button, Dialog, DatePicker } from "playbook-ui";
+
+const DatePickerDialogSubmission = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [payoffDateFixed, setPayoffDateFixed] = useState("");
+    const [openCount, setOpenCount] = useState(0);
+
+    const close = () => setIsOpen(false);
+    const open = () => setIsOpen(true);
+
+    useEffect(() => {
+        if (isOpen) {
+            setOpenCount((c) => c + 1);
+        }
+    }, [isOpen]);
+
+    const handleSubmit = () => {
+        if (!payoffDateFixed.trim()) return;
+        close();
+    };
+
+    return (
+        <>
+            <Button 
+                onClick={open} 
+                text="Open Dialog" 
+            />
+            <Dialog
+                onClose={close}
+                opened={isOpen}
+                size="md"
+                title="Date Picker: Dialog Submission Example"
+            >
+                <Dialog.Body>
+                    <DatePicker
+                        defaultDate={payoffDateFixed || undefined}
+                        key={`fixed-${isOpen}`}
+                        label="Payoff Date (fixed)"
+                        marginBottom="none"
+                        maxDate="4/17/2026"
+                        minDate="3/17/2026"
+                        onChange={(dateStr) => setPayoffDateFixed(dateStr || "")}
+                        pickerId={`payoffStatementDatePickerFixed-${openCount}`}
+                        staticPosition={false}
+                    />
+                </Dialog.Body>
+                <Dialog.Footer>
+                    <Button 
+                        onClick={handleSubmit}
+                        text="Submit"
+                    />
+                    <Button 
+                        onClick={close} 
+                        text="Cancel" 
+                        variant="link" 
+                    />
+                </Dialog.Footer>
+            </Dialog>
+        </>
+    );
+};
+
+export default DatePickerDialogSubmission;

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
@@ -1,19 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Button, Dialog, DatePicker } from "playbook-ui";
 
 const DatePickerDialogSubmission = () => {
     const [isOpen, setIsOpen] = useState(false);
     const [payoffDateFixed, setPayoffDateFixed] = useState("");
-    const [openCount, setOpenCount] = useState(0);
+    const [pickerInstance, setPickerInstance] = useState(0);
 
     const close = () => setIsOpen(false);
-    const open = () => setIsOpen(true);
-
-    useEffect(() => {
-        if (isOpen) {
-            setOpenCount((c) => c + 1);
-        }
-    }, [isOpen]);
+    const open = () => {
+        setPickerInstance((current) => current + 1);
+        setIsOpen(true);
+    };
 
     const handleSubmit = () => {
         if (!payoffDateFixed.trim()) return;
@@ -35,13 +32,13 @@ const DatePickerDialogSubmission = () => {
                 <Dialog.Body>
                     <DatePicker
                         defaultDate={payoffDateFixed || undefined}
-                        key={`fixed-${isOpen}`}
+                        key={`fixed-${pickerInstance}`}
                         label="Payoff Date (fixed)"
                         marginBottom="none"
                         maxDate="4/17/2026"
                         minDate="3/17/2026"
                         onChange={(dateStr) => setPayoffDateFixed(dateStr || "")}
-                        pickerId={`payoffStatementDatePickerFixed-${openCount}`}
+                        pickerId={`payoffStatementDatePickerFixed-${pickerInstance}`}
                         staticPosition={false}
                     />
                 </Dialog.Body>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.jsx
@@ -38,8 +38,6 @@ const DatePickerDialogSubmission = () => {
                         defaultDate={dateFixed || undefined}
                         key={`fixed-${pickerInstance}`}
                         label="Date"
-                        maxDate="4/12/2026"
-                        minDate="3/17/2026"
                         onChange={(dateStr) => setDateFixed(dateStr || "")}
                         pickerId={`datePickerFixed-${pickerInstance}`}
                         staticPosition={false}

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.md
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.md
@@ -1,1 +1,1 @@
-Use this pattern when a DatePicker lives inside a Dialog and needs to submit a selected value before closing. A unique `key` and `pickerId` will force the datePicker is remounted each time the dialog opens.  
+Use this pattern when a DatePicker lives inside a Dialog and needs to submit a selected value before closing. A unique `key` and `pickerId` will force the datePicker to remount each time the dialog opens.  

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.md
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.md
@@ -1,0 +1,1 @@
+Use this pattern when a DatePicker lives inside a Dialog and needs to submit a selected value before closing. The picker is remounted each time the dialog opens.

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.md
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_dialog_submission.md
@@ -1,1 +1,1 @@
-Use this pattern when a DatePicker lives inside a Dialog and needs to submit a selected value before closing. The picker is remounted each time the dialog opens.
+Use this pattern when a DatePicker lives inside a Dialog and needs to submit a selected value before closing. A unique `key` and `pickerId` will force the datePicker is remounted each time the dialog opens.  

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/example.yml
@@ -66,3 +66,4 @@ examples:
   - date_picker_positions: Custom Positions
   - date_picker_positions_element: Custom Position (based on element)
   - date_picker_required_indicator: Required Indicator
+  - date_picker_dialog_submission: Dialog Form Submission

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/index.js
@@ -29,3 +29,4 @@ export { default as DatePickerQuickPickDefaultDate } from './_date_picker_quick_
 export { default as DatePickerRangePattern } from './_date_picker_range_pattern'
 export { default as DatePickerAndDropdownRange } from './_date_picker_and_dropdown_range.jsx'
 export { default as DatePickerRequiredIndicator } from "./_date_picker_required_indicator.jsx";
+export { default as DatePickerDialogSubmission } from "./_date_picker_dialog_submission.jsx";


### PR DESCRIPTION
[PLAY-2907](https://runway.powerhrg.com/backlog_items/PLAY-2907)

This PR adds a doc example of how to remount a datepicker inside a dialog so it renders the year dropdown correctly. 

<img width="794" height="370" alt="Screenshot 2026-04-14 at 9 37 58 AM" src="https://github.com/user-attachments/assets/16e55637-29a2-46e8-b754-82066d860b8b" />





#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.