### PR TITLE
[PLAY-3013] Remove remaining FA references from kits and website

### DIFF
--- a/playbook-website/app/javascript/entrypoints/application.js
+++ b/playbook-website/app/javascript/entrypoints/application.js
@@ -25,7 +25,9 @@ function pascalToKebabCase(str) {
     .replace(/([a-z])([A-Z])/g, '$1-$2')
     .replace(/([a-zA-Z])([0-9])/g, '$1-$2')
     .replace(/([0-9])([a-zA-Z])/g, '$1-$2')
-    .toLowerCase(); 
+    .toLowerCase()
+    // Heading icons export as H1..H6 but icon props use h1..h6 (no hyphen)
+    .replace(/^h-(\d)$/, 'h$1')
 }
 
 Object.entries(icons).forEach(([key, value]) => {

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -7,7 +7,10 @@ import timeSelectPlugin from './plugins/timeSelect'
 import quickPickPlugin from './plugins/quickPick'
 import { getAllIcons } from '../utilities/icons/allicons';
 
-const angleDown = getAllIcons().angleDown.string
+const { angleDown, angleLeft, angleRight } = getAllIcons()
+const angleDownString = angleDown.string
+const angleLeftString = angleLeft.string
+const angleRightString = angleRight.string
 
 const getPositionElement = (element: string | Element) => {
   return (typeof element === 'string') ? document.querySelectorAll(element)[0] : element
@@ -365,7 +368,7 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
     maxDate: effectiveMaxDate,
     minDate: effectiveMinDate,
     mode,
-    nextArrow: '<i class="far fa-angle-right"></i>',
+    nextArrow: `<div style="height: 14px;">${angleRightString}</div>`,
     onOpen: [(_selectedDates, _dateStr, fp) => {
       // If defaultDate was out of range of a dev set min/max date, restore it when calendar opens (in situation where the input was manually cleared or the calendar was closed without selection)
       if (hasOutOfRangeDefault) {
@@ -437,7 +440,7 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
     plugins: setPlugins(thisRangesEndToday, customQuickPickDates),
     position,
     positionElement: getPositionElement(positionElement),
-    prevArrow: '<i class="far fa-angle-left"></i>',
+    prevArrow: `<div style="height: 14px;">${angleLeftString}</div>`,
     static: staticPosition,
   })
 
@@ -651,12 +654,9 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
   }
 
   // Adding dropdown icons to year and month select
-  dropdown.insertAdjacentHTML('afterend', `<i class="year-dropdown-icon">${angleDown}</i>`)
+  dropdown.insertAdjacentHTML('afterend', `<i class="year-dropdown-icon">${angleDownString}</i>`)
   if (picker.monthElements[0].parentElement) {
-    return picker.monthElements[0].insertAdjacentHTML('afterend', `<i class="month-dropdown-icon">${angleDown}</i>`)}
-  // if (picker.weekElements[0].parentElement){
-  //   return  picker.weekElements[0].insertAdjacentHTML('afterend', '<i class="far fa-angle-down year-dropdown-icon" id="test-id"></i>')
-  // }
+    return picker.monthElements[0].insertAdjacentHTML('afterend', `<i class="month-dropdown-icon">${angleDownString}</i>`)}
 
   // Remove readonly attribute for validation and or text input
   if (allowInput){

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_background.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_filter_no_background.html.erb
@@ -32,7 +32,7 @@
     <%= form.collection_select :example_collection_select, example_collection, :value, :name, props: { label: true } %>
 
     <%= form.actions do |action| %>
-      <%= action.submit props: { text: "Apply", data: { disable_with: "<i class='far fa-spinner fa-spin mr-3'></i>Searching...".html_safe },}%>
+      <%= action.submit props: { text: "Apply", data: { disable_with: "pb_rails('icon', props: { icon: 'spinner', spin: true, fixed_width: true })Searching...".html_safe },}%>
       <%= action.button props: { type: "reset", text: "Clear", variant: "secondary" } %>
     <% end %>
   <% end %>

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
@@ -21,7 +21,7 @@ const PopoverWithButton = (props) => {
     >
       <Flex 
           align="center"
-          gap="xs" 
+          gap="xxs" 
       >
         {"Filter By"}
         <Icon

--- a/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
+++ b/playbook/app/pb_kits/playbook/pb_popover/docs/_popover_list.jsx
@@ -19,18 +19,16 @@ const PopoverWithButton = (props) => {
         onClick={handleTogglePopover}
         variant="secondary"
     >
-      <Flex align="center">
+      <Flex 
+          align="center"
+          gap="xs" 
+      >
         {"Filter By"}
-        <Flex
-            className={showPopover ? "fa-flip-vertical" : ""}
-            display="inline_flex"
-        >
-          <Icon
-              fixedWidth
-              icon="angle-down"
-              margin-left="xxs"
-          />
-        </Flex>
+        <Icon
+            fixedWidth
+            flip={showPopover ? "vertical" : "none"}
+            icon="angle-down"
+        />
       </Flex>
     </Button>
   )

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarDropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/TipTap/ToolbarDropdown.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react'
 
-import { getAllIcons } from "../../utilities/icons/allicons"
-
 import Flex from '../../pb_flex/_flex'
 import PbReactPopover from '../../pb_popover/_popover'
 import Button from '../../pb_button/_button'
@@ -67,8 +65,6 @@ const toolbarDropdownItems = [
     },
 ]
 
-  const angleDown = getAllIcons()["angleDown"].icon as unknown as { [key: string]: SVGElement }
-
   const handleTogglePopover = () => {
     setShowPopover(!showPopover)
   }
@@ -92,16 +88,12 @@ for (const { text, isActive, icon } of toolbarDropdownItems) {
             size="lg"
         />
         <div>{text}</div>
-        <Flex className={showPopover ? "fa-flip-vertical" : ""}
-            display="inline_flex"
-        >
-          <Icon 
-              className="svg-inline--fa"
-              customIcon={angleDown}
-              fixedWidth
-              margin-left="xs"
-          />
-        </Flex>
+        <Icon
+            fixedWidth
+            flip={showPopover ? "vertical" : "none"}
+            icon="angle-down"
+            margin-left="xs"
+        />
       </Flex>
     );
   }
@@ -127,16 +119,12 @@ const popoverReference = (
                 size="lg"
             />
             <div>Paragraph</div>
-            <Flex className={showPopover ? "fa-flip-vertical" : ""}
-                display="inline_flex"
-            >
-              <Icon 
-                  className="svg-inline--fa"
-                  customIcon={angleDown}
-                  fixedWidth
-                  margin-left="xs"
-              />
-            </Flex>
+            <Icon
+                fixedWidth
+                flip={showPopover ? "vertical" : "none"}
+                icon="angle-down"
+                margin-left="xs"
+            />
           </Flex>
         )
        )

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/docs/_playground.json
@@ -1,7 +1,10 @@
 {
   "template": "<RichTextEditor{{props}} />",
   "propTargets": {},
-  "defaults": {},
+  "defaults": {
+    "requiredIndicator": false,
+    "simple": false
+  },
   "groups": [
     {
       "name": "Props",

--- a/playbook/app/pb_kits/playbook/utilities/icons/allicons.tsx
+++ b/playbook/app/pb_kits/playbook/utilities/icons/allicons.tsx
@@ -147,6 +147,36 @@ const angleDown = (
   </svg>
 )
 
+const angleLeft = (
+  <svg
+      fill="none"
+      height="25"
+      viewBox="0 0 31 25"
+      width="31"
+      xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+        d="M10.6074 11.3086L18.1074 3.85547C18.5293 3.38672 19.2324 3.38672 19.7012 3.85547C20.123 4.27734 20.123 4.98047 19.7012 5.40234L12.9512 12.1055L19.6543 18.8555C20.123 19.2773 20.123 19.9805 19.6543 20.4023C19.2324 20.8711 18.5293 20.8711 18.1074 20.4023L10.6074 12.9023C10.1387 12.4805 10.1387 11.7773 10.6074 11.3086Z"
+        fill="#242B42"
+    />
+  </svg>
+)
+
+const angleRight = (
+  <svg
+      fill="none"
+      height="25"
+      viewBox="0 0 31 25"
+      width="31"
+      xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+        d="M21.2012 11.3086C21.623 11.7773 21.623 12.4805 21.2012 12.9023L13.7012 20.4023C13.2324 20.8711 12.5293 20.8711 12.1074 20.4023C11.6387 19.9805 11.6387 19.2773 12.1074 18.8555L18.8105 12.1523L12.1074 5.40234C11.6387 4.98047 11.6387 4.27734 12.1074 3.85547C12.5293 3.38672 13.2324 3.38672 13.6543 3.85547L21.2012 11.3086Z"
+        fill="#242B42"
+    />
+  </svg>
+)
+
 export const getAllIcons = () => {
 
     return {
@@ -177,6 +207,14 @@ export const getAllIcons = () => {
         angleDown: {
             icon: angleDown,
             string: ReactDOMServer.renderToStaticMarkup(angleDown)
+        },
+        angleLeft: {
+            icon: angleLeft,
+            string: ReactDOMServer.renderToStaticMarkup(angleLeft)
+        },
+        angleRight: {
+            icon: angleRight,
+            string: ReactDOMServer.renderToStaticMarkup(angleRight)
         }
     }
 }

--- a/playbook/jest.setup.js
+++ b/playbook/jest.setup.js
@@ -17,7 +17,9 @@ function pascalToKebabCase(str) {
     .replace(/([a-z])([A-Z])/g, '$1-$2')
     .replace(/([a-zA-Z])([0-9])/g, '$1-$2')
     .replace(/([0-9])([a-zA-Z])/g, '$1-$2')
-    .toLowerCase(); 
+    .toLowerCase()
+    // Heading icons export as H1..H6 but icon props use h1..h6 (no hyphen)
+    .replace(/^h-(\d)$/, 'h$1')
 }
 
 Object.entries(icons).forEach(([key, value]) => {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-3013?from=backlog)


Removes the last hardcoded Font Awesome icon references from Playbook kits so icons render via playbook-icons without requiring FA in consuming apps.

1. Date Picker : Replaces flatpickr prevArrow / nextArrow FA markup with playbook-icons SVGs (angleLeft, angleRight) from getAllIcons(), and adds those icons to allicons.tsx.
2. Filter docs : Replaces inline FA spinner in _filter_no_background.html.erb with pb_rails('icon', ...), matching other filter doc examples.
3. Popover docs :  Replaces fa-flip-vertical wrappers and FA-specific classes with the Icon kit’s flip prop and standard icon="angle-down"
4.  Rich Text Editor : Replaces fa-flip-vertical wrappers and FA-specific classes with the Icon kit’s flip prop and standard icon="angle-down" 
5. Heading icons (h1–h6) : Fixes pascalToKebabCase in the website and Jest setup so H1…H6 from @powerhome/playbook-icons-react register as h1…h6 (not h-1…h-6), restoring icons on the website Icons page and in the Rich Text Editor heading dropdown.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
6. Click on '....'
7. Scroll down to '....'
8. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.