### PR TITLE
Adding search to beta website Icons page

### DIFF
--- a/playbook-website/app/javascript/components/Icons/IconsIndex.tsx
+++ b/playbook-website/app/javascript/components/Icons/IconsIndex.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import type { ChangeEvent } from 'react'
+import { matchSorter, rankings } from 'match-sorter'
 
 import {
   Background,
@@ -6,12 +8,14 @@ import {
   Button,
   Caption,
   Dropdown,
+  EmptyState,
   Flex,
   Nav,
   NavItem,
   SectionSeparator,
   Title,
-  SelectableCardIcon
+  SelectableCardIcon,
+  TextInput,
 } from 'playbook-ui'
 
 type IconCategory = {
@@ -44,10 +48,27 @@ const IconsIndex = ({
   iconsByCategory,
 }: IconsIndexProps) => {
   const [selectedCategoryLabel, setSelectedCategoryLabel] = useState(dropdownLabel)
+  const [searchQuery, setSearchQuery] = useState('')
 
-  const sortedSections = Object.entries(iconsByCategory).sort(([left], [right]) =>
-    left.localeCompare(right)
-  )
+  const displayedSections = useMemo(() => {
+    const sorted = Object.entries(iconsByCategory).sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+    const q = searchQuery.trim()
+    if (!q) return sorted
+
+    return sorted
+      .map(([category, icons]) => [
+        category,
+        matchSorter(icons, q, {
+          keys: ['name'],
+          threshold: rankings.CONTAINS,
+        }),
+      ] as [string, IconData[]])
+      .filter(([, icons]) => icons.length > 0)
+  }, [iconsByCategory, searchQuery])
+
+  const hasVisibleIcons = displayedSections.some(([, icons]) => icons.length > 0)
 
   const getCategoryId = (category: string) => {
     return iconCategories.find((item) => item.text === category)?.value || category
@@ -56,7 +77,7 @@ const IconsIndex = ({
       .replace(/(^-|-$)/g, '')
   }
 
-  const handleCategorySelect = (option: { label?: string, value?: string } | null) => {
+  const handleCategorySelect = (option: { label?: string, value?: string } | null): null => {
     if (!option?.value) return null
 
     setSelectedCategoryLabel(option.label || dropdownLabel)
@@ -109,52 +130,81 @@ const IconsIndex = ({
                 </a>
               </div>
 
-              <Dropdown id="icon-category-dropdown" onSelect={handleCategorySelect} options={iconCategories}>
-                <Dropdown.Trigger>
-                  <div data-dropdown-custom-trigger>
-                    <Button
-                      fullWidth
-                      icon="sort"
-                      iconRight
-                      id="icon-category-trigger-button"
-                      text={selectedCategoryLabel}
-                      variant="secondary"
-                    />
-                  </div>
-                </Dropdown.Trigger>
-                <Dropdown.Container maxWidth="xs">
-                  {iconCategories.map((option) => (
-                    <Dropdown.Option key={option.value} option={option}>
-                      <Body size="sm" text={option.label} />
-                    </Dropdown.Option>
-                  ))}
-                </Dropdown.Container>
-              </Dropdown>
-
-              {sortedSections.map(([category, icons]) => (
-                <Flex alignSelf="stretch" 
-                  alignItems="stretch"
-                  gap="sm"
-                  key={category}
-                  orientation="column" 
-                  >
-                  <Caption 
-                    id={getCategoryId(category)}
-                    size="lg" 
-                    text={category}
+              <div className="icons-index-toolbar">
+                <div className="icons-index-search">
+                  <TextInput
+                    marginBottom="none"
+                    name="icons_index_search"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      setSearchQuery(e.target.value)
+                    }
+                    placeholder="Search for icons..."
+                    value={searchQuery}
+                    width="100%"
                   />
-                  <div className="pb_layout_kit_collection icon-grid">
-                    <div className="layout_body">
-                      {icons
-                        .slice()
-                        .sort((left, right) => left.name.localeCompare(right.name))
-                        .map((icon) => (
-                          <SelectableCardIcon className="icon-card" icon={icon.name} titleText={icon.name} key={`${category}-${icon.name}`}/>
-                        ))}
+                </div>
+
+                <Dropdown id="icon-category-dropdown" onSelect={handleCategorySelect} options={iconCategories}>
+                  <Dropdown.Trigger>
+                    <div data-dropdown-custom-trigger>
+                      <Button
+                        icon="sort"
+                        iconRight
+                        id="icon-category-trigger-button"
+                        text={selectedCategoryLabel}
+                        variant="secondary"
+                      />
                     </div>
-                  </div>
+                  </Dropdown.Trigger>
+                  <Dropdown.Container maxWidth="xs">
+                    {iconCategories.map((option) => (
+                      <Dropdown.Option key={option.value} option={option}>
+                        <Body size="sm" text={option.label} />
+                      </Dropdown.Option>
+                    ))}
+                  </Dropdown.Container>
+                </Dropdown>
+              </div>
+
+              {!hasVisibleIcons ? (
+                <Flex justify="center" width="100%">
+                  <EmptyState
+                    header="No results"
+                    image="default"
+                    size="lg"
+                  />
                 </Flex>
-              ))}
+              ) : (
+                displayedSections.map(([category, icons]) => (
+                  <Flex alignSelf="stretch"
+                    alignItems="stretch"
+                    gap="sm"
+                    key={category}
+                    orientation="column"
+                  >
+                    <Caption
+                      id={getCategoryId(category)}
+                      size="lg"
+                      text={category}
+                    />
+                    <div className="pb_layout_kit_collection icon-grid">
+                      <div className="layout_body">
+                        {icons
+                          .slice()
+                          .sort((left, right) => left.name.localeCompare(right.name))
+                          .map((icon) => (
+                            <SelectableCardIcon
+                              className="icon-card"
+                              icon={icon.name}
+                              key={`${category}-${icon.name}`}
+                              titleText={icon.name}
+                            />
+                          ))}
+                      </div>
+                    </div>
+                  </Flex>
+                ))
+              )}
             </Flex>
           </div>
 

--- a/playbook-website/app/javascript/site_styles/_playbook_icons_index.scss
+++ b/playbook-website/app/javascript/site_styles/_playbook_icons_index.scss
@@ -1,8 +1,119 @@
 @import "playbook-tokens/colors";
+@import "playbook-tokens/container";
 @import "playbook-tokens/spacing";
 @import "playbook-tokens/screen_sizes";
 
 .playbook_icons_index{
+    .icons-index-toolbar {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: $space_md;
+        margin-bottom: $space_md;
+        width: 100%;
+
+        .icons-index-search {
+            box-sizing: border-box;
+            margin-left: auto;
+            margin-right: auto;
+            width: 100%;
+            max-width: min(100%, $container_xxs);
+
+            @include break_on($screen-sm-min) {
+                max-width: min(100%, $container_sm);
+            }
+
+            @include break_on($screen-lg-min) {
+                max-width: min(100%, $container_md);
+            }
+
+            .pb_text_input_kit {
+                max-width: 100%;
+            }
+        }
+
+        @media screen and (max-width: $screen-md-max) {
+            align-items: stretch;
+
+            .icons-index-search {
+                align-self: center;
+                max-width: 100%;
+                width: 100%;
+            }
+
+            #icon-category-dropdown {
+                align-self: stretch;
+                max-width: 100%;
+                width: 100% !important;
+            }
+
+            #icon-category-dropdown .dropdown_wrapper {
+                width: 100%;
+            }
+
+            #icon-category-dropdown_trigger {
+                box-sizing: border-box;
+                display: block !important;
+                width: 100% !important;
+            }
+
+            .pb_dropdown_trigger {
+                width: 100%;
+            }
+
+            [data-dropdown-custom-trigger] {
+                display: block;
+                width: 100%;
+            }
+
+            [data-dropdown-custom-trigger] .pb_button_kit {
+                box-sizing: border-box;
+                width: 100% !important;
+            }
+        }
+
+        @media screen and (min-width: $screen-md-min) and (max-width: 1071px) {
+            flex-direction: row;
+            align-items: center;
+            justify-content: flex-start;
+            gap: $space_md;
+
+            .icons-index-search {
+                flex: 1 1 auto;
+                margin-left: 0;
+                margin-right: 0;
+                max-width: none;
+                min-width: 0;
+                width: auto;
+            }
+
+            [data-dropdown-custom-trigger],
+            #icon-category-dropdown {
+                flex: 0 0 auto;
+                width: auto !important;
+                max-width: none;
+                min-width: auto;
+            }
+
+            [data-dropdown-custom-trigger] .pb_button_kit {
+                flex-shrink: 0;
+                max-width: none;
+                white-space: nowrap;
+                width: max-content;
+            }
+        }
+
+        [data-dropdown-custom-trigger],
+        #icon-category-dropdown {
+            display: block;
+
+            @media screen and (min-width: 1072px) {
+                display: none;
+            }
+        }
+    }
+
     .content-wrapper {
         padding: $space_md;
         background-color: $white;
@@ -53,16 +164,6 @@
         display: block;
 
         @media screen and (max-width: 1072px) {
-          display: none;
-        }
-    }
-    
-    [data-dropdown-custom-trigger], 
-    #icon-category-dropdown {
-        display: block;
-        width: 100%;
-
-        @media screen and (min-width: 1072px) {
           display: none;
         }
     }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
2026.4 Create

Adds Search to Icons page - search by icon name, Empty State kit for no results

**Screenshots:** Screenshots to visualize your addition/change
<img width="1082" height="819" alt="PR 3 search" src="https://github.com/user-attachments/assets/b9b319e6-ec96-42e3-b5d4-9d7b495afab1" />
<img width="497" height="730" alt="PR 3 no results" src="https://github.com/user-attachments/assets/c0f796fa-6d06-4ece-a5cd-d1d72d8b06c3" />


**How to test?** Steps to confirm the desired behavior:
1. Go to icons pages.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.