### PR TITLE
[PLAY-3010] Upgrades Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -1220,6 +1220,10 @@
     "category": "Interface Core"
   },
   {
+    "name": "distribute-spacing-horizontal",
+    "category": "Interface Core"
+  },
+  {
     "name": "dot-circle",
     "category": "Interface Core"
   },
@@ -1333,6 +1337,10 @@
   },
   {
     "name": "object-group",
+    "category": "Interface Core"
+  },
+  {
+    "name": "object-intersect",
     "category": "Interface Core"
   },
   {
@@ -2124,6 +2132,10 @@
     "category": "Technology"
   },
   {
+    "name": "mobile-rotate",
+    "category": "Technology"
+  },
+  {
     "name": "mouse",
     "category": "Technology"
   },
@@ -2328,6 +2340,10 @@
     "category": "Tools"
   },
   {
+    "name": "atom",
+    "category": "Tools"
+  },
+  {
     "name": "binoculars",
     "category": "Tools"
   },
@@ -2352,6 +2368,10 @@
     "category": "Tools"
   },
   {
+    "name": "gem",
+    "category": "Tools"
+  },
+  {
     "name": "hammer",
     "category": "Tools"
   },
@@ -2365,6 +2385,10 @@
   },
   {
     "name": "pen-line",
+    "category": "Tools"
+  },
+  {
+    "name": "pen-ruler",
     "category": "Tools"
   },
   {

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "2.1.0",
-    "@powerhome/playbook-icons-react": "2.1.0",
+    "@powerhome/playbook-icons": "2.2.0",
+    "@powerhome/playbook-icons-react": "2.2.0",
     "@powerhome/power-fonts": "0.0.1",
     "maplibre-gl": "^4.7.1",
     "highcharts": "^11.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,15 +3170,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@2.1.0":
-  version "2.1.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/4977fa273a6b6b882370a3c67c667b32b4d0e5ac#4977fa273a6b6b882370a3c67c667b32b4d0e5ac"
-  integrity sha512-O29A6HNzjg+MT+afZkOjQ40LDiJjMC4axwXNM5iivcwAOvnPa9cu4lzrGereEI8LigtTxSLqfzfKhkuYRcDzWQ==
+"@powerhome/playbook-icons-react@2.2.0":
+  version "2.2.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/43db661bc334923b7da1dc417ca51063d34abf9a#43db661bc334923b7da1dc417ca51063d34abf9a"
+  integrity sha512-87aQHdzZ7eG1Voef+sBTjexiXlr1AVHSYDgwWsMyTBod72Djv2MCll+B5hT3gjNozZEfgRL0A+nEBXTKQPiFWA==
 
-"@powerhome/playbook-icons@2.1.0":
-  version "2.1.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/f3cd9f00a21a910ad1850ae28ccaf941cc30ff4a#f3cd9f00a21a910ad1850ae28ccaf941cc30ff4a"
-  integrity sha512-2PLmXoGeRW+fgFIroUz31FUQTm4laPg1Si3YwjVd5PRFwhKGI5gy+wRVeH0adAcxwTT5xIQK1bAC6xGW9B+PYw==
+"@powerhome/playbook-icons@2.2.0":
+  version "2.2.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/1d1ed3dadb8f6460e6db24e0915dddb1e2ef0a5b#1d1ed3dadb8f6460e6db24e0915dddb1e2ef0a5b"
+  integrity sha512-J0H66AIeWgoMWx0Ds8rWaYXhmcZ9o8fB6ISsBq5WEkj4cMfavHbP/aG8HeleI5RrppOkAWSDXUQmCKZW5yAGxw==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3010](https://runway.powerhrg.com/backlog_items/PLAY-3010) adds 6 icons to the playbook-icons repo including some used on the Getting Started and Design Guidelines index pages. https://github.com/powerhome/playbook-icons/pull/60

**Screenshots:** Screenshots to visualize your addition/change
<img width="964" height="703" alt="Screenshot 2026-05-29 at 8 07 55 AM" src="https://github.com/user-attachments/assets/664281c2-654c-4da8-9e4c-51f9bd8bcc30" />
<img width="769" height="403" alt="Screenshot 2026-05-29 at 8 08 06 AM" src="https://github.com/user-attachments/assets/df0e6601-b9ca-4e20-9c7f-b990c01fac34" />
<img width="375" height="222" alt="Screenshot 2026-05-29 at 8 08 17 AM" src="https://github.com/user-attachments/assets/21683fca-9311-4759-b5ad-81b436d4e23f" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /guides/getting_started and /guides/design_guidelines - see all entries have icons again.
2. Go to /playbook_icons page - see icon cards for all 6 icons.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.