### PR TITLE
[PLAY-2927] Button Kit: Match Icon-only Button Height with Icon-less Button Height

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.scss
@@ -11,6 +11,13 @@ $pb_button_sizes: (
   "lg":   ($font_large - 2px),
 );
 
+// Icon-only: fixed square hit targets (not derived from font padding).
+$pb_button_icon_only_dimensions: (
+  "sm": 35px,
+  "md": 40px,
+  "lg": 45px,
+);
+
 // Base button class
 .pb_button_kit {
   @include pb_button;
@@ -113,32 +120,27 @@ $pb_button_sizes: (
     }
   }
 
-  // Icon-only button (icon prop set, no text) - square with equal padding
-  // Rails: uses .pb_button_icon_only class
-  // React: when pb_button_content is empty (no text). Do not match when content has
-  // text + icon (e.g. "Exit Fullscreen" + FA icon) which can include empty spans.
+  // Icon-only button (icon prop set, no text) — fixed squares; icon scales via font-size from size prop.
+  // Rails: .pb_button_icon_only; React: class or :has(...) when label is empty.
+  // Rails uses a truly empty .pb_button_content; React wraps text in a child span (may be empty).
   &.pb_button_icon_only,
-  &:has(.pb_button_content:empty) {
+  &:has(.pb_button_content:empty),
+  &:has(.pb_button_content > span:empty) {
     aspect-ratio: 1;
-    min-width: auto;
-    width: auto;
-    height: auto;
-    padding: $pb_button_v_padding !important;
-    min-height: ($pb_button_v_padding * 2) + $font_small;
-    
-    &.pb_button_size_sm {
-      padding: $font_smaller !important;
-      min-height: ($font_smaller * 2) + $font_smaller;
-    }
-    
-    &.pb_button_size_md {
-      padding: $font_small !important;
-      min-height: ($font_small * 2) + $font_small;
-    }
-    
-    &.pb_button_size_lg {
-      padding: ($font_large - 2px) !important;
-      min-height: (($font_large - 2px) * 2) + ($font_large - 2px);
+    box-sizing: border-box;
+    $pb_button_icon_only_default: map-get($pb_button_icon_only_dimensions, "md");
+    width: $pb_button_icon_only_default;
+    min-width: $pb_button_icon_only_default;
+    height: $pb_button_icon_only_default;
+    min-height: $pb_button_icon_only_default;
+    padding: 0 !important;
+    @each $name, $dim in $pb_button_icon_only_dimensions {
+      &.pb_button_size_#{$name} {
+        width: $dim;
+        min-width: $dim;
+        height: $dim;
+        min-height: $dim;
+      }
     }
 
     // Remove margins from icons

--- a/playbook/app/pb_kits/playbook/pb_button/button.rb
+++ b/playbook/app/pb_kits/playbook/pb_button/button.rb
@@ -73,8 +73,10 @@ module Playbook
         emoji_regex.match?(icon)
       end
 
+      # Icon-only = icon with no label. Label may come from `text` or from a block (e.g. CopyButton);
+      # block content must not be treated as icon-only when `text` is unset.
       def icon_only?
-        icon.present? && text.blank? && variant != "reaction"
+        icon.present? && text.blank? && children.blank? && variant != "reaction"
       end
 
       def classname

--- a/playbook/spec/pb_kits/playbook/kits/button_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/button_spec.rb
@@ -164,6 +164,10 @@ RSpec.describe Playbook::PbButton::Button do
       expect(subject.new(icon: "bars", text: "").icon_only?).to be true
     end
 
+    it "returns false when a block provides the label (text prop may still be blank)" do
+      expect(subject.new(icon: "plus") { "Copy Text" }.icon_only?).to be false
+    end
+
     it "returns false when text is present", :aggregate_failures do
       expect(subject.new(icon: "plus", text: "Click me").icon_only?).to be false
       expect(subject.new(icon: "user", text: "Button").icon_only?).to be false
@@ -192,6 +196,10 @@ RSpec.describe Playbook::PbButton::Button do
     it "does not include pb_button_icon_only when text is present", :aggregate_failures do
       expect(subject.new(icon: "plus", text: "Click me").classname).to_not include("pb_button_icon_only")
       expect(subject.new(icon: "user", text: "Button").classname).to_not include("pb_button_icon_only")
+    end
+
+    it "does not include pb_button_icon_only when a block provides the label" do
+      expect(subject.new(icon: "copy") { "Copy Text" }.classname).to_not include("pb_button_icon_only")
     end
 
     it "does not include pb_button_icon_only when variant is reaction", :aggregate_failures do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-2927

The icon-only buttons were "taller" than icon-less buttons. This sets the icon-only button to be the same height, while still retaining the square ratio:
- sm: 35px
- md: 40px
- lg: 45px

Icon-less buttons do not have a fixed height. This is set by font, padding, and line-height. 

Also, the Rails Copy Button kit was fixed (the dimensions broke before from https://github.com/powerhome/playbook/pull/5698).

**Screenshots:** Screenshots to visualize your addition/change
<img width="485" height="398" alt="Screenshot 2026-04-24 at 9 56 28 AM" src="https://github.com/user-attachments/assets/6ab31bb2-a2cd-4bf7-bc14-d6e25d4abcee" />

**How to test?** Steps to confirm the desired behavior:
/kits/button/react#icon-button-variant

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.