### PR TITLE
[PLAY-2922] Update Last QuickPick Logic - AVNGR-1107 without verification issue

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -310,4 +310,34 @@ describe('DatePicker Kit', () => {
     expect(label).toBeInTheDocument()
     expect(kit).not.toHaveTextContent("*")
   })
+
+  test('Last month quickpick includes the correct last day of previous month', async () => {
+    const testId = 'datepicker-last-month'
+    render(
+      <DatePicker
+          allowInput
+          data={{ testid: testId }}
+          mode="range"
+          pickerId="date-picker-last-month"
+          placeholder="mm/dd/yyyy to mm/dd/yyyy"
+          selectionType="quickpick"
+      />
+    )
+  
+    const kit = screen.getByTestId(testId)
+    const input = within(kit).getByPlaceholderText('mm/dd/yyyy to mm/dd/yyyy')
+  
+    fireEvent(input, new MouseEvent('click', { bubbles: true, cancelable: true }))
+  
+    const lastMonth = within(kit).getByText('Last month')
+    fireEvent(lastMonth, new MouseEvent('click', { bubbles: true, cancelable: true }))
+  
+    await waitFor(() => {
+      expect(input).toHaveValue(
+        DateTime.getPreviousMonthStartDate(new Date()).formatDate() +
+        " to " +
+        DateTime.getPreviousMonthEndDate(new Date()).formatDate()
+      )
+    })
+  })
 })

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react"
-import { render, screen, fireEvent } from "../utilities/test-utils"
+import { render, screen, fireEvent, waitFor } from "../utilities/test-utils"
 
 import { Dropdown, Icon, IconCircle } from 'playbook-ui'
-
+import DateTime from "../pb_kit/dateTime.ts"
 
 const testId = 'dropdown'
 
@@ -778,3 +778,52 @@ test("requiredIndicator prop renders asterisk when true", () => {
   expect(label).toBeInTheDocument();
   expect(kit).toHaveTextContent("*");
 });
+
+describe("quickpick Last Month range when current month is shorter than the previous month", () => {
+  const quickpickTestId = "dropdown-quickpick-last-month-march"
+
+  const formatDate = (date) => {
+    const month = (date.getMonth() + 1).toString().padStart(2, "0")
+    const day = date.getDate().toString().padStart(2, "0")
+    const year = date.getFullYear()
+    return `${month}/${day}/${year}`
+  }
+
+  beforeEach(() => {
+    jest.setSystemTime(new Date(2026, 3, 15, 12, 0, 0))
+  })
+
+  afterEach(() => {
+    jest.setSystemTime()
+  })
+
+  test("selecting Last Month matches DateTime previous-month range (full March when today is in April)", async () => {
+    const onSelect = jest.fn()
+    const now = new Date()
+
+    render(
+      <Dropdown
+          data={{ testid: quickpickTestId }}
+          onSelect={onSelect}
+          variant="quickpick"
+      />
+    )
+
+    const kit = screen.getByTestId(quickpickTestId)
+    const lastMonthOption = Array.from(kit.querySelectorAll(".pb_dropdown_option_list")).find(
+      (el) => el.textContent === "Last Month"
+    )
+
+    expect(lastMonthOption).toBeTruthy()
+    fireEvent.click(lastMonthOption)
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalled()
+    })
+
+    const [startDate, endDate] = onSelect.mock.calls[0][0].value
+
+    expect(formatDate(startDate)).toBe(formatDate(DateTime.getPreviousMonthStartDate(now)))
+    expect(formatDate(endDate)).toBe(formatDate(DateTime.getPreviousMonthEndDate(now)))
+  })
+})

--- a/playbook/app/pb_kits/playbook/pb_kit/dateTime.ts
+++ b/playbook/app/pb_kits/playbook/pb_kit/dateTime.ts
@@ -281,17 +281,8 @@ export const getPreviousMonthStartDate = (newDate: Date | string): Date => {
 }
 
 export const getPreviousMonthEndDate = (newDate: Date | string): Date => {
-  const lastDayOfMonth = getMonthEndDate(newDate)
-  const lastDayOfPreviousMonth = new Date(
-    lastDayOfMonth.getFullYear(),
-    lastDayOfMonth.getMonth() - 1,
-    lastDayOfMonth.getDate(),
-    lastDayOfMonth.getHours(),
-    lastDayOfMonth.getMinutes(),
-    lastDayOfMonth.getSeconds()
-  )
-
-  return lastDayOfPreviousMonth
+  const date = formatDate(newDate)
+  return new Date(date.getFullYear(), date.getMonth(), 0, 23, 59, 59)
 }
 
 // Quarters
@@ -325,17 +316,8 @@ export const getPreviousQuarterStartDate = (newDate: Date | string): Date => {
 }
 
 export const getPreviousQuarterEndDate = (newDate: Date | string): Date => {
-  const endOfQuarter = getQuarterEndDate(newDate)
-  const lastDayOfPreviousQuarter = new Date(
-    endOfQuarter.getFullYear(),
-    endOfQuarter.getMonth() - 3,
-    endOfQuarter.getDate(),
-    endOfQuarter.getHours(),
-    endOfQuarter.getMinutes(),
-    endOfQuarter.getSeconds()
-  )
-
-  return lastDayOfPreviousQuarter
+  const startOfQuarter = getQuarterStartDate(newDate)
+  return new Date(startOfQuarter.getFullYear(), startOfQuarter.getMonth(), 0, 23, 59, 59)
 }
 
 // Years

--- a/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe Playbook::PbDatePicker::DatePicker do
     end
   end
 
+  describe "#date_picker_config" do
+    it "includes selectionType and mode for range quickpick so React can compute quick pick ranges" do
+      picker = subject.new(
+        picker_id: "spec-quickpick",
+        mode: "range",
+        selection_type: "quickpick"
+      )
+      config = JSON.parse(picker.date_picker_config)
+      expect(config["selectionType"]).to eq("quickpick")
+      expect(config["mode"]).to eq("range")
+    end
+  end
+
   it "raises an error when not given a picker_id" do
     expect { subject.new {} }.to raise_error(Playbook::Props::Error)
   end

--- a/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
@@ -257,6 +257,24 @@ RSpec.describe Playbook::PbDropdown::Dropdown do
       expect(this_month_option[:formatted_end_date]).to eq(Date.today.strftime("%m/%d/%Y"))
     end
 
+    it "last month quickpick spans the full previous month when the current month has fewer days" do
+      allow(Date).to receive(:today).and_return(Date.new(2026, 4, 15))
+
+      dropdown = subject.new(variant: "quickpick")
+      last_month = dropdown.send(:quickpick_options).find { |opt| opt[:label] == "Last Month" }
+      expect(last_month[:formatted_start_date]).to eq("03/01/2026")
+      expect(last_month[:formatted_end_date]).to eq("03/31/2026")
+    end
+
+    it "last quarter quickpick aligns to the previous calendar quarter boundaries" do
+      allow(Date).to receive(:today).and_return(Date.new(2026, 4, 10))
+
+      dropdown = subject.new(variant: "quickpick")
+      last_quarter = dropdown.send(:quickpick_options).find { |opt| opt[:label] == "Last Quarter" }
+      expect(last_quarter[:formatted_start_date]).to eq("01/01/2026")
+      expect(last_quarter[:formatted_end_date]).to eq("03/31/2026")
+    end
+
     it "supports blank_selection with quickpick to clear date inputs" do
       dropdown = subject.new(
         variant: "quickpick",


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2922](https://runway.powerhrg.com/backlog_items/PLAY-2922?from=active_sprint)
[Umesh's PR](https://github.com/powerhome/playbook/pull/6057) hit verified commit issue - this PR redoes the original (dateTime.ts and Date Picker jest test from his original commits, additional tests for DatePicker/Dropdown from me).

**Screenshots:** Screenshots to visualize your addition/change
The Bug: "Last Month" and "Last Quarter" omit last days of the previous month if the current month has fewer days (April 30 vs March 31)
<img width="2762" height="482" alt="image" src="https://github.com/user-attachments/assets/eeb07002-69ad-430f-9b7f-9c7688a5172e" />
Fixed:
<img width="231" height="155" alt="Screenshot 2026-04-24 at 1 05 07 PM" src="https://github.com/user-attachments/assets/bac667d8-13b4-4cc1-8d49-ac6c493899df" />
<img width="1517" height="244" alt="Screenshot 2026-04-24 at 1 05 58 PM" src="https://github.com/user-attachments/assets/1c47387b-cd1f-4898-a7ca-f0b7953fbe66" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Date Picker Range or Dropdown QuickPick doc examples - in review env, Last Month or Last Quarter will include 3/31/26 (compare to prod where it ends at 3/30/26).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.