### PR TITLE
Revert "[PLAY-2868] Input Kits: Expose `data-default-value` for smart filter reset"

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -12,20 +12,6 @@ import Caption from '../pb_caption/_caption'
 import Body from '../pb_body/_body'
 import colors from "../tokens/exports/_colors.module.scss"
 
-function serializeDefaultDateForFilterReset(defaultDate: unknown): string | undefined {
-  if (defaultDate === '' || defaultDate == null) return undefined
-  if (Array.isArray(defaultDate)) {
-    const parts = defaultDate.map((d) => {
-      if (d == null || d === '') return ''
-      if (d instanceof Date) return d.toISOString()
-      return String(d)
-    }).filter(Boolean)
-    return parts.length ? parts.join(',') : undefined
-  }
-  if (defaultDate instanceof Date) return defaultDate.toISOString()
-  return String(defaultDate)
-}
-
 type DatePickerProps = {
   allowInput?: boolean,
   aria?: { [key: string]: string },
@@ -127,11 +113,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
   } = props
 
   const ariaProps = buildAriaProps(aria)
-  const filterResetDefaultSerialized = serializeDefaultDateForFilterReset(defaultDate)
-  const dataProps = buildDataProps({
-    ...data,
-    ...(filterResetDefaultSerialized ? { 'default-value': filterResetDefaultSerialized } : {}),
-  })
+  const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
   const inputAriaProps = buildAriaProps(inputAria)
   const inputDataProps = buildDataProps(inputData)

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -1,11 +1,8 @@
-<% date_picker_root_attrs = {
-  class: object.classname + object.error_class,
-  'data-pb-date-picker' => true,
-  'data-validation-message' => object.validation_message,
-}
-  date_picker_root_attrs['data-default-value'] = object.serialized_default_date_for_dom if object.serialized_default_date_for_dom.present?
-%>
-<%= pb_content_tag(:div, date_picker_root_attrs) do %>
+<%= pb_content_tag(:div,
+    class: object.classname + object.error_class,
+    'data-pb-date-picker' => true,
+    'data-validation-message' => object.validation_message,
+      ) do %>
   <div class="input_wrapper">
     <% if !object.hide_label && object.label %>
       <label for="<%= object.picker_id %>">

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
@@ -145,18 +145,6 @@ module Playbook
       def angle_down_path
         "app/pb_kits/playbook/utilities/icons/angle-down.svg"
       end
-
-      # Serialized business default for opt-in smart filter reset (Nitro / data-default-value).
-      def serialized_default_date_for_dom
-        case default_date
-        when nil, ""
-          nil
-        when Array
-          default_date.compact_blank.map(&:to_s).join(",")
-        else
-          default_date.to_s.presence
-        end
-      end
     end
   end
 end

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -40,32 +40,6 @@ describe('DatePicker Kit', () => {
     expect(kit).toHaveClass('pb_date_picker_kit mb_sm')
   })
 
-  test('exposes data-default-value on kit root when defaultDate is set', () => {
-    const testId = 'datepicker-def-attr'
-    render(
-      <DatePicker
-          data={{ testid: testId }}
-          defaultDate={DEFAULT_DATE}
-          pickerId="date-picker-def-attr"
-      />
-    )
-    const kit = screen.getByTestId(testId)
-    expect(kit).toHaveAttribute('data-default-value', DEFAULT_DATE.toISOString())
-  })
-
-  test('omits data-default-value when defaultDate is empty', () => {
-    const testId = 'datepicker-no-def-attr'
-    render(
-      <DatePicker
-          data={{ testid: testId }}
-          defaultDate=""
-          pickerId="date-picker-no-def-attr"
-      />
-    )
-    const kit = screen.getByTestId(testId)
-    expect(kit).not.toHaveAttribute('data-default-value')
-  })
-
   test('inLine alone adds inline-date-picker class and inline control icons, not the calendar icon', () => {
     const testId = 'datepicker-inline-only'
     render(

--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
@@ -21,58 +21,6 @@ import {
     handleClickOutside,
 } from "./utilities";
 
-function serializeDropdownFilterResetDefault(
-    variant: "default" | "subtle" | "quickpick" | undefined,
-    multiSelect: boolean,
-    defaultValue: GenericObject | GenericObject[] | string | undefined,
-    dropdownOptions: GenericObject[] | GenericObject | undefined,
-): string | undefined {
-    const optionList: GenericObject[] = Array.isArray(dropdownOptions)
-        ? dropdownOptions
-        : [];
-    const optionDefaultId = (option: GenericObject | undefined): string | undefined => {
-        if (!option) return undefined;
-
-        const id = option.id;
-        if (id != null && id !== "") return String(id);
-
-        const matched = optionList.find((listOption: GenericObject) => (
-            (option.value != null && listOption.value === option.value) ||
-            (option.label != null && listOption.label === option.label)
-        ));
-
-        if (matched?.id != null && matched.id !== "") return String(matched.id);
-        return undefined;
-    };
-
-    if (variant === "quickpick") {
-        if (typeof defaultValue === "string" && defaultValue) {
-            const matched = optionList.find(
-                (opt: GenericObject) => opt.label?.toLowerCase() === defaultValue.toLowerCase()
-            );
-            if (matched?.id != null && matched.id !== "") return String(matched.id);
-        }
-        return undefined;
-    }
-    if (multiSelect) {
-        const arr = Array.isArray(defaultValue)
-            ? defaultValue
-            : defaultValue && typeof defaultValue === "object" && Object.keys(defaultValue).length
-                ? [defaultValue as GenericObject]
-                : [];
-        if (!arr.length) return undefined;
-        const ids = arr
-            .map((v) => optionDefaultId(v as GenericObject))
-            .filter((id) => id != null && id !== "");
-        return ids.length ? ids.join(",") : undefined;
-    }
-    if (defaultValue && typeof defaultValue === "object" && !Array.isArray(defaultValue)) {
-        const id = optionDefaultId(defaultValue as GenericObject);
-        if (id) return id;
-    }
-    return undefined;
-}
-
 type CustomQuickPickDate = {
     label: string;
     value: string[] | { timePeriod: string; amount: number };
@@ -207,11 +155,6 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
 
     const [selected, setSelected] = useState<GenericObject | GenericObject[]>(
       initialSelected
-    );
-
-    const filterResetDefaultSerialized = useMemo(
-        () => serializeDropdownFilterResetDefault(variant, multiSelect, defaultValue, dropdownOptions),
-        [variant, multiSelect, defaultValue, dropdownOptions]
     );
 
     const [isInputFocused, setIsInputFocused] = useState(false);
@@ -489,7 +432,6 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
         <div {...ariaProps}
             {...dataProps}
             {...htmlProps}
-            {...(filterResetDefaultSerialized ? { "data-default-value": filterResetDefaultSerialized } : {})}
             className={classes}
             id={id}
             ref={outerDivRef}

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
@@ -12,9 +12,7 @@
     <% end %>
     <div class="dropdown_wrapper<%= error_class %>" style="position: relative">
         <input
-            <% if input_default_value.present? %>
             data-default-value="<%= input_default_value %>"
-            <% end %>
             data-dropdown-selected-option
             name="<%= object.name %><%= '[]' if object.multi_select %>"
             style="display: none"

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -51,7 +51,6 @@ test('generated default kit and classname', () => {
   const kit = screen.getByTestId(testId)
   expect(kit).toBeInTheDocument()
   expect(kit).toHaveClass('pb_dropdown_default')
-  expect(kit).not.toHaveAttribute('data-default-value')
 })
 
 test('generated default Trigger and Container when none passed in', () => {
@@ -434,16 +433,12 @@ test("defaultValue works with multiSelect", () => {
     render(
       <Dropdown
           data={{ testid: testId }}
-          defaultValue={[
-            { label: options[0].label, value: options[0].value },
-            { label: options[2].label, value: options[2].value },
-          ]}
+          defaultValue={[options[0], options[2]]}
           multiSelect
           options={options}
       />
     )
     const kit = screen.getByTestId(testId)
-    expect(kit).toHaveAttribute("data-default-value", "United-states,pakistan")
     expect(kit.querySelectorAll(".pb_form_pill_kit.pb_form_pill_primary")).toHaveLength(2)
     const option2 = Array.from(kit.querySelectorAll(".pb_dropdown_option_list"));
     const firstOpt = options[0].label
@@ -504,7 +499,6 @@ test("quickpick variant accepts string defaultValue", () => {
   const trigger = kit.querySelector('.pb_dropdown_trigger')
   
   expect(trigger).toHaveTextContent("This Month")
-  expect(kit).toHaveAttribute("data-default-value", "quickpick-this-month")
 })
 
 test("quickpick attaches _dropdownRef to DOM element when id is provided", () => {

--- a/playbook/app/pb_kits/playbook/pb_select/select.rb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.rb
@@ -50,16 +50,7 @@ module Playbook
       def validation_data
         fields = input_options[:data] || {}
         fields[:message] = validation_message unless validation_message.blank?
-        dv = filter_reset_default_value
-        fields[:default_value] = dv if dv.present?
         fields
-      end
-
-      def filter_reset_default_value
-        s = selected
-        return if s.blank?
-
-        s.join(",")
       end
 
       # Same resolved id as the native +<select>+ (+all_attributes[:id]+) for label +for+.

--- a/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/text_input.rb
@@ -121,16 +121,7 @@ module Playbook
         fields[:message] = validation_message unless validation_message.blank?
         fields[:pb_input_mask] = true if mask
         fields[:pb_emoji_mask] = true if emoji_mask
-        dv = filter_reset_default_value
-        fields[:default_value] = dv if dv.present?
         fields
-      end
-
-      def filter_reset_default_value
-        return if value.nil?
-        return if value.is_a?(String) && value.empty?
-
-        value.to_s
       end
 
       def error_class

--- a/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
@@ -59,19 +59,4 @@ RSpec.describe Playbook::PbDatePicker::DatePicker do
   it "raises an error when not given a picker_id" do
     expect { subject.new {} }.to raise_error(Playbook::Props::Error)
   end
-
-  describe "#serialized_default_date_for_dom" do
-    it "returns nil when default_date is blank" do
-      picker = subject.new(picker_id: "p1", default_date: "")
-      expect(picker.serialized_default_date_for_dom).to be_nil
-    end
-
-    it "returns the default_date string for quick pick and ISO values" do
-      quick = subject.new(picker_id: "p2", default_date: "This quarter")
-      expect(quick.serialized_default_date_for_dom).to eq("This quarter")
-
-      iso = subject.new(picker_id: "p3", default_date: "2020-07-25T00:00:00Z")
-      expect(iso.serialized_default_date_for_dom).to eq("2020-07-25T00:00:00Z")
-    end
-  end
 end

--- a/playbook/spec/pb_kits/playbook/kits/select_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/select_spec.rb
@@ -76,31 +76,6 @@ RSpec.describe Playbook::PbSelect::Select do
 
       expect(select.all_attributes[:data]).to eq({})
     end
-
-    it "includes data-default-value when an option is marked selected" do
-      select = subject.new(
-        name: "territory",
-        options: [
-          { value: "phl", value_text: "Philadelphia", selected: true },
-          { value: "nyc", value_text: "New York" },
-        ]
-      )
-
-      expect(select.all_attributes[:data]).to eq({ default_value: "phl" })
-    end
-
-    it "joins multiple selected values for data-default-value" do
-      select = subject.new(
-        name: "tags",
-        multiple: true,
-        options: [
-          { value: "a", value_text: "A", selected: true },
-          { value: "b", value_text: "B", selected: true },
-        ]
-      )
-
-      expect(select.all_attributes[:data][:default_value]).to eq("a,b")
-    end
   end
 
   describe "#validation_data" do

--- a/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/text_input_spec.rb
@@ -108,21 +108,4 @@ RSpec.describe Playbook::PbTextInput::TextInput do
       end
     end
   end
-
-  describe "filter reset integration (data-default-value)" do
-    it "adds data-default-value on the input when value is present" do
-      text_input = subject.new(value: "Philadelphia", name: "city")
-      expect(text_input.input_tag).to include('data-default-value="Philadelphia"')
-    end
-
-    it "omits data-default-value when value is nil or empty string" do
-      expect(subject.new(value: nil, name: "city").input_tag).not_to include("data-default-value")
-      expect(subject.new(value: "", name: "city").input_tag).not_to include("data-default-value")
-    end
-
-    it "serializes numeric value for data-default-value" do
-      text_input = subject.new(value: 0, name: "count")
-      expect(text_input.input_tag).to include('data-default-value="0"')
-    end
-  end
 end


### PR DESCRIPTION
Reverts powerhome/playbook#6141