### PR TITLE
[PLAY-2986] Date Picker: Expose data-default-value for Smart Filter Reset (Part 2) - React & Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -12,17 +12,38 @@ import Caption from '../pb_caption/_caption'
 import Body from '../pb_body/_body'
 import colors from "../tokens/exports/_colors.module.scss"
 
+function isValidDateInstance(value: Date): boolean {
+  return !Number.isNaN(value.getTime())
+}
+
+function normalizeDefaultDate<T>(defaultDate: T): T {
+  if (defaultDate instanceof Date) {
+    return (isValidDateInstance(defaultDate) ? defaultDate : '') as unknown as T
+  }
+  if (Array.isArray(defaultDate)) {
+    const normalized = defaultDate.filter(
+      (d) => !(d instanceof Date) || isValidDateInstance(d)
+    )
+    return (normalized.length ? normalized : '') as unknown as T
+  }
+  return defaultDate
+}
+
 function serializeDefaultDateForFilterReset(defaultDate: unknown): string | undefined {
   if (defaultDate === '' || defaultDate == null) return undefined
   if (Array.isArray(defaultDate)) {
     const parts = defaultDate.map((d) => {
       if (d == null || d === '') return ''
-      if (d instanceof Date) return d.toISOString()
+      if (d instanceof Date) {
+        return isValidDateInstance(d) ? d.toISOString() : ''
+      }
       return String(d)
     }).filter(Boolean)
     return parts.length ? parts.join(',') : undefined
   }
-  if (defaultDate instanceof Date) return defaultDate.toISOString()
+  if (defaultDate instanceof Date) {
+    return isValidDateInstance(defaultDate) ? defaultDate.toISOString() : undefined
+  }
   return String(defaultDate)
 }
 
@@ -127,7 +148,8 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
   } = props
 
   const ariaProps = buildAriaProps(aria)
-  const filterResetDefaultSerialized = serializeDefaultDateForFilterReset(defaultDate)
+  const normalizedDefaultDate = normalizeDefaultDate(defaultDate)
+  const filterResetDefaultSerialized = serializeDefaultDateForFilterReset(normalizedDefaultDate)
   const dataProps = buildDataProps({
     ...data,
     ...(filterResetDefaultSerialized ? { 'default-value': filterResetDefaultSerialized } : {}),
@@ -154,7 +176,7 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
     datePickerHelper({
       allowInput,
       customQuickPickDates,
-      defaultDate,
+      defaultDate: normalizedDefaultDate,
       disableDate,
       disableRange,
       disableWeekdays,

--- a/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/_date_picker.tsx
@@ -12,6 +12,20 @@ import Caption from '../pb_caption/_caption'
 import Body from '../pb_body/_body'
 import colors from "../tokens/exports/_colors.module.scss"
 
+function serializeDefaultDateForFilterReset(defaultDate: unknown): string | undefined {
+  if (defaultDate === '' || defaultDate == null) return undefined
+  if (Array.isArray(defaultDate)) {
+    const parts = defaultDate.map((d) => {
+      if (d == null || d === '') return ''
+      if (d instanceof Date) return d.toISOString()
+      return String(d)
+    }).filter(Boolean)
+    return parts.length ? parts.join(',') : undefined
+  }
+  if (defaultDate instanceof Date) return defaultDate.toISOString()
+  return String(defaultDate)
+}
+
 type DatePickerProps = {
   allowInput?: boolean,
   aria?: { [key: string]: string },
@@ -113,7 +127,11 @@ const DatePicker = (props: DatePickerProps): React.ReactElement => {
   } = props
 
   const ariaProps = buildAriaProps(aria)
-  const dataProps = buildDataProps(data)
+  const filterResetDefaultSerialized = serializeDefaultDateForFilterReset(defaultDate)
+  const dataProps = buildDataProps({
+    ...data,
+    ...(filterResetDefaultSerialized ? { 'default-value': filterResetDefaultSerialized } : {}),
+  })
   const htmlProps = buildHtmlProps(htmlOptions)
   const inputAriaProps = buildAriaProps(inputAria)
   const inputDataProps = buildDataProps(inputData)

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.html.erb
@@ -1,8 +1,11 @@
-<%= pb_content_tag(:div,
-    class: object.classname + object.error_class,
-    'data-pb-date-picker' => true,
-    'data-validation-message' => object.validation_message,
-      ) do %>
+<% date_picker_root_attrs = {
+  class: object.classname + object.error_class,
+  'data-pb-date-picker' => true,
+  'data-validation-message' => object.validation_message,
+}
+  date_picker_root_attrs['data-default-value'] = object.serialized_default_date_for_dom if object.serialized_default_date_for_dom.present?
+%>
+<%= pb_content_tag(:div, date_picker_root_attrs) do %>
   <div class="input_wrapper">
     <% if !object.hide_label && object.label %>
       <label for="<%= object.picker_id %>">

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.rb
@@ -145,6 +145,18 @@ module Playbook
       def angle_down_path
         "app/pb_kits/playbook/utilities/icons/angle-down.svg"
       end
+
+      # Serialized business default for opt-in smart filter reset (Nitro / data-default-value).
+      def serialized_default_date_for_dom
+        case default_date
+        when nil, ""
+          nil
+        when Array
+          default_date.compact_blank.map(&:to_s).join(",")
+        else
+          default_date.to_s.presence
+        end
+      end
     end
   end
 end

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -66,6 +66,40 @@ describe('DatePicker Kit', () => {
     expect(kit).not.toHaveAttribute('data-default-value')
   })
 
+  test('renders without error when defaultDate is an invalid Date', () => {
+    const testId = 'datepicker-invalid-date'
+    const invalidDate = new Date('UndefinedT00:00')
+
+    expect(() => {
+      render(
+        <DatePicker
+            data={{ testid: testId }}
+            defaultDate={invalidDate}
+            pickerId="date-picker-invalid-date"
+        />
+      )
+    }).not.toThrow()
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).not.toHaveAttribute('data-default-value')
+  })
+
+  test('omits data-default-value when defaultDate is constructed from undefined', () => {
+    const testId = 'datepicker-undefined-date'
+    const invalidDate = new Date(undefined + 'T00:00')
+
+    render(
+      <DatePicker
+          data={{ testid: testId }}
+          defaultDate={invalidDate}
+          pickerId="date-picker-undefined-date"
+      />
+    )
+
+    const kit = screen.getByTestId(testId)
+    expect(kit).not.toHaveAttribute('data-default-value')
+  })
+
   test('inLine alone adds inline-date-picker class and inline control icons, not the calendar icon', () => {
     const testId = 'datepicker-inline-only'
     render(

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -40,6 +40,32 @@ describe('DatePicker Kit', () => {
     expect(kit).toHaveClass('pb_date_picker_kit mb_sm')
   })
 
+  test('exposes data-default-value on kit root when defaultDate is set', () => {
+    const testId = 'datepicker-def-attr'
+    render(
+      <DatePicker
+          data={{ testid: testId }}
+          defaultDate={DEFAULT_DATE}
+          pickerId="date-picker-def-attr"
+      />
+    )
+    const kit = screen.getByTestId(testId)
+    expect(kit).toHaveAttribute('data-default-value', DEFAULT_DATE.toISOString())
+  })
+
+  test('omits data-default-value when defaultDate is empty', () => {
+    const testId = 'datepicker-no-def-attr'
+    render(
+      <DatePicker
+          data={{ testid: testId }}
+          defaultDate=""
+          pickerId="date-picker-no-def-attr"
+      />
+    )
+    const kit = screen.getByTestId(testId)
+    expect(kit).not.toHaveAttribute('data-default-value')
+  })
+
   test('inLine alone adds inline-date-picker class and inline control icons, not the calendar icon', () => {
     const testId = 'datepicker-inline-only'
     render(

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -278,7 +278,9 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
   // Default Date + Min/Max Date Initialization Helper Functions section ----/
   const toDateObject = (dateValue: any): Date | null => {
     if (!dateValue) return null
-    if (dateValue instanceof Date) return dateValue
+    if (dateValue instanceof Date) {
+      return isNaN(dateValue.getTime()) ? null : dateValue
+    }
     if (typeof dateValue === 'string') {
       const parsed = new Date(dateValue)
       return isNaN(parsed.getTime()) ? null : parsed

--- a/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/date_picker_spec.rb
@@ -59,4 +59,19 @@ RSpec.describe Playbook::PbDatePicker::DatePicker do
   it "raises an error when not given a picker_id" do
     expect { subject.new {} }.to raise_error(Playbook::Props::Error)
   end
+
+  describe "#serialized_default_date_for_dom" do
+    it "returns nil when default_date is blank" do
+      picker = subject.new(picker_id: "p1", default_date: "")
+      expect(picker.serialized_default_date_for_dom).to be_nil
+    end
+
+    it "returns the default_date string for quick pick and ISO values" do
+      quick = subject.new(picker_id: "p2", default_date: "This quarter")
+      expect(quick.serialized_default_date_for_dom).to eq("This quarter")
+
+      iso = subject.new(picker_id: "p3", default_date: "2020-07-25T00:00:00Z")
+      expect(iso.serialized_default_date_for_dom).to eq("2020-07-25T00:00:00Z")
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-2986

This adds Date Picker data-default-values when defaultDate is passed in. It was based off of https://github.com/powerhome/playbook/pull/6141. 

More importantly, for "invalid" dates like `new Date(undefined + 'T00:00')`, the date picker does not throw an error. 

**Screenshots:** Screenshots to visualize your addition/change
<img width="414" height="329" alt="Screenshot 2026-05-27 at 10 59 34 AM" src="https://github.com/user-attachments/assets/3f766864-3cf6-477d-852c-441267458cf2" />


**How to test?** Steps to confirm the desired behavior:
Test on nitro-web.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.