### PR TITLE
[PLAY-2929] Dialog/Popover shared Portal logic - Implement for Typeahead

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.scss
@@ -151,11 +151,33 @@
   border-radius: $border_radius_md;
   max-height: calc(100vh - #{$gutter * 2});
   max-width: calc(100vw - #{$gutter * 2});
-  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: visible;
   animation-name: modalFadeIn;
   animation-duration: $animation-duration;
   outline: none;
   animation-timing-function: $easeInOutQuint;
+
+  .pb_dialog_scroll_region {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .pb_dialog_floating_root {
+    flex: 0 0 auto;
+    min-height: 0;
+    pointer-events: none;
+    position: relative;
+    z-index: 1;
+  }
+
+  .pb_dialog_floating_root > * {
+    pointer-events: auto;
+  }
 }
 
 // Left placement animations
@@ -583,5 +605,36 @@
     background-color: unset;
     border: none;
     cursor: pointer;
+  }
+
+  // Rails native dialog: scroll region + floating portal host for portaled form inputs
+  dialog.pb_dialog_rails:not([open]) {
+    display: none !important;
+  }
+
+  .pb_dialog_rails[open] {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .pb_dialog_scroll_region {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .pb_dialog_floating_root {
+    flex: 0 0 auto;
+    min-height: 0;
+    pointer-events: none;
+    position: relative;
+    z-index: 1;
+  }
+
+  .pb_dialog_floating_root > * {
+    pointer-events: auto;
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-handler-names */
 /* eslint-disable react/no-multi-comp */
 
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import classnames from "classnames";
 import Modal from "react-modal";
 
@@ -16,7 +16,7 @@ import DialogBody from "./child_kits/_dialog_body";
 import Flex from "../pb_flex/_flex";
 import IconCircle from "../pb_icon_circle/_icon_circle";
 import Title from "../pb_title/_title";
-import { DialogContext } from "./_dialog_context";
+import { DialogContext, DialogContextValue } from "./_dialog_context";
 
 type DialogProps = {
   aria?: { [key: string]: string };
@@ -101,12 +101,20 @@ const Dialog = (props: DialogProps): React.ReactElement => {
   const [triggerOpened, setTriggerOpened] = useState(false),
     modalIsOpened = trigger ? triggerOpened : opened;
 
-  const api = {
+  const [selectMenuPortalTarget, setSelectMenuPortalTarget] =
+    useState<HTMLElement | null>(null);
+
+  const floatingRootRefCallback = useCallback((node: HTMLElement | null) => {
+    setSelectMenuPortalTarget(node);
+  }, []);
+
+  const api: DialogContextValue = {
     onClose: trigger
       ? function () {
           setTriggerOpened(false);
         }
       : onClose,
+    selectMenuPortalTarget,
   };
 
   if (trigger) {
@@ -187,7 +195,7 @@ const Dialog = (props: DialogProps): React.ReactElement => {
             shouldCloseOnOverlayClick={shouldCloseOnOverlayClick && !loading}
             style={{ content: dynamicInlineProps }}
         >
-          <>
+          <div className="pb_dialog_scroll_region">
             {title && !status ? <Dialog.Header closeable={closeable}>{title}</Dialog.Header> : null}
             {!status && text ? <Dialog.Body>{text}</Dialog.Body> : null}
             {status && (
@@ -238,7 +246,13 @@ const Dialog = (props: DialogProps): React.ReactElement => {
               </Dialog.Footer>
             ) : null}
             {children}
-          </>
+          </div>
+          {/* No aria-hidden: portaled form inputs with dropdowns live here and must remain interactive. */}
+          <div
+              className="pb_dialog_floating_root"
+              data-pb-dialog-floating-root="true"
+              ref={floatingRootRefCallback}
+          />
         </Modal>
       </div>
     </DialogContext.Provider>

--- a/playbook/app/pb_kits/playbook/pb_dialog/_dialog_context.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/_dialog_context.tsx
@@ -1,3 +1,9 @@
-import React from 'react'
+import React from "react"
 
-export const DialogContext = React.createContext(null)
+export type DialogContextValue = {
+  onClose?: () => void
+  // Mount point for form inputs with dropdowns so they escape dialog scroll/overflow.
+  selectMenuPortalTarget?: HTMLElement | null
+}
+
+export const DialogContext = React.createContext<DialogContextValue | null>(null)

--- a/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_header.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/child_kits/_dialog_header.tsx
@@ -56,7 +56,7 @@ const DialogHeader = (props: DialogHeaderProps): React.ReactElement => {
         {children}
         {closeable &&
           <CloseIcon
-              onClose={api.onClose}
+              onClose={api?.onClose}
           />
         }
         

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.html.erb
@@ -13,6 +13,7 @@
     <% end %>
 >
     <%= pb_content_tag(:dialog, role: "dialog", "aria-modal": "true", "aria-label": "Dialog") do %>
+            <div class="pb_dialog_scroll_region">
             <% if object.status === "" && object.title %>
                 <%= pb_rails("dialog/dialog_header", props: { title: object.title, id: object.id, closeable: object.closeable }) %>
             <% end %>
@@ -44,5 +45,8 @@
             <% end %>
 
             <%= content %>
+            </div>
+            <%# No aria-hidden: portaled form inputs with dropdowns live here and must remain interactive. %>
+            <div class="pb_dialog_floating_root" data-pb-dialog-floating-root="true"></div>
     <% end %>
 </div>

--- a/playbook/app/pb_kits/playbook/pb_dialog/dialog.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dialog/dialog.test.jsx
@@ -1,6 +1,10 @@
 import React, {useState} from 'react'
 import { render, cleanup, waitFor, fireEvent, screen } from "../utilities/test-utils";
 import { Dialog, Button } from 'playbook-ui'
+import {
+  resolveDialogFloatingPortalHost,
+  resolveTypeaheadMenuPortalHost,
+} from "../utilities/floatingPortalHosts"
 
 const text="Hello Body Text, Nice to meet ya."
 const title="Header Title is the Title Prop"
@@ -43,6 +47,23 @@ test('renders the component when clicked', async () => {
   fireEvent.click(queryByText('Open Dialog'));
 
   await waitFor(() => expect(queryByText("Header Title is the Title Prop")).toBeInTheDocument());
+
+  cleanup()
+})
+
+test('renders scroll region and floating root for portaled inputs (Typeahead, etc.)', async () => {
+  const { queryByText } = render(<DialogTest />)
+
+  fireEvent.click(queryByText('Open Dialog'))
+
+  await waitFor(() =>
+    expect(queryByText("Header Title is the Title Prop")).toBeInTheDocument(),
+  )
+
+  expect(document.querySelector('.pb_dialog_scroll_region')).toBeInTheDocument()
+  expect(
+    document.querySelector('[data-pb-dialog-floating-root="true"]'),
+  ).toBeInTheDocument()
 
   cleanup()
 })
@@ -142,4 +163,73 @@ test('renders dialog without close button when closeable is false', async () => 
   expect(closeBtn).not.toBeInTheDocument();
 
   cleanup()
+})
+
+describe('Dialog floating portal host (Typeahead)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('resolveDialogFloatingPortalHost returns null outside dialog, modal, or popover', () => {
+    const div = document.createElement('div')
+    document.body.appendChild(div)
+    expect(resolveDialogFloatingPortalHost(div)).toBeNull()
+  })
+
+  test('resolveDialogFloatingPortalHost returns floating root inside native dialog', () => {
+    const dialog = document.createElement('dialog')
+    const scroll = document.createElement('div')
+    scroll.className = 'pb_dialog_scroll_region'
+    const floating = document.createElement('div')
+    floating.setAttribute('data-pb-dialog-floating-root', 'true')
+    const inner = document.createElement('div')
+    dialog.appendChild(scroll)
+    dialog.appendChild(floating)
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+
+    expect(resolveDialogFloatingPortalHost(inner)).toBe(floating)
+  })
+
+  test('resolveDialogFloatingPortalHost falls back to dialog when floating root missing', () => {
+    const dialog = document.createElement('dialog')
+    const inner = document.createElement('div')
+    dialog.appendChild(inner)
+    document.body.appendChild(dialog)
+
+    expect(resolveDialogFloatingPortalHost(inner)).toBe(dialog)
+  })
+
+  test('resolveDialogFloatingPortalHost returns floating root inside .pb_dialog', () => {
+    const shell = document.createElement('div')
+    shell.className = 'pb_dialog'
+    const floating = document.createElement('div')
+    floating.setAttribute('data-pb-dialog-floating-root', 'true')
+    const inner = document.createElement('div')
+    shell.appendChild(floating)
+    shell.appendChild(inner)
+    document.body.appendChild(shell)
+
+    expect(resolveDialogFloatingPortalHost(inner)).toBe(floating)
+  })
+
+  test('resolveTypeaheadMenuPortalHost uses dialog floating root when inside dialog', () => {
+    const dialog = document.createElement('dialog')
+    const floating = document.createElement('div')
+    floating.setAttribute('data-pb-dialog-floating-root', 'true')
+    const kit = document.createElement('div')
+    dialog.appendChild(floating)
+    dialog.appendChild(kit)
+    document.body.appendChild(dialog)
+
+    expect(resolveTypeaheadMenuPortalHost(kit, null)).toBe(floating)
+  })
+
+  test('resolveTypeaheadMenuPortalHost uses context target when host not in tree', () => {
+    const host = document.createElement('div')
+    const kit = document.createElement('div')
+    document.body.appendChild(kit)
+
+    expect(resolveTypeaheadMenuPortalHost(kit, host)).toBe(host)
+  })
 })

--- a/playbook/app/pb_kits/playbook/pb_popover/_popover.scss
+++ b/playbook/app/pb_kits/playbook/pb_popover/_popover.scss
@@ -47,7 +47,31 @@
   background-color: $white;
   border: 0;
   box-shadow: $shadow_deeper;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: inherit;
 }
+
+.pb_popover_scroll_region {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.pb_popover_floating_root {
+  flex: 0 0 auto;
+  min-height: 0;
+  pointer-events: none;
+  position: relative;
+  z-index: 1;
+}
+
+.pb_popover_floating_root > * {
+  pointer-events: auto;
+}
+
 .overflow_handling {
   overflow: auto;
 }

--- a/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/_popover.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import {
   Popper,
@@ -20,6 +20,8 @@ import {
 import classnames from "classnames";
 import { globalProps, GlobalProps } from "../utilities/globalProps";
 import { uniqueId } from '../utilities/object';
+import { DialogContext, DialogContextValue } from "../pb_dialog/_dialog_context";
+import { targetIsInsidePortaledFloatingKit } from "../utilities/floatingPortalHosts";
 
 type ModifiedGlobalProps = Omit<GlobalProps, 'minWidth' | 'maxHeight' | 'minHeight'>
 
@@ -112,6 +114,17 @@ const Popover = (props: PbPopoverProps) => {
       : filteredGlobalProps
   const overflowHandling = maxHeight || maxWidth ? "overflow_handling" : "";
   const zIndexStyle = zIndex ? { zIndex: zIndex } : {};
+
+  const [selectMenuPortalTarget, setSelectMenuPortalTarget] =
+    useState<HTMLElement | null>(null);
+  const floatingRootRef = useCallback((node: HTMLElement | null) => {
+    setSelectMenuPortalTarget(node);
+  }, []);
+
+  const menuPortalApi: DialogContextValue = useMemo(
+    () => ({ selectMenuPortalTarget }),
+    [selectMenuPortalTarget],
+  );
   const widthHeightStyles = () => {
     return Object.assign(
       {},
@@ -152,17 +165,28 @@ const Popover = (props: PbPopoverProps) => {
             <div
                 className={classnames(`${buildCss("pb_popover_tooltip")} show`)}
             >
-              <div
-                  className={classnames(
-                    "pb_popover_body",
-                    popoverSpacing,
-                    overflowHandling
-                  )}
-                  id={targetId}
-                  style={widthHeightStyles()}
-              >
-                {children}
-              </div>
+            <div
+                className={classnames("pb_popover_body", popoverSpacing)}
+                id={targetId}
+                style={widthHeightStyles()}
+            >
+              <DialogContext.Provider value={menuPortalApi}>
+                <div
+                    className={classnames(
+                      "pb_popover_scroll_region",
+                      overflowHandling,
+                    )}
+                >
+                  {children}
+                </div>
+                <div
+                    aria-hidden="true"
+                    className="pb_popover_floating_root"
+                    data-pb-dialog-floating-root="true"
+                    ref={floatingRootRef}
+                />
+              </DialogContext.Provider>
+            </div>
             </div>
           </div>
         );
@@ -214,7 +238,8 @@ const PbReactPopover = (props: PbPopoverProps): React.ReactElement => {
       const target = e.target as HTMLElement
 
       const targetIsPopover =
-        target.closest("#" + targetId) !== null;
+        target.closest("#" + targetId) !== null ||
+        targetIsInsidePortaledFloatingKit(target);
       const targetIsReference =
         target.closest("#reference-" + targetId) !== null;
 
@@ -227,9 +252,11 @@ const PbReactPopover = (props: PbPopoverProps): React.ReactElement => {
           if (!targetIsPopover && !targetIsReference) shouldClose();
           break;
         case "inside":
+          if (targetIsInsidePortaledFloatingKit(target)) return
           if (targetIsPopover) shouldClose();
           break;
         case "any":
+          if (targetIsInsidePortaledFloatingKit(target)) return
           if (targetIsPopover || !targetIsPopover && !targetIsReference) shouldClose();
           break;
       }
@@ -287,7 +314,7 @@ const PbReactPopover = (props: PbPopoverProps): React.ReactElement => {
                 )}
             </>
           ) : (
-            { popoverComponent }
+            popoverComponent
           ))}
       </>
     </PopperManager>

--- a/playbook/app/pb_kits/playbook/pb_popover/index.ts
+++ b/playbook/app/pb_kits/playbook/pb_popover/index.ts
@@ -1,5 +1,6 @@
 import PbEnhancedElement from '../pb_enhanced_element'
 import { createPopper, Instance, Placement } from '@popperjs/core'
+import { targetIsInsidePortaledFloatingKit } from '../utilities/floatingPortalHosts'
 
 const POPOVER_OFFSET_Y = [0, 20]
 
@@ -61,17 +62,20 @@ export default class PbPopover extends PbEnhancedElement {
 
   checkCloseTooltip() {
     document.querySelector('body').addEventListener('click', ({ target } ) => {
-      const isTooltipElement = (target as HTMLElement).closest(`#${this.tooltipId}`) !== null
-      const isTriggerElement = (target as HTMLElement).closest(`#${this.triggerElementId}`) !== null
+      const t = target as HTMLElement
+      const isTooltipElement = t.closest(`#${this.tooltipId}`) !== null
+      const isTriggerElement = t.closest(`#${this.triggerElementId}`) !== null
+      const isPortaledKit = targetIsInsidePortaledFloatingKit(t)
 
       switch (this.closeOnClick) {
       case 'any':
+        if (isPortaledKit) return
         if (isTooltipElement || !isTooltipElement && !isTriggerElement) {
           this.hideTooltip()
         }
         break
       case 'outside':
-        if (!isTooltipElement && !isTriggerElement) {
+        if (!isTooltipElement && !isTriggerElement && !isPortaledKit) {
           this.hideTooltip()
         }
         break

--- a/playbook/app/pb_kits/playbook/pb_popover/popover.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_popover/popover.html.erb
@@ -1,7 +1,10 @@
 <%= pb_content_tag do %>
   <div class="pb_popover_tooltip hide" id="<%= object.tooltip_id %>" role="tooltip" style="<%= object.z_index_helper %>">
     <div class="pb_popover_body <%= object.width_height_class_helper %> <%= object.popover_spacing_helper %>" style="<%= object.width_height_helper %>">
-      <%= content.presence %>
+      <div class="pb_popover_scroll_region">
+        <%= content.presence %>
+      </div>
+      <div class="pb_popover_floating_root" data-pb-dialog-floating-root="true" aria-hidden="true"></div>
     </div>
   </div>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_popover/popover.test.js
+++ b/playbook/app/pb_kits/playbook/pb_popover/popover.test.js
@@ -1,6 +1,11 @@
 import React from "react";
 import { render, screen, fireEvent } from "../utilities/test-utils";
 import { Button, PbReactPopover } from "playbook-ui";
+import {
+  resolveDialogFloatingPortalHost,
+  resolveTypeaheadMenuPortalHost,
+  targetIsInsidePortaledFloatingKit,
+} from "../utilities/floatingPortalHosts";
 
 const testId = "popover-kit";
 
@@ -228,16 +233,23 @@ const PopoverTestAppendToSelector = () => {
     render(<PopoverTestZIndex data={{ testid: testId}}/>)
     const btn = screen.getByText(/click me/i)
     fireEvent.click(btn);
-    const kit = screen.getByText("Click Anywhere");
-    expect(kit).toHaveClass("pb_popover_body z_index_3");
+    const label = screen.getByText("Click Anywhere");
+    const kit = label.closest(".pb_popover_body");
+    expect(kit).not.toBeNull();
+    expect(kit).toHaveClass("pb_popover_body", "z_index_3");
   });
 
   test("renders Popover with max height and max width", () => {
     render(<PopoverTestHeight data={{ testid: testId}}/>)
     const btn = screen.getByText(/click me/i)
     fireEvent.click(btn);
-    const kit = screen.getByText("Click Anywhere");
-    expect(kit).toHaveClass("pb_popover_body p_sm overflow_handling");
+    const label = screen.getByText("Click Anywhere");
+    const body = label.closest(".pb_popover_body");
+    const scrollRegion = label.closest(".pb_popover_scroll_region");
+    expect(body).not.toBeNull();
+    expect(body).toHaveClass("pb_popover_body", "p_sm");
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion).toHaveClass("pb_popover_scroll_region", "overflow_handling");
   });
 
   test("closes Popover on click anywhere", async () => {
@@ -298,3 +310,45 @@ const PopoverTestAppendToSelector = () => {
     const customContainer = screen.getByTestId("custom-container");
     expect(customContainer).toContainElement(kit);
   });
+
+describe("Popover Typeahead portal host", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("resolveDialogFloatingPortalHost returns floating root inside popover tooltip", () => {
+    const pop = document.createElement("div");
+    pop.className = "pb_popover_tooltip";
+    const floating = document.createElement("div");
+    floating.setAttribute("data-pb-dialog-floating-root", "true");
+    const inner = document.createElement("div");
+    pop.appendChild(floating);
+    pop.appendChild(inner);
+    document.body.appendChild(pop);
+
+    expect(resolveDialogFloatingPortalHost(inner)).toBe(floating);
+  });
+
+  test("resolveTypeaheadMenuPortalHost uses document.body when kit is in popover tooltip", () => {
+    const pop = document.createElement("div");
+    pop.className = "pb_popover_tooltip show";
+    const kit = document.createElement("div");
+    pop.appendChild(kit);
+    document.body.appendChild(pop);
+
+    expect(resolveTypeaheadMenuPortalHost(kit, null)).toBe(document.body);
+  });
+
+  test("targetIsInsidePortaledFloatingKit is true inside typeahead menu portal", () => {
+    const portal = document.createElement("div");
+    portal.className = "typeahead-kit-select__menu-portal";
+    const option = document.createElement("div");
+    portal.appendChild(option);
+    document.body.appendChild(portal);
+
+    expect(targetIsInsidePortaledFloatingKit(option)).toBe(true);
+    expect(targetIsInsidePortaledFloatingKit(document.createElement("button"))).toBe(
+      false,
+    );
+  });
+});

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -1,5 +1,5 @@
-import React, {useState, useEffect, forwardRef, useRef} from "react"
-import Select from "react-select"
+import React, {useState, useEffect, useLayoutEffect, useMemo, forwardRef, useRef, useContext} from "react"
+import Select, {mergeStyles} from "react-select"
 import AsyncSelect from "react-select/async"
 import CreateableSelect from "react-select/creatable"
 import AsyncCreateableSelect from "react-select/async-creatable"
@@ -22,7 +22,26 @@ import {
 import * as kitComponents from "./components"
 
 import {noop, buildDataProps, buildHtmlProps} from "../utilities/props"
+import {
+  PB_FLOATING_UI_Z_INDEX,
+  resolveTypeaheadMenuPortalHost,
+} from "../utilities/floatingPortalHosts"
+import {DialogContext} from "../pb_dialog/_dialog_context"
 import {GenericObject, Noop} from "../types"
+
+type TypeaheadStylesConfig = Parameters<typeof mergeStyles>[0]
+
+// Stack above filter popover ($z_9) when menu is portaled to `document.body`.
+const typeaheadBodyPortalZIndexStyles = {
+  menuPortal: (base: Record<string, unknown>) => ({
+    ...base,
+    zIndex: Number(PB_FLOATING_UI_Z_INDEX),
+  }),
+  menu: (base: Record<string, unknown>) => ({
+    ...base,
+    zIndex: Number(PB_FLOATING_UI_Z_INDEX),
+  }),
+} as TypeaheadStylesConfig
 
 /**
  * @typedef {object} Props
@@ -82,6 +101,8 @@ type TypeaheadProps = {
   searchContextSelector?: string
   clearOnContextChange?: boolean
   preserveSearchInput?: boolean
+  // Passed through to react-select; merged when menu is portaled to `document.body`.
+  styles?: TypeaheadStylesConfig
 } & GlobalProps
 
 export type SelectValueType = {
@@ -129,6 +150,7 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(
     validation,
     clearOnContextChange = false,
     preserveSearchInput = false, // Default to false to maintain backward compatibility
+    styles: stylesProp,
     ...props
   }: TypeaheadProps) => {
     // State to manage the input value when preserveSearchInput is true
@@ -196,6 +218,28 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(
 
     // Create a ref to access React Select instance
     const selectRef = useRef<any>(null)
+
+    const dialogCtx = useContext(DialogContext)
+
+    const kitContainerRef = useRef<HTMLDivElement>(null)
+    const [menuPortalHost, setMenuPortalHost] = useState<HTMLElement | null>(
+      null,
+    )
+
+    useLayoutEffect(() => {
+      const el = kitContainerRef.current
+      setMenuPortalHost(
+        resolveTypeaheadMenuPortalHost(
+          el,
+          dialogCtx?.selectMenuPortalTarget ?? null,
+        ),
+      )
+    }, [dialogCtx?.selectMenuPortalTarget])
+
+    const mergedSelectStyles = useMemo(() => {
+      if (menuPortalHost !== document.body) return stylesProp
+      return mergeStyles(stylesProp ?? {}, typeaheadBodyPortalZIndexStyles)
+    }, [menuPortalHost, stylesProp])
 
     // Helper function to flatten grouped options if custom groups are used
     const flattenOptions = (options: any[]): any[] => {
@@ -403,6 +447,13 @@ const resolvedLoadOptions =
       required,
       requiredIndicator: requiredIndicator,
       ...props,
+      ...(menuPortalHost
+        ? {
+            menuPortalTarget: menuPortalHost,
+            menuPosition: "fixed" as const,
+          }
+        : {}),
+      styles: mergedSelectStyles,
     }
 
     const [contextValue, setContextValue] = useState("")
@@ -579,6 +630,7 @@ const resolvedLoadOptions =
 
     return (
     <div
+        ref={kitContainerRef}
         {...dataProps}
         {...htmlProps}
         aria-busy={asyncLoading ? "true" : "false"}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
@@ -180,6 +180,12 @@
       ],
       "default": false
     },
+    "styles": {
+      "type": "TypeaheadStylesConfig",
+      "platforms": [
+        "react"
+      ]
+    },
     "defaultOptions": {
       "platforms": [
         "rails"

--- a/playbook/app/pb_kits/playbook/utilities/floatingPortalHosts.ts
+++ b/playbook/app/pb_kits/playbook/utilities/floatingPortalHosts.ts
@@ -1,0 +1,71 @@
+/**
+ * Portal host resolution for Typeahead (react-select) when menus render outside
+ * overflow/scroll regions (e.g. inside Dialog or Filter Popover).
+ *
+ * This module will be extended when wiring Dropdown, DatePicker, MultiLevelSelect, and TimePicker
+ */
+
+/** Prefer mounting here (sibling to scroll region) so menus are not clipped. */
+export const PB_DIALOG_FLOATING_ROOT_SELECTOR = "[data-pb-dialog-floating-root]"
+
+export function resolveDialogFloatingPortalHost(
+  fromElement: Element | null | undefined,
+): HTMLElement | null {
+  const dialogEl = fromElement?.closest("dialog")
+  if (dialogEl) {
+    return (
+      dialogEl.querySelector<HTMLElement>(PB_DIALOG_FLOATING_ROOT_SELECTOR) ??
+      dialogEl
+    )
+  }
+  // react-modal (Playbook React Dialog) uses a div.pb_dialog, not a native <dialog> element.
+  const reactModalShell = fromElement?.closest(".pb_dialog")
+  if (reactModalShell) {
+    return (
+      reactModalShell.querySelector<HTMLElement>(PB_DIALOG_FLOATING_ROOT_SELECTOR) ??
+      (reactModalShell as HTMLElement)
+    )
+  }
+  const popoverEl = fromElement?.closest(".pb_popover_tooltip")
+  if (popoverEl) {
+    return (
+      popoverEl.querySelector<HTMLElement>(PB_DIALOG_FLOATING_ROOT_SELECTOR) ??
+      (popoverEl as HTMLElement)
+    )
+  }
+  return null
+}
+
+/**
+ * Host for react-select (Typeahead) `menuPortalTarget`.
+ *
+ * Popper applies `transform` to the popover root. A `position: fixed` menu that is portaled
+ * *inside* that subtree is positioned against the transformed ancestor, not the viewport, so
+ * react-select's menu coordinates (from the control's getBoundingClientRect) no longer match
+ * — the menu appears shifted (often to the bottom/right of the popover).
+ *
+ * For kits inside `.pb_popover_tooltip`, portal menus to `document.body` so fixed positioning
+ * matches viewport math. Native `<dialog>` / React Modal still use the floating root or context.
+ */
+export function resolveTypeaheadMenuPortalHost(
+  kitRoot: HTMLElement | null | undefined,
+  dialogCtxTarget: HTMLElement | null | undefined,
+): HTMLElement | null {
+  if (typeof document === "undefined") return null
+
+  if (kitRoot?.closest(".pb_popover_tooltip")) {
+    return document.body
+  }
+
+  return (
+    resolveDialogFloatingPortalHost(kitRoot) ?? dialogCtxTarget ?? null
+  )
+}
+
+/** Above popover ($z_9), dialogs ($z_10), below $z_max. */
+export const PB_FLOATING_UI_Z_INDEX = "100100"
+
+/** Kits that portal menus to `document.body` still belong to the open popover for close-on-click. */
+export function targetIsInsidePortaledFloatingKit(target: HTMLElement): boolean {
+  return target.closest(".typeahead-kit-select__menu-portal") !== null
+}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2929](https://runway.powerhrg.com/backlog_items/PLAY-2929?from=active_sprint) begins Dialog + Filter Popover portaling work by making the initial code changes for these kits + wiring up the Typeahead. Implementing previous work from [PLAY-2890](https://gist.github.com/ElisaShapiro/b0e8f05d5a28e22ee47fcadfa4b4b184) and [PLAY-2866](https://gist.github.com/ElisaShapiro/433a7547ccec3d4deb4afb3df77936af). Will go through extensive alpha testing. [CSB with alpha](https://codesandbox.io/p/devbox/hidden-framework-ks8j3p?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5).

**Screenshots:** Screenshots to visualize your addition/change
<img width="982" height="618" alt="dialog plus typeahead" src="https://github.com/user-attachments/assets/a847e60b-d8fa-4907-9ef4-5bd4b4bbe250" />
<img width="446" height="318" alt="filter popover plus typeahead" src="https://github.com/user-attachments/assets/2eb27812-d580-429a-be84-bea1cf280587" />
<img width="427" height="307" alt="filter popover with max height plus typehead" src="https://github.com/user-attachments/assets/a41a0f01-0487-41c5-a8fe-3732e460ea04" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Typeahead, Dialog, Popover kit pages - each kit/doc examples should fundamentally work as they currently do.
2. Check out this functionality in a [CSB with alpha here](https://codesandbox.io/p/devbox/hidden-framework-ks8j3p?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5)


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.