### PR TITLE
[PLAY-3031] UI Consistency: Select and MultiLevelSelect Chevrons

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/_multi_level_select.tsx
@@ -690,7 +690,7 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>(
                 >
                   <Icon icon="chevron-down"
                       id={arrowDownElementId}
-                      size="xs"
+                      size="sm"
                   />
                 </div>
               ) : (
@@ -699,7 +699,7 @@ const MultiLevelSelect = forwardRef<HTMLInputElement, MultiLevelSelectProps>(
                 >
                   <Icon icon="chevron-up"
                       id={arrowUpElementId}
-                      size="xs"
+                      size="sm"
                   />
                 </div>
               )}

--- a/playbook/app/pb_kits/playbook/pb_select/_select.tsx
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.tsx
@@ -158,6 +158,7 @@ const Select = ({
               className="pb_select_kit_caret svg-inline--fa"
               customIcon={angleDown}
               fixedWidth
+              size="sm"
          />
          : 
          null

--- a/playbook/app/pb_kits/playbook/pb_select/select.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/select.html.erb
@@ -30,7 +30,7 @@
       <%= pb_rails("body", props: { status: "negative", text: object.error, dark: object.dark }) %>
     <% end %>
     <% if object.multiple != true %>
-      <%= pb_rails("icon", props: { custom_icon: Playbook::Engine::root.join(angle_down_path), fixed_width: true, classname: "pb_select_kit_caret"}) %>
+      <%= pb_rails("icon", props: { custom_icon: Playbook::Engine::root.join(angle_down_path), fixed_width: true, classname: "pb_select_kit_caret", size: "sm"}) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3031](https://runway.powerhrg.com/backlog_items/PLAY-3031?from=active_sprint) adds some consistency to the chevron sizing for our input kits, which were previously all over the map. Dropdown chevrons are size small and that is the standard: this PR takes Select chevrons from large to small and MultiLevelSelect chevrons from xs to small. Typeaheads were looked at but will be handled on their own [in a follow up](https://runway.powerhrg.com/backlog_items/PBHUB-928?from=backlog) because the current chevron and clear indicator icons come from React-Select and cannot be modified without changing that entirely.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1452" height="553" alt="arrows update side by side" src="https://github.com/user-attachments/assets/e5efade0-2197-4a2b-b6e7-bbe7624cf747" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Select kit page and see smaller chevrons when compared to prod, React and Rails.
2. Go to the Multi Level Select kit page and see larger chevrons when compared to prod, React and Rails.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.