### PR TITLE
[PLAY-2923] Update ViewComponent to 3.8.0

### DIFF
--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 5.2.4.5)
       actionview (>= 5.2.4.5)
       activesupport (>= 5.2.4.5)
-      view_component (= 2.83.0)
+      view_component (= 3.8.0)
       vite_rails
 
 GEM
@@ -302,7 +302,7 @@ GEM
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
     useragent (0.16.11)
-    view_component (2.83.0)
+    view_component (3.8.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/playbook/Gemfile.lock
+++ b/playbook/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 5.2.4.5)
       actionview (>= 5.2.4.5)
       activesupport (>= 5.2.4.5)
-      view_component (= 2.83.0)
+      view_component (= 3.8.0)
       vite_rails
 
 GEM
@@ -83,10 +83,11 @@ GEM
       racc
     builder (3.2.4)
     byebug (11.1.3)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.6)
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.4.4)
+    drb (2.2.3)
     dry-cli (1.0.0)
     erubi (1.12.0)
     faraday (1.10.3)
@@ -124,7 +125,7 @@ GEM
       retriable (~> 3.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.4)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
@@ -137,10 +138,12 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    method_source (1.0.0)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.22.3)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
     multi_json (1.15.0)
     multipart-post (2.4.0)
     net-imap (0.4.10)
@@ -163,6 +166,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    prism (1.9.0)
     public_suffix (4.0.6)
     racc (1.8.1)
     rack (2.2.9)
@@ -255,7 +259,7 @@ GEM
     tzinfo-data (1.2018.9)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
-    view_component (2.83.0)
+    view_component (3.8.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/playbook/bin/rails
+++ b/playbook/bin/rails
@@ -10,5 +10,7 @@ APP_PATH = File.expand_path('../spec/dummy/config/application', __dir__)
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
+require "logger"
+
 require "rails"
 require 'rails/engine/commands'

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -12,6 +12,7 @@ module Playbook
     end
 
     config.view_component.render_monkey_patch_enabled = false
+    config.view_component.capture_compatibility_patch_enabled = true
 
     if config.respond_to?(:assets)
       config.assets.paths ||= []

--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack", ">= 5.2.4.5"
   s.add_dependency "actionview", ">= 5.2.4.5"
   s.add_dependency "activesupport", ">= 5.2.4.5"
-  s.add_dependency "view_component", "2.83.0"
+  s.add_dependency "view_component", "3.8.0"
   s.add_dependency "vite_rails"
 
   s.add_development_dependency "brakeman", "7.0.0"

--- a/playbook/spec/dummy/config/boot.rb
+++ b/playbook/spec/dummy/config/boot.rb
@@ -3,3 +3,5 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+
+require "logger"

--- a/playbook/spec/rails_helper.rb
+++ b/playbook/spec/rails_helper.rb
@@ -2,7 +2,6 @@
 
 ENV["RAILS_ENV"] ||= "test"
 
-require "logger"
 require File.expand_path("dummy/config/environment", __dir__)
 require "spec_helper"
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/playbook/spec/rails_helper.rb
+++ b/playbook/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 
 ENV["RAILS_ENV"] ||= "test"
 
+require "logger"
 require File.expand_path("dummy/config/environment", __dir__)
 require "spec_helper"
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2923](https://runway.powerhrg.com/backlog_items/PLAY-2923?from=active_sprint) updates ViewComponent to 3.8.0 in order to add the `capture_compatibility_patch_enabled` feature (see [changelog](https://viewcomponent.org/CHANGELOG.html)) - context [here](https://stackoverflowteams.com/c/powerhome/questions/549/551#551) and in ticket. Also includes requiring logger which appears to be unrelated (Ruby 3.3 and ActiveSupport 7.0 issue?) but required to get PR up.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to Playbook website - no changes expected.
2. Go to Nitro/satellite apps on Alpha - no changes to current ViewComponent behavior expected (and when testing alt rendering methods they should not encounter the same issue as before).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.