### PR TITLE
[PLAY-2914] Circle Chart: Centered Subtitle Pattern Doc Example

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.html.erb
@@ -1,0 +1,90 @@
+<% data = [
+  {
+    name: "EV",
+    y: 23.9,
+  },
+  {
+    name: "Hybrids",
+    y: 12.6,
+  },
+  {
+    name: "Diesel",
+    y: 37.0,
+  },
+  {
+    name: "Petrol",
+    y: 26.4,
+  },
+] %>
+
+<% total = data.sum { |point| point[:y] } %>
+<% subtitle_rows = data.map { |point| "#{point[:name]}: #{point[:y]}%" }.join("<br>") %>
+
+<% chart_options = {
+  chart: {
+    type: "pie",
+  },
+  accessibility: {
+    point: {
+      valueSuffix: "%",
+    },
+  },
+  title: {
+    text: "2023 Norway car registrations",
+    floating: true,
+    align: "center",
+    verticalAlign: "top",
+    y: 8,
+  },
+  subtitle: {
+    text: "Total<br><strong>#{total.round(1)}</strong><br><br>#{subtitle_rows}",
+    useHTML: true,
+    floating: true,
+    align: "center",
+    verticalAlign: "middle",
+    y: 8,
+    style: {
+      textAlign: "center",
+    },
+  },
+  tooltip: {
+    pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",
+  },
+  legend: {
+    enabled: false,
+  },
+  plotOptions: {
+    series: {
+      allowPointSelect: true,
+      cursor: "pointer",
+      borderRadius: 8,
+      dataLabels: [
+        {
+          enabled: true,
+          distance: 20,
+          format: "{point.name}",
+        },
+        {
+          enabled: true,
+          distance: -15,
+          format: "{point.percentage:.0f}%",
+          style: {
+            fontSize: "0.9em",
+          },
+        },
+      ],
+      showInLegend: true,
+    },
+  },
+  series: [
+    {
+      name: "Registrations",
+      colorByPoint: true,
+      center: ["50%", "50%"],
+      innerSize: "75%",
+      data: data,
+    },
+  ],
+} %>
+
+<%= pb_rails("pb_circle_chart", props: { options: chart_options }) %>

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.jsx
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.jsx
@@ -1,7 +1,5 @@
 import React from "react";
 import PbCircleChart from "../_pb_circle_chart";
-import Body from "../../pb_body/_body";
-import Title from "../../pb_title/_title";
 
 const data = [
   {
@@ -23,6 +21,7 @@ const data = [
 ];
 
 const total = data.reduce((sum, point) => sum + point.y, 0);
+const subtitleRows = data.map((point) => `${point.name}: ${point.y}%`).join("<br>");
 
 const chartOptions = {
   chart: {
@@ -35,9 +34,21 @@ const chartOptions = {
   },
   title: {
     text: "2023 Norway car registrations",
+    floating: true,
+    align: "center",
+    verticalAlign: "top",
+    y: 8,
   },
   subtitle: {
-    text: 'Source: <a href="https://www.ssb.no/transport-og-reiseliv/faktaside/bil-og-transport">SSB</a>',
+    text: `Total<br><strong>${total.toFixed(1)}</strong><br><br>${subtitleRows}`,
+    useHTML: true,
+    floating: true,
+    align: "center",
+    verticalAlign: "middle",
+    y: 8,
+    style: {
+      textAlign: "center",
+    },
   },
   tooltip: {
     pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",
@@ -72,44 +83,18 @@ const chartOptions = {
     {
       name: "Registrations",
       colorByPoint: true,
+      center: ["50%", "50%"],
       innerSize: "75%",
       data,
     },
   ],
 };
 
-const PbCircleChartDefault = (props) => (
-  <div style={{ position: "relative" }}>
-    <PbCircleChart
-        options={chartOptions}
-        {...props}
-    />
-    <div
-        style={{
-          position: "absolute",
-          inset: 0,
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          zIndex: 1,
-          textAlign: "center",
-          pointerEvents: "none",
-        }}
-    >
-      <div>
-        <Body
-            color="light"
-            text="Total"
-        />
-        <Title
-            size={3}
-            tag="div"
-        >
-          {total.toFixed(1)}
-        </Title>
-      </div>
-    </div>
-  </div>
+const PbCircleChartCenteredData = (props) => (
+  <PbCircleChart
+      options={chartOptions}
+      {...props}
+  />
 );
 
-export default PbCircleChartDefault;
+export default PbCircleChartCenteredData;

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.md
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.md
@@ -1,1 +1,1 @@
-This example shows how to achieve centered data. This data will remain in the on all screen sizes.
+This example shows how to achieve centered data. This data will remain in the center of all screen sizes.

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.md
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_centered_data.md
@@ -1,0 +1,1 @@
+This example shows how to achieve centered data. This data will remain in the on all screen sizes.

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
@@ -1,88 +1,20 @@
-<% data = [
-  {
-    name: "EV",
-    y: 23.9,
-  },
-  {
-    name: "Hybrids",
-    y: 12.6,
-  },
-  {
-    name: "Diesel",
-    y: 37.0,
-  },
-  {
-    name: "Petrol",
-    y: 26.4,
-  },
-] %>
-
-<% total = data.sum { |point| point[:y] } %>
-<% subtitle_rows = data.map { |point| "#{point[:name]}: #{point[:y]}%" }.join("<br>") %>
-
 <% chart_options = {
-  chart: {
-    type: "pie",
-  },
-  accessibility: {
-    point: {
-      valueSuffix: "%",
-    },
-  },
-  title: {
-    text: "2023 Norway car registrations",
-    floating: true,
-    align: "center",
-    verticalAlign: "top",
-    y: 8,
-  },
-  subtitle: {
-    text: "Total<br><strong>#{total.round(1)}</strong><br><br>#{subtitle_rows}",
-    useHTML: true,
-    floating: true,
-    align: "center",
-    verticalAlign: "middle",
-    y: 8,
-    style: {
-      textAlign: "center",
-    },
-  },
-  tooltip: {
-    pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",
-  },
-  legend: {
-    enabled: false,
-  },
-  plotOptions: {
-    series: {
-      allowPointSelect: true,
-      cursor: "pointer",
-      borderRadius: 8,
-      dataLabels: [
-        {
-          enabled: true,
-          distance: 20,
-          format: "{point.name}",
-        },
-        {
-          enabled: true,
-          distance: -15,
-          format: "{point.percentage:.0f}%",
-          style: {
-            fontSize: "0.9em",
-          },
-        },
-      ],
-      showInLegend: true,
-    },
-  },
   series: [
     {
-      name: "Registrations",
-      colorByPoint: true,
-      center: ["50%", "50%"],
-      innerSize: "75%",
-      data: data,
+      data: [
+        {
+          name: "Waiting for Calls",
+          y: 41,
+        },
+        {
+          name: "On Call",
+          y: 49,
+        },
+        {
+          name: "After Call",
+          y: 10,
+        },
+      ],
     },
   ],
 } %>

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
@@ -18,6 +18,7 @@
 ] %>
 
 <% total = data.sum { |point| point[:y] } %>
+<% subtitle_rows = data.map { |point| "#{point[:name]}: #{point[:y]}%" }.join("<br>") %>
 
 <% chart_options = {
   chart: {
@@ -36,7 +37,7 @@
     y: 8,
   },
   subtitle: {
-    text: "Total<br><strong>#{total.round(1)}</strong>",
+    text: "Total<br><strong>#{total.round(1)}</strong><br><br>#{subtitle_rows}",
     useHTML: true,
     floating: true,
     align: "center",

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
@@ -34,7 +34,7 @@
     floating: true,
     align: "center",
     verticalAlign: "middle",
-    y: 8,
+    y: 28,
     style: {
       textAlign: "center",
     },
@@ -43,10 +43,6 @@
     text: "2023 Norway car registrations",
     align: "center",
     x: 0,
-  },
-  caption: {
-    text: 'Source: <a href="https://www.ssb.no/transport-og-reiseliv/faktaside/bil-og-transport">SSB</a>',
-    useHTML: true,
   },
   tooltip: {
     pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
@@ -29,10 +29,24 @@
     },
   },
   title: {
-    text: "2023 Norway car registrations",
+    text: "Total<br><strong>#{total.round(1)}</strong>",
+    useHTML: true,
+    floating: true,
+    align: "center",
+    verticalAlign: "middle",
+    y: 8,
+    style: {
+      textAlign: "center",
+    },
   },
   subtitle: {
+    text: "2023 Norway car registrations",
+    align: "center",
+    x: 0,
+  },
+  caption: {
     text: 'Source: <a href="https://www.ssb.no/transport-og-reiseliv/faktaside/bil-og-transport">SSB</a>',
+    useHTML: true,
   },
   tooltip: {
     pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",
@@ -67,21 +81,11 @@
     {
       name: "Registrations",
       colorByPoint: true,
+      center: ["50%", "50%"],
       innerSize: "75%",
       data: data,
     },
   ],
 } %>
 
-<div style="position: relative;">
-  <%= pb_rails("pb_circle_chart", props: { options: chart_options }) %>
-
-  <div
-    style="position: absolute; inset: 0; display: flex; justify-content: center; align-items: center; z-index: 1; text-align: center; pointer-events: none;"
-  >
-    <div>
-      <%= pb_rails("body", props: { text: "Total", color: "light" }) %>
-      <%= pb_rails("title", props: { size: 3, tag: "div", text: total.round(1).to_s }) %>
-    </div>
-  </div>
-</div>
+<%= pb_rails("pb_circle_chart", props: { options: chart_options }) %>

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
@@ -1,22 +1,87 @@
+<% data = [
+  {
+    name: "EV",
+    y: 23.9,
+  },
+  {
+    name: "Hybrids",
+    y: 12.6,
+  },
+  {
+    name: "Diesel",
+    y: 37.0,
+  },
+  {
+    name: "Petrol",
+    y: 26.4,
+  },
+] %>
+
+<% total = data.sum { |point| point[:y] } %>
+
 <% chart_options = {
-  series: [
-    {
-      data: [
+  chart: {
+    type: "pie",
+  },
+  accessibility: {
+    point: {
+      valueSuffix: "%",
+    },
+  },
+  title: {
+    text: "2023 Norway car registrations",
+  },
+  subtitle: {
+    text: 'Source: <a href="https://www.ssb.no/transport-og-reiseliv/faktaside/bil-og-transport">SSB</a>',
+  },
+  tooltip: {
+    pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",
+  },
+  legend: {
+    enabled: false,
+  },
+  plotOptions: {
+    series: {
+      allowPointSelect: true,
+      cursor: "pointer",
+      borderRadius: 8,
+      dataLabels: [
         {
-          name: "Waiting for Calls",
-          y: 41,
+          enabled: true,
+          distance: 20,
+          format: "{point.name}",
         },
         {
-          name: "On Call",
-          y: 49,
-        },
-        {
-          name: "After Call",
-          y: 10,
+          enabled: true,
+          distance: -15,
+          format: "{point.percentage:.0f}%",
+          style: {
+            fontSize: "0.9em",
+          },
         },
       ],
+      showInLegend: true,
+    },
+  },
+  series: [
+    {
+      name: "Registrations",
+      colorByPoint: true,
+      innerSize: "75%",
+      data: data,
     },
   ],
 } %>
 
-<%= pb_rails("pb_circle_chart", props: { options: chart_options }) %>
+<div style="position: relative;">
+  <%= pb_rails("pb_circle_chart", props: { options: chart_options }) %>
+
+  <div
+    style="position: absolute; inset: 0; display: flex; justify-content: center; align-items: center; z-index: 1; text-align: center; pointer-events: none;"
+  >
+    <div>
+      <%= pb_rails("body", props: { text: "Total", color: "light" }) %>
+      <%= pb_rails("title", props: { size: 3, tag: "div", text: total.round(1).to_s }) %>
+    </div>
+  </div>
+</div>

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.html.erb
@@ -29,20 +29,22 @@
     },
   },
   title: {
+    text: "2023 Norway car registrations",
+    floating: true,
+    align: "center",
+    verticalAlign: "top",
+    y: 8,
+  },
+  subtitle: {
     text: "Total<br><strong>#{total.round(1)}</strong>",
     useHTML: true,
     floating: true,
     align: "center",
     verticalAlign: "middle",
-    y: 28,
+    y: 8,
     style: {
       textAlign: "center",
     },
-  },
-  subtitle: {
-    text: "2023 Norway car registrations",
-    align: "center",
-    x: 0,
   },
   tooltip: {
     pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.jsx
@@ -1,114 +1,32 @@
 import React from "react";
 import PbCircleChart from "../_pb_circle_chart";
-import Body from "../../pb_body/_body";
-import Title from "../../pb_title/_title";
-
-const data = [
-  {
-    name: "EV",
-    y: 23.9,
-  },
-  {
-    name: "Hybrids",
-    y: 12.6,
-  },
-  {
-    name: "Diesel",
-    y: 37.0,
-  },
-  {
-    name: "Petrol",
-    y: 26.4,
-  },
-];
-
-const total = data.reduce((sum, point) => sum + point.y, 0);
 
 const chartOptions = {
-  chart: {
-    type: "pie",
-  },
-  accessibility: {
-    point: {
-      valueSuffix: "%",
-    },
-  },
-  title: {
-    text: "2023 Norway car registrations",
-  },
-  subtitle: {
-    text: 'Source: <a href="https://www.ssb.no/transport-og-reiseliv/faktaside/bil-og-transport">SSB</a>',
-  },
-  tooltip: {
-    pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",
-  },
-  legend: {
-    enabled: false,
-  },
-  plotOptions: {
-    series: {
-      allowPointSelect: true,
-      cursor: "pointer",
-      borderRadius: 8,
-      dataLabels: [
-        {
-          enabled: true,
-          distance: 20,
-          format: "{point.name}",
-        },
-        {
-          enabled: true,
-          distance: -15,
-          format: "{point.percentage:.0f}%",
-          style: {
-            fontSize: "0.9em",
-          },
-        },
-      ],
-      showInLegend: true,
-    },
-  },
   series: [
     {
-      name: "Registrations",
-      colorByPoint: true,
-      innerSize: "75%",
-      data,
+      data: [
+        {
+          name: "Waiting for Calls",
+          y: 41,
+        },
+        {
+          name: "On Call",
+          y: 49,
+        },
+        {
+          name: "After Call",
+          y: 10,
+        },
+      ],
     },
   ],
 };
-
 const PbCircleChartDefault = (props) => (
-  <div style={{ position: "relative" }}>
+  <div>
     <PbCircleChart
         options={chartOptions}
         {...props}
     />
-    <div
-        style={{
-          position: "absolute",
-          inset: 0,
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          zIndex: 1,
-          textAlign: "center",
-          pointerEvents: "none",
-        }}
-    >
-      <div>
-        <Body
-            color="light"
-            text="Total"
-        />
-        <Title
-            size={3}
-            tag="div"
-        >
-          {total.toFixed(1)}
-        </Title>
-      </div>
-    </div>
   </div>
 );
 

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/_pb_circle_chart_default.jsx
@@ -1,32 +1,114 @@
 import React from "react";
 import PbCircleChart from "../_pb_circle_chart";
+import Body from "../../pb_body/_body";
+import Title from "../../pb_title/_title";
+
+const data = [
+  {
+    name: "EV",
+    y: 23.9,
+  },
+  {
+    name: "Hybrids",
+    y: 12.6,
+  },
+  {
+    name: "Diesel",
+    y: 37.0,
+  },
+  {
+    name: "Petrol",
+    y: 26.4,
+  },
+];
+
+const total = data.reduce((sum, point) => sum + point.y, 0);
 
 const chartOptions = {
-  series: [
-    {
-      data: [
+  chart: {
+    type: "pie",
+  },
+  accessibility: {
+    point: {
+      valueSuffix: "%",
+    },
+  },
+  title: {
+    text: "2023 Norway car registrations",
+  },
+  subtitle: {
+    text: 'Source: <a href="https://www.ssb.no/transport-og-reiseliv/faktaside/bil-og-transport">SSB</a>',
+  },
+  tooltip: {
+    pointFormat: "{series.name}: <b>{point.percentage:.0f}%</b>",
+  },
+  legend: {
+    enabled: false,
+  },
+  plotOptions: {
+    series: {
+      allowPointSelect: true,
+      cursor: "pointer",
+      borderRadius: 8,
+      dataLabels: [
         {
-          name: "Waiting for Calls",
-          y: 41,
+          enabled: true,
+          distance: 20,
+          format: "{point.name}",
         },
         {
-          name: "On Call",
-          y: 49,
-        },
-        {
-          name: "After Call",
-          y: 10,
+          enabled: true,
+          distance: -15,
+          format: "{point.percentage:.0f}%",
+          style: {
+            fontSize: "0.9em",
+          },
         },
       ],
+      showInLegend: true,
+    },
+  },
+  series: [
+    {
+      name: "Registrations",
+      colorByPoint: true,
+      innerSize: "75%",
+      data,
     },
   ],
 };
+
 const PbCircleChartDefault = (props) => (
-  <div>
+  <div style={{ position: "relative" }}>
     <PbCircleChart
         options={chartOptions}
         {...props}
     />
+    <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          zIndex: 1,
+          textAlign: "center",
+          pointerEvents: "none",
+        }}
+    >
+      <div>
+        <Body
+            color="light"
+            text="Total"
+        />
+        <Title
+            size={3}
+            tag="div"
+        >
+          {total.toFixed(1)}
+        </Title>
+      </div>
+    </div>
   </div>
 );
 

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/example.yml
@@ -11,6 +11,7 @@ examples:
   - pb_circle_chart_with_title: With Title
   - pb_circle_chart_inner_sizes: Inner Circle Size Options
   - pb_circle_chart_custom_tooltip: Tooltip Customization
+  - pb_circle_chart_centered_data: Centered Data
 
   
   react:
@@ -25,5 +26,6 @@ examples:
   - pb_circle_chart_with_title: With Title
   - pb_circle_chart_inner_sizes: Inner Circle Size Options
   - pb_circle_chart_custom_tooltip: Tooltip Customization
+  - pb_circle_chart_centered_data: Centered Data
   
   

--- a/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_pb_circle_chart/docs/index.js
@@ -9,3 +9,4 @@ export { default as PbCircleChartDataLegendPosition } from './_pb_circle_chart_d
 export { default as PbCircleChartWithTitle } from './_pb_circle_chart_with_title.jsx'
 export { default as PbCircleChartInnerSizes } from './_pb_circle_chart_inner_sizes.jsx'
 export { default as PbCircleChartCustomTooltip } from './_pb_circle_chart_custom_tooltip.jsx'
+export { default as PbCircleChartCenteredData } from './_pb_circle_chart_centered_data.jsx'


### PR DESCRIPTION
[PLAY-2914](https://runway.powerhrg.com/backlog_items/PLAY-2914)

Adds Centered Subtitle Pattern doc example.


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.