### PR TITLE
[PLAY-3048] Fix React Advanced Table Row Styling Data Import

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling.jsx
@@ -1,6 +1,6 @@
 import React from "react"
 import AdvancedTable from '../_advanced_table'
-import MOCK_DATA from "./advanced_table_mock_data_with_id.json"
+import MOCK_DATA_WITH_ID from "./advanced_table_mock_data_with_id.json"
 import colors from '../../tokens/exports/_colors.module.scss'
 
 
@@ -55,7 +55,7 @@ const rowStyling = [
       <AdvancedTable
           columnDefinitions={columnDefinitions}
           rowStyling={rowStyling}
-          tableData={MOCK_DATA}
+          tableData={MOCK_DATA_WITH_ID}
           {...props}
       />
     </div>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Noticed the React RowStyling Doc was not correctly displaying the styled rows. It just needed an update to the mock data import - updated for all other AT docs in the New Website migration but just missed here.

**Screenshots:** Screenshots to visualize your addition/change
<img width="694" height="715" alt="rowstyling doc prod" src="https://github.com/user-attachments/assets/55e56091-0dc7-4f02-a071-f7c912adcb2c" />
<img width="594" height="627" alt="rowstyling doc fixed" src="https://github.com/user-attachments/assets/5d242a0f-1d35-4fb6-a8ca-d96a358431ef" />


**How to test?** Steps to confirm the desired behavior:
1. Go to React Advanced Table Row Styling doc - should now display two rows with rowStyling applied.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.