### PR TITLE
[PLAY-3052] Upgrades Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -752,6 +752,14 @@
     "category": "Communication"
   },
   {
+    "name": "phone-arrow-down-left",
+    "category": "Communication"
+  },
+  {
+    "name": "phone-arrow-up-right",
+    "category": "Communication"
+  },
+  {
     "name": "phone-office",
     "category": "Communication"
   },
@@ -1896,6 +1904,10 @@
     "category": "Power Products"
   },
   {
+    "name": "circle-product-hardboard-siding",
+    "category": "Power Products"
+  },
+  {
     "name": "circle-product-roofing",
     "category": "Power Products"
   },
@@ -1933,6 +1945,10 @@
   },
   {
     "name": "product-gutters",
+    "category": "Power Products"
+  },
+  {
+    "name": "product-hardboard-siding",
     "category": "Power Products"
   },
   {

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "2.4.0",
-    "@powerhome/playbook-icons-react": "2.4.0",
+    "@powerhome/playbook-icons": "2.5.0",
+    "@powerhome/playbook-icons-react": "2.5.0",
     "@powerhome/power-fonts": "0.0.1",
     "maplibre-gl": "^4.7.1",
     "highcharts": "^11.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,15 +3170,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@2.4.0":
-  version "2.4.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/37bee9e91e03926d6081d8d0bc52bde5fca50960#37bee9e91e03926d6081d8d0bc52bde5fca50960"
-  integrity sha512-01RbThJ62UmGzT5sZd/splLEGT+AtFZUEMz6lBSMAfxA5YqYxQQ0ZForPGQ2tnrrhT6ianYXLaotNi3220hLNA==
+"@powerhome/playbook-icons-react@2.5.0":
+  version "2.5.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/045d750f92e1f72832b5d283170e976128d78676#045d750f92e1f72832b5d283170e976128d78676"
+  integrity sha512-kRxl8bJNempM0coxHQjMerkjWmEGDgBOxk0cyWLgFgd7EOpnLAnMcv09ZZQFfm02VOAFeirFVU7QeKJLCIIoLw==
 
-"@powerhome/playbook-icons@2.4.0":
-  version "2.4.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/a9fb026bf3dc84c32e9f7fbee3d226d18531ce6a#a9fb026bf3dc84c32e9f7fbee3d226d18531ce6a"
-  integrity sha512-ntvRiqxPHRtGdiTxgemT2VJIMx4uYgnfiYQKKY2Po5zrpN0qmp0y+npPIH+pL0yQXqSQJYBvSYD+M/9UnStWxg==
+"@powerhome/playbook-icons@2.5.0":
+  version "2.5.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/a348fc5ed50322813a4a63f0bd20304ee444b653#a348fc5ed50322813a4a63f0bd20304ee444b653"
+  integrity sha512-Xsvbxcq7eWnEYTC5qLjcywZ4+Es+Wg2/5DEQ4vfBMA3oDNIo/Tdvvx14JInY6LOXDILRiwavEbojNcx61o8dtQ==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3052](https://runway.powerhrg.com/backlog_items/PLAY-3052) adds 4 icons to the playbook-icons repo. https://github.com/powerhome/playbook-icons/pull/63

**Screenshots:** Screenshots to visualize your addition/change
<img width="432" height="192" alt="react" src="https://github.com/user-attachments/assets/1c9093b3-8a6a-4437-9b30-5e4db3dc9bae" />
<img width="998" height="159" alt="communication" src="https://github.com/user-attachments/assets/5d96b14f-3ca9-44f0-8ece-a7f984ed4cb5" />
<img width="1015" height="912" alt="power products" src="https://github.com/user-attachments/assets/5cff1fda-d3bb-4b27-a46d-e239c8a521a9" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /icons page - see icon cards for phone-arrow- and hardboard-siding icons.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.