### PR TITLE
[GOG-1832] Update deployer image tag to one that exists

### DIFF
--- a/playbook-website/bin/deployer
+++ b/playbook-website/bin/deployer
@@ -7,7 +7,7 @@ if [ -t 0 ]; then
   AWS_CREDS_MOUNT="--mount type=bind,source=${HOME}/.aws/credentials,destination=/root/.aws/credentials,readonly"
 fi
 
-DEPLOYER_IMAGE="image-registry.powerapp.cloud/app/deployer:main-559f8a815f07c3e04dc82bf416c403ef80f6eacb-42"
+DEPLOYER_IMAGE="image-registry.powerapp.cloud/app/deployer:main-b7d3415b8760f3f9ea3c1fb6cede68c56404f951-61"
 DEPLOYER_MOUNTS="${AWS_CREDS_MOUNT} --mount type=bind,source=$(pwd),destination=/app --mount type=bind,source=${HOME}/.kube,destination=/root/.kube"
 RUN_DEPLOYER="docker run --tty ${INTERACTIVE} ${EXTRA_ARGS} --rm --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY ${DEPLOYER_MOUNTS} ${DEPLOYER_IMAGE}"
 


### PR DESCRIPTION
**What does this PR do?**
This PR replaces the deployer image that has been pruned with one that exists.

Outlined in [[GOG-1832](https://runway.powerhrg.com/backlog_items/GOG-1832)]

**Screenshots:**
There are no visual or functional changes to Playbook or the Playbook website.

**How to test?** Steps to confirm the desired behavior:
A review environment successfully is deployed to.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [N/A] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.