### PR TITLE
Format rails code examples on Beta

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -104,6 +104,7 @@ class PagesController < ApplicationController
         source: source_code,
         description: description,
         rendered: rendered_example(example_key),
+        highlighted_source: (@type == "rails" ? render_code(source_code, "erb") : nil),
       }
     end
 

--- a/playbook-website/app/javascript/components/Website/src/components/SyntaxHighlightedCode.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/SyntaxHighlightedCode.tsx
@@ -1,45 +1,83 @@
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 
-export type SyntaxLanguage = "jsx" | "tsx" | "markup" | "ruby" | "swift";
+export type SyntaxLanguage =
+  | "jsx"
+  | "tsx"
+  | "markup"
+  | "erb"
+  | "ruby"
+  | "swift";
 
 type SyntaxHighlightedCodeProps = {
   code: string;
   language: SyntaxLanguage;
   className?: string;
+  rougeHtml?: string | null;
 };
 
 export const SyntaxHighlightedCode = ({
   code,
   language,
   className,
-}: SyntaxHighlightedCodeProps) => (
-  <div
-    className={className}
-    style={{
-      overflow: "auto",
-      borderRadius: 6,
-      fontSize: 13,
-      lineHeight: 1.5,
-    }}
-  >
-    <SyntaxHighlighter
-      language={language}
-      style={vscDarkPlus}
-      PreTag="div"
-      customStyle={{
-        margin: 0,
-        padding: "16px 20px",
+  rougeHtml,
+}: SyntaxHighlightedCodeProps) => {
+  if (rougeHtml && rougeHtml.length > 0) {
+    return (
+      <div
+        className={className}
+        style={{
+          overflow: "auto",
+          borderRadius: 6,
+          fontSize: 13,
+          lineHeight: 1.5,
+        }}
+      >
+        <div className="pb--codeCopy">
+          <pre
+            className="highlight"
+            style={{
+              margin: 0,
+              padding: "16px 20px",
+              borderRadius: 6,
+              fontFamily:
+                'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+            }}
+            dangerouslySetInnerHTML={{ __html: rougeHtml }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      style={{
+        overflow: "auto",
         borderRadius: 6,
-      }}
-      codeTagProps={{
-        style: {
-          fontFamily:
-            'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-        },
+        fontSize: 13,
+        lineHeight: 1.5,
       }}
     >
-      {code}
-    </SyntaxHighlighter>
-  </div>
-);
+      <SyntaxHighlighter
+        language={language}
+        style={vscDarkPlus}
+        PreTag="div"
+        customStyle={{
+          margin: 0,
+          padding: "16px 20px",
+          borderRadius: 6,
+        }}
+        codeTagProps={{
+          style: {
+            fontFamily:
+              'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+          },
+        }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+};

--- a/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
+++ b/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
@@ -29,32 +29,40 @@ export const ComponentsLoader: () => Promise<CategoryTypes[]> = async () => {
   return data;
 };
 
-export const ComponentShowLoader = async ({ params, request }:any) => {
+export const ComponentShowLoader = async ({
+  params,
+  request,
+}: LoaderFunctionArgs) => {
   // Check if this is an advanced_table section route using the request URL
   const requestUrl = new URL(request.url);
-  const isAdvancedTableSection = requestUrl.pathname.includes('/kits/advanced_table/');
+  const isAdvancedTableSection = requestUrl.pathname.includes(
+    "/kits/advanced_table/",
+  );
   
   // Get platform from route params (react, rails, swift)
-  const platform = params.platform || 'react';
-  
-  let url;
+  const platform =
+    typeof params.platform === "string" && params.platform.length > 0
+      ? params.platform
+      : "react";
+
+  let url: string;
   if (isAdvancedTableSection) {
     // For advanced_table sections like /kits/advanced_table/default/react
     // params.name is the section name, fetch from advanced_table with section param
-    url = `/beta/kits/advanced_table.json?section=${params.name}&platform=${platform}`;
+    url = `/beta/kits/advanced_table/${params.name}/${platform}.json`;
   } else {
     // Normal kit route
-    url = `/beta/kits/${params.name}.json?platform=${platform}`;
+    url = `/beta/kits/${params.name}/${platform}.json`;
   }
-  
+
   const response = await fetch(url);
-  const data = await response.json();  
-  return data; 
+  const data = await response.json();
+  return data;
 };
 
 export const CategoryLoader: (
   props: LoaderFunctionArgs
-) => Promise<CategoryTypes> = async ({ params }) => {
+) => Promise<ComponentTypes> = async ({ params }) => {
   const response = await fetch("/beta/kits.json");
   const { kits } = await response.json();
 

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
@@ -26,8 +26,8 @@ export const DocsTab = ({
   sections,
 }: DocsTabProps) => {
   const { platform } = usePlatform();
-  const codeLanguage =
-    platform === "rails" ? "markup" : platform === "swift" ? "swift" : "tsx";
+  const codeLanguage: "erb" | "swift" | "tsx" =
+    platform === "rails" ? "erb" : platform === "swift" ? "swift" : "tsx";
 
   const [visibleCode, setVisibleCode] = useState<{ [key: string]: boolean }>(
     {},
@@ -63,7 +63,7 @@ export const DocsTab = ({
       <Card marginBottom="lg" padding="none" width="100%">
         <Caption text={example.title} color="lighter" margin="md" />
         {platform === "rails" ? (
-          <LiveExampleRails html={example.rendered} />
+          <LiveExampleRails html={example.rendered ?? ""} />
         ) : (
           <LiveExample code={example.source} exampleProps={exampleProps} />
         )}
@@ -97,8 +97,11 @@ export const DocsTab = ({
           {visibleCode[example.example_key] && (
             <Card borderNone width="100%">
               <SyntaxHighlightedCode
-                code={example.source}
+                code={example.source ?? ""}
                 language={codeLanguage}
+                rougeHtml={
+                  platform === "rails" ? example.highlighted_source : undefined
+                }
               />
             </Card>
           )}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
2026.4 Create
Rails docs were added to Beta website, this formats the code examples (follow up from earlier this week which did React)

**Screenshots:** Screenshots to visualize your addition/change
<img width="1134" height="823" alt="PR 4" src="https://github.com/user-attachments/assets/87c8e648-63f5-40b9-85da-1f62500a70eb" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Beta website Rails kit page and see code exampled formatted.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.