### PR TITLE
[PLAY-2970] Message Mentions are Smaller to Avoid Overlaps

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_message/_message.scss
+++ b/playbook/app/pb_kits/playbook/pb_message/_message.scss
@@ -20,7 +20,7 @@ $mention_bg_color_blue: #e5eefa;
   border-radius: $space_xxs;
   color: $primary;
   display: inline;
-  padding: $space_xxs;
+  padding: 1px 2px;
 }
 
 .pb_message_mention_user {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-2970](https://runway.powerhrg.com/backlog_items/PLAY-2970?from=active_sprint) adjusts the padding around Message kit Mentions to avoid overlapping on wrapped text blocks. See [CSB with alpha](https://codesandbox.io/p/devbox/play-2946-currency-kit-forked-zr8jrw?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) for wrapped text block example.

**Screenshots:** Screenshots to visualize your addition/change
Current Prod:
<img width="340" height="77" alt="current prod" src="https://github.com/user-attachments/assets/7f7e9cd1-b23d-48ab-93b7-81491039ac84" />
Updated:
<img width="386" height="92" alt="new spacing old yellow" src="https://github.com/user-attachments/assets/d39a0dfa-b7d3-420e-bfe8-208d2067b82c" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Message kit Mentions doc - see basically the same as prod, just slightly less Mentions space around the text.
2. Go to [CSB with alpha](https://codesandbox.io/p/devbox/play-2946-currency-kit-forked-zr8jrw?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) - see how this update avoids Mentions overlapping.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.