### PR TITLE
Website: Global props and tokens pages + search

### DIFF
--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex.tsx
@@ -61,14 +61,18 @@ const COMPONENT_MAP = {
   shadow: ShadowGlobalProps,
 };
 
-const GlobalPropsExamples = () => {
-  // extract the global props example needed from the URL path
+type GlobalPropsExamplesProps = {
+  routeParamName?: string,
+}
+
+const GlobalPropsExamples = ({ routeParamName }: GlobalPropsExamplesProps = {}) => {
   function getGlobalPropsExample(pathname: string): string | null {
     const parts: string[] = pathname.split("/").filter(Boolean);
-    return parts[0] === "global_props" ? parts[1] : null;
+    const idx = parts.indexOf("global_props");
+    return idx >= 0 ? parts[idx + 1] ?? null : null;
   }
 
-  const key = getGlobalPropsExample(window.location.pathname);
+  const key = routeParamName ?? getGlobalPropsExample(window.location.pathname);
   type ComponentKey = keyof typeof COMPONENT_MAP;
 
   const ExampleComponent = COMPONENT_MAP[key as ComponentKey] || null;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
@@ -41,14 +41,18 @@ const COMPONENT_MAP = {
   z_index: ZIndex,
 };
 
-const TokensExamples = () => {
-  // extract the tokens example needed from the URL path
+type TokensExamplesProps = {
+  routeParamName?: string,
+}
+
+const TokensExamples = ({ routeParamName }: TokensExamplesProps = {}) => {
   function getTokensExample(pathname: string): string | null {
     const parts: string[] = pathname.split("/").filter(Boolean);
-    return parts[0] === "tokens" ? parts[1] : null;
+    const idx = parts.indexOf("tokens");
+    return idx >= 0 ? parts[idx + 1] ?? null : null;
   }
 
-  const key = getTokensExample(window.location.pathname);
+  const key = routeParamName ?? getTokensExample(window.location.pathname);
   type ComponentKey = keyof typeof COMPONENT_MAP;
 
   const ExampleComponent = COMPONENT_MAP[key as ComponentKey] || null;

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/GlobalPropsIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/GlobalPropsIndex.tsx
@@ -12,7 +12,11 @@ import {
 import HeaderImage from "../../images/getting-started.svg";
 import { GlobalPropsCards } from "./Data/GlobalPropsCards";
 
-const GlobalProps = () => {
+type GlobalPropsProps = {
+  linkPrefix?: string,
+}
+
+const GlobalProps = ({ linkPrefix = "" }: GlobalPropsProps) => {
   return (
     <Background
       flexDirection="column"
@@ -43,7 +47,7 @@ const GlobalProps = () => {
           <Layout.Body>
             {GlobalPropsCards.sort((a, b) => a.title.localeCompare(b.title)).map(({ title, description, link, icon }) => {
               return (
-                <Link key={title} href={link}>
+                <Link key={title} href={`${linkPrefix}${link}`}>
                   <Card padding="none" hover={{ shadow: "deep" }} flex={1} minHeight="300px">
                     <Background backgroundColor="light">
                       <Flex justify="center" padding="xl">

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/GlobalPropsIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/GlobalPropsIndex.tsx
@@ -24,6 +24,7 @@ const GlobalProps = ({ linkPrefix = "" }: GlobalPropsProps) => {
       display="flex"
       justifyContent="center"
       alignItems="center"
+      height="100%"
     >
       <Background
         imageUrl={HeaderImage}

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/TokensIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/TokensIndex.tsx
@@ -24,6 +24,7 @@ const Tokens = ({ linkPrefix = "" }: TokensProps) => {
       display="flex"
       justifyContent="center"
       alignItems="center"
+      height="100%"
     >
       <Background
         imageUrl={HeaderImage}

--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/TokensIndex.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/TokensIndex.tsx
@@ -12,7 +12,11 @@ import {
 import HeaderImage from "../../images/getting-started.svg";
 import { TokenCards } from "./Data/TokenCards";
 
-const Tokens = () => {
+type TokensProps = {
+  linkPrefix?: string,
+}
+
+const Tokens = ({ linkPrefix = "" }: TokensProps) => {
   return (
     <Background
       flexDirection="column"
@@ -43,7 +47,7 @@ const Tokens = () => {
           <Layout.Body>
             {TokenCards.sort((a, b) => a.title.localeCompare(b.title)).map(({ title, description, link, icon }) => {
               return (
-                <Link key={title} href={link}>
+                <Link key={title} href={`${linkPrefix}${link}`}>
                   <Card padding="none" hover={{ shadow: "deep" }} flex={1}>
                     <Background backgroundColor="light">
                       <Flex justify="center" padding="xl">

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -14,6 +14,8 @@ type KitSearchProps = {
   id: string,
   global_props_and_tokens?: Record<string, any>,
   marginBottom?: string,
+  beta?: boolean,
+  onBetaNavigate?: (path: string) => void,
 }
 
 const combineKitsandVisualGuidelines = (
@@ -35,7 +37,7 @@ const combineKitsandVisualGuidelines = (
   return [...kits, ...globalPropsItems, ...tokensItems].sort((a, b) => a.label.localeCompare(b.label))
 }
 
-const KitSearch = ({ classname, id, kits, global_props_and_tokens, marginBottom }: KitSearchProps) => {
+const KitSearch = ({ classname, id, kits, global_props_and_tokens, marginBottom, beta, onBetaNavigate }: KitSearchProps) => {
   const kitsAndGuidelines = combineKitsandVisualGuidelines(kits, global_props_and_tokens)
 
   const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)
@@ -53,7 +55,12 @@ const KitSearch = ({ classname, id, kits, global_props_and_tokens, marginBottom 
 
   const handleChange = (selection: any) => {
     if (selection) {
-      window.location = selection.value
+      const path = beta ? `/beta${selection.value}` : selection.value
+      if (beta && onBetaNavigate) {
+        onBetaNavigate(path)
+      } else {
+        window.location.href = path
+      }
     }
   }
 

--- a/playbook-website/app/javascript/components/Website/src/components/PlatformToggle/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/PlatformToggle/index.tsx
@@ -1,7 +1,7 @@
 import { Flex, Icon, Nav, NavItem } from "playbook-ui";
 import { ReactSVG } from "./ReactSVG";
 import { RailsSVG } from "./RailsSVG";
-import { SwiftSVG } from "./SwiftSVG";
+// import { SwiftSVG } from "./SwiftSVG";
 import "./styles.scss";
 
 type PlatformToggleProps = {

--- a/playbook-website/app/javascript/components/Website/src/components/PlatformToggle/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/PlatformToggle/index.tsx
@@ -9,11 +9,13 @@ type PlatformToggleProps = {
   setPlatform: (platform: string) => void;
 };
 
+// TODO: Add Swift back in when we have a Swift kit
 const platforms = [
   { name: "react", label: "React", Icon: ReactSVG },
   { name: "rails", label: "Rails", Icon: RailsSVG },
-  { name: "swift", label: "Swift", Icon: SwiftSVG },
+  // { name: "swift", label: "Swift", Icon: SwiftSVG },
 ];
+
 
 export const PlatformToggle = ({
   platform,

--- a/playbook-website/app/javascript/components/Website/src/layouts/Header.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Header.tsx
@@ -1,4 +1,5 @@
 import { Flex, Image, Badge, SectionSeparator, FlexItem } from "playbook-ui";
+import { useNavigate } from "react-router-dom";
 // @ts-ignore
 import PBLogo from "../../../../images/pb-logo.svg";
 import KitSearch from "../../../KitSearch";
@@ -23,6 +24,8 @@ const Header = ({
   platform,
   setPlatform,
 }: HeaderProps) => {
+  const navigate = useNavigate();
+
   return (
     <>
       <Flex 
@@ -77,9 +80,11 @@ const Header = ({
                 id="desktop-kit-search"
                 kits={search_list}
                 global_props_and_tokens={global_props_and_tokens}
+                beta={true}
+                onBetaNavigate={(path) => navigate(path)}
                 marginBottom="none"
               />
-              <DarkModeToggle initMode={dark} />
+              <DarkModeToggle initMode={JSON.stringify(!!dark)} />
             </Flex>
           </FlexItem>
           {/* End Search Bar + dark mode toggle */}

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/MenuData/SidebarNavItems.ts
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/MenuData/SidebarNavItems.ts
@@ -20,20 +20,20 @@ export const SideBarNavItems = [
         children: true,
         leftIcon:"grid-2"
     },
-    // {
-    //     name: "Global Props",
-    //     key: "top-nav-item-4",
-    //     link: "/global_props",
-    //     children: true,
-    //     leftIcon:"globe"
-    // },
-    // {
-    //     name: "Tokens",
-    //     key: "top-nav-item-8",
-    //     link: "/tokens",
-    //     children: true,
-    //     leftIcon:"shapes"
-    // },
+    {
+        name: "Global Props",
+        key: "top-nav-item-4",
+        link: "/global_props",
+        children: true,
+        leftIcon:"globe"
+    },
+    {
+        name: "Tokens",
+        key: "top-nav-item-8",
+        link: "/tokens",
+        children: true,
+        leftIcon:"shapes"
+    },
     {
         name: "Design Guidelines",
         key: "top-nav-item-5",

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
@@ -75,6 +75,12 @@ export const TopLevelNavItem = ({
         // Active on the overview page but NOT on individual guide pages
         return currentURL === "/beta/guides/design_guidelines" || currentURL === "/beta/guides/design_guidelines?";
       }
+      if (link === "/global_props") {
+        return currentURL === "/beta/global_props" || currentURL === "/beta/global_props?";
+      }
+      if (link === "/tokens") {
+        return currentURL === "/beta/tokens" || currentURL === "/beta/tokens?";
+      }
       
       // For other items with children, only active on exact match
       return currentURL === betaLink || currentURL.startsWith(`${betaLink}?`);
@@ -99,6 +105,12 @@ export const TopLevelNavItem = ({
     }
     if (link === "/guides/design_guidelines") {
       return currentURL.startsWith("/beta/guides/design_guidelines");
+    }
+    if (link === "/global_props") {
+      return currentURL.startsWith("/beta/global_props");
+    }
+    if (link === "/tokens") {
+      return currentURL.startsWith("/beta/tokens");
     }
     
     return currentURL.startsWith(betaLink);

--- a/playbook-website/app/javascript/components/app.tsx
+++ b/playbook-website/app/javascript/components/app.tsx
@@ -4,6 +4,7 @@ import {
   Navigate,
   Route,
   RouterProvider,
+  useParams,
 } from 'react-router-dom'
 
 import App from './Website'
@@ -20,6 +21,20 @@ import Spacing from './Website/src/pages/DesignGuidelines/Spacing'
 import Typography from './Website/src/pages/DesignGuidelines/Typography'
 import Error from './Error'
 import { CategoryLoader, ComponentsLoader, ComponentShowLoader, GuidesLoader, GuidePageLoader } from './Website/src/hooks/loaders'
+import GlobalPropsIndex from './GlobalPropsAndTokens/GlobalPropsIndex'
+import GlobalPropsExamples from './GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex'
+import TokensIndex from './GlobalPropsAndTokens/TokensIndex'
+import TokensExamples from './GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex'
+
+function GlobalPropsShowPage() {
+  const { name } = useParams()
+  return <GlobalPropsExamples routeParamName={name} />
+}
+
+function TokensShowPage() {
+  const { name } = useParams()
+  return <TokensExamples routeParamName={name} />
+}
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -54,6 +69,26 @@ const router = createBrowserRouter(
           element={<CategoryShow />}
           loader={CategoryLoader}
           path="kit_category/:category"
+      />
+      <Route
+          element={<GlobalPropsIndex linkPrefix="/beta" />}
+          loader={ComponentsLoader}
+          path="global_props"
+      />
+      <Route
+          element={<GlobalPropsShowPage />}
+          loader={ComponentsLoader}
+          path="global_props/:name"
+      />
+      <Route
+          element={<TokensIndex linkPrefix="/beta" />}
+          loader={ComponentsLoader}
+          path="tokens"
+      />
+      <Route
+          element={<TokensShowPage />}
+          loader={ComponentsLoader}
+          path="tokens/:name"
       />
       <Route
           element={<IconList />}

--- a/playbook-website/config/routes.rb
+++ b/playbook-website/config/routes.rb
@@ -29,6 +29,10 @@ Rails.application.routes.draw do
   get "beta/guides/getting_started/:page", to: "pages#application_beta"
   get "beta/guides/design_guidelines", to: "pages#application_beta"
   get "beta/guides/design_guidelines/:page", to: "pages#application_beta"
+  get "beta/global_props", to: "pages#application_beta"
+  get "beta/global_props/:name", to: "pages#application_beta"
+  get "beta/tokens", to: "pages#application_beta"
+  get "beta/tokens/:name", to: "pages#application_beta"
 
   # Legacy View
   get "kits", to: "pages#kits"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Adds Global Props and Tokens to beta website
- hides swift tab
- links search to beta pages

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.