### PR TITLE
Draggable: Update drag event listeners docs for mobile support

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_event_listeners_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_draggable/docs/_draggable_event_listeners_rails.md
@@ -1,1 +1,1 @@
-You can add drag event listeners for `drag`, `dragend`, `dragenter`, `dragleave`, `dragover`, `dragstart`, and `drop`.
+You can add drag event listeners for desktop `drag`, `dragend`, `dragenter`, `dragleave`, `dragover`, `dragstart`, and `drop` or mobile `touch`, `touchend`, `touchcancel`,`touchleave`,  `touchmove`, `touchstart`


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
While working on https://runway.powerhrg.com/backlog_items/INC-2874?from=active_sprint, INC team noticed that dragabble listeners wasn't working for mobile devices. By researching and adding "touch" listeners, the bug was fixed.

**How to test?** Steps to confirm the desired behavior:
1. Go to [Docs draggable#draggable_event_listeners](https://playbook.powerapp.cloud/kits/draggable/react#draggable_event_listeners)

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.