### PR TITLE
[PLAY-2940] Minor clean up of Select Docs

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
@@ -28,7 +28,7 @@ const SelectError = (props) => {
       <Select
           error={error}
           label="Favorite Food"
-          name="food"
+          name="food-error"
           options={options}
           value="2"
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_inline.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_inline.jsx
@@ -23,7 +23,7 @@ const SelectInline = (props) => {
       <Select
           inline
           label="Favorite Food"
-          name="food"
+          name="food-inline"
           options={options}
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_inline_compact.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_inline_compact.jsx
@@ -24,7 +24,7 @@ const SelectInlineCompact = (props) => {
           compact
           inline
           label="Favorite Food"
-          name="food"
+          name="food-inline-compact"
           options={options}
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_inline_show_arrow.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_inline_show_arrow.jsx
@@ -23,7 +23,7 @@ const SelectInlineShowArrow = (props) => {
       <Select
           inline
           label="Favorite Food"
-          name="food"
+          name="food-inline-show-arrow"
           options={options}
           showArrow
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_multiple.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_multiple.html.erb
@@ -22,15 +22,15 @@
       value_text: "BBQ",
     },
     {
-      value: "4",
+      value: "5",
       value_text: "Sushi",
     },
     {
-      value: "4",
+      value: "6",
       value_text: "Chinese",
     },
     {
-      value: "4",
+      value: "7",
       value_text: "Hot Dogs",
     },
   ]

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_multiple.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_multiple.jsx
@@ -17,19 +17,19 @@ const SelectMultiple = (props) => {
       text: 'Tacos',
     },
     {
-      value: '3',
+      value: '4',
       text: 'BBQ',
     },
     {
-      value: '3',
+      value: '5',
       text: 'Sushi',
     },
     {
-      value: '3',
+      value: '6',
       text: 'Chinese',
     },
     {
-      value: '3',
+      value: '7',
       text: 'Hot Dogs',
     },
   ]
@@ -39,7 +39,7 @@ const SelectMultiple = (props) => {
       <Select
           label="Favorite Food"
           multiple
-          name="food"
+          name="food-multiple"
           options={options}
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_react_hook.jsx
@@ -7,12 +7,12 @@ import Button from "../../pb_button/_button"
 const SelectReactHook = (props) => {
   const { register, handleSubmit, formState: { errors } } = useForm({
     defaultValues: {
-      food: '',
+      "food-react-hook": '',
     },
   })
 
   const [submittedData, setSubmittedData] = useState({
-    food: '',
+    "food-react-hook": '',
   })
 
   const onSubmit = (data) => {
@@ -39,8 +39,8 @@ const SelectReactHook = (props) => {
       <form onSubmit={handleSubmit(onSubmit)}>
         <Select
             {...props}
-            {...register("food", { required: true })}
-            error={errors.food ? "Please select a food." : null}
+            {...register("food-react-hook", { required: true })}
+            error={errors["food-react-hook"] ? "Please select a food." : null}
             label="Favorite Food"
             options={options}
         />
@@ -51,7 +51,7 @@ const SelectReactHook = (props) => {
           />
       </form>
       <Body padding="xs"
-          text={`Food: ${submittedData.food}`}
+          text={`Food: ${submittedData["food-react-hook"]}`}
       />
     </>
   )

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_required_indicator.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_required_indicator.jsx
@@ -22,7 +22,7 @@ const SelectRequiredIndicator = () => {
     <div>
       <Select
           label="Favorite Snack"
-          name="food"
+          name="food-required-indicator"
           options={options}
           requiredIndicator
       />


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2940](https://runway.powerhrg.com/backlog_items/PLAY-2940?from=active_sprint) adds unique names to React Select docs for accessibility purposes (clicking the label currently associates each of the examples with the default one). Also adjusts the Multiple doc (Rails and React) to have unique values for each option.


**How to test?** Steps to confirm the desired behavior:
1. Go to React Select kit pages. Click on the label for each of the docs in Review env vs Prod to appreciate improved label-input association.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.