### PR TITLE
Playbook Website: AT on rails side + playground only on react

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -54,13 +54,6 @@ class PagesController < ApplicationController
           @examples = all_examples.select do |example|
             @kit_section.include?(example.values.first)
           end
-
-          # Load mock data for advanced_table (beta only: use separate variables)
-          @beta_table_data = advanced_table_mock_data_beta
-          @beta_table_data_with_id = advanced_table_mock_data_with_id_beta
-          @beta_table_data_no_subrows = advanced_table_mock_data_no_subrows_beta
-          @beta_table_data_pagination = advanced_table_pagination_mock_data
-          @beta_table_data_infinite_scroll = advanced_table_infinite_scroll_mock_data
         else
           @examples = pb_doc_kit_examples(@kit, @type)
         end
@@ -70,6 +63,8 @@ class PagesController < ApplicationController
     else
       @examples = pb_doc_kit_examples(@kit, @type)
     end
+
+    assign_advanced_table_doc_mocks
 
     @css = view_context.vite_asset_path("site_styles/main.scss")
 
@@ -805,6 +800,28 @@ private
     puts "Active Variants: #{@variants.inspect}"
 
     render template: "pages/kit_variants_collection", layout: "layouts/fullscreen"
+  end
+
+  # Beta JSON + Rails prerendered examples: ERB under pb_advanced_table/docs expects @table_data (OpenStruct),
+  # while the SPA passes plain JSON via @beta_table_* keys in the kit payload.
+  def assign_advanced_table_doc_mocks
+    return unless @kit.to_s == "advanced_table" || @kit_parent.to_s == "advanced_table"
+
+    @beta_table_data = advanced_table_mock_data_beta if @beta_table_data.nil?
+    @beta_table_data_with_id = advanced_table_mock_data_with_id_beta if @beta_table_data_with_id.nil?
+    @beta_table_data_no_subrows = advanced_table_mock_data_no_subrows_beta if @beta_table_data_no_subrows.nil?
+    @beta_table_data_pagination = advanced_table_pagination_mock_data if @beta_table_data_pagination.nil?
+    @beta_table_data_infinite_scroll = advanced_table_infinite_scroll_mock_data if @beta_table_data_infinite_scroll.nil?
+
+    return unless @type.to_s == "rails"
+
+    @table_data = advanced_table_mock_data if @table_data.nil?
+    @table_data_with_id = advanced_table_mock_data_with_id if @table_data_with_id.nil?
+    @table_data_no_subrows = advanced_table_mock_data_no_subrows if @table_data_no_subrows.nil?
+    @table_data_pagination = advanced_table_pagination_mock_data if @table_data_pagination.nil?
+    @table_data_infinite_scroll = advanced_table_infinite_scroll_mock_data if @table_data_infinite_scroll.nil?
+    @table_data_inline_loading = advanced_table_mock_data_inline_loading if @table_data_inline_loading.nil?
+    @table_data_inline_loading_empty_children = advanced_table_mock_data_inline_loading_empty_children if @table_data_inline_loading_empty_children.nil?
   end
 
   def advanced_table_mock_data

--- a/playbook-website/app/javascript/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/KitSearch.tsx
@@ -16,6 +16,8 @@ type KitSearchProps = {
   marginBottom?: string,
   beta?: boolean,
   onBetaNavigate?: (path: string) => void,
+  /** When set with `beta`, remounts Typeahead on navigation so query/selection clears (e.g. pathname+search from useLocation). */
+  betaSearchResetKey?: string,
 }
 
 const combineKitsandVisualGuidelines = (
@@ -37,7 +39,7 @@ const combineKitsandVisualGuidelines = (
   return [...kits, ...globalPropsItems, ...tokensItems].sort((a, b) => a.label.localeCompare(b.label))
 }
 
-const KitSearch = ({ classname, id, kits, global_props_and_tokens, marginBottom, beta, onBetaNavigate }: KitSearchProps) => {
+const KitSearch = ({ classname, id, kits, global_props_and_tokens, marginBottom, beta, onBetaNavigate, betaSearchResetKey }: KitSearchProps) => {
   const kitsAndGuidelines = combineKitsandVisualGuidelines(kits, global_props_and_tokens)
 
   const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)
@@ -85,8 +87,11 @@ const KitSearch = ({ classname, id, kits, global_props_and_tokens, marginBottom,
     </Flex>
   )
 
+  const typeaheadKey = beta ? `${id}__${betaSearchResetKey ?? ''}` : id
+
   return (
       <Typeahead
+        key={typeaheadKey}
         className={classname}
         dark={document.cookie.split("; ").includes("dark_mode=true")}
         id={id}

--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 import { Layout } from "playbook-ui";
 import Sidebar from "./src/layouts/Sidebar";
 import LayoutRight from "./src/layouts/LayoutRight";
@@ -27,23 +27,16 @@ function Website() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const [platform, setPlatform] = useState(type || 'react');
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const normalizedPath = location.pathname.replace(/\/+$/, "") || "/";
 
-  useEffect(() => {
+  const platform = useMemo(() => {
     const pathPlatform = normalizedPath.match(/\/(react|rails|swift)$/)?.[1];
     const queryPlatform = new URLSearchParams(location.search).get("type");
-    const nextPlatform = pathPlatform || queryPlatform || "react";
-
-    if (nextPlatform !== platform) {
-      setPlatform(nextPlatform);
-    }
-  }, [normalizedPath, location.search, platform]);
+    return pathPlatform || queryPlatform || type || "react";
+  }, [normalizedPath, location.search, type]);
 
   const handlePlatformChange = (nextPlatform: string) => {
-    setPlatform(nextPlatform);
-
     const isKitDetailRoute =
       /^\/beta\/kits\/advanced_table\/[^/]+\/(react|rails|swift)$/.test(normalizedPath) ||
       /^\/beta\/kits\/[^/]+\/(react|rails|swift)$/.test(normalizedPath);

--- a/playbook-website/app/javascript/components/Website/src/layouts/Header.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Header.tsx
@@ -1,6 +1,5 @@
-import { Link } from "react-router-dom"
+import { Link, useLocation, useNavigate } from "react-router-dom"
 import { Flex, Image, Badge, SectionSeparator, FlexItem } from "playbook-ui";
-import { useNavigate } from "react-router-dom";
 // @ts-ignore
 import PBLogo from "../../../../images/pb-logo.svg";
 import KitSearch from "../../../KitSearch";
@@ -26,6 +25,7 @@ const Header = ({
   setPlatform,
 }: HeaderProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
 
   return (
     <>
@@ -77,6 +77,7 @@ const Header = ({
               gap="md"
             >
               <KitSearch
+                betaSearchResetKey={`${location.pathname}${location.search}`}
                 classname="desktop-kit-search-new"
                 id="desktop-kit-search"
                 kits={search_list}

--- a/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/ComponentList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react"
 import type { ChangeEvent } from "react"
 import { NavLink, Outlet, useOutlet, useRouteLoaderData } from "react-router-dom"
-import { EmptyState, Flex, TextInput, Body } from "playbook-ui"
+import { EmptyState, Flex, TextInput } from "playbook-ui"
 import { matchSorter } from "match-sorter"
 
 import { KitCard } from "../components/KitCard"

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/index.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { PageContainer } from "../../components/PageContainer";
+import { usePlatform } from "../../contexts/PlatformContext";
 import { linkFormat } from "../../../../../utilities/website_sidebar_helper";
 import { DocsTab } from "./Tabs/DocsTab";
 import { PropsTab } from "./Tabs/PropsTab";
@@ -13,6 +14,7 @@ import { PlaygroundTab } from "./Tabs/PlaygroundTab";
 
 const KitShow = () => {
   const { name } = useParams();
+  const { platform } = usePlatform();
   const loaderData = useLoaderData() as any;
   const {
     examples,
@@ -40,6 +42,9 @@ const KitShow = () => {
   }, [loaderData]);
 
   const [activeTab, setActiveTab] = useState<string>("docs");
+  const showPlayground = platform !== "rails";
+  const displayTab =
+    activeTab === "playground" && !showPlayground ? "docs" : activeTab;
 
   return (
     <>
@@ -69,19 +74,21 @@ const KitShow = () => {
         <Nav orientation="horizontal" paddingX="xl">
           <NavItem
             text="Docs"
-            active={activeTab === "docs"}
+            active={displayTab === "docs"}
             onClick={() => setActiveTab("docs")}
           />
           <NavItem
             text="Props"
-            active={activeTab === "props"}
+            active={displayTab === "props"}
             onClick={() => setActiveTab("props")}
           />
-          <NavItem
-            text="Playground"
-            active={activeTab === "playground"}
-            onClick={() => setActiveTab("playground")}
-          />
+          {showPlayground && (
+            <NavItem
+              text="Playground"
+              active={displayTab === "playground"}
+              onClick={() => setActiveTab("playground")}
+            />
+          )}
 
           {/* Building Blocks and References tabs, commented out until building blocks and references are implemented */}
           {/* <NavItem
@@ -97,8 +104,8 @@ const KitShow = () => {
         </Nav>
         <SectionSeparator marginBottom="lg" />
 
-        {/* Playground Tab Content */}
-        {activeTab === "playground" && (
+        {/* Playground Tab Content (React-only for now; hidden on Rails) */}
+        {showPlayground && displayTab === "playground" && (
           <PlaygroundTab
             kitSchema={kit_schema}
             globalPropsSchema={global_props_schema}
@@ -109,7 +116,7 @@ const KitShow = () => {
         )}
 
         {/* Docs Tab Content */}
-        {activeTab === "docs" && (
+        {displayTab === "docs" && (
           <DocsTab
             examples={examples}
             exampleProps={exampleProps}
@@ -119,7 +126,7 @@ const KitShow = () => {
         )}
 
         {/* Props Tab Content */}
-        {activeTab === "props" && <PropsTab availableProps={available_props} />}
+        {displayTab === "props" && <PropsTab availableProps={available_props} />}
 
         {/* Building Blocks Tab Content, commented out until building blocks are implemented */}
         {/* {activeTab === "building-blocks" && <BuildingBlocksTab />} */}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Beta website:
- Rails side does not have playgrounds tab
- AT to work
- Search to clear on navigation

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.