### PR TITLE
[PLAY-2936] Advanced Table Kit: Column Styling Width Props - React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
@@ -5,6 +5,7 @@ import { flexRender, Row, Cell } from "@tanstack/react-table"
 import { GenericObject } from "../../types"
 import { isChrome } from "../Utilities/BrowserCheck"
 import { findColumnDefByAccessor } from "../Utilities/ColumnStylingHelper"
+import { playbookColumnLayoutStylesFromMeta } from "../Utilities/ColumnLayoutHelper"
 import { getRowColorClass, shouldShowLoadingIndicator } from "../Utilities/RowUtils"
 
 import LoadingInline from "../../pb_loading_inline/_loading_inline"
@@ -94,6 +95,7 @@ const TableCellRenderer = ({
               )}
               key={`${cell.id}-data`}
               style={{
+                ...playbookColumnLayoutStylesFromMeta(column.columnDef),
                 left: isPinnedLeft
                   ? i === 1 // Accounting for set min-width for first column
                     ? '180px'

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/TableHeaderCell.tsx
@@ -16,6 +16,7 @@ import { SortIconButton } from "./SortIconButton"
 import { ToggleIconButton } from "./ToggleIconButton"
 import { displayIcon } from "../Utilities/IconHelpers"
 import { findColumnDefByAccessor } from "../Utilities/ColumnStylingHelper"
+import { playbookColumnLayoutStylesFromMeta } from "../Utilities/ColumnLayoutHelper"
 import { updateExpandAndCollapseState } from "../Utilities/ExpansionControlHelpers"
 
 import { isChrome } from "../Utilities/BrowserCheck"
@@ -198,6 +199,7 @@ const isToggleExpansionEnabled =
         id={cellId}
         key={`${header?.id}-header`}
         style={{
+          ...playbookColumnLayoutStylesFromMeta(header?.column?.columnDef),
           backgroundColor: headerBackgroundColor,
           color: headerFontColor,
           left: isPinnedLeft

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/VirtualizedTableView.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/VirtualizedTableView.tsx
@@ -19,6 +19,7 @@ import { LoadingCell } from "../Components/LoadingCell"
 import { renderCollapsibleTrail } from "../Components/CollapsibleTrail"
 
 import AdvancedTableContext from "../Context/AdvancedTableContext"
+import { playbookColumnLayoutStylesFromMeta } from "../Utilities/ColumnLayoutHelper"
 
 type VirtualizedTableViewProps = {
   collapsibleTrail?: boolean
@@ -224,7 +225,10 @@ export const VirtualizedTableView = ({
                         isLastCell && 'last-cell',
                       )}
                       key={`${cell.id}-data`}
-                      style={{ width: cellWidth }}
+                      style={{
+                        ...playbookColumnLayoutStylesFromMeta(cell.column.columnDef),
+                        width: cellWidth,
+                      }}
                   >
                     {collapsibleTrail && i === 0 && row.depth > 0 && renderCollapsibleTrail(row.depth)}
                     <span id={`${cell.id}-span`}>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -12,6 +12,10 @@ import {
 import { GenericObject } from "../../types";
 import { createColumnHelper } from "@tanstack/react-table";
 import { createCellFunction } from "../Utilities/CellRendererUtils";
+import {
+  buildPlaybookColumnLayoutStyles,
+  buildTanStackSizingFromColumn,
+} from "../Utilities/ColumnLayoutHelper";
 import { getParentOnlySortedRowModel } from "../Utilities/RowModelUtils";
 
 interface UseTableStateProps {
@@ -105,11 +109,31 @@ export function useTableState({
           columns: buildColumns(column.columns, false),
         };
       }
+      const tanStackSizing = buildTanStackSizingFromColumn(column);
+      const layoutStyles = buildPlaybookColumnLayoutStyles(column, tanStackSizing);
+      const userMeta =
+        column.meta &&
+        typeof column.meta === "object" &&
+        !Array.isArray(column.meta)
+          ? column.meta
+          : {};
+      const hasLayoutStyles =
+        layoutStyles.width !== undefined ||
+        layoutStyles.minWidth !== undefined ||
+        layoutStyles.maxWidth !== undefined;
+
       // Define the base column structure
       const columnStructure = {
         ...columnHelper.accessor(column.accessor, {
           header: column.header ?? column.label ?? "",
           enableSorting: isFirstColumn || column.enableSort === true,
+          ...tanStackSizing,
+          meta: {
+            ...userMeta,
+            ...(hasLayoutStyles
+              ? { playbookColumnLayoutStyles: layoutStyles }
+              : {}),
+          },
         }),
       };
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/ColumnLayoutHelper.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/ColumnLayoutHelper.ts
@@ -1,0 +1,123 @@
+import type { CSSProperties } from "react"
+
+import { GenericObject } from "../../types"
+
+/**
+ * Converts a Playbook column width value to a CSS length string.
+ * Numbers are treated as pixels; strings are passed through (e.g. `"12rem"`, `"200px"`).
+ */
+export function cssLength(
+  value: number | string | undefined | null
+): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined
+  if (typeof value === "number" && Number.isFinite(value)) return `${value}px`
+  return String(value)
+}
+
+const columnStylingKeys = (column: GenericObject) =>
+  (column.columnStyling || column.column_styling || {}) as GenericObject
+
+function readStylingLength(
+  styling: GenericObject,
+  camel: string,
+  snake?: string
+): string | number | undefined {
+  if (snake) return styling[camel] ?? styling[snake]
+  return styling[camel] as string | number | undefined
+}
+
+/**
+ * TanStack Table v8 `ColumnDef` sizing fields we forward from each `columnDefinitions` entry.
+ * See AdvancedTable kit docs for precedence with `columnStyling` width keys.
+ */
+export const PLAYBOOK_FORWARDED_COLUMN_DEF_SIZING_KEYS = [
+  "size",
+  "minSize",
+  "maxSize",
+] as const
+
+export type PlaybookForwardedColumnSizing = Partial<
+  Record<(typeof PLAYBOOK_FORWARDED_COLUMN_DEF_SIZING_KEYS)[number], number>
+>
+
+export function buildTanStackSizingFromColumn(
+  column: GenericObject
+): PlaybookForwardedColumnSizing {
+  const out: PlaybookForwardedColumnSizing = {}
+  PLAYBOOK_FORWARDED_COLUMN_DEF_SIZING_KEYS.forEach((key) => {
+    const v = column[key]
+    if (typeof v === "number" && Number.isFinite(v)) out[key] = v
+  })
+
+  const styling = columnStylingKeys(column)
+
+  if (out.size === undefined && readStylingLength(styling, "width") !== undefined) {
+    const w = readStylingLength(styling, "width")
+    if (typeof w === "number" && Number.isFinite(w)) out.size = w
+  }
+  if (out.minSize === undefined && readStylingLength(styling, "minWidth", "min_width") !== undefined) {
+    const w = readStylingLength(styling, "minWidth", "min_width")
+    if (typeof w === "number" && Number.isFinite(w)) out.minSize = w
+  }
+  if (out.maxSize === undefined && readStylingLength(styling, "maxWidth", "max_width") !== undefined) {
+    const w = readStylingLength(styling, "maxWidth", "max_width")
+    if (typeof w === "number" && Number.isFinite(w)) out.maxSize = w
+  }
+
+  return out
+}
+
+/**
+ * Inline width styles for `<th>` / `<td>` so `table-layout: fixed` tables keep stable
+ * columns when row content changes (e.g. expand/collapse). Values mirror TanStack sizing
+ * and/or `columnStyling` width keys; string values in `columnStyling` win over numeric
+ * TanStack fields when both describe the same axis.
+ */
+export function buildPlaybookColumnLayoutStyles(
+  column: GenericObject,
+  tanStackSizing: PlaybookForwardedColumnSizing
+): CSSProperties {
+  const styling = columnStylingKeys(column)
+  const styles: CSSProperties = {}
+
+  const widthFromStyling = cssLength(
+    readStylingLength(styling, "width") as string | number | undefined
+  )
+  const minFromStyling = cssLength(
+    readStylingLength(styling, "minWidth", "min_width") as string | number | undefined
+  )
+  const maxFromStyling = cssLength(
+    readStylingLength(styling, "maxWidth", "max_width") as string | number | undefined
+  )
+
+  const widthFromTanStack =
+    tanStackSizing.size !== undefined
+      ? cssLength(tanStackSizing.size)
+      : undefined
+  const minFromTanStack =
+    tanStackSizing.minSize !== undefined
+      ? cssLength(tanStackSizing.minSize)
+      : undefined
+  const maxFromTanStack =
+    tanStackSizing.maxSize !== undefined
+      ? cssLength(tanStackSizing.maxSize)
+      : undefined
+
+  if (widthFromStyling !== undefined) styles.width = widthFromStyling
+  else if (widthFromTanStack !== undefined) styles.width = widthFromTanStack
+
+  if (minFromStyling !== undefined) styles.minWidth = minFromStyling
+  else if (minFromTanStack !== undefined) styles.minWidth = minFromTanStack
+
+  if (maxFromStyling !== undefined) styles.maxWidth = maxFromStyling
+  else if (maxFromTanStack !== undefined) styles.maxWidth = maxFromTanStack
+
+  return styles
+}
+
+export function playbookColumnLayoutStylesFromMeta(
+  columnDef: GenericObject | undefined
+): CSSProperties {
+  const meta = columnDef?.meta as GenericObject | undefined
+  return (meta?.playbookColumnLayoutStyles || {}) as CSSProperties
+}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/ColumnLayoutHelper.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/ColumnLayoutHelper.ts
@@ -64,6 +64,12 @@ export function buildTanStackSizingFromColumn(
     if (typeof w === "number" && Number.isFinite(w)) out.maxSize = w
   }
 
+  // width/size only → fixed column (min and max match preferred)
+  if (out.size !== undefined && out.minSize === undefined && out.maxSize === undefined) {
+    out.minSize = out.size
+    out.maxSize = out.size
+  }
+
   return out
 }
 
@@ -80,37 +86,46 @@ export function buildPlaybookColumnLayoutStyles(
   const styling = columnStylingKeys(column)
   const styles: CSSProperties = {}
 
-  const widthFromStyling = cssLength(
-    readStylingLength(styling, "width") as string | number | undefined
-  )
-  const minFromStyling = cssLength(
-    readStylingLength(styling, "minWidth", "min_width") as string | number | undefined
-  )
-  const maxFromStyling = cssLength(
-    readStylingLength(styling, "maxWidth", "max_width") as string | number | undefined
-  )
+  const stylingWidth = readStylingLength(styling, "width")
+  const stylingMin = readStylingLength(styling, "minWidth", "min_width")
+  const stylingMax = readStylingLength(styling, "maxWidth", "max_width")
 
-  const widthFromTanStack =
-    tanStackSizing.size !== undefined
-      ? cssLength(tanStackSizing.size)
-      : undefined
-  const minFromTanStack =
-    tanStackSizing.minSize !== undefined
-      ? cssLength(tanStackSizing.minSize)
-      : undefined
-  const maxFromTanStack =
-    tanStackSizing.maxSize !== undefined
-      ? cssLength(tanStackSizing.maxSize)
-      : undefined
+  const hasStylingWidth = stylingWidth !== undefined && stylingWidth !== ""
+  const hasStylingMin = stylingMin !== undefined && stylingMin !== ""
+  const hasStylingMax = stylingMax !== undefined && stylingMax !== ""
 
-  if (widthFromStyling !== undefined) styles.width = widthFromStyling
-  else if (widthFromTanStack !== undefined) styles.width = widthFromTanStack
+  let widthValue: string | number | undefined = hasStylingWidth
+    ? stylingWidth
+    : tanStackSizing.size
+  let minValue: string | number | undefined = hasStylingMin
+    ? stylingMin
+    : tanStackSizing.minSize
+  let maxValue: string | number | undefined = hasStylingMax
+    ? stylingMax
+    : tanStackSizing.maxSize
 
-  if (minFromStyling !== undefined) styles.minWidth = minFromStyling
-  else if (minFromTanStack !== undefined) styles.minWidth = minFromTanStack
+  const preferredForLock = hasStylingWidth ? stylingWidth : tanStackSizing.size
+  const explicitMin = hasStylingMin || tanStackSizing.minSize !== undefined
+  const explicitMax = hasStylingMax || tanStackSizing.maxSize !== undefined
 
-  if (maxFromStyling !== undefined) styles.maxWidth = maxFromStyling
-  else if (maxFromTanStack !== undefined) styles.maxWidth = maxFromTanStack
+  if (
+    preferredForLock !== undefined &&
+    preferredForLock !== "" &&
+    !explicitMin &&
+    !explicitMax
+  ) {
+    minValue = preferredForLock
+    maxValue = preferredForLock
+    widthValue = preferredForLock
+  }
+
+  const widthCss = cssLength(widthValue)
+  const minCss = cssLength(minValue)
+  const maxCss = cssLength(maxValue)
+
+  if (widthCss !== undefined) styles.width = widthCss
+  if (minCss !== undefined) styles.minWidth = minCss
+  if (maxCss !== undefined) styles.maxWidth = maxCss
 
   return styles
 }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -774,6 +774,82 @@ test("columnStyling.cellPadding sets cell padding", () => {
   expect(firstEnrollmentCell).toHaveClass('p_none')
 });
 
+test("columnStyling minWidth, width, and maxWidth apply to header and body cells", () => {
+  const styledColumnDefs = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+      columnStyling: { minWidth: 240, width: 260, maxWidth: 400 },
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+  ];
+
+  render(
+    <AdvancedTable
+        columnDefinitions={styledColumnDefs}
+        data={{ testid: testId }}
+        tableData={MOCK_DATA}
+    />
+  );
+
+  const yearHeader = screen.getByText("Year").closest("th");
+  expect(yearHeader).toHaveStyle({ minWidth: "240px", width: "260px", maxWidth: "400px" });
+
+  const yearCell = screen.getAllByText("2021")[0].closest("td");
+  expect(yearCell).toHaveStyle({ minWidth: "240px", width: "260px", maxWidth: "400px" });
+});
+
+test("columnDefinitions size, minSize, and maxSize apply layout styles", () => {
+  const styledColumnDefs = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+      size: 180,
+      minSize: 160,
+      maxSize: 320,
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+  ];
+
+  render(
+    <AdvancedTable
+        columnDefinitions={styledColumnDefs}
+        data={{ testid: testId }}
+        tableData={MOCK_DATA}
+    />
+  );
+
+  const enrollmentsHeader = screen.getByText("New Enrollments").closest("th");
+  expect(enrollmentsHeader).toHaveStyle({
+    width: "180px",
+    minWidth: "160px",
+    maxWidth: "320px",
+  });
+
+  const enrollmentsCell = screen.getAllByText("20")[0].closest("td");
+  expect(enrollmentsCell).toHaveStyle({
+    width: "180px",
+    minWidth: "160px",
+    maxWidth: "320px",
+  });
+});
+
 test("columnStyling.fontColor sets cell font color", () => {
   const styledColumnDefs = [
     {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -807,6 +807,74 @@ test("columnStyling minWidth, width, and maxWidth apply to header and body cells
   expect(yearCell).toHaveStyle({ minWidth: "240px", width: "260px", maxWidth: "400px" });
 });
 
+test("columnStyling width only locks minWidth and maxWidth to the same value", () => {
+  const styledColumnDefs = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+      columnStyling: { width: 128 },
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+  ];
+
+  render(
+    <AdvancedTable
+        columnDefinitions={styledColumnDefs}
+        data={{ testid: testId }}
+        tableData={MOCK_DATA}
+    />
+  );
+
+  const yearHeader = screen.getByText("Year").closest("th");
+  expect(yearHeader).toHaveStyle({
+    width: "128px",
+    minWidth: "128px",
+    maxWidth: "128px",
+  });
+});
+
+test("columnDefinitions size only locks minSize and maxSize to the same value", () => {
+  const styledColumnDefs = [
+    {
+      accessor: "year",
+      label: "Year",
+      cellAccessors: ["quarter", "month", "day"],
+    },
+    {
+      accessor: "newEnrollments",
+      label: "New Enrollments",
+      size: 200,
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Scheduled Meetings",
+    },
+  ];
+
+  render(
+    <AdvancedTable
+        columnDefinitions={styledColumnDefs}
+        data={{ testid: testId }}
+        tableData={MOCK_DATA}
+    />
+  );
+
+  const enrollmentsHeader = screen.getByText("New Enrollments").closest("th");
+  expect(enrollmentsHeader).toHaveStyle({
+    width: "200px",
+    minWidth: "200px",
+    maxWidth: "200px",
+  });
+});
+
 test("columnDefinitions size, minSize, and maxSize apply layout styles", () => {
   const styledColumnDefs = [
     {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.jsx
@@ -10,8 +10,7 @@ const AdvancedTableColumnStyling = (props) => {
       accessor: "year",
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
-      // Floor only — see "Column Styling: Width" doc for fixed width and min/pref/max bands.
-      columnStyling: { minWidth: 124 },
+      columnStyling: { width: 124 },
     },
     {
       accessor: "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.jsx
@@ -10,8 +10,8 @@ const AdvancedTableColumnStyling = (props) => {
       accessor: "year",
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
-      // Keeps the hierarchy column narrow and stable when rows expand (see kit docs).
-      columnStyling: { minWidth: 108, width: 124, maxWidth: 168 },
+      // Floor only — see "Column Styling: Width" doc for fixed width and min/pref/max bands.
+      columnStyling: { minWidth: 124 },
     },
     {
       accessor: "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.jsx
@@ -10,6 +10,8 @@ const AdvancedTableColumnStyling = (props) => {
       accessor: "year",
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
+      // Keeps the hierarchy column narrow and stable when rows expand (see kit docs).
+      columnStyling: { minWidth: 108, width: 124, maxWidth: 168 },
     },
     {
       accessor: "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -6,7 +6,7 @@ The `columnStyling` prop is an optional item that can be used within `columnDefi
 
 3) `fontColor`: This will allow you to control the font color for a given column.
 
-4) Column width: optional keys on `columnStyling` are `minWidth`, `width`, and `maxWidth` (numbers = pixels; CSS strings allowed). This example sets `minWidth` on Year so the hierarchy column does not shrink when rows expand.
+4) Column width: optional keys on `columnStyling` are `minWidth`, `width`, and `maxWidth` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `minWidth` and bands).
 
 Fixed width: pass `width` only (or TanStack `size` only) and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -6,4 +6,12 @@ The `columnStyling` prop is an optional item that can be used within `columnDefi
 
 3) `fontColor`: This will allow you to control the font color for a given column.
 
+4) **Column width (layout stability)** — optional keys on `columnStyling` (numbers are treated as **pixels**; you may also use CSS length strings such as `"12rem"` or `"200px"`):
+
+- `minWidth`: minimum width for the column’s header and body cells (helps prevent horizontal “jump” when row content or expansion depth changes on tables using fixed layout).
+- `width`: preferred column width.
+- `maxWidth`: maximum column width.
+
+The same sizing can be expressed with TanStack `ColumnDef` fields on each column definition object (merged into the underlying table model): `size` (width), `minSize`, and `maxSize` (numbers, pixels). If both are present for the same axis, **`columnStyling` string values take precedence**; otherwise `columnStyling` numeric/string values override TanStack numbers when only one source sets that axis. **Grouped columns:** apply width controls on **leaf** column definitions (the columns that have an `accessor`).
+
 `columnStyling` can be used within the columnDefinition of all the columns or some of them, as shown. Each column has its own individual control in this way. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -12,6 +12,8 @@ The `columnStyling` prop is an optional item that can be used within `columnDefi
 - `width`: preferred column width.
 - `maxWidth`: maximum column width.
 
+The live example below narrows the **Year** column (`minWidth` / `width` / `maxWidth`) so the first column stays compact while leaving room for expand and sort controls.
+
 The same sizing can be expressed with TanStack `ColumnDef` fields on each column definition object (merged into the underlying table model): `size` (width), `minSize`, and `maxSize` (numbers, pixels). If both are present for the same axis, **`columnStyling` string values take precedence**; otherwise `columnStyling` numeric/string values override TanStack numbers when only one source sets that axis. **Grouped columns:** apply width controls on **leaf** column definitions (the columns that have an `accessor`).
 
 `columnStyling` can be used within the columnDefinition of all the columns or some of them, as shown. Each column has its own individual control in this way. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -6,14 +6,10 @@ The `columnStyling` prop is an optional item that can be used within `columnDefi
 
 3) `fontColor`: This will allow you to control the font color for a given column.
 
-4) **Column width (layout stability)** — optional keys on `columnStyling` (numbers are treated as **pixels**; you may also use CSS length strings such as `"12rem"` or `"200px"`):
+4) Column width: optional keys on `columnStyling` are `minWidth`, `width`, and `maxWidth` (numbers = pixels; CSS strings allowed). This example sets `minWidth` on Year so the hierarchy column does not shrink when rows expand.
 
-- `minWidth`: minimum width for the column’s header and body cells (helps prevent horizontal “jump” when row content or expansion depth changes on tables using fixed layout).
-- `width`: preferred column width.
-- `maxWidth`: maximum column width.
+Fixed width: pass `width` only (or TanStack `size` only) and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 
-The live example below narrows the **Year** column (`minWidth` / `width` / `maxWidth`) so the first column stays compact while leaving room for expand and sort controls.
-
-The same sizing can be expressed with TanStack `ColumnDef` fields on each column definition object (merged into the underlying table model): `size` (width), `minSize`, and `maxSize` (numbers, pixels). If both are present for the same axis, **`columnStyling` string values take precedence**; otherwise `columnStyling` numeric/string values override TanStack numbers when only one source sets that axis. **Grouped columns:** apply width controls on **leaf** column definitions (the columns that have an `accessor`).
+See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/react#column-styling-width) for the full guide (Playbook ↔ TanStack mapping, floor-only vs bands, and when to use one vs three values).
 
 `columnStyling` can be used within the columnDefinition of all the columns or some of them, as shown. Each column has its own individual control in this way. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.jsx
@@ -1,0 +1,57 @@
+import React from "react"
+import AdvancedTable from "../_advanced_table"
+import MOCK_DATA from "./advanced_table_mock_data.json"
+
+/**
+ * Kit doc: compares fixed width, floor-only, TanStack band, and min/preferred/max band.
+ */
+const AdvancedTableColumnStylingWidth = (props) => {
+  const columnDefinitions = [
+    {
+      accessor: "year",
+      label: "Year (fixed)",
+      cellAccessors: ["quarter", "month", "day"],
+      // width alone locks min + max to the same value (128px).
+      columnStyling: { width: 128 },
+    },
+    {
+      accessor: "newEnrollments",
+      label: "Enrollments (floor)",
+      columnStyling: { minWidth: 160 },
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Meetings (TanStack band)",
+      size: 200,
+      minSize: 160,
+      maxSize: 240,
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance (min / pref / max)",
+      columnStyling: { minWidth: 108, width: 124, maxWidth: 168 },
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Completion %",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated",
+    },
+  ]
+
+  return (
+    <AdvancedTable
+        columnDefinitions={columnDefinitions}
+        tableData={MOCK_DATA}
+        {...props}
+    />
+  )
+}
+
+export default AdvancedTableColumnStylingWidth

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.md
@@ -1,0 +1,66 @@
+AdvancedTable column width is controlled in two equivalent places on each leaf `columnDefinitions` entry. Playbook maps them to inline styles on header and body cells (and forwards numeric values into TanStack Table’s column model).
+
+1) Playbook `columnStyling` and TanStack `ColumnDef` use the same three ideas:
+
+- Preferred / target width: `columnStyling` `width` maps to TanStack `size` on the same column object.
+- Minimum width (floor): `columnStyling` `minWidth` maps to TanStack `minSize`.
+- Maximum width (ceiling): `columnStyling` `maxWidth` maps to TanStack `maxSize`.
+
+Numbers are pixels. You can also pass CSS length strings on `columnStyling` (e.g. `"12rem"`, `"200px"`). TanStack fields accept numbers only.
+
+If both APIs set the same axis, `columnStyling` wins for that axis when Playbook builds cell styles.
+
+2) Fixed width: set `width` only
+
+If you pass only `width` (or only `size`) and do not set `minWidth` / `maxWidth` (or `minSize` / `maxSize`), Playbook treats that as a fixed column: it sets all three to the same value under the hood so you do not have to repeat yourself.
+
+```jsx
+columnStyling: { width: 128 }
+// Applied as width, minWidth, and maxWidth: 128px
+```
+
+```jsx
+size: 200
+// Forwarded as size, minSize, and maxSize: 200
+```
+
+Use this when the column should stay one width (e.g. a hierarchy column with expand controls).
+
+3) Floor only: `minWidth` / `minSize`
+
+Set only a minimum when the column may grow with the table or content but must not shrink below a baseline (common fix for horizontal “jump” when rows expand):
+
+```jsx
+columnStyling: { minWidth: 160 }
+```
+
+4) Flexible band: min + preferred + max
+
+Set two or three values when you want a range. CSS uses preferred `width` clamped between `minWidth` and `maxWidth`:
+
+- `minWidth`: won’t shrink below this.
+- `width`: preferred size when space allows.
+- `maxWidth`: won’t grow above this.
+
+Example from the table below (Attendance): `minWidth: 108`, `width: 124`, `maxWidth: 168` → preferred 124px, allowed between 108 and 168.
+
+You only need all three when you want that band. If min and max are omitted, `width` alone is enough for a fixed column.
+
+5) TanStack band without `columnStyling`
+
+The Meetings column uses only TanStack fields:
+
+```jsx
+{ accessor: "scheduledMeetings", size: 200, minSize: 160, maxSize: 240 }
+```
+
+Playbook applies the same min / preferred / max idea to cell styles. Setting only `size: 200` would lock all three to 200, same as `width: 200` in `columnStyling`.
+
+6) What the example table shows
+
+- Year (fixed): `columnStyling: { width: 128 }` — locked to 128px.
+- Enrollments (floor): `columnStyling: { minWidth: 160 }` — at least 160px; can grow.
+- Meetings (TanStack band): `size` / `minSize` / `maxSize` — preferred 200px, between 160–240.
+- Attendance (min / pref / max): all three in `columnStyling` — preferred 124px, between 108–168.
+
+Grouped columns: put width options on leaf definitions (columns with an `accessor`), not on parent group headers.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
@@ -313,7 +313,7 @@
     },
     "column_styling_info": {
       "presetName": "Column Styling",
-      "message": "This sample uses columnStyling on column definitions. The Year column uses minWidth, width, and maxWidth for a compact, stable first column; other columns show background colors on headers and cells.",
+      "message": "This sample uses columnStyling on column definitions. Year uses minWidth for a stable hierarchy column; other columns show background colors. See the Column Styling Width doc for fixed width and min/pref/max bands.",
       "type": "info"
     }
   },
@@ -2630,9 +2630,7 @@
               "day"
             ],
             "columnStyling": {
-              "minWidth": 108,
-              "width": 124,
-              "maxWidth": 168
+              "minWidth": 124
             }
           },
           {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
@@ -313,7 +313,7 @@
     },
     "column_styling_info": {
       "presetName": "Column Styling",
-      "message": "This sample uses columnStyling on column definitions. You can style headers and cells for the whole table or per column.",
+      "message": "This sample uses columnStyling on column definitions. The Year column uses minWidth, width, and maxWidth for a compact, stable first column; other columns show background colors on headers and cells.",
       "type": "info"
     }
   },
@@ -2628,7 +2628,12 @@
               "quarter",
               "month",
               "day"
-            ]
+            ],
+            "columnStyling": {
+              "minWidth": 108,
+              "width": 124,
+              "maxWidth": 168
+            }
           },
           {
             "accessor": "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
@@ -313,7 +313,7 @@
     },
     "column_styling_info": {
       "presetName": "Column Styling",
-      "message": "This sample uses columnStyling on column definitions. Year uses minWidth for a stable hierarchy column; other columns show background colors. See the Column Styling Width doc for fixed width and min/pref/max bands.",
+      "message": "This sample uses columnStyling on column definitions. Year uses width for a fixed hierarchy column; other columns show background colors. See the Column Styling Width doc for minWidth and min/pref/max bands.",
       "type": "info"
     }
   },
@@ -2630,7 +2630,7 @@
               "day"
             ],
             "columnStyling": {
-              "minWidth": 124
+              "width": 124
             }
           },
           {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
@@ -371,7 +371,7 @@
     },
     "column_styling_info": {
       "presetName": "Column Styling",
-      "message": "This sample uses columnStyling on column definitions. You can style headers and cells for the whole table or per column.",
+      "message": "This sample uses columnStyling on column definitions. The Year column uses minWidth, width, and maxWidth for a compact, stable first column; other columns show background colors on headers and cells.",
       "type": "info"
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
@@ -371,7 +371,7 @@
     },
     "column_styling_info": {
       "presetName": "Column Styling",
-      "message": "This sample uses columnStyling on column definitions. Year uses minWidth for a stable hierarchy column; other columns show background colors. See the Column Styling Width doc for fixed width and min/pref/max bands.",
+      "message": "This sample uses columnStyling on column definitions. Year uses width for a fixed hierarchy column; other columns show background colors. See the Column Styling Width doc for minWidth and min/pref/max bands.",
       "type": "info"
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
@@ -371,7 +371,7 @@
     },
     "column_styling_info": {
       "presetName": "Column Styling",
-      "message": "This sample uses columnStyling on column definitions. The Year column uses minWidth, width, and maxWidth for a compact, stable first column; other columns show background colors on headers and cells.",
+      "message": "This sample uses columnStyling on column definitions. Year uses minWidth for a stable hierarchy column; other columns show background colors. See the Column Styling Width doc for fixed width and min/pref/max bands.",
       "type": "info"
     }
   }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_column_definitions_styling.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_column_definitions_styling.json
@@ -2,7 +2,12 @@
   {
     "accessor": "year",
     "label": "Year",
-    "cellAccessors": ["quarter", "month", "day"]
+    "cellAccessors": ["quarter", "month", "day"],
+    "columnStyling": {
+      "minWidth": 108,
+      "width": 124,
+      "maxWidth": 168
+    }
   },
   {
     "accessor": "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_column_definitions_styling.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_column_definitions_styling.json
@@ -4,7 +4,7 @@
     "label": "Year",
     "cellAccessors": ["quarter", "month", "day"],
     "columnStyling": {
-      "minWidth": 124
+      "width": 124
     }
   },
   {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_column_definitions_styling.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/advanced_table_column_definitions_styling.json
@@ -4,9 +4,7 @@
     "label": "Year",
     "cellAccessors": ["quarter", "month", "day"],
     "columnStyling": {
-      "minWidth": 108,
-      "width": 124,
-      "maxWidth": 168
+      "minWidth": 124
     }
   },
   {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -80,6 +80,7 @@ examples:
   - advanced_table_row_styling: Row Styling
   - advanced_table_padding_control_per_row: Padding Control using Row Styling
   - advanced_table_column_styling: Column Styling
+  - advanced_table_column_styling_width: Column Styling Width
   - advanced_table_column_styling_column_headers: Column Styling with Multiple Headers
   - advanced_table_column_styling_background: Column Styling Background Color
   - advanced_table_column_styling_background_custom: Column Styling Background Color (Custom)

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -37,6 +37,7 @@ export { default as AdvancedTablePinnedRows } from './_advanced_table_pinned_row
 export { default as AdvancedTableScrollbarNone} from './_advanced_table_scrollbar_none.jsx'
 export { default as AdvancedTableRowStyling } from './_advanced_table_row_styling.jsx'
 export { default as AdvancedTableColumnStyling } from './_advanced_table_column_styling.jsx'
+export { default as AdvancedTableColumnStylingWidth } from './_advanced_table_column_styling_width.jsx'
 export { default as AdvancedTableColumnStylingColumnHeaders } from './_advanced_table_column_styling_column_headers.jsx'
 export { default as AdvancedTableInfiniteScroll} from './_advanced_table_infinite_scroll.jsx'
 export {default as AdvancedTableWithCustomHeader} from './_advanced_table_with_custom_header.jsx'


### PR DESCRIPTION
https://runway.powerhrg.com/backlog_items/PLAY-2936

**What does this PR do?**

- Add column width controls to React Advanced Table so devs can stabilize column layout (especially the first column) using `columnDefinitions`, without custom CSS. 
- Add `minWidth`, `width`, and `maxWidth` props for columnStyling. 
  - You can also use CSS strings, not just numbers (e.g., "12rem")
  - If you use numbers, pass these to Tanstack to use with corresponding `size` props.
- Can still use the Tanstack `size`, `minSize`, and `maxSize` fields too
- Docs and testing 


**Screenshots:** Screenshots to visualize your addition/change
<img width="2137" height="1316" alt="Screenshot 2026-05-19 at 8 56 44 AM" src="https://github.com/user-attachments/assets/0aac83ea-de3d-4d05-bf65-67c765044183" />
<img width="2138" height="462" alt="Screenshot 2026-05-19 at 8 57 06 AM" src="https://github.com/user-attachments/assets/7abcc628-26c9-468d-bc36-aa6ce45d18c5" />


<img width="2136" height="618" alt="Screenshot 2026-05-19 at 8 56 17 AM" src="https://github.com/user-attachments/assets/8d89c3fb-594b-4c20-951b-287ac672d12a" />

**How to test?** Steps to confirm the desired behavior:
1. Test in nitro-web.
2. /kits/advanced_table/styling/react#column-styling
3. /kits/advanced_table/styling/react#column-styling-width


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.