### PR TITLE
[PLAY-2941] Button Kit: Fix Font Awesome Icons

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_button/_button.scss
+++ b/playbook/app/pb_kits/playbook/pb_button/_button.scss
@@ -124,8 +124,7 @@ $pb_button_icon_only_dimensions: (
   // Rails: .pb_button_icon_only; React: class or :has(...) when label is empty.
   // Rails uses a truly empty .pb_button_content; React wraps text in a child span (may be empty).
   &.pb_button_icon_only,
-  &:has(.pb_button_content:empty),
-  &:has(.pb_button_content > span:empty) {
+  &:has(.pb_button_content:empty) {
     aspect-ratio: 1;
     box-sizing: border-box;
     $pb_button_icon_only_default: map-get($pb_button_icon_only_dimensions, "md");


### PR DESCRIPTION
**What does this PR do?**
https://runway.powerhrg.com/backlog_items/PLAY-2941

Fix a bug where buttons with Font Awesome icons had Icon-only button styles applied, even though there was text. 

This was because this PR, https://github.com/powerhome/playbook/pull/6106,  added a [selector](https://github.com/powerhome/playbook/pull/6106/changes#diff-4a8bb45faa6ddb8f6055a610936e9922adb3bad8850db4f23c8bbc781f57a08eR128)
`&:has(.pb_button_content > span:empty) {`

This PR removes that selector. 

**Screenshots:** Screenshots to visualize your addition/change
Fix this scenario where there is a Font Awesome icon:
<img width="501" height="597" alt="Screenshot 2026-04-29 at 1 21 05 PM" src="https://github.com/user-attachments/assets/b47eab67-4941-401e-b64a-9e48bde5b38f" />

which has a hidden span:
```<span aria-label="up-right-and-down-left-from-center icon" hidden=""></span>```

**How to test?** Steps to confirm the desired behavior:
1. Make sure the icon-only button variants still work. 


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.