### PR TITLE
[PLAY-2939] Dropdown constrainHeight prop with subcomponent structure

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_with_constrain_height.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_with_constrain_height.jsx
@@ -26,6 +26,24 @@ const DropdownWithConstrainHeight = (props) => {
           options={options}
           {...props}
       />
+
+    <br />
+
+      <Dropdown
+          label="Sub Component With Constrain Height"
+          options={options}
+          {...props}
+      >
+        <Dropdown.Trigger />
+        <Dropdown.Container constrainHeight>
+          {options.map((option) => (
+            <Dropdown.Option
+                key={option.id}
+                option={option}
+            />
+          ))}
+        </Dropdown.Container>
+      </Dropdown>
     </>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_with_constrain_height.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_with_constrain_height.jsx
@@ -30,7 +30,7 @@ const DropdownWithConstrainHeight = (props) => {
     <br />
 
       <Dropdown
-          label="Sub Component With Constrain Height"
+          label="Subcomponent With Constrain Height"
           options={options}
           {...props}
       >

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_with_constrain_height_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_with_constrain_height_rails.html.erb
@@ -18,3 +18,14 @@
   constrain_height: true,
   label: "With Constrain Height"
 }) %>
+
+<br>
+
+<%= pb_rails("dropdown", props: {options: options, label: "Subcomponent With Constrain Height"}) do %>
+  <%= pb_rails("dropdown/dropdown_trigger") %>
+  <%= pb_rails("dropdown/dropdown_container", props: { constrain_height: true }) do %>
+    <% options.each do |option| %>
+      <%= pb_rails("dropdown/dropdown_option", props: {option: option}) %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
[PLAY-2939](https://runway.powerhrg.com/backlog_items/PLAY-2939?from=active_sprint)

This PR adds new docs to show how to use constrainHeight with subcomponent structure 

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.