### PR TITLE
[PLAY-3054] Add New Siding Color Tokens to Product Colors

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/Colors.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/Colors.tsx
@@ -962,6 +962,22 @@ const Colors = () => {
               </Card>,
             ],
             [
+              <ColorSwatch color="#8D5500" />,
+              <Title size={4}>$product_11_background</Title>,
+              "#8D5500",
+              <Card borderRadius="sm" background="light" padding="xxs" borderNone>
+                <Body>Product 11 Background</Body>
+              </Card>,
+            ],  
+            [
+              <ColorSwatch color="#A36D00" />,
+              <Title size={4}>$product_11_highlight</Title>,
+              "#A36D00",
+              <Card borderRadius="sm" background="light" padding="xxs" borderNone>
+                <Body>Product 11 Highlight</Body>
+              </Card>,
+            ],
+            [
               <ColorSwatch color="#003DB2" />,
               <Title size={4}>$windows</Title>,
               "$product_1_background",

--- a/playbook-website/app/javascript/components/Website/src/pages/DesignGuidelines/Color.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/DesignGuidelines/Color.tsx
@@ -306,7 +306,7 @@ const Color = () => {
 
           <Title text="Product Colors" size={4} marginTop="md" marginBottom="sm" />
           <Body marginBottom="md">
-            Playbook's offers a set of ten product tokens, useful for grouping reoccurring items with a consistent color assignment.
+            Playbook's offers a set of eleven product tokens, useful for grouping reoccurring items with a consistent color assignment.
             Each product color is accompanied by corresponding background and highlight token, providing flexibility in design implementation. Background tokens are ideal for accommodating text, while highlight tokens stand out independently, perfect for icons or emphasis within design elements.
           </Body>
 
@@ -321,12 +321,12 @@ const Color = () => {
             <tbody>
               <tr>
                 <td><img src="https://github.com/powerhome/playbook/assets/89551222/9729ae41-c614-4436-a79d-c2962e804bde" alt="Product Background" /></td>
-                <td><small>PRODUCT BACKGROUND 1 - 10<br />$product_1_background - $product_10_background</small></td>
+                <td><small>PRODUCT BACKGROUND 1 - 11<br />$product_1_background - $product_11_background</small></td>
                 <td>Used as a background color and text color for a grouping of reoccurring items</td>
               </tr>
               <tr>
                 <td><img src="https://github.com/powerhome/playbook/assets/89551222/43b5012c-c27d-4587-9e72-5fff35785c82" alt="Product Highlight" /></td>
-                <td><small>PRODUCT HIGHLIGHT 1 - 10<br />$product_1_highlight - $product_10_highlight</small></td>
+                <td><small>PRODUCT HIGHLIGHT 1 - 11<br />$product_1_highlight - $product_11_highlight</small></td>
                 <td>Used as a highlight color perfect for icons or emphasis for a grouping of reoccurring items</td>
               </tr>
             </tbody>

--- a/playbook-website/app/views/guides/design_guidelines/color.md
+++ b/playbook-website/app/views/guides/design_guidelines/color.md
@@ -104,13 +104,13 @@ These eight tokens are Playbook’s core set of data visualization colors. Desig
 
 #### Product Colors
 
-Playbook's offers a set of ten product tokens, useful for grouping reoccurring items with a consistent color assignment.
+Playbook's offers a set of eleven product tokens, useful for grouping reoccurring items with a consistent color assignment.
 Each product color is accompanied by corresponding background and highlight token, providing flexibility in design implementation. Background tokens are ideal for accommodating text, while highlight tokens stand out independently, perfect for icons or emphasis within design elements.
 
 | Product Colors                                                                                                    | Name & Token                                                                                    | Usage                                                                                       |
 | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| ![Product Background](https://github.com/powerhome/playbook/assets/89551222/9729ae41-c614-4436-a79d-c2962e804bde) | <small> PRODUCT BACKGROUND 1 - 10 <br/> $product_1_background - $product_10_background </small> | Used as a background color and text color for a grouping of reoccurring items               |
-| ![Product Highlight](https://github.com/powerhome/playbook/assets/89551222/43b5012c-c27d-4587-9e72-5fff35785c82)  | <small> PRODUCT HIGHLIGHT 1 - 10 <br/> $product_1_highlight - $product_10_highlight </small>    | Used as a highlight color perfect for icons or emphasis for a grouping of reoccurring items |
+| ![Product Background](https://github.com/powerhome/playbook/assets/89551222/9729ae41-c614-4436-a79d-c2962e804bde) | <small> PRODUCT BACKGROUND 1 - 11 <br/> $product_1_background - $product_11_background </small> | Used as a background color and text color for a grouping of reoccurring items               |
+| ![Product Highlight](https://github.com/powerhome/playbook/assets/89551222/43b5012c-c27d-4587-9e72-5fff35785c82)  | <small> PRODUCT HIGHLIGHT 1 - 11 <br/> $product_1_highlight - $product_11_highlight </small>    | Used as a highlight color perfect for icons or emphasis for a grouping of reoccurring items |
 
 #### Category Colors
 

--- a/playbook/app/pb_kits/playbook/pb_card/card.rb
+++ b/playbook/app/pb_kits/playbook/pb_card/card.rb
@@ -15,7 +15,7 @@ module Playbook
                            values: %w[xs sm md lg xl none rounded],
                            default: "md"
       prop :background, type: Playbook::Props::Enum,
-                        values: %w[white light dark product_1_background product_1_highlight product_2_background product_2_highlight product_3_background product_3_highlight product_4_background product_4_highlight product_5_background product_5_highlight product_6_background product_6_highlight product_7_background product_7_highlight product_8_background product_8_highlight product_9_background product_9_highlight product_10_background product_10_highlight windows siding doors solar roofing gutters insulation none success_subtle warning_subtle error_subtle info_subtle neutral_subtle],
+                        values: %w[white light dark product_1_background product_1_highlight product_2_background product_2_highlight product_3_background product_3_highlight product_4_background product_4_highlight product_5_background product_5_highlight product_6_background product_6_highlight product_7_background product_7_highlight product_8_background product_8_highlight product_9_background product_9_highlight product_10_background product_10_highlight product_11_background product_11_highlight windows siding doors solar roofing gutters insulation none success_subtle warning_subtle error_subtle info_subtle neutral_subtle],
                         default: "none"
       prop :drag_id, type: Playbook::Props::String
       prop :draggable_item, type: Playbook::Props::Boolean,

--- a/playbook/app/pb_kits/playbook/pb_card/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_card/kit.schema.json
@@ -37,6 +37,8 @@
         "product_9_highlight",
         "product_10_background",
         "product_10_highlight",
+        "product_11_background",
+        "product_11_highlight",
         "windows",
         "siding",
         "doors",

--- a/playbook/app/pb_kits/playbook/tokens/_colors.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_colors.scss
@@ -253,6 +253,8 @@ $product_9_background:  #fcc419 !default;
 $product_9_highlight:   #ffd43b !default;
 $product_10_background: #20c997 !default;
 $product_10_highlight:  #38d9a9 !default;
+$product_11_background: #8D5500 !default;
+$product_11_highlight:  #A36D00 !default;
 $windows:               $product_1_background !default; // deprecated
 $siding:                $product_2_background !default; // deprecated
 $doors:                 $product_3_background !default; // deprecated
@@ -289,7 +291,9 @@ $product_colors: (
   product_9_background:   $product_9_background,
   product_9_highlight:    $product_9_highlight,
   product_10_background:  $product_10_background,
-  product_10_highlight:   $product_10_highlight
+  product_10_highlight:   $product_10_highlight,
+  product_11_background:  $product_11_background,
+  product_11_highlight:   $product_11_highlight
 ) !default;
 
 /* Category colors ---------------------*/

--- a/playbook/app/pb_kits/playbook/types/colors.ts
+++ b/playbook/app/pb_kits/playbook/types/colors.ts
@@ -5,7 +5,8 @@ export type ProductColors = 'windows' | 'siding' | 'doors' | 'solar' | 'roofing'
     'product_3_background' | 'product_3_highlight' | 'product_4_background' | 'product_4_highlight' |
     'product_5_background' | 'product_5_highlight' | 'product_6_background' | 'product_6_highlight' |
     'product_7_background' | 'product_7_highlight' | 'product_8_background' | 'product_8_highlight' |
-    'product_9_background' | 'product_9_highlight' | 'product_10_background' | 'product_10_highlight'
+    'product_9_background' | 'product_9_highlight' | 'product_10_background' | 'product_10_highlight'|
+    'product_11_background' | 'product_11_highlight'
 
 export type StatusColors = 'success' | 'success_secondary' | 'success_sm' | 'success_subtle' |
     'warning' | 'warning_secondary' | 'warning_subtle' | 'error' | 'error_secondary' | 'error_subtle' |

--- a/playbook/spec/pb_kits/playbook/kits/card_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/card_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Playbook::PbCard::Card do
   it do
     is_expected.to define_enum_prop(:background)
       .with_default("none")
-      .with_values("white", "light", "dark", "product_1_background", "product_1_highlight", "product_2_background", "product_2_highlight", "product_3_background", "product_3_highlight", "product_4_background", "product_4_highlight", "product_5_background", "product_5_highlight", "product_6_background", "product_6_highlight", "product_7_background", "product_7_highlight", "product_8_background", "product_8_highlight", "product_9_background", "product_9_highlight", "product_10_background", "product_10_highlight", "windows", "siding", "doors", "solar", "roofing", "gutters", "insulation", "none", "success_subtle", "warning_subtle", "error_subtle", "info_subtle", "neutral_subtle")
+      .with_values("white", "light", "dark", "product_1_background", "product_1_highlight", "product_2_background", "product_2_highlight", "product_3_background", "product_3_highlight", "product_4_background", "product_4_highlight", "product_5_background", "product_5_highlight", "product_6_background", "product_6_highlight", "product_7_background", "product_7_highlight", "product_8_background", "product_8_highlight", "product_9_background", "product_9_highlight", "product_10_background", "product_10_highlight", "product_11_background", "product_11_highlight", "windows", "siding", "doors", "solar", "roofing", "gutters", "insulation", "none", "success_subtle", "warning_subtle", "error_subtle", "info_subtle", "neutral_subtle")
   end
 
   describe "#classname" do


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR adds the new siding color tokens $product_11_background: #8D5500 and $product_11_highlight: #A36D00 to Playbook's Product Colors. Updates Color token page, design guidelines page, and passes the color token along to a few kits that require it directly.

**Screenshots:** Screenshots to visualize your addition/change
Local Color token testing:
<img width="1497" height="480" alt="product 11 colors on card kit" src="https://github.com/user-attachments/assets/b0f3a280-bfa7-4d2e-a5b1-7c430d1baf28" />
<img width="105" height="93" alt="product 11 colors on icon kit" src="https://github.com/user-attachments/assets/4f23cd37-416c-4c1d-af1f-a999033244fe" />
<img width="997" height="120" alt="color token page" src="https://github.com/user-attachments/assets/257270bc-f6f9-4ef5-891f-aa77ff664cbd" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Color token page and design page, see information and colors for new product_11 color tokens.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.