### PR TITLE
[PLAY-2996] Update TextInput AddOn styles for consistent Disabled state

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
+++ b/playbook/app/pb_kits/playbook/pb_text_input/_text_input.scss
@@ -100,6 +100,29 @@
         color: $input_text_disabled_dark;
       }
     }
+
+    .text_input_wrapper_add_on {
+      &:has(input:disabled),
+      &:has(.text_input:disabled) {
+        .add-on-card,
+        .add-on-card-dark {
+          border-color: $input_border_disabled_dark;
+          background-color: $input_background_disabled_dark;
+        }
+
+        .add-on-icon {
+          color: $input_text_disabled_dark;
+        }
+
+        .text_input:focus ~ .add-on-card-dark,
+        input:focus ~ .add-on-card-dark {
+          background-color: $input_background_disabled_dark;
+          border-color: $input_border_disabled_dark;
+          border-width: 1px;
+        }
+      }
+    }
+
     &.error {
       .text_input_wrapper {
         // The `:not` here prevents error styling from affecting the country search input in the Phone Number Input Kit.
@@ -192,6 +215,20 @@
       }
     }
   }
+  &:not(.dark) .text_input_wrapper_add_on {
+    &:has(input:disabled),
+    &:has(.text_input:disabled) {
+      .add-on-card {
+        border-color: $input_border_disabled;
+        background-color: $input_background_disabled;
+      }
+
+      .add-on-icon {
+        color: $input_text_disabled;
+      }
+    }
+  }
+
   &.inline {
     .text_input_wrapper input::placeholder,
     .text_input_wrapper .text_input .placeholder {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2996](https://runway.powerhrg.com/backlog_items/PLAY-2996?from=backlog) updates the TextInput AddOn styles to match the input's disabled style in light and dark mode. A small visual oversight not accounted for in the set of accessibility input update stories earlier this.
[CSB with alpha](https://codesandbox.io/p/devbox/play-2946-currency-kit-forked-wz47l4?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5)
**Screenshots:** Screenshots to visualize your addition/change
Current Prod
<img width="324" height="258" alt="textinputdisabledaddonpbchannel" src="https://github.com/user-attachments/assets/4d5980ed-4a86-4d89-a22d-e691484a0ee6" />
With Fix
<img width="1366" height="620" alt="react light mode" src="https://github.com/user-attachments/assets/afa3b660-8eb0-40c9-ba55-6b2fd0b5e37e" />
<img width="1380" height="529" alt="rails dark mode" src="https://github.com/user-attachments/assets/bac46864-e7bc-4d00-b84a-ed4c9386b645" />

**How to test?** Steps to confirm the desired behavior:
1. Go to Text Input doc page see consistent styles throughout all doc examples light and dark mode.
2. Go to [CSB with alpha](https://codesandbox.io/p/devbox/play-2946-currency-kit-forked-wz47l4?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) see disabled + addon examples in light and dark mode.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.- [ ] 