### PR TITLE
[PLAY-3023] Upgrades Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -1056,6 +1056,10 @@
     "category": "Hands"
   },
   {
+    "name": "hand",
+    "category": "Hands"
+  },
+  {
     "name": "hands-holding-diamond",
     "category": "Hands"
   },
@@ -1950,6 +1954,10 @@
   {
     "name": "product-windows",
     "category": "Power Products"
+  },
+  {
+    "name": "nitro-intelligence",
+    "category": "Power Tooling"
   },
   {
     "name": "nitro-logo",

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "2.3.0",
-    "@powerhome/playbook-icons-react": "2.3.0",
+    "@powerhome/playbook-icons": "2.4.0",
+    "@powerhome/playbook-icons-react": "2.4.0",
     "@powerhome/power-fonts": "0.0.1",
     "maplibre-gl": "^4.7.1",
     "highcharts": "^11.4.8",

--- a/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_icon/docs/_icon_default.jsx
@@ -5,7 +5,7 @@ const IconDefault = (props) => {
   return (
     <div>
       <Icon
-          fixedWidth
+          fixedWidth 
           icon="user"
           {...props}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,15 +3170,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@2.3.0":
-  version "2.3.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/42482e741e797d3dac4f5822547f0d60a1f0f08d#42482e741e797d3dac4f5822547f0d60a1f0f08d"
-  integrity sha512-Y4h7AXK7oKu0vQNCPPnk6pHcFrhqkQsEWGJ/DVyQSgk0C2Yug6FwHVQI/rYz3b5KBakDV0LPNuIk59WAb9CUHw==
+"@powerhome/playbook-icons-react@2.4.0":
+  version "2.4.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/37bee9e91e03926d6081d8d0bc52bde5fca50960#37bee9e91e03926d6081d8d0bc52bde5fca50960"
+  integrity sha512-01RbThJ62UmGzT5sZd/splLEGT+AtFZUEMz6lBSMAfxA5YqYxQQ0ZForPGQ2tnrrhT6ianYXLaotNi3220hLNA==
 
-"@powerhome/playbook-icons@2.3.0":
-  version "2.3.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/79b343cdacdb02fba7a1f25a835e3b6386a77549#79b343cdacdb02fba7a1f25a835e3b6386a77549"
-  integrity sha512-VBBWr7ZS47SD97Zg0LYlQOjWufFaaZ5eMJxKlAulSYqJ7GwKgvhYigR6fe8T0x/hyF5k6K72dVLxlBYVkIHSuQ==
+"@powerhome/playbook-icons@2.4.0":
+  version "2.4.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/a9fb026bf3dc84c32e9f7fbee3d226d18531ce6a#a9fb026bf3dc84c32e9f7fbee3d226d18531ce6a"
+  integrity sha512-ntvRiqxPHRtGdiTxgemT2VJIMx4uYgnfiYQKKY2Po5zrpN0qmp0y+npPIH+pL0yQXqSQJYBvSYD+M/9UnStWxg==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3023](https://runway.powerhrg.com/backlog_items/PLAY-3023) adds 2 icons to the playbook-icons repo. https://github.com/powerhome/playbook-icons/pull/62

**Screenshots:** Screenshots to visualize your addition/change
<img width="355" height="163" alt="icon test" src="https://github.com/user-attachments/assets/dbb727b2-9065-4b6b-add1-fefa446b783e" />
<img width="492" height="177" alt="Screenshot 2026-06-11 at 12 29 41 PM" src="https://github.com/user-attachments/assets/2b4e65a9-156d-4643-84ad-3a5bf98bee61" />
<img width="670" height="506" alt="Screenshot 2026-06-11 at 12 30 05 PM" src="https://github.com/user-attachments/assets/3df6cb60-f397-4a63-8a01-6df1ebcaa8a0" />

**How to test?** Steps to confirm the desired behavior:
1. Go to /playbook_icons page - see icon cards for hand and nitro-intelligence icons.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.