### PR TITLE
[PLAY-3008]  Fix Dropdown and Popup Clipping in Playbook Website Documentation Examples

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleRails.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleRails.tsx
@@ -56,9 +56,28 @@ function applyDarkModeToRenderedRoots(container: HTMLDivElement, darkMode: boole
   });
 }
 
+function resetExampleOverflow(element: HTMLElement) {
+  element.style.overflowX = "auto";
+  element.style.removeProperty("overflow-y");
+}
+
+function showExampleOverflow(event: React.SyntheticEvent<HTMLDivElement>) {
+  event.currentTarget.style.overflowX = "visible";
+  event.currentTarget.style.overflowY = "visible";
+}
+
 const LiveExampleRails: React.FC<LiveExampleRailsProps> = ({ html }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { darkMode } = useDarkMode();
+
+  const handleBlurCapture = (event: React.FocusEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget as Node | null;
+
+    if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
+      resetExampleOverflow(event.currentTarget);
+    }
+  };
+
   useEffect(() => {
     if (!containerRef.current || !html) return;
 
@@ -122,6 +141,9 @@ const LiveExampleRails: React.FC<LiveExampleRailsProps> = ({ html }) => {
       }}
     >
       <div
+        onBlurCapture={handleBlurCapture}
+        onFocusCapture={showExampleOverflow}
+        onPointerDownCapture={showExampleOverflow}
         style={{
           boxSizing: "border-box",
           width: "100%",

--- a/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleRails.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleRails.tsx
@@ -73,9 +73,18 @@ const LiveExampleRails: React.FC<LiveExampleRailsProps> = ({ html }) => {
   const handleBlurCapture = (event: React.FocusEvent<HTMLDivElement>) => {
     const nextTarget = event.relatedTarget as Node | null;
 
-    if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
-      resetExampleOverflow(event.currentTarget);
+    if (nextTarget && event.currentTarget.contains(nextTarget)) {
+      return;
     }
+
+    const wrapper = event.currentTarget;
+    setTimeout(() => {
+      const hasOpenPopup = wrapper.querySelector(
+        ".pb_dropdown_container.open, .pb_multi_level_select .dropdown_menu.open, .pb_time_picker .pb_time_picker_container",
+      );
+      if (hasOpenPopup) return;
+      resetExampleOverflow(wrapper);
+    }, 0);
   };
 
   useEffect(() => {

--- a/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleReact.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleReact.tsx
@@ -156,9 +156,18 @@ const LiveExample: React.FC<LiveExampleProps> = ({
   const handleBlurCapture = (event: React.FocusEvent<HTMLDivElement>) => {
     const nextTarget = event.relatedTarget as Node | null;
 
-    if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
-      resetExampleOverflow(event.currentTarget);
+    if (nextTarget && event.currentTarget.contains(nextTarget)) {
+      return;
     }
+
+    const wrapper = event.currentTarget;
+    setTimeout(() => {
+      const hasOpenPopup = wrapper.querySelector(
+        ".pb_dropdown_container.open, .pb_multi_level_select .dropdown_menu.open, .pb_time_picker .pb_time_picker_container",
+      );
+      if (hasOpenPopup) return;
+      resetExampleOverflow(wrapper);
+    }, 0);
   };
 
   useEffect(() => {

--- a/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleReact.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleReact.tsx
@@ -114,6 +114,16 @@ async function loadThirdPartyLibs(raw: string): Promise<ThirdPartyScope> {
   return Object.assign({}, ...scopes);
 }
 
+function resetExampleOverflow(element: HTMLElement) {
+  element.style.overflowX = "auto";
+  element.style.removeProperty("overflow-y");
+}
+
+function showExampleOverflow(event: React.SyntheticEvent<HTMLDivElement>) {
+  event.currentTarget.style.overflowX = "visible";
+  event.currentTarget.style.overflowY = "visible";
+}
+
 // Main Component
 const LiveExample: React.FC<LiveExampleProps> = ({
   code,
@@ -142,6 +152,14 @@ const LiveExample: React.FC<LiveExampleProps> = ({
     () => ({ ...exampleProps, dark: darkMode, darkMode }),
     [exampleProps, darkMode],
   );
+
+  const handleBlurCapture = (event: React.FocusEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget as Node | null;
+
+    if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
+      resetExampleOverflow(event.currentTarget);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -243,6 +261,9 @@ const LiveExample: React.FC<LiveExampleProps> = ({
           }}
         >
           <div
+            onBlurCapture={handleBlurCapture}
+            onFocusCapture={showExampleOverflow}
+            onPointerDownCapture={showExampleOverflow}
             style={{
               boxSizing: "border-box",
               width: "100%",

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
@@ -309,8 +309,8 @@ export const DocsTab = ({ examples, exampleProps, sections }: DocsTabProps) => {
       }}
     >
       {/*
-        Keep horizontal overflow clipping on the examples column only. `overflow-x: hidden` on an
-        ancestor of `position: sticky` breaks sticking to the main scrollport (see RightSideNav).
+        Keep horizontal overflow clipping on the examples column only. `overflow-x: hidden` also
+        clips vertical popups, so use `clip` to avoid creating a scroll container.
       */}
       <Flex
         flexDirection="column"
@@ -322,7 +322,8 @@ export const DocsTab = ({ examples, exampleProps, sections }: DocsTabProps) => {
             boxSizing: "border-box",
             maxWidth: "100%",
             minWidth: 0,
-            overflowX: "hidden",
+            overflowX: "clip",
+            overflowY: "visible",
           },
         }}
       >


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Fixes popup/dropdown clipping in the Playbook website docs without changing any kit code

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.