### PR TITLE
[PLAY-2932] DatePicker Inline Prop Works By Itself

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -180,6 +180,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     //@ts-ignore
     globalProps(filteredProps),
     error ? 'error' : null,
+    inLine && 'inline-date-picker',
     className
   )
 
@@ -262,7 +263,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
               }
             </div>
 
-            {!hideIcon &&
+            {!hideIcon && !inLine &&
               <div
                   className={iconWrapperClass()}
                   id={`cal-icon-${pickerId}`}
@@ -274,7 +275,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
               </div>
             }
 
-            {hideIcon && inLine ?
+            {inLine ?
               <div>
                 <div
                     className={`${iconWrapperClass()} date-picker-inline-icon-plus`}

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -39,7 +39,7 @@
       <input type="hidden" id="<%= "#{object.end_date_id}" %>" name="<%= "#{object.end_date_name}" %>">
     <% end %>
 
-    <% if !object.hide_icon %>
+    <% if !object.hide_icon && !object.inline %>
       <div
           class="<%= object.icon_wrapper_class %>"
           id="cal-icon-<%= object.picker_id %>"
@@ -52,7 +52,7 @@
     <% end %>
 
     <!-- Inline -->
-    <% if object.hide_icon && object.inline %>
+    <% if object.inline %>
       <!-- Plus Icon -->
       <div
           class="<%= object.icon_wrapper_class %> date-picker-inline-icon-plus"

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
@@ -92,7 +92,8 @@ module Playbook
 
       def classname
         default_margin_bottom = margin_bottom.present? ? "" : " mb_sm"
-        generate_classname("pb_date_picker_kit") + default_margin_bottom
+        inline_class = inline ? " inline-date-picker" : ""
+        generate_classname("pb_date_picker_kit") + default_margin_bottom + inline_class
       end
 
       def date_picker_config

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -40,6 +40,37 @@ describe('DatePicker Kit', () => {
     expect(kit).toHaveClass('pb_date_picker_kit mb_sm')
   })
 
+  test('inLine alone adds inline-date-picker class and inline control icons, not the calendar icon', () => {
+    const testId = 'datepicker-inline-only'
+    render(
+      <DatePicker
+          data={{ testid: testId }}
+          inLine
+          pickerId="date-picker-inline-only"
+      />
+    )
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveClass('inline-date-picker')
+    expect(kit.querySelector('#cal-icon-date-picker-inline-only')).not.toBeInTheDocument()
+    expect(kit.querySelector('#date-picker-inline-only-icon-plus')).toBeInTheDocument()
+    expect(kit.querySelector('#date-picker-inline-only-angle-down')).toBeInTheDocument()
+  })
+
+  test('hideIcon without inLine does not render inline control icons', () => {
+    const testId = 'datepicker-hide-icon-only'
+    render(
+      <DatePicker
+          data={{ testid: testId }}
+          hideIcon
+          pickerId="date-picker-hide-icon-only"
+      />
+    )
+
+    const kit = screen.getByTestId(testId)
+    expect(kit.querySelector('#date-picker-hide-icon-only-icon-plus')).not.toBeInTheDocument()
+  })
+
   test('shows DatePicker date format m/d/Y', async () => {
     const testId = 'datepicker-date'
     render(

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_inline.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_inline.html.erb
@@ -1,6 +1,4 @@
 <%= pb_rails("date_picker", props: {
-  classname: "inline-date-picker",
-  hide_icon: true,
   inline: true,
   picker_id: "date-picker-inline"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_inline.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_inline.jsx
@@ -6,8 +6,6 @@ const DatePickerInline = (props) => {
   return (
     <div>
       <DatePicker
-          className="inline-date-picker"
-          hideIcon
           inLine
           pickerId="date-picker-inline"
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_playground.json
@@ -113,9 +113,7 @@
         "name": "inline_date",
         "pickerId": "playground-date-inline",
         "label": "Inline",
-        "className": "inline-date-picker",
-        "inLine": true,
-        "hideIcon": true
+        "inLine": true
       }
     },
     {

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_playground.overrides.json
@@ -88,9 +88,7 @@
         "name": "inline_date",
         "pickerId": "playground-date-inline",
         "label": "Inline",
-        "className": "inline-date-picker",
-        "inLine": true,
-        "hideIcon": true
+        "inLine": true
       }
     },
     {

--- a/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Playbook::PbDatePicker::DatePicker do
       expect(subject.new({ picker_id: "spec-test" }).classname).to eq "pb_date_picker_kit cursor_pointer mb_sm"
       expect(subject.new({ classname: "additional_class", picker_id: "spec-test" }).classname).to eq "pb_date_picker_kit additional_class cursor_pointer mb_sm"
       expect(subject.new({ classname: "dark", picker_id: "spec-test" }).classname).to eq "pb_date_picker_kit dark cursor_pointer mb_sm"
+      expect(subject.new({ picker_id: "spec-test", inline: true }).classname).to eq "pb_date_picker_kit cursor_pointer mb_sm inline-date-picker"
     end
   end
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2932](https://runway.powerhrg.com/backlog_items/PLAY-2932?from=active_sprint) fixes what appears to be two longstanding quirks with the inline DatePicker variant (React and Rails). Currently, an inline DatePicker must have `className="inline-date-picker"` directly applied in order to get all the [inline_styles.scss](https://github.com/powerhome/playbook/blob/master/playbook/app/pb_kits/playbook/pb_date_picker/sass_partials/_inline_styles.scss) and also must have the hideIcon boolean applied as well in order to hide the Calendar icon. This PR makes adding the required class a part of the classname generation when the boolean inLine prop is used AND allows inLine to hide the icon on its own (hideIcon still works on its own see hideIcon docs).

[CSB with alpha](https://codesandbox.io/p/sandbox/cocky-matsumoto-7zmhf8) showcasing different prop combos.

**Screenshots:** Screenshots to visualize your addition/change
Current Prod: screenshot of CSB showing finicky inLine prop and what happens with different prop permutations
<img width="1391" height="804" alt="CSB of current prod:permutations" src="https://github.com/user-attachments/assets/1db05cd9-d660-416c-8b3e-b6f1c3e69668" />
CSB with Alpha screenshot:
<img width="1448" height="798" alt="csb with alpha screenshot" src="https://github.com/user-attachments/assets/42a80ee4-afb5-4e34-a97d-808c076fee11" />

Review env Docs showing props and classnames:
<img width="1377" height="410" alt="rails doc ex" src="https://github.com/user-attachments/assets/12a1ce8b-1745-45c9-8584-65f3ea82768a" />
<img width="1311" height="618" alt="react doc ex" src="https://github.com/user-attachments/assets/c8a3c454-cd11-42be-b3aa-7c15dfe4eb04" />

**How to test?** Steps to confirm the desired behavior:
1. Go to DatePicker Inline doc example ([rails](https://pr6150.playbook.wc.beta.hq.powerapp.cloud/kits/date_picker#inline), [react](https://pr6150.playbook.wc.beta.hq.powerapp.cloud/kits/date_picker/react#inline)) and see an inLine Date Picker with only two props added. Inspect to see the `inline-date-picker` class applied. Scroll up to the hideIcon doc example to see that that prop still works on its own.
2. Go to the CSB with alpha and see a few more prop combos on inline DatePickers.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.