### PR TITLE
Corrected typo on Border Global Props page

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/BorderGlobalProps.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/BorderGlobalProps.tsx
@@ -26,7 +26,7 @@ const borderValues: { label: string; name: BorderValue; description: string }[] 
   { label: "Default", name: "default", description: "1px default" },
   { label: "Active", name: "active", description: "1px active" },
   { label: "Default Thick", name: "default_thick", description: "2px default" },
-  { label: "Active Thickn", name: "active_thick", description: "2px active" },
+  { label: "Active Thick", name: "active_thick", description: "2px active" },
   { label: "Default Thicker", name: "default_thicker", description: "4px default" },
   { label: "Active Thicker", name: "active_thicker", description: "4px active" },
 ];


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fixed a typo in the Visual Guide Section of the new Border Global Props page - nothing to see here.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to /global_props/border and see "Thickn" is now "Thick".


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.