### PR TITLE
[PLAY-3039] Add fontWeight Support to Advanced Table rowStyling

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
@@ -6,7 +6,7 @@ import { GenericObject } from "../../types"
 import { isChrome } from "../Utilities/BrowserCheck"
 import { findColumnDefByAccessor } from "../Utilities/ColumnStylingHelper"
 import { playbookColumnLayoutStylesFromMeta } from "../Utilities/ColumnLayoutHelper"
-import { getRowColorClass, shouldShowLoadingIndicator } from "../Utilities/RowUtils"
+import { getFontWeight, getRowColorClass, getRowStyle, shouldShowLoadingIndicator } from "../Utilities/RowUtils"
 
 import LoadingInline from "../../pb_loading_inline/_loading_inline"
 import Checkbox from "../../pb_checkbox/_checkbox"
@@ -81,6 +81,7 @@ const TableCellRenderer = ({
         
         const paddingValue = colDef?.columnStyling?.cellPadding ?? customRowStyle?.cellPadding
         const paddingClass = paddingValue ? `p_${paddingValue}` : undefined
+        const fontWeight = getFontWeight(customRowStyle)
 
         return (
           <td
@@ -103,6 +104,7 @@ const TableCellRenderer = ({
                   : undefined,
                   backgroundColor: cellBackgroundColor || (i === 0 && customRowStyle?.backgroundColor),
                   color: cellFontColor || customRowStyle?.fontColor,
+                  fontWeight,
             }}
           >
             {collapsibleTrail && i === 0 && row.depth > 0 && renderCollapsibleTrail(row.depth)}
@@ -161,7 +163,7 @@ export const RegularTableView = ({
 
   // Row pinning
   function PinnedRow({ row }: { row: Row<any> }) {
-    const customRowStyle = rowStyling?.length > 0 && rowStyling?.find((s: GenericObject) => s?.rowId === row.id);
+    const customRowStyle = getRowStyle(rowStyling, row);
     return (
       <tr
           className={classnames(
@@ -175,7 +177,8 @@ export const RegularTableView = ({
               row.getIsPinned() === 'top'
                   ? `${row.getPinnedIndex() * rowHeight + headerHeight + actionBarHeight}px`
                   : undefined,
-            zIndex: '3'
+            zIndex: '3',
+            fontWeight: getFontWeight(customRowStyle),
           }}
       >
         <TableCellRenderer
@@ -205,7 +208,7 @@ export const RegularTableView = ({
         const isFirstChildofSubrow = row.depth > 0 && row.index === 0;
         const numberOfColumns = table.getAllFlatColumns().length;
         const isFirstRegularRow = rowIndex === 0 && !row.getIsPinned();
-        const customRowStyle = rowStyling?.length > 0 && rowStyling?.find((s: GenericObject) => s?.rowId === row.id);
+        const customRowStyle = getRowStyle(rowStyling, row);
 
         // Use functions from RowUtils for consistent cell coloring
         const rowColor = getRowColorClass(row, inlineRowLoading || false);
@@ -228,7 +231,11 @@ export const RegularTableView = ({
                 className={`${rowColor} ${row.depth > 0 ? `depth-sub-row-${row.depth}` : ""}`}
                 id={`${row.index}-${row.id}-${row.depth}-row`}
                 ref={isFirstRegularRow ? sampleRowRef : null}
-                style={{backgroundColor: customRowStyle?.backgroundColor, color: customRowStyle?.fontColor}}
+                style={{
+                  backgroundColor: customRowStyle?.backgroundColor,
+                  color: customRowStyle?.fontColor,
+                  fontWeight: getFontWeight(customRowStyle),
+                }}
             >
               {/* Render custom checkbox column when we want selectableRows for non-expanding tables */}
               {selectableRows && !hasAnySubRows && (

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -39,7 +39,7 @@ interface UseTableStateProps {
   tableOptions?: GenericObject;
   onRowSelectionChange?: (arg: RowSelectionState) => void;
   columnVisibilityControl?: GenericObject;
-  rowStyling?: GenericObject;
+  rowStyling?: GenericObject[];
   inlineRowLoading?: boolean;
   sortParentOnly?: boolean;
 }
@@ -150,7 +150,7 @@ export function useTableState({
 
       return columnStructure;
     }) || [];
-  }, [columnHelper, onRowToggleClick, selectableRows]);
+  }, [columnHelper, onRowToggleClick, rowStyling, selectableRows]);
 
   const columns = useMemo(() => buildColumns(columnDefinitions), [buildColumns, columnDefinitions]);
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/CellRendererUtils.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/CellRendererUtils.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Row, Getter } from "@tanstack/react-table";
 import { GenericObject } from "../../types";
 import { CustomCell } from "../Components/CustomCell";
+import { getRowStyle } from "./RowUtils";
 
 /**
  * Creates a cell render function for table columns
@@ -18,7 +19,7 @@ export const createCellFunction = (
   isFirstColumn?: boolean,
   onRowToggleClick?: (row: Row<GenericObject>) => void,
   selectableRows?: boolean,
-  rowStyling?: GenericObject
+  rowStyling?: GenericObject[]
 ) => {
   // Add display name to the returned function
   const cellRenderer = ({
@@ -29,7 +30,7 @@ export const createCellFunction = (
     getValue: Getter<string>
   }) => {
     const rowData = row.original;
-    const customStyle = rowStyling?.length > 0 && rowStyling?.find((s:GenericObject) => s?.rowId === row.id);
+    const customStyle = getRowStyle(rowStyling, row);
 
     if (isFirstColumn) {
       switch (row.depth) {
@@ -52,6 +53,7 @@ export const createCellFunction = (
           return accessorValue ? (
             <CustomCell
                 customRenderer={customRenderer}
+                customStyle={customStyle}
                 onRowToggleClick={onRowToggleClick}
                 row={row}
                 selectableRows={selectableRows}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/RowUtils.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Utilities/RowUtils.ts
@@ -36,6 +36,23 @@ export const shouldShowLoadingIndicator = (
     (row.depth < cellAccessorsLength);
 }
 
+export const getRowStyle = (
+  rowStyling: GenericObject[] | undefined,
+  row: Row<GenericObject>
+) => {
+  const rowId = row.original?.id ?? row.id
+  if (rowId == null) return
+
+  return rowStyling?.find((style: GenericObject) => (
+    String(style?.rowId) === String(rowId)
+  ))
+}
+
+export const getFontWeight = (rowStyle?: GenericObject) => {
+  if (rowStyle?.fontWeight === "bold") return 700
+  if (rowStyle?.fontWeight === "regular") return 400
+}
+
 /**
  * Creates a virtual item style object for virtualized rows
  */

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -1055,7 +1055,12 @@ test("rowStyling prop works as expected", () => {
   {
     rowId: "1",
     backgroundColor: colors.white,
-    fontColor: colors.black
+    fontColor: colors.black,
+    fontWeight: "bold",
+  },
+  {
+    rowId: "2",
+    fontWeight: "regular",
   },
 ];
 
@@ -1072,6 +1077,55 @@ test("rowStyling prop works as expected", () => {
   const tableBody = kit.querySelector('tbody')
   const row1 = tableBody.querySelector('tr:nth-child(1)') 
   expect(row1).toHaveStyle({backgroundColor: colors.white, color: colors.black})
+  expect(row1).toHaveStyle({fontWeight: "700"})
+  const row2 = tableBody.querySelector('tr:nth-child(2)')
+  expect(row2).toHaveStyle({fontWeight: "400"})
+})
+
+test("rowStyling fontWeight applies to expandable rows", () => {
+  const rowStyling = [
+    {
+      rowId: "1",
+      fontWeight: "bold",
+    },
+  ];
+
+  const tableData = [
+    {
+      id: "1",
+      year: "2021",
+      quarter: null,
+      month: null,
+      day: null,
+      newEnrollments: "20",
+      scheduledMeetings: "10",
+      children: [
+        {
+          id: "1-1",
+          year: "2021",
+          quarter: "Q1",
+          month: null,
+          day: null,
+          newEnrollments: "2",
+          scheduledMeetings: "35",
+        },
+      ],
+    },
+  ];
+
+  render(
+    <AdvancedTable
+        columnDefinitions={columnDefinitions}
+        data={{ testid: testId }}
+        rowStyling={rowStyling}
+        tableData={tableData}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  const tableBody = kit.querySelector('tbody')
+  const expandableRow = tableBody.querySelector('tr:nth-child(1)')
+  expect(expandableRow).toHaveStyle({fontWeight: "700"})
 })
 
 test("rowStyling prop to allow padding control", () => {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling.html.erb
@@ -41,6 +41,10 @@
     font_color: "white",
     expand_button_color: "white",
   },
+  {
+    row_id: "15",
+    font_weight: "bold",
+  },
 ] %>
 
 <%= pb_rails("advanced_table", props: { id: "row-styling", table_data: @table_data_with_id, column_definitions: column_definitions, row_styling: row_styling }) %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling.jsx
@@ -48,6 +48,10 @@ const rowStyling = [
     fontColor: colors.white,
     expandButtonColor: colors.white,
   },
+  {
+    rowId: "15",
+    fontWeight: "bold",
+  },
 ];
 
   return (

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling_rails.md
@@ -3,5 +3,6 @@ The `row_styling` prop can be used in conjunction with row ids to control certai
 - `background_color` : use this to control the background color of the row
 - `font_color`: use this to control font color for each row if needed, for example if using a darker background color.
 - `expand_button_color`: use this to control the color of the expand icon if needed, for example if using a darker background color.
+- `font_weight`: use this to control row font weight. Accepted values are `regular` (default appearance) and `bold`.
 
 **NOTE:** Each object within the `table_data` Array must contain a unique id in order to attach an id to all Rows for this to function.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling_react.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_row_styling_react.md
@@ -3,5 +3,6 @@ The `rowStyling` prop can be used in conjunction with row ids to control certain
 - `backgroundColor` : use this to control the background color of the row
 - `fontColor`: use this to control font color for each row if needed, for example if using a darker background color.
 - `expandButtonColor`: use this to control the color of the expand icon if needed, for example if using a darker background color.
+- `fontWeight`: use this to control row font weight. Accepted values are `regular` (default appearance) and `bold`.
 
 **NOTE:** Each object within the `tableData` Array must contain a unique id in order to attach an id to all Rows for this to function.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
@@ -28,7 +28,8 @@
         "rowId": "1",
         "backgroundColor": "#0056CF",
         "fontColor": "#FFFFFF",
-        "expandButtonColor": "#FFFFFF"
+        "expandButtonColor": "#FFFFFF",
+        "fontWeight": "bold"
       }
     ],
     "expandByDepth": [

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.overrides.json
@@ -106,7 +106,7 @@
     "tableProps": {
       "container": false
     },
-    "rowStyling": [{ "rowId": "1", "backgroundColor": "#0056CF", "fontColor": "#FFFFFF", "expandButtonColor": "#FFFFFF" }],
+    "rowStyling": [{ "rowId": "1", "backgroundColor": "#0056CF", "fontColor": "#FFFFFF", "expandButtonColor": "#FFFFFF", "fontWeight": "bold" }],
     "expandByDepth": [
       {
         "depth": 0,

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.html.erb
@@ -3,6 +3,7 @@
   button_color = row_style&.[](:expand_button_color)
   bg_color = row_style&.[](:background_color)
   font_color = row_style&.[](:font_color)
+  font_weight = row_style&.[](:font_weight)
   tr_options = (object.html_options || {}).stringify_keys
   tr_options["class"] = [tr_options["class"], object.classname].reject(&:blank?).join(" ")
 %>
@@ -14,7 +15,7 @@
     <% end %>
     <% object.column_definitions.each_with_index do |column, index| %>
         <% next unless column[:accessor].present? %>
-        <% component_info = object.cell_component_info(column, index, bg_color, font_color) %>
+        <% component_info = object.cell_component_info(column, index, bg_color, font_color, font_weight) %>
         <%= pb_rails(component_info[:name], props: component_info[:props]) do %>
             <%= pb_rails("flex", props:{ align: "center", justify: object.justify_for(column, index), classname: object.loading ? "loading-cell" : "" }) do %>
                 <% if collapsible_trail && index.zero? %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
@@ -107,9 +107,10 @@ module Playbook
       end
 
       # Uses a regular table/table_cell component if there is no custom background color; if there is a cell_background_color uses a background component with tag "td"
-      def cell_component_info(column, index, bg_color, font_color)
+      def cell_component_info(column, index, bg_color, font_color, font_weight = nil)
         column_font_color = cell_font_color(column)
         effective_font_color = column_font_color || font_color
+        effective_font_weight = font_weight_value(font_weight)
 
         if has_custom_background_color?(column)
           custom_bg_color = cell_background_color(column)
@@ -119,11 +120,15 @@ module Playbook
             tag: "td",
             classname: td_classname(column, index),
           }
-          component_props[:html_options] = { style: { color: effective_font_color } } if effective_font_color.present?
+          style_hash = {}
+          style_hash[:color] = effective_font_color if effective_font_color.present?
+          style_hash[:"font-weight"] = effective_font_weight if effective_font_weight.present?
+          component_props[:html_options] = { style: style_hash } if style_hash.present?
         else
           component_name = "table/table_cell"
           style_hash = { "background-color": bg_color }
           style_hash[:color] = effective_font_color if effective_font_color.present?
+          style_hash[:"font-weight"] = effective_font_weight if effective_font_weight.present?
           component_props = {
             html_options: {
               style: style_hash,
@@ -213,6 +218,15 @@ module Playbook
           row.children
         elsif row.respond_to?(:[])
           row[:children] || row["children"]
+        end
+      end
+
+      def font_weight_value(font_weight)
+        case font_weight.to_s
+        when "bold"
+          "700"
+        when "regular"
+          "400"
         end
       end
 

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
@@ -435,6 +435,43 @@ RSpec.describe Playbook::PbAdvancedTable::TableRow do
         expect(result[:props][:html_options][:style][:color]).to eq "red"
       end
     end
+
+    context "with row font weight" do
+      it "adds bold font weight to table cell styles" do
+        result = instance.cell_component_info({ accessor: "none" }, 0, nil, nil, "bold")
+        expect(result[:props][:html_options][:style][:"font-weight"]).to eq "700"
+      end
+
+      it "adds regular font weight to table cell styles" do
+        result = instance.cell_component_info({ accessor: "none" }, 0, nil, nil, "regular")
+        expect(result[:props][:html_options][:style][:"font-weight"]).to eq "400"
+      end
+
+      it "adds font weight alongside row font color" do
+        result = instance.cell_component_info({ accessor: "none" }, 0, nil, "red", "bold")
+        expect(result[:props][:html_options][:style][:color]).to eq "red"
+        expect(result[:props][:html_options][:style][:"font-weight"]).to eq "700"
+      end
+
+      it "adds font weight to background component styles" do
+        result = instance.cell_component_info({ accessor: "with_bg_only" }, 0, nil, nil, "bold")
+        expect(result[:name]).to eq "background"
+        expect(result[:props][:html_options][:style][:"font-weight"]).to eq "700"
+      end
+    end
+  end
+
+  describe "#font_weight_value" do
+    let(:instance) { subject.new(row: {}, depth: 0) }
+
+    it "maps supported font weight values", :aggregate_failures do
+      expect(instance.font_weight_value("bold")).to eq "700"
+      expect(instance.font_weight_value("regular")).to eq "400"
+    end
+
+    it "returns nil for unsupported values" do
+      expect(instance.font_weight_value("heavy")).to be_nil
+    end
   end
 
   describe "#show_expand_button?" do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3039](https://runway.powerhrg.com/backlog_items/PLAY-3039?from=active_sprint) adds `fontWeight`/`font_weight` to the `rowStyling`/`row_styling` prop which defaults to `regular` and accepts `bold` to make the font style of regular cells (not overly custom/customRender) Bold. See screenshot below and [CSB with alpha](https://codesandbox.io/p/devbox/no-scss-template-forked-lf3qnr?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) showing a basic and multi-column header example - the updated Row Styling docs just add to the current Basic Advanced Table doc.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1255" height="893" alt="complex doc example rails" src="https://github.com/user-attachments/assets/3c967e3b-dd80-43c0-8f2d-eb488a50019f" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Row Styling doc ([rails](https://pr6327.playbook.wc.beta.gm.powerapp.cloud/kits/advanced_table/styling/rails#advanced_table_row_styling), [react](https://pr6327.playbook.wc.beta.gm.powerapp.cloud/kits/advanced_table/styling/react#advanced_table_row_styling) to see added fontWeight example and markdown.
2. Go to [CSB with alpha](https://codesandbox.io/p/devbox/no-scss-template-forked-lf3qnr?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) to see a more complex example for React.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.