### PR TITLE
[PLAY-2948] Upgrades Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -1676,6 +1676,10 @@
     "category": "Power Products"
   },
   {
+    "name": "circle-product-estimate-photos",
+    "category": "Power Products"
+  },
+  {
     "name": "circle-product-gutters",
     "category": "Power Products"
   },
@@ -1689,6 +1693,10 @@
   },
   {
     "name": "circle-product-solar",
+    "category": "Power Products"
+  },
+  {
+    "name": "circle-product-trim",
     "category": "Power Products"
   },
   {
@@ -1708,6 +1716,10 @@
     "category": "Power Products"
   },
   {
+    "name": "product-estimate-photos",
+    "category": "Power Products"
+  },
+  {
     "name": "product-gutters",
     "category": "Power Products"
   },
@@ -1721,6 +1733,10 @@
   },
   {
     "name": "product-solar",
+    "category": "Power Products"
+  },
+  {
+    "name": "product-trim",
     "category": "Power Products"
   },
   {

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "1.3.0",
-    "@powerhome/playbook-icons-react": "1.3.0",
+    "@powerhome/playbook-icons": "1.4.0",
+    "@powerhome/playbook-icons-react": "1.4.0",
     "@powerhome/power-fonts": "0.0.1",
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^4.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3175,15 +3175,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@1.3.0":
-  version "1.3.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/db10284f53f9933e38b3c1b14022c2f6f52bbd27#db10284f53f9933e38b3c1b14022c2f6f52bbd27"
-  integrity sha512-JKEeS3Ux4BwaVgzgAb6QIY8ZVe3/amEJwjJlAEvTdPk+eGJArVbvprvHebobL5Fy52Ay1O3EyKMBuUfhkRimrg==
+"@powerhome/playbook-icons-react@1.4.0":
+  version "1.4.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/1edb01993b3501de932a5d7186daa843ecfb796a#1edb01993b3501de932a5d7186daa843ecfb796a"
+  integrity sha512-JJtApOI8THm+4of/iXuZQPKWNPICruTCzRkog7raWRf72Rf8vaWD5C6pFnLzX23mxp1V4o6X5j9Vz/qTTxrIeQ==
 
-"@powerhome/playbook-icons@1.3.0":
-  version "1.3.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/1038bd892bfa2204f81f63176c5a9bac507cf3f5#1038bd892bfa2204f81f63176c5a9bac507cf3f5"
-  integrity sha512-W4OR9KB7ZfNoSTa62hsLRH62/0TbrjNoWxpTcnpfUg00RCaZON5NeVPX5JCPDLsCpCBUg3qMkUw845+IPkCCkw==
+"@powerhome/playbook-icons@1.4.0":
+  version "1.4.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/c2d48411b86a08475f2c40d23683f14eeffb58ac#c2d48411b86a08475f2c40d23683f14eeffb58ac"
+  integrity sha512-ZsVp3LKuHTxNNRuY34cKQFa6am0mBb9U+Z+Hcu2kuy7R/B8TtqpcX9/fOvZiSe4xMRBeDoGchjLVwBkctkFScA==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2948](https://runway.powerhrg.com/backlog_items/PLAY-2948) adds 4 new and modifies 15 pre-existing Power Product Icons to the playbook-icons repo (product-roofing did not need to be updated). This is a version bump PR to v1.4.0. https://github.com/powerhome/playbook-icons/pull/57

**Screenshots:** Screenshots to visualize your addition/change
<img width="1256" height="584" alt="product icons react" src="https://github.com/user-attachments/assets/c2485b1c-be79-435a-adb7-1a61a23b29b4" />

Prod Power Products (16 icons)
<img width="858" height="674" alt="current product icons" src="https://github.com/user-attachments/assets/0541370d-b293-4200-99e1-4902e3733be0" />

New Power Products (20 icons)
<img width="1024" height="800" alt="new product icons section" src="https://github.com/user-attachments/assets/12dc7167-3d87-4aa4-a58c-4864bc8caf38" />

**How to test?** Steps to confirm the desired behavior:
1. Go to /playbook_icons page Power Products section - see four new icons added (circle-product-estimate-photos, product-estimate-photos, circle-product-trim, product-trim) and updated appearances for all the rest! product-roofing will look the same.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.