### PR TITLE
[PLAY-2963] Upgrades Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -28,6 +28,14 @@
     "category": "Alert"
   },
   {
+    "name": "square-bolt",
+    "category": "Alert"
+  },
+  {
+    "name": "star-half-stroke",
+    "category": "Alert"
+  },
+  {
     "name": "star",
     "category": "Alert"
   },
@@ -37,6 +45,10 @@
   },
   {
     "name": "bat",
+    "category": "Animals"
+  },
+  {
+    "name": "bee",
     "category": "Animals"
   },
   {
@@ -56,6 +68,10 @@
     "category": "Animals"
   },
   {
+    "name": "frog",
+    "category": "Animals"
+  },
+  {
     "name": "paw",
     "category": "Animals"
   },
@@ -69,6 +85,10 @@
   },
   {
     "name": "angle-double-right",
+    "category": "Arrows"
+  },
+  {
+    "name": "angle-double-up",
     "category": "Arrows"
   },
   {
@@ -101,6 +121,10 @@
   },
   {
     "name": "arrow-down-short-wide",
+    "category": "Arrows"
+  },
+  {
+    "name": "arrow-down-to-bracket",
     "category": "Arrows"
   },
   {
@@ -348,6 +372,10 @@
     "category": "Arrows"
   },
   {
+    "name": "redo-alt",
+    "category": "Arrows"
+  },
+  {
     "name": "redo",
     "category": "Arrows"
   },
@@ -400,6 +428,10 @@
     "category": "Arrows"
   },
   {
+    "name": "undo-alt",
+    "category": "Arrows"
+  },
+  {
     "name": "undo",
     "category": "Arrows"
   },
@@ -424,7 +456,15 @@
     "category": "Awards"
   },
   {
+    "name": "gift",
+    "category": "Awards"
+  },
+  {
     "name": "sparkles",
+    "category": "Awards"
+  },
+  {
+    "name": "stars",
     "category": "Awards"
   },
   {
@@ -448,6 +488,14 @@
     "category": "Buildings"
   },
   {
+    "name": "hotel",
+    "category": "Buildings"
+  },
+  {
+    "name": "house-chimney-crack",
+    "category": "Buildings"
+  },
+  {
     "name": "house-chimney",
     "category": "Buildings"
   },
@@ -468,7 +516,23 @@
     "category": "Buildings"
   },
   {
+    "name": "landmark",
+    "category": "Buildings"
+  },
+  {
+    "name": "store",
+    "category": "Buildings"
+  },
+  {
+    "name": "tent",
+    "category": "Buildings"
+  },
+  {
     "name": "university",
+    "category": "Buildings"
+  },
+  {
+    "name": "warehouse",
     "category": "Buildings"
   },
   {
@@ -477,6 +541,10 @@
   },
   {
     "name": "address-card",
+    "category": "Business"
+  },
+  {
+    "name": "archive",
     "category": "Business"
   },
   {
@@ -493,6 +561,10 @@
   },
   {
     "name": "circle-dollar",
+    "category": "Business"
+  },
+  {
+    "name": "clipboard-check",
     "category": "Business"
   },
   {
@@ -521,6 +593,10 @@
   },
   {
     "name": "inventory",
+    "category": "Business"
+  },
+  {
+    "name": "money-check",
     "category": "Business"
   },
   {
@@ -608,6 +684,10 @@
     "category": "Communication"
   },
   {
+    "name": "comment-slash",
+    "category": "Communication"
+  },
+  {
     "name": "comment",
     "category": "Communication"
   },
@@ -640,6 +720,10 @@
     "category": "Communication"
   },
   {
+    "name": "inbox-in",
+    "category": "Communication"
+  },
+  {
     "name": "inbox",
     "category": "Communication"
   },
@@ -649,6 +733,14 @@
   },
   {
     "name": "mobile",
+    "category": "Communication"
+  },
+  {
+    "name": "note-medical",
+    "category": "Communication"
+  },
+  {
+    "name": "note",
     "category": "Communication"
   },
   {
@@ -729,6 +821,10 @@
   },
   {
     "name": "cubes",
+    "category": "Data Visualization"
+  },
+  {
+    "name": "poll",
     "category": "Data Visualization"
   },
   {
@@ -824,6 +920,10 @@
     "category": "Files"
   },
   {
+    "name": "file-circle-xmark",
+    "category": "Files"
+  },
+  {
     "name": "file-code",
     "category": "Files"
   },
@@ -884,6 +984,10 @@
     "category": "Files"
   },
   {
+    "name": "file-slash",
+    "category": "Files"
+  },
+  {
     "name": "file-spreadsheet",
     "category": "Files"
   },
@@ -924,6 +1028,10 @@
     "category": "Files"
   },
   {
+    "name": "memo-circle-info",
+    "category": "Files"
+  },
+  {
     "name": "flag-checkered",
     "category": "Flags"
   },
@@ -936,6 +1044,10 @@
     "category": "Flags"
   },
   {
+    "name": "hand-heart",
+    "category": "Hands"
+  },
+  {
     "name": "hand-holding-usd",
     "category": "Hands"
   },
@@ -945,6 +1057,14 @@
   },
   {
     "name": "hands-holding-diamond",
+    "category": "Hands"
+  },
+  {
+    "name": "hands-usd",
+    "category": "Hands"
+  },
+  {
+    "name": "handshake-2",
     "category": "Hands"
   },
   {
@@ -1056,6 +1176,10 @@
     "category": "Interface Core"
   },
   {
+    "name": "circle-x",
+    "category": "Interface Core"
+  },
+  {
     "name": "circle-xmark",
     "category": "Interface Core"
   },
@@ -1108,11 +1232,23 @@
     "category": "Interface Core"
   },
   {
+    "name": "eject",
+    "category": "Interface Core"
+  },
+  {
     "name": "ellipsis-vertical",
     "category": "Interface Core"
   },
   {
     "name": "ellipsis",
+    "category": "Interface Core"
+  },
+  {
+    "name": "empty-set",
+    "category": "Interface Core"
+  },
+  {
+    "name": "equals",
     "category": "Interface Core"
   },
   {
@@ -1152,6 +1288,10 @@
     "category": "Interface Core"
   },
   {
+    "name": "hashtag",
+    "category": "Interface Core"
+  },
+  {
     "name": "icons",
     "category": "Interface Core"
   },
@@ -1181,6 +1321,10 @@
   },
   {
     "name": "minus",
+    "category": "Interface Core"
+  },
+  {
+    "name": "not-equal",
     "category": "Interface Core"
   },
   {
@@ -1224,7 +1368,15 @@
     "category": "Interface Core"
   },
   {
+    "name": "qrcode",
+    "category": "Interface Core"
+  },
+  {
     "name": "question",
+    "category": "Interface Core"
+  },
+  {
+    "name": "rectangle-history",
     "category": "Interface Core"
   },
   {
@@ -1233,10 +1385,6 @@
   },
   {
     "name": "rectangle-wide",
-    "category": "Interface Core"
-  },
-  {
-    "name": "refresh",
     "category": "Interface Core"
   },
   {
@@ -1320,11 +1468,23 @@
     "category": "Interface Core"
   },
   {
+    "name": "underline",
+    "category": "Interface Core"
+  },
+  {
     "name": "up-down-left-right",
     "category": "Interface Core"
   },
   {
     "name": "upload",
+    "category": "Interface Core"
+  },
+  {
+    "name": "x",
+    "category": "Interface Core"
+  },
+  {
+    "name": "xmark-to-slot",
     "category": "Interface Core"
   },
   {
@@ -1353,6 +1513,10 @@
   },
   {
     "name": "location-arrow",
+    "category": "Location"
+  },
+  {
+    "name": "location",
     "category": "Location"
   },
   {
@@ -1512,8 +1676,28 @@
     "category": "Media"
   },
   {
+    "name": "volume-slash",
+    "category": "Media"
+  },
+  {
     "name": "volume",
     "category": "Media"
+  },
+  {
+    "name": "leaf",
+    "category": "Nature"
+  },
+  {
+    "name": "lemon",
+    "category": "Nature"
+  },
+  {
+    "name": "tree-large",
+    "category": "Nature"
+  },
+  {
+    "name": "trees",
+    "category": "Nature"
   },
   {
     "name": "face-angry",
@@ -1552,7 +1736,11 @@
     "category": "People"
   },
   {
-    "name": "male",
+    "name": "house-person-return",
+    "category": "People"
+  },
+  {
+    "name": "people-arrows",
     "category": "People"
   },
   {
@@ -1576,6 +1764,10 @@
     "category": "People"
   },
   {
+    "name": "person-walking-dashed-line-arrow-right",
+    "category": "People"
+  },
+  {
     "name": "person",
     "category": "People"
   },
@@ -1589,6 +1781,10 @@
   },
   {
     "name": "smile",
+    "category": "People"
+  },
+  {
+    "name": "street-view",
     "category": "People"
   },
   {
@@ -1625,6 +1821,10 @@
   },
   {
     "name": "user-helmet-safety",
+    "category": "People"
+  },
+  {
+    "name": "user-magnifying-glass",
     "category": "People"
   },
   {
@@ -1772,6 +1972,10 @@
     "category": "Powergon"
   },
   {
+    "name": "balance-scale-right",
+    "category": "Sales"
+  },
+  {
     "name": "balance-scale",
     "category": "Sales"
   },
@@ -1852,6 +2056,10 @@
     "category": "Security"
   },
   {
+    "name": "camcorder",
+    "category": "Technology"
+  },
+  {
     "name": "code",
     "category": "Technology"
   },
@@ -1872,11 +2080,19 @@
     "category": "Technology"
   },
   {
+    "name": "keyboard",
+    "category": "Technology"
+  },
+  {
     "name": "laptop-code",
     "category": "Technology"
   },
   {
     "name": "laptop-mobile",
+    "category": "Technology"
+  },
+  {
+    "name": "laptop",
     "category": "Technology"
   },
   {
@@ -1908,11 +2124,23 @@
     "category": "Technology"
   },
   {
+    "name": "mouse",
+    "category": "Technology"
+  },
+  {
     "name": "robot",
     "category": "Technology"
   },
   {
     "name": "rss",
+    "category": "Technology"
+  },
+  {
+    "name": "scanner-image",
+    "category": "Technology"
+  },
+  {
+    "name": "scanner",
     "category": "Technology"
   },
   {
@@ -1924,7 +2152,19 @@
     "category": "Technology"
   },
   {
+    "name": "tablet-button",
+    "category": "Technology"
+  },
+  {
+    "name": "tablet",
+    "category": "Technology"
+  },
+  {
     "name": "tv",
+    "category": "Technology"
+  },
+  {
+    "name": "usb-drive",
     "category": "Technology"
   },
   {
@@ -2020,6 +2260,10 @@
     "category": "Time"
   },
   {
+    "name": "calendar-circle-user",
+    "category": "Time"
+  },
+  {
     "name": "calendar-day",
     "category": "Time"
   },
@@ -2028,7 +2272,15 @@
     "category": "Time"
   },
   {
+    "name": "calendar-pen",
+    "category": "Time"
+  },
+  {
     "name": "calendar-plus",
+    "category": "Time"
+  },
+  {
+    "name": "calendar-star",
     "category": "Time"
   },
   {
@@ -2044,6 +2296,10 @@
     "category": "Time"
   },
   {
+    "name": "clock-five",
+    "category": "Time"
+  },
+  {
     "name": "clock",
     "category": "Time"
   },
@@ -2053,6 +2309,14 @@
   },
   {
     "name": "hourglass-half",
+    "category": "Time"
+  },
+  {
+    "name": "hourglass-start",
+    "category": "Time"
+  },
+  {
+    "name": "hourglass",
     "category": "Time"
   },
   {
@@ -2084,6 +2348,10 @@
     "category": "Tools"
   },
   {
+    "name": "fork-knife",
+    "category": "Tools"
+  },
+  {
     "name": "hammer",
     "category": "Tools"
   },
@@ -2092,11 +2360,23 @@
     "category": "Tools"
   },
   {
+    "name": "paint-brush",
+    "category": "Tools"
+  },
+  {
+    "name": "pen-line",
+    "category": "Tools"
+  },
+  {
     "name": "pencil-paintbrush",
     "category": "Tools"
   },
   {
     "name": "ruler-triangle",
+    "category": "Tools"
+  },
+  {
+    "name": "toolbox",
     "category": "Tools"
   },
   {
@@ -2128,6 +2408,10 @@
     "category": "Vehicles"
   },
   {
+    "name": "gauge-high",
+    "category": "Vehicles"
+  },
+  {
     "name": "helicopter-symbol",
     "category": "Vehicles"
   },
@@ -2136,11 +2420,19 @@
     "category": "Vehicles"
   },
   {
+    "name": "plane-slash",
+    "category": "Vehicles"
+  },
+  {
     "name": "plane",
     "category": "Vehicles"
   },
   {
     "name": "rocket",
+    "category": "Vehicles"
+  },
+  {
+    "name": "shuttle-van",
     "category": "Vehicles"
   },
   {
@@ -2204,11 +2496,11 @@
     "category": "Weather"
   },
   {
-    "name": "gauge-high",
+    "name": "humidity",
     "category": "Weather"
   },
   {
-    "name": "humidity",
+    "name": "moon-stars",
     "category": "Weather"
   },
   {
@@ -2232,6 +2524,10 @@
     "category": "Weather"
   },
   {
+    "name": "sunrise",
+    "category": "Weather"
+  },
+  {
     "name": "thermometer-half",
     "category": "Weather"
   },
@@ -2245,14 +2541,6 @@
   },
   {
     "name": "tint",
-    "category": "Weather"
-  },
-  {
-    "name": "tree-large",
-    "category": "Weather"
-  },
-  {
-    "name": "trees",
     "category": "Weather"
   },
   {

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "6.2.1",
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "2.0.0",
-    "@powerhome/playbook-icons-react": "2.0.0",
+    "@powerhome/playbook-icons": "2.1.0",
+    "@powerhome/playbook-icons-react": "2.1.0",
     "@powerhome/power-fonts": "0.0.1",
     "anchor-js": "^5.0.0",
     "maplibre-gl": "^4.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3175,15 +3175,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@2.0.0":
-  version "2.0.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/2fb2aa4555375eb1add423460250dadd7c72f056#2fb2aa4555375eb1add423460250dadd7c72f056"
-  integrity sha512-r+yQGOOTOKS17feXd2pWgzkY36gz2pyCtZuHSyxnS7Buxkic+SfPtCsioXhkIJT0iVh9tRuye/H3nEhHuAYBPw==
+"@powerhome/playbook-icons-react@2.1.0":
+  version "2.1.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/4977fa273a6b6b882370a3c67c667b32b4d0e5ac#4977fa273a6b6b882370a3c67c667b32b4d0e5ac"
+  integrity sha512-O29A6HNzjg+MT+afZkOjQ40LDiJjMC4axwXNM5iivcwAOvnPa9cu4lzrGereEI8LigtTxSLqfzfKhkuYRcDzWQ==
 
-"@powerhome/playbook-icons@2.0.0":
-  version "2.0.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/7ac28d87a9da4f21abb9f609ed58fb71f30d4cef#7ac28d87a9da4f21abb9f609ed58fb71f30d4cef"
-  integrity sha512-SAxnAGZO81ffNbnlxr+zzN22ukog2TS9IJr07MRLYecUEvI/tzZewX4FF9rdQUKTPqI7/HgKkq48eM1glUAmbA==
+"@powerhome/playbook-icons@2.1.0":
+  version "2.1.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/f3cd9f00a21a910ad1850ae28ccaf941cc30ff4a#f3cd9f00a21a910ad1850ae28ccaf941cc30ff4a"
+  integrity sha512-2PLmXoGeRW+fgFIroUz31FUQTm4laPg1Si3YwjVd5PRFwhKGI5gy+wRVeH0adAcxwTT5xIQK1bAC6xGW9B+PYw==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2963](https://runway.powerhrg.com/backlog_items/PLAY-2963) adds 76 icons and 37 aliases to the playbook-icons repo as version 2.1.0. A few duplicate icons had one version removed and their alternative names turned into aliases of the primary, and the Nature category was added. https://github.com/powerhome/playbook-icons/pull/59

**Screenshots:** Screenshots to visualize your addition/change
<img width="514" height="180" alt="react" src="https://github.com/user-attachments/assets/4b7adb7f-e19d-4240-8acc-33150fdb3e66" />
<img width="988" height="911" alt="icon page" src="https://github.com/user-attachments/assets/c89d5957-a7e7-4ce9-bb80-f0992b863138" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /playbook_icons page - see new icons compared to prod, new Nature category, and the removal of duplicate icon entries (in prod compare "person" and "male", "sync" and "refresh").


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.