### PR TITLE
[PBHUB-880] Change background color for Border Radius Global Prop examples

### DIFF
--- a/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/BorderRadiusGlobalProps.tsx
+++ b/playbook-website/app/javascript/components/GlobalPropsAndTokens/ExamplesPage/Examples/BorderRadiusGlobalProps.tsx
@@ -22,7 +22,7 @@ const BorderRadiusGlobalProps = () => {
         {borderRadiusOptions.map((option) => (
           <Flex key={option.value} flexDirection="column" align="center" gap="xs">
             <Card 
-              background="light"
+              background="info_subtle"
               borderRadius={option.value as any}
               className="visual_guide_card_border_radius"
               padding="xs" 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PBHUB-880](https://runway.powerhrg.com/backlog_items/PBHUB-880?from=backlog) will investigate an apparent conflict between Border Radius Medium and Background color Light in more detail (discovered today). This PR changes the background color for the Border Radius Global Prop examples to info_subtle which is just as clear and correctly shows border radius medium as 6px instead of 4px.

**Screenshots:** Screenshots to visualize your addition/change
<img width="900" height="386" alt="PBHUB880quickfixinfosubtle" src="https://github.com/user-attachments/assets/37325f55-fd40-4c35-ba8e-281c69826c7c" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Border Radius Global Props page - inspect medium example and see 6px border radius now.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.