### PR TITLE
[PLAY-3003] Playbook Website: Fix Small Expand-All and Sort Icons in Rails Advanced Table Header

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon/_icon.scss
+++ b/playbook/app/pb_kits/playbook/pb_icon/_icon.scss
@@ -69,9 +69,10 @@ svg {
       transform: scaleX(-1) scaleY(-1);
     }
     &.svg-inline--fa {
+      box-sizing: content-box;
       height: 1em;
       overflow: visible;
-      vertical-align: -.125em
+      vertical-align: -.125em;
     }
     &.svg_inverse {
       color: #fff;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3003](https://runway.powerhrg.com/backlog_items/PLAY-3003?from=active_sprint) removing FA from the Playbook website entirely caused an icon size issue for a few Icon-containing kits. FA JS adds a <style> tag with `box-sizing: content-box` - adding that rule back to the FA-based svg-inline--fa class helps put it back in the places where it was important.
Relevant for Rails Advanced Table and React and Rails Icon Button - I did a website smoketest/check for many other icon-containing kits and none of them had this icon regression (all Icon_ kits, all Button kits, Badge, Collapsible, DatePicker, DateRangeInline, DateRangeStacked, Dialog, Dropdown, Filter, FixedConfirmationToast, LoadingInline, Nav, Passphrase, RichTextEditor, Select, Table, TextInput, TimeRangeInline, Typeahead).

**Screenshots:** Screenshots to visualize your addition/change
Current Prod - a few tiny icons:
<img width="257" height="145" alt="small at default" src="https://github.com/user-attachments/assets/0372723b-987f-4982-9a31-0e9c735c2182" />
<img width="252" height="161" alt="small at sorting" src="https://github.com/user-attachments/assets/ac43d043-642f-4902-8ae9-c1dca031aed5" />
<img width="252" height="398" alt="small icon button" src="https://github.com/user-attachments/assets/8fe6a82f-ccb1-4a98-a2d3-54168e54711a" />
Updated - icons back to normal:
<img width="277" height="156" alt="default for PR" src="https://github.com/user-attachments/assets/c78635d8-b5e4-4c31-a612-94fbe6a97672" />
<img width="256" height="173" alt="sorting for PR" src="https://github.com/user-attachments/assets/03033d8e-b957-4b62-bf11-969290c89557" />
<img width="219" height="443" alt="icon button for PR" src="https://github.com/user-attachments/assets/187a7672-5af4-4236-84fb-f5d7d6bfbf7c" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Rails Advanced Table docs - see normal size expand all toggle and sorting icons.
2. Go to Icon Button docs (Rails and React) - see normal icons/normal spacing for the Sizes doc.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.