### PR TITLE
[PLAY-3032] Dropdown kit - Add Disabled Input State

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.scss
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.scss
@@ -50,6 +50,17 @@
           color: $input_text_default;
         }
       }
+
+      .dropdown_input:disabled {
+        background-color: $input_background_disabled;
+        color: $input_text_disabled;
+        cursor: default;
+      }
+
+      .dropdown_input:disabled::placeholder {
+        color: $input_text_disabled;
+      }
+
       &:focus {
         box-shadow: 0px 0px 0 1px $status_border_primary !important;
         outline: unset;
@@ -375,6 +386,27 @@
         &.pb_dropdown_option_selected_focused {
           background-color: $primary;
           border-bottom: rgba($white, 0.15);
+        }
+      }
+    }
+  }
+
+  &.disabled {
+    .dropdown_wrapper {
+      .dropdown_trigger_wrapper,
+      .dropdown_trigger_wrapper_focus,
+      .dropdown_trigger_wrapper_focus_select_only,
+      .dropdown_trigger_wrapper_select_only {
+        background-color: $input_background_disabled;
+        box-shadow: none !important;
+        cursor: default !important;
+        opacity: 0.5;
+        pointer-events: none;
+
+        input {
+          background-color: $input_background_disabled;
+          color: $input_text_disabled;
+          cursor: default !important;
         }
       }
     }

--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
@@ -93,6 +93,7 @@ type DropdownProps = {
     closeOnClick?: "outside" | "inside" | "any";
     constrainHeight?: boolean;
     customQuickPickDates?: CustomQuickPickDates;
+    disabled?: boolean;
     formPillProps?: GenericObject;
     dark?: boolean;
     data?: { [key: string]: string };
@@ -139,6 +140,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
         dark = false,
         data = {},
         defaultValue = {},
+        disabled = false,
         error,
         htmlOptions = {},
         id,
@@ -164,6 +166,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
     const separatorsClass = separators ? '' : 'separators_hidden'
     const classes = classnames(
         buildCss("pb_dropdown", variant, separatorsClass),
+        disabled && "disabled",
         globalProps(props),
         className
     );
@@ -174,7 +177,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
         : (options || []);
     // ----------------------------------------------------------
 
-    const [isDropDownClosed, setIsDropDownClosed, toggleDropdown] = useDropdown(isClosed);
+    const [isDropDownClosed, setIsDropDownClosed, toggleDropdown] = useDropdown(disabled ? true : isClosed);
 
     // Use a suffix for the trigger ID to avoid conflict with the outer div's id
     const sanitizeForId = (str: string) =>
@@ -228,6 +231,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
 
     const handleLabelClick = (e: React.MouseEvent) => {
       e.stopPropagation();
+      if (disabled) return;
       if (selectId) {
         const trigger = document.getElementById(selectId);
         if (trigger) trigger.focus();
@@ -269,8 +273,8 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
 
     // dropdown to toggle with external control
     useEffect(() => {
-        setIsDropDownClosed(isClosed)
-    }, [isClosed])
+        setIsDropDownClosed(disabled ? true : isClosed)
+    }, [disabled, isClosed])
 
     const blankSelectionOption: GenericObject = blankSelection ? [{ label: blankSelection, value: "" }] : [];
     const optionsWithBlankSelection = blankSelectionOption.concat(dropdownOptions);
@@ -330,12 +334,14 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
 
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (disabled) return;
         setFilterItem(e.target.value);
         setIsDropDownClosed(false);
     };
 
 
       const handleOptionClick = (clickedItem: GenericObject) => {
+                if (disabled) return;
                 const shouldCloseOnClick = closeOnClick === "any" || closeOnClick === "inside";
                 
                 if (multiSelect) {
@@ -378,11 +384,13 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
              };
 
     const handleWrapperClick = () => {
+        if (disabled) return;
         autocomplete && inputRef?.current?.focus();
         toggleDropdown();
     };
 
     const handleBackspace = () => {
+      if (disabled) return;
       if (multiSelect) {
         setSelected([]);
         onSelect && onSelect([]);
@@ -502,6 +510,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
                     blankSelection,
                     clearable,
                     dropdownContainerRef,
+                    disabled,
                     error,
                     errorId,
                     filterItem,
@@ -564,7 +573,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
                             }
                         }, 0);
                     }}
-                    onFocus={() => setIsInputFocused(true)}
+                    onFocus={() => !disabled && setIsInputFocused(true)}
                     ref={dropdownRef}
                 >
                     {children ? (

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_disabled.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_disabled.html.erb
@@ -1,0 +1,10 @@
+<% 
+  options = [
+    { label: 'United States', value: 'unitedStates', id: 'us' },
+    { label: 'Canada', value: 'canada', id: 'ca' },
+    { label: 'Pakistan', value: 'pakistan', id: 'pk' },
+  ]
+
+%>
+
+<%= pb_rails("dropdown", props: {id: "dropdown-disabled", disabled: true,label: "Default Dropdown", options: options}) %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_disabled.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_disabled.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import Dropdown from '../_dropdown'
+
+const DropdownDisabled = (props) => {
+
+  const options = [
+    {
+      label: "United States",
+      value: "unitedStates",
+      id: "us"
+    },
+    {
+      label: "Canada",
+      value: "canada",
+      id: "ca"
+    },
+    {
+      label: "Pakistan",
+      value: "pakistan",
+      id: "pk"
+    }
+  ];  
+
+
+  return (
+  <div>
+    <Dropdown
+        disabled
+        label="Default Dropdown"
+        options={options}
+        {...props}
+    />
+  </div>
+  )
+}
+
+export default DropdownDisabled

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/example.yml
@@ -33,6 +33,7 @@ examples:
   - dropdown_quickpick_with_date_pickers_rails: Quick Pick with Date Pickers
   - dropdown_quickpick_with_date_pickers_default_rails: Quick Pick with Date Pickers (Default Value)
   - dropdown_required_indicator: Required Indicator
+  - dropdown_disabled: Disabled Input
   - dropdown_custom_event_type: Custom Event Type
 
   react:
@@ -71,3 +72,4 @@ examples:
   - dropdown_quickpick_custom: Quick Pick Variant (Custom Quick Pick Dates)
   - dropdown_quickpick_with_date_pickers: Quick Pick Variant with Date Pickers
   - dropdown_required_indicator: Required Indicator
+  - dropdown_disabled: Disabled Input

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/index.js
@@ -33,3 +33,4 @@ export { default as DropdownWithClearable } from './_dropdown_with_clearable.jsx
 export { default as DropdownWithConstrainHeight } from './_dropdown_with_constrain_height.jsx'
 export { default as DropdownClosingOptions } from './_dropdown_closing_options.jsx'
 export { default as DropdownRequiredIndicator } from "./_dropdown_required_indicator.jsx";
+export { default as DropdownDisabled } from "./_dropdown_disabled.jsx";

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.html.erb
@@ -18,11 +18,12 @@
             data-dropdown-selected-option
             name="<%= object.name %><%= '[]' if object.multi_select %>"
             style="display: none"
+            <%= object.disabled ? "disabled" : ""%>
             <%= object.required ? "required" : ""%>
         />
         <% if object.variant == "quickpick" %>
-          <input id="<%= object.start_date_id %>" name="<%= object.start_date_name %>" style="display: none">
-          <input id="<%= object.end_date_id %>" name="<%= object.end_date_name %>" style="display: none">
+          <input id="<%= object.start_date_id %>" name="<%= object.start_date_name %>" style="display: none" <%= object.disabled ? "disabled" : ""%>>
+          <input id="<%= object.end_date_id %>" name="<%= object.end_date_name %>" style="display: none" <%= object.disabled ? "disabled" : ""%>>
         <% end %>
         <% if content.present? %>
             <%= content.presence %>
@@ -30,8 +31,8 @@
                 <%= pb_rails("body", props: { status: "negative", text: object.error, id: object.error_id, aria: { atomic: "true", live: "polite" }, html_options: { role: "alert" }, dark: object.dark }) %>
             <% end %>
         <% else %>
-            <%= pb_rails("dropdown/dropdown_trigger", props: { autocomplete: object.autocomplete, multi_select: object.multi_select, placeholder: object.placeholder, select_id: object.select_id, label: object.label, error_id: object.error_id, error: object.error }) %>
-            <%= pb_rails("dropdown/dropdown_container", props: { searchbar: object.searchbar, constrain_height: object.constrain_height }) do %>
+            <%= pb_rails("dropdown/dropdown_trigger", props: { autocomplete: object.autocomplete, disabled: object.disabled, multi_select: object.multi_select, placeholder: object.placeholder, select_id: object.select_id, label: object.label, error_id: object.error_id, error: object.error }) %>
+            <%= pb_rails("dropdown/dropdown_container", props: { searchbar: object.searchbar, constrain_height: object.constrain_height, disabled: object.disabled }) do %>
                 <% if options_with_blank.present? %>
                     <% options_with_blank.each do |option| %>
                         <%= pb_rails("dropdown/dropdown_option", props: {option: option}) %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.rb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.rb
@@ -18,6 +18,8 @@ module Playbook
                              default: ""
       prop :custom_quick_pick_dates, type: Playbook::Props::HashProp,
                                      default: {}
+      prop :disabled, type: Playbook::Props::Boolean,
+                      default: false
       prop :variant, type: Playbook::Props::Enum,
                      values: %w[default subtle quickpick],
                      default: "default"
@@ -62,6 +64,7 @@ module Playbook
         Hash(prop(:data)).merge(
           pb_dropdown: true,
           pb_dropdown_multi_select: multi_select,
+          pb_dropdown_disabled: disabled,
           pb_dropdown_variant: variant,
           pb_dropdown_clearable: clearable,
           pb_dropdown_close_on_click: close_on_click,
@@ -75,7 +78,9 @@ module Playbook
       end
 
       def classname
-        generate_classname("pb_dropdown", variant, separators_class)
+        classes = generate_classname("pb_dropdown", variant, separators_class)
+        classes << " disabled" if disabled
+        classes
       end
 
       def select_id

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -833,3 +833,59 @@ describe("quickpick Last Month range when current month is shorter than the prev
     expect(formatDate(endDate)).toBe(formatDate(DateTime.getPreviousMonthEndDate(now)))
   })
 })
+
+test('disabled prop prevents dropdown from opening', () => {
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        disabled
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass('disabled')
+
+  const trigger = kit.querySelector('.dropdown_trigger_wrapper_select_only')
+  const container = kit.querySelector('.pb_dropdown_container')
+
+  fireEvent.click(trigger)
+
+  expect(container).toHaveClass('close')
+  expect(container).not.toHaveClass('open')
+})
+
+test('disabled prop prevents dropdown from opening with keyboard', () => {
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        disabled
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  const trigger = kit.querySelector('.dropdown_trigger_wrapper_select_only')
+  const container = kit.querySelector('.pb_dropdown_container')
+
+  fireEvent.keyDown(trigger, { key: 'Enter' })
+
+  expect(container).toHaveClass('close')
+  expect(container).not.toHaveClass('open')
+})
+
+test('disabled prop disables autocomplete input', () => {
+  render(
+    <Dropdown
+        autocomplete
+        data={{ testid: testId }}
+        disabled
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  const input = kit.querySelector('.dropdown_input')
+
+  expect(input).toBeDisabled()
+})

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.html.erb
@@ -5,6 +5,7 @@
             type="text"
             placeholder="Search…"
             data-dropdown-search
+            <%= object.disabled ? "disabled" : "" %>
             autocomplete="off"
             />
         <% end %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.rb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_container.rb
@@ -7,6 +7,8 @@ module Playbook
                        default: false
       prop :constrain_height, type: Playbook::Props::Boolean,
                               default: false
+      prop :disabled, type: Playbook::Props::Boolean,
+                      default: false
 
       def classname
         classes = %w[pb_dropdown_container close]

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.html.erb
@@ -1,6 +1,6 @@
 <%= pb_content_tag do %>
     <% if content.present? %>
-        <div style="display: inline-block" tabindex="0" data-dropdown="pb-dropdown-trigger" data-dropdown-custom-trigger aria-invalid="<%= object.error.present? %>"
+        <div style="display: inline-block" tabindex="<%= object.disabled ? "-1" : "0" %>" data-dropdown="pb-dropdown-trigger" data-dropdown-custom-trigger aria-disabled="<%= object.disabled %>" aria-invalid="<%= object.error.present? %>"
             <% if object.label.present? %> aria-label="<%= [object.label, object.default_display_placeholder].join(', ') %>"<% end %>
             <% if object.select_id.present? %> id="<%= object.select_id %>"<% end %>
             <% if object.error_id.present? %> aria-describedby="<%= object.error_id %>"<% end %>
@@ -17,7 +17,7 @@
         justify: "between",
         padding_x:"sm",
         padding_y:"xs",
-        html_options: { tabindex: "0", "aria-label": object.label.present? ? [object.label, object.default_display_placeholder].join(", ") : nil, "aria-describedby": object.error_id, "aria-invalid": object.error.present?, "data-dropdown": "pb-dropdown-trigger" }
+        html_options: { tabindex: object.disabled ? "-1" : "0", "aria-disabled": object.disabled, "aria-label": object.label.present? ? [object.label, object.default_display_placeholder].join(", ") : nil, "aria-describedby": object.error_id, "aria-invalid": object.error.present?, "data-dropdown": "pb-dropdown-trigger" }
         }) do %>
         <%= pb_rails("flex/flex_item", props: { fixed_size: object.multi_select ? "85%" : "" }) do %>
             <%= pb_rails("flex", props: {align: "center"}) do %>
@@ -37,6 +37,7 @@
                                 <input
                                     data-dropdown-autocomplete
                                     class="dropdown_input"
+                                    <%= object.disabled ? "disabled" : "" %>
                                     type="text"
                                     placeholder="<%= object.placeholder || 'Select…' %>"
                                     autocomplete="off"
@@ -50,6 +51,7 @@
                             <input
                                 data-dropdown-autocomplete
                                 class="dropdown_input"
+                                <%= object.disabled ? "disabled" : "" %>
                                 type="text"
                                 placeholder="<%= object.placeholder || 'Select…' %>"
                                 autocomplete="off"

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.rb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown_trigger.rb
@@ -11,6 +11,8 @@ module Playbook
       prop :custom_display
       prop :autocomplete, type: Playbook::Props::Boolean,
                           default: false
+      prop :disabled, type: Playbook::Props::Boolean,
+                      default: false
       prop :multi_select, type: Playbook::Props::Boolean,
                           default: false
       prop :select_id, type: Playbook::Props::String

--- a/playbook/app/pb_kits/playbook/pb_dropdown/index.js
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/index.js
@@ -67,6 +67,7 @@ export default class PbDropdown extends PbEnhancedElement {
     this.cacheElements();
 
     this.keyboardHandler = new PbDropdownKeyboard(this);
+    this.isDisabled = this.element.dataset.pbDropdownDisabled === "true";
     this.isMultiSelect = this.element.dataset.pbDropdownMultiSelect === "true";
     this.closeOnClick = this.element.dataset.pbDropdownCloseOnClick || "any";
     this.formPillProps = this.element.dataset.formPillProps
@@ -95,6 +96,7 @@ export default class PbDropdown extends PbEnhancedElement {
       this.clearBtn.addEventListener("click", this.clearBtnHandler);
     }
     this.updateClearButton();
+    this.applyDisabledState();
 
     // Listen for clear and select events from external source
     this.handleClearEventBound = this.handleClearEvent.bind(this);
@@ -193,10 +195,45 @@ export default class PbDropdown extends PbEnhancedElement {
     this.clearBtn.style.display = hasSelection ? "" : "none";
   }
 
+  applyDisabledState() {
+    if (!this.isDisabled) return;
+
+    const focusableSelector = [
+      "a[href]",
+      "button",
+      "input",
+      "select",
+      "textarea",
+      "[tabindex]",
+      "[contenteditable='true']",
+      CLEAR_ICON_SELECTOR,
+      DOWN_ARROW_SELECTOR,
+      UP_ARROW_SELECTOR,
+    ].join(",");
+
+    this.element.querySelectorAll(focusableSelector).forEach((element) => {
+      element.setAttribute("aria-disabled", "true");
+      element.setAttribute("tabindex", "-1");
+
+      if (element.matches("input, select, textarea, button")) {
+        element.setAttribute("disabled", "disabled");
+      }
+    });
+
+    this.element.querySelectorAll(`${CLEAR_ICON_SELECTOR}, ${DOWN_ARROW_SELECTOR}, ${UP_ARROW_SELECTOR}`).forEach((icon) => {
+      icon.setAttribute("aria-hidden", "true");
+      icon.setAttribute("focusable", "false");
+    });
+
+    this.hideElement(this.target);
+    this.updateArrowDisplay(false);
+  }
+
   bindEventListeners() {
     const customTrigger = this.customTrigger || this.element;
     this.customTriggerClickHandler = (e) => {
       const label = e.target.closest(LABEL_SELECTOR);
+      if (this.isDisabled) return;
       if (label && label.htmlFor) {
         const trigger = this.element.querySelector(
           `#${CSS.escape(label.htmlFor)}`,
@@ -296,6 +333,7 @@ export default class PbDropdown extends PbEnhancedElement {
   }
 
   handleSearch(term = "") {
+    if (this.isDisabled) return;
     const lcTerm = term.toLowerCase();
     let hasMatch = false;
     this.element.querySelectorAll(OPTION_SELECTOR).forEach((opt) => {
@@ -344,6 +382,7 @@ export default class PbDropdown extends PbEnhancedElement {
   }
 
   handleOptionClick(event) {
+    if (this.isDisabled) return;
     const option = event.target.closest(OPTION_SELECTOR);
     const hiddenInput = this.baseInput;
 
@@ -389,6 +428,7 @@ export default class PbDropdown extends PbEnhancedElement {
   // ----- External events handling section -----
   // Handles pb:dropdown:clear - clear this dropdown when event.detail.dropdownId matches.
   handleClearEvent(event) {
+    if (this.isDisabled) return;
     const targetId = event.detail?.dropdownId;
     if (targetId && this.element.id === targetId) {
       this.clearSelection();
@@ -397,6 +437,7 @@ export default class PbDropdown extends PbEnhancedElement {
 
   // Handles custom_event_type events (e.g. turbo:submit-end) - clear when detail.dropdownId matches or is omitted.
   handleCustomClearEvent(event) {
+    if (this.isDisabled) return;
     const targetId = event.detail?.dropdownId;
     if (targetId == null || this.element.id === targetId) {
       this.clearSelection();
@@ -406,6 +447,7 @@ export default class PbDropdown extends PbEnhancedElement {
   // Handles pb:dropdown:select - set dropdown selection by option id(s).
   // Single: detail: { dropdownId, optionId }. Multi: detail: { dropdownId, optionIds: ['id1', 'id2'] }.
   handleSelectEvent(event) {
+    if (this.isDisabled) return;
     const targetId = event.detail?.dropdownId;
     if (!targetId || this.element.id !== targetId) return;
 
@@ -702,6 +744,7 @@ export default class PbDropdown extends PbEnhancedElement {
   }
 
   showElement(elem) {
+    if (this.isDisabled) return;
     elem.classList.remove("close");
     elem.classList.add("open");
     
@@ -741,6 +784,7 @@ export default class PbDropdown extends PbEnhancedElement {
   }
 
   toggleElement(elem) {
+    if (this.isDisabled) return;
     const isOpen = toggleVisibility({
       isVisible: elem.classList.contains("open"),
       onHide: () => this.hideElement(elem),
@@ -1028,6 +1072,7 @@ export default class PbDropdown extends PbEnhancedElement {
   }
 
   clearSelection() {
+    if (this.isDisabled) return;
     if (this.isMultiSelect) {
       this.selectedOptions.clear();
       this.element.querySelectorAll(OPTION_SELECTOR).forEach((opt) => {

--- a/playbook/app/pb_kits/playbook/pb_dropdown/keyboard_accessibility.js
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/keyboard_accessibility.js
@@ -51,6 +51,8 @@ export class PbDropdownKeyboard {
   }
 
   openDropdownIfClosed() {
+    if (this.dropdown.isDisabled) return;
+
     if (!this.dropdown.target.classList.contains("open")) {
       this.dropdown.showElement(this.dropdown.target);
       this.dropdown.updateArrowDisplay(true);
@@ -58,6 +60,8 @@ export class PbDropdownKeyboard {
   }
 
   handleKeyDown(event) {
+    if (this.dropdown.isDisabled) return;
+
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();
@@ -133,6 +137,8 @@ moveFocus(direction) {
 
 
   selectOption() {
+    if (this.dropdown.isDisabled) return;
+
     const allOptions = Array.from(
       this.dropdownElement.querySelectorAll(OPTION_SELECTOR)
     );

--- a/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
@@ -59,6 +59,14 @@
         "rails"
       ]
     },
+    "disabled": {
+      "type": "boolean",
+      "platforms": [
+        "react",
+        "rails"
+      ],
+      "default": false
+    },
     "formPillProps": {
       "type": "GenericObject",
       "platforms": [

--- a/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownOption.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownOption.tsx
@@ -42,6 +42,7 @@ const DropdownOption = (props: DropdownOptionProps) => {
 
   const {
     activeStyle,
+    disabled,
     filteredOptions,
     filterItem,
     focusedOptionIndex,
@@ -101,10 +102,10 @@ const DropdownOption = (props: DropdownOptionProps) => {
         className={classes}
         id={id}
         key={key}
-        onClick= {() => handleOptionClick(option)}
+        onClick= {() => !disabled && handleOptionClick(option)}
     >
       <ListItem
-          cursor="pointer"
+          cursor={disabled ? "default" : "pointer"}
           dark={dark}
           data-name={option?.value}
           key={option?.label}

--- a/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownTrigger.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/DropdownTrigger.tsx
@@ -46,6 +46,7 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
     autocomplete,
     blankSelection,
     clearable,
+    disabled,
     error,
     errorId,
     filterItem,
@@ -113,6 +114,9 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
   const triggerAriaLabel = contextLabel
     ? (children ? contextLabel : `${contextLabel}, ${defaultDisplayPlaceholder}`)
     : undefined;
+  const disabledTriggerProps = disabled
+    ? { "aria-disabled": true, tabIndex: -1 }
+    : { tabIndex: 0 };
 
   return (
     <div {...ariaProps} 
@@ -128,11 +132,11 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
                 aria-invalid={!!error}
                 aria-label={triggerAriaLabel}
                 id={selectId}
-                onClick={() => toggleDropdown()}
-                onKeyDown= {handleKeyDown}
+                onClick={() => !disabled && toggleDropdown()}
+                onKeyDown= {(e) => !disabled && handleKeyDown(e)}
                 ref={inputWrapperRef}
                 style={{ display: "inline-block" }}
-                tabIndex= {0}
+                {...disabledTriggerProps}
             >
               {children}
             </div>
@@ -142,15 +146,16 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
                   align="center"
                   borderRadius="lg"
                   className={triggerWrapperClasses}
-                  cursor={`${autocomplete ? "text" : "pointer"}`}
+                  cursor={disabled ? "default" : `${autocomplete ? "text" : "pointer"}`}
                   htmlOptions={{
                     "aria-describedby": errorId,
+                    "aria-disabled": disabled,
                     "aria-invalid": !!error,
                     "aria-label": triggerAriaLabel,
                     id: selectId,
-                    onClick: () => handleWrapperClick(),
-                    onKeyDown: handleKeyDown,
-                    tabIndex: "0",
+                    onClick: () => !disabled && handleWrapperClick(),
+                    onKeyDown: (e: React.KeyboardEvent) => !disabled && handleKeyDown(e),
+                    tabIndex: disabled ? "-1" : "0",
                     ref:inputWrapperRef
                   }}
                   justify="between"
@@ -182,12 +187,14 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
                         {autocomplete && (
                           <input
                               className="dropdown_input"
+                              disabled={disabled}
                               onChange={handleChange}
                               onClick={(e) => {
                                 e.stopPropagation();// keep the wrapper’s handler from firing
+                                if (disabled) return;
                                 toggleDropdown();
                               }}
-                              onFocus={() => setIsInputFocused(true)}
+                              onFocus={() => !disabled && setIsInputFocused(true)}
                               onKeyDown={(e) => {
                                  handleKeyDown(e);
                                  e.stopPropagation(); //Fixes issue with keyboard accessibility
@@ -213,12 +220,14 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
                     {autocomplete && !multiSelect && (
                       <input
                           className="dropdown_input"
+                          disabled={disabled}
                           onChange={handleChange}
                           onClick={(e) => {
                             e.stopPropagation();// keep the wrapper’s handler from firing
+                            if (disabled) return;
                             toggleDropdown();
                           }}
-                          onFocus={() => setIsInputFocused(true)}
+                          onFocus={() => !disabled && setIsInputFocused(true)}
                           onKeyDown={handleKeyDown}
                           placeholder={
                             joinedLabels
@@ -239,16 +248,16 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
                       dark={dark}
                       display="flex"
                       htmlOptions={{
-                        onClick: (e: Event) => {e.stopPropagation();handleWrapperClick()}
+                        onClick: (e: Event) => {e.stopPropagation(); !disabled && handleWrapperClick()}
                       }}
                       key={`${isDropDownClosed ? "chevron-down" : "chevron-up"}`}
                   >
                     {(!blankSelection || selected?.value !== optionsWithBlankSelection?.[0]?.value) && (
                       <>
                         {clearable !== false && selectedArray.length > 0 && (
-                          <div onClick={(e)=>{e.stopPropagation();handleBackspace()}}>
+                          <div onClick={(e)=>{e.stopPropagation(); !disabled && handleBackspace()}}>
                             <Icon
-                                cursor="pointer"
+                                cursor={disabled ? "default" : "pointer"}
                                 dark={dark}
                                 icon="times"
                                 paddingRight="xs"
@@ -259,7 +268,7 @@ const DropdownTrigger = (props: DropdownTriggerProps) => {
                       </>
                     )}
                     <Icon
-                        cursor="pointer"
+                        cursor={disabled ? "default" : "pointer"}
                         dark={dark}
                         icon={`${isDropDownClosed ? "chevron-down" : "chevron-up"}`}
                         size="sm"

--- a/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/dropdown_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Playbook::PbDropdown::Dropdown do
   it { is_expected.to define_string_prop(:end_date_id).with_default("end_date_id") }
   it { is_expected.to define_string_prop(:end_date_name).with_default("end_date_name") }
   it { is_expected.to define_hash_prop(:custom_quick_pick_dates).with_default({}) }
+  it { is_expected.to define_boolean_prop(:disabled).with_default(false) }
   it { is_expected.to define_boolean_prop(:clearable).with_default(true) }
   it { is_expected.to define_enum_prop(:close_on_click).with_values("outside", "inside", "any").with_default("any") }
   it { is_expected.to define_boolean_prop(:constrain_height).with_default(false) }
@@ -38,6 +39,7 @@ RSpec.describe Playbook::PbDropdown::Dropdown do
       expect(subject.new(dark: true).classname).to eq "pb_dropdown_default dark"
       expect(subject.new(margin: "lg").classname).to eq "pb_dropdown_default m_lg"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_dropdown_default additional_class"
+      expect(subject.new(disabled: true).classname).to eq "pb_dropdown_default disabled"
     end
   end
 
@@ -463,6 +465,13 @@ RSpec.describe Playbook::PbDropdown::Dropdown do
     it "omits custom_event_type from data when not passed" do
       dropdown = subject.new({})
       expect(dropdown.data).not_to have_key(:custom_event_type)
+    end
+  end
+
+  describe "#disabled" do
+    it "includes disabled state in data when true" do
+      dropdown = subject.new(disabled: true)
+      expect(dropdown.data).to include(pb_dropdown_disabled: true)
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3032](https://runway.powerhrg.com/backlog_items/PLAY-3032?from=active_sprint) adds a disabled input state + style to the Dropdown kit. The input is disabled from click + keyboard functionality for Rails and React. I tested multiple variants of the Dropdown kit locally but the kept the doc examples simple - see [CSB with alpha](https://codesandbox.io/p/devbox/play-2970-message-kit-mention-height-forked-2kfty3?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) to see the testing examples disabled on the alpha.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1154" height="501" alt="dropdown disabled rails doc" src="https://github.com/user-attachments/assets/d720501f-90a2-4824-8b07-bc3d74e17519" />
<img width="750" height="473" alt="csb react" src="https://github.com/user-attachments/assets/bd622919-1583-4cf3-bf21-d47d233f3345" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Dropdown Disabled Input doc example ([rails](https://pr6340.playbook.wc.beta.px.powerapp.cloud/kits/dropdown/rails#dropdown_disabled), [react](https://pr6340.playbook.wc.beta.px.powerapp.cloud/kits/dropdown/react#dropdown_disabled)) and the [CSB with alpha](https://codesandbox.io/p/devbox/play-2970-message-kit-mention-height-forked-2kfty3?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) to evaluate the disabled Dropdown input.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.