### PR TITLE
Beta All Kits Search, Kit Category Hero, Kit Card Placeholder

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/Hero/styles.scss
+++ b/playbook-website/app/javascript/components/Website/src/components/Hero/styles.scss
@@ -13,6 +13,15 @@
     justify-content: center;
     min-height: 192px;
   }
+
+  .pb_title_kit,
+  &-description {
+    hyphens: none;
+    -webkit-hyphens: none;
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+
   &-description {
     @media screen and (max-width: $screen-xs-min) {
       display: none !important;

--- a/playbook-website/app/javascript/components/Website/src/components/KitCard/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/KitCard/index.tsx
@@ -31,6 +31,7 @@ export const KitCard = ({ description, name, platform, parent }: KitCardProps) =
 
   return (
     <Link
+      className="kit-card-link"
       to={generateLink({
         componentName: name,
         platform,
@@ -38,40 +39,43 @@ export const KitCard = ({ description, name, platform, parent }: KitCardProps) =
         parent,
       })}
     >
-      <Card
-        className="kit-card"
-        paddingX={{
-          xs: "sm",
-          sm: "md",
-          md: "md",
-          lg: "md",
-          xl: "md",
-        }}
-        paddingTop={{ xs: "xxs", default: "md" }}
-        paddingBottom={{ xs: "xxs", default: "md" }}
-        borderRadius="lg"
-      >
-        <Flex align="center" className="kit-card-header" justify="between">
-          <Title text={linkFormat(name)} size={4} truncate="1" />
-          <Icon
-            className="icon mobile"
-            fixedWidth
-            icon="angle-right"
-            size="sm"
-          />
-          <Icon
-            className="icon desktop"
-            fixedWidth
-            icon="angle-right"
-            size="2x"
+      <Card className="kit-card" padding="none" borderRadius="lg">
+        <div aria-hidden className="kit-card-media" />
+        <Flex
+          className="kit-card-content"
+          orientation="column"
+          paddingBottom={{ xs: "xxs", default: "sm" }}
+          paddingTop={{ xs: "xxs", default: "sm" }}
+          paddingX={{
+            xs: "sm",
+            sm: "md",
+            md: "md",
+            lg: "md",
+            xl: "md",
+          }}
+        >
+          <Flex align="center" className="kit-card-header" justify="between">
+            <Title text={linkFormat(name)} size={4} truncate="1" />
+            <Icon
+              className="icon mobile"
+              fixedWidth
+              icon="angle-right"
+              size="sm"
+            />
+            <Icon
+              className="icon desktop"
+              fixedWidth
+              icon="angle-right"
+              size="2x"
+            />
+          </Flex>
+          <Body
+            className="kit-card-description"
+            color="light"
+            truncate="2"
+            text={description}
           />
         </Flex>
-        <Body
-          className="kit-card-description"
-          color="light"
-          truncate="2"
-          text={description}
-        />
       </Card>
     </Link>
   );

--- a/playbook-website/app/javascript/components/Website/src/components/KitCard/styles.scss
+++ b/playbook-website/app/javascript/components/Website/src/components/KitCard/styles.scss
@@ -1,14 +1,42 @@
 @import "playbook-tokens/colors";
+@import "playbook-tokens/line_height";
 @import "playbook-tokens/screen_sizes";
 @import "playbook-tokens/shadows";
 @import "playbook-tokens/typography";
 @import "playbook-tokens/animation-curves";
 @import "playbook-tokens/transition";
 
+.kit-card-link {
+  color: inherit;
+  display: block;
+  height: 100%;
+  text-decoration: none;
+}
+
 .kit-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 180px;
+  overflow: hidden;
+
   @media screen and (min-width: $screen-xs-min) {
-    min-height: 138px;
+    min-height: 220px;
   }
+
+  // TODO: update this once kit images are added, this provides gray placeholder
+  .kit-card-media {
+    background-color: $bg_light;
+    flex: 2 1 0;
+    min-height: 0;
+  }
+
+  .kit-card-content {
+    flex: 1 1 0;
+    justify-content: flex-start;
+    min-height: 0;
+  }
+
   .icon {
     visibility: hidden;
     opacity: 0;
@@ -32,7 +60,15 @@
     height: 40px;
   }
   &-description {
-    font-size: $text-small !important;
+    flex-shrink: 0;
+    font-size: $text_small !important;
+    hyphens: none;
+    -webkit-hyphens: none;
+    overflow-wrap: normal;
+    word-break: normal;
+    @media screen and (min-width: $screen-xs-min) {
+      min-height: $text_small * $lh_tight * 2;
+    }
     @media screen and (max-width: $screen-xs-min) {
       display: none;
     }

--- a/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
+++ b/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
@@ -51,7 +51,7 @@ export const ComponentShowLoader = async ({ params, request }:any) => {
 
 export const CategoryLoader: (
   props: LoaderFunctionArgs
-) => Promise<ComponentTypes> = async ({ params }) => {
+) => Promise<CategoryTypes> = async ({ params }) => {
   const response = await fetch("/beta/kits.json");
   const { kits } = await response.json();
 

--- a/playbook-website/app/javascript/components/Website/src/pages/CategoryShow/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/CategoryShow/index.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import { NavLink, useLoaderData } from "react-router-dom";
-import { Body, Flex, Title } from "playbook-ui";
+import { Body, Flex } from "playbook-ui";
 
+import { Hero } from "../../components/Hero";
 import { KitCard } from "../../components/KitCard";
 import { KitGrid } from "../../components/KitGrid";
 import { PageContainer } from "../../components/PageContainer";
@@ -21,10 +22,11 @@ interface Component {
 type LoaderData = {
   components: Component[];
   category: string;
+  description: string;
 };
 
 export default function CategoryShow() {
-  const { components, category } = useLoaderData() as LoaderData;
+  const { components, category, description } = useLoaderData() as LoaderData;
   const [kitsToShow, setKitsToShow] = useState(components);
   const { platform } = usePlatform();
 
@@ -43,13 +45,6 @@ export default function CategoryShow() {
 
   return (
     <>
-      <Title
-        marginLeft="lg"
-        marginTop="lg"
-        size={1}
-        text={linkFormat(category)}
-      />
-
       <PageContainer>
         <Flex
           align="center"
@@ -59,7 +54,7 @@ export default function CategoryShow() {
         >
           <NavLink to="/beta/kits">
             <Body className="previous-route" color="link">
-              <b>Components</b>
+              <b>All Components</b>
             </Body>
           </NavLink>
           <Body marginX="xxs" text="/" />
@@ -67,6 +62,11 @@ export default function CategoryShow() {
             <b>{linkFormat(category)}</b>
           </Body>
         </Flex>
+
+        <Hero
+          description={description ?? ""}
+          title={linkFormat(category)}
+        />
 
         {!kitsToShow.length && (
           <Flex justify="center" orientation="row">

--- a/playbook-website/app/javascript/components/Website/src/pages/ComponentList.scss
+++ b/playbook-website/app/javascript/components/Website/src/pages/ComponentList.scss
@@ -1,0 +1,23 @@
+@import "playbook-tokens/container";
+@import "playbook-tokens/screen_sizes";
+
+.component-list-search {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+
+  max-width: min(100%, $container_xxs);
+
+  @include break_on($screen-sm-min) {
+    max-width: min(100%, $container_sm);
+  }
+
+  @include break_on($screen-lg-min) {
+    max-width: min(100%, $container_md);
+  }
+
+  .pb_text_input_kit {
+    max-width: 100%;
+  }
+}

--- a/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
+import type { ChangeEvent } from "react"
 import { NavLink, Outlet, useLoaderData, useOutlet } from "react-router-dom"
-import { Body, Flex } from 'playbook-ui'
+import { EmptyState, Flex, TextInput } from "playbook-ui"
+import { matchSorter } from "match-sorter"
 
 import { KitCard } from "../components/KitCard"
 import { Hero } from "../components/Hero"
@@ -8,6 +10,8 @@ import { KitGrid } from "../components/KitGrid"
 import { PageContainer } from "../components/PageContainer"
 import { CategoryTitle } from "../components/CategoryTitle"
 import { usePlatform } from "../contexts/PlatformContext"
+
+import "./ComponentList.scss"
 
 export type Kit = {
   id?: any
@@ -20,6 +24,7 @@ export type Kit = {
     description: string;
     platforms: string[];
     status: "stable" | "beta";
+    parent?: string;
   }[];
   description: string;
   parent?: string;
@@ -36,8 +41,9 @@ const description =
 
 export default function ComponentList() {
   const outlet = useOutlet()
-  const { kits } = useLoaderData()
+  const { kits } = useLoaderData() as { kits: Kit[]; }
   const [kitsToShow, setKitsToShow] = useState(kits)
+  const [searchQuery, setSearchQuery] = useState("")
   const { platform } = usePlatform()
 
   // Filter kits based on platform
@@ -52,6 +58,25 @@ export default function ComponentList() {
     setKitsToShow(filtered)
   }, [platform, kits])
 
+  const displayedKits = useMemo(() => {
+    const q = searchQuery.trim()
+    if (!q) return kitsToShow
+    return kitsToShow
+      .map((kit) => ({
+        ...kit,
+        components: matchSorter(
+          kit.components.filter((c) => c.status === "stable"),
+          q,
+          { keys: ["name"] }
+        ),
+      }))
+      .filter((kit) => kit.components.length > 0)
+  }, [kitsToShow, searchQuery])
+
+  const hasVisibleKits = displayedKits.some((kit) =>
+    kit.components.some((c) => c.status === "stable")
+  )
+
   return (
     <>
       {!outlet && (
@@ -59,41 +84,63 @@ export default function ComponentList() {
           <Hero description={description} title="Components" />
 
           <PageContainer>
-            {kitsToShow.filter(({ components }: {components: Component[] }) => 
-            components.some((component: Component) => component.status === "stable")).length === 0 ? (
+            <Flex orientation="column" width="100%">
               <Flex
                 justify="center"
-                orientation="row"
+                marginBottom="lg"
+                paddingX={{ xs: "md", sm: "lg", xl: "none" }}
+                width="100%"
               >
-                <Body
-                  text="No Results, Try Again"
-                />
+                <div className="component-list-search">
+                  <TextInput
+                    marginBottom="none"
+                    name="component_list_search"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      setSearchQuery(e.target.value)
+                    }
+                    placeholder="Search All Components"
+                    value={searchQuery}
+                    width="100%"
+                  />
+                </div>
               </Flex>
-            ) : (
-              kitsToShow.map(({ category, components }: Kit, index: number) => (
-                <section
-                  className="category mb_xl"
-                  key={`${category}-${index}`}
-                  id={category}
-                >
-                  <NavLink to={`/beta/kit_category/${category}`}>
-                    <CategoryTitle category={category} />
-                  </NavLink>
-                  <KitGrid>
-                    {components
-                    .filter(component => component.status === "stable")
-                    .map(({ name, description }, index) => (
-                      <KitCard
-                        description={description}
-                        name={name}
-                        key={`${name}-${index}`}
-                        platform={platform}
-                      />
-                    ))}
-                  </KitGrid>
-                </section>
-              ))
-            )}
+
+              {!hasVisibleKits ? (
+                <Flex justify="center" width="100%">
+                  <EmptyState
+                    header="No results"
+                    image="default"
+                    size="lg"
+                  />
+                </Flex>
+              ) : (
+                displayedKits.map(({ category, components }: Kit, index: number) => (
+                  <section
+                    className="category mb_xl"
+                    key={`${category}-${index}`}
+                    id={category}
+                    style={{ marginLeft: "40px" }}
+                  >
+                    <NavLink to={`/beta/kit_category/${category}`}>
+                      <CategoryTitle category={category} />
+                    </NavLink>
+                    <KitGrid>
+                      {components
+                      .filter(component => component.status === "stable")
+                      .map(({ name, description, parent }, index) => (
+                        <KitCard
+                          description={description}
+                          name={name}
+                          key={`${name}-${index}`}
+                          parent={parent}
+                          platform={platform}
+                        />
+                      ))}
+                    </KitGrid>
+                  </section>
+                ))
+              )}
+            </Flex>
           </PageContainer>
         </>
       )}

--- a/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
@@ -60,22 +60,24 @@ export default function ComponentList() {
 
   const displayedKits = useMemo(() => {
     const q = searchQuery.trim()
-    if (!q) return kitsToShow
-    return kitsToShow
+    const stableByKit = kitsToShow
       .map((kit) => ({
         ...kit,
-        components: matchSorter(
-          kit.components.filter((c) => c.status === "stable"),
-          q,
-          { keys: ["name"] }
-        ),
+        components: kit.components.filter((c) => c.status === "stable"),
+      }))
+      .filter((kit) => kit.components.length > 0)
+
+    if (!q) return stableByKit
+
+    return stableByKit
+      .map((kit) => ({
+        ...kit,
+        components: matchSorter(kit.components, q, { keys: ["name"] }),
       }))
       .filter((kit) => kit.components.length > 0)
   }, [kitsToShow, searchQuery])
 
-  const hasVisibleKits = displayedKits.some((kit) =>
-    kit.components.some((c) => c.status === "stable")
-  )
+  const hasVisibleKits = displayedKits.length > 0
 
   return (
     <>
@@ -125,9 +127,7 @@ export default function ComponentList() {
                       <CategoryTitle category={category} />
                     </NavLink>
                     <KitGrid>
-                      {components
-                      .filter(component => component.status === "stable")
-                      .map(({ name, description, parent }, index) => (
+                      {components.map(({ name, description, parent }, index) => (
                         <KitCard
                           description={description}
                           name={name}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
2026.4 Create
Adds Search to All Kits page - search by kit name, Empty State kit for no results
Adds Hero component to Kit Category page
Prevents hero and kit descriptions from having weird word wrap
Some recentering of Kit Grid and addition of gray placeholder background (to be replaced with an image for each kit in the future)


**Screenshots:** Screenshots to visualize your addition/change
<img width="1496" height="989" alt="PR 2 all kits" src="https://github.com/user-attachments/assets/419e580c-fed4-47a5-a654-cd45b2a67341" />
<img width="1211" height="730" alt="PR 2 no results" src="https://github.com/user-attachments/assets/3fd5561e-fb8f-438c-b701-a9a9195db687" />
<img width="1439" height="734" alt="PR 2 kit category" src="https://github.com/user-attachments/assets/f13a62dc-034c-47c9-9f8b-cc856b28445a" />


**How to test?** Steps to confirm the desired behavior:
1. Go to beta all kits and kit category pages.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.