### PR TITLE
[PLAY-3024] Playbook Website: markdown styling fixes

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/MarkdownContent.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/MarkdownContent.tsx
@@ -1,9 +1,16 @@
 import { useMemo, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
+import { Pill } from "playbook-ui";
 
 type MarkdownContentProps = {
   children: string;
+  dark?: boolean;
 };
+
+const DISCLAIMER_PILL_PATTERN =
+  /<div class="pb_pill_kit_warning"><div class="pb_title_kit_size_4 pb_pill_text">([^<]*)<\/div><\/div>/gi;
+
+const DISCLAIMER_MARKER_PATTERN = /^\[\[pb-disclaimer-pill:(.+)\]\]$/;
 
 function htmlAttributeValue(attributes: string, name: string): string {
   const match = attributes.match(new RegExp(`${name}=["']([^"']*)["']`, "i"));
@@ -31,12 +38,14 @@ function normalizeImageTags(source: string): string {
 
 /**
  * react-markdown does not interpret raw HTML in the source string.
- * Kit/docs copy often mixes markdown with a few HTML tags, normalize those
- * to markdown so they render without extra plugins.
+ * Kit/docs copy often mixes markdown with a few HTML tags; normalize those
+ * to markdown (or block markers) so they render without extra plugins.
  */
 function normalizeHtmlInMarkdown(source: string): string {
   return (
     normalizeImageTags(source)
+      .replace(/<\/br\s*>/gi, "<br />")
+      .replace(DISCLAIMER_PILL_PATTERN, "\n\n[[pb-disclaimer-pill:$1]]\n\n")
       .replace(/<br\s*\/?>/gi, "  \n")
       .replace(/<\/p>\s*<p>/gi, "\n\n")
       .replace(/<p\b[^>]*>/gi, "")
@@ -133,7 +142,7 @@ function renderMarkdownTable(rows: string[], key: string): ReactNode {
 }
 
 function renderMarkdownBlocks(source: string): ReactNode[] {
-  const normalizedSource = normalizeImageTags(source);
+  const normalizedSource = normalizeHtmlInMarkdown(source);
   const lines = normalizedSource.split(/\r?\n/);
   const blocks: ReactNode[] = [];
   const textBuffer: string[] = [];
@@ -151,6 +160,21 @@ function renderMarkdownBlocks(source: string): ReactNode[] {
 
   while (index < lines.length) {
     const line = lines[index];
+    const disclaimerMatch = line.trim().match(DISCLAIMER_MARKER_PATTERN);
+
+    if (!insideFence && disclaimerMatch) {
+      flushText();
+      blocks.push(
+        <Pill
+          key={`pill-${blocks.length}`}
+          text={disclaimerMatch[1].trim() || "Disclaimer"}
+          variant="warning"
+          textTransform="none"
+        />,
+      );
+      index += 1;
+      continue;
+    }
 
     if (line.trim().startsWith("```")) {
       insideFence = !insideFence;
@@ -186,7 +210,9 @@ function renderMarkdownBlocks(source: string): ReactNode[] {
  * Markdown with common embedded HTML normalized to real markdown.
  * Content is expected to be authored/trusted (kit copy, internal docs).
  */
-export function MarkdownContent({ children }: MarkdownContentProps) {
+export function MarkdownContent({ children, dark = false }: MarkdownContentProps) {
   const blocks = useMemo(() => renderMarkdownBlocks(children), [children]);
-  return <>{blocks}</>;
+  const className = dark ? "markdown dark" : "markdown";
+
+  return <div className={className}>{blocks}</div>;
 }

--- a/playbook-website/app/javascript/components/Website/src/components/MarkdownContent.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/MarkdownContent.tsx
@@ -45,6 +45,8 @@ function normalizeHtmlInMarkdown(source: string): string {
   return (
     normalizeImageTags(source)
       .replace(/<\/br\s*>/gi, "<br />")
+      // A <br> on its own line is intentional vertical space, not an inline break.
+      .replace(/^\s*<br\s*\/?>\s*$/gim, "\n\n")
       .replace(DISCLAIMER_PILL_PATTERN, "\n\n[[pb-disclaimer-pill:$1]]\n\n")
       .replace(/<br\s*\/?>/gi, "  \n")
       .replace(/<\/p>\s*<p>/gi, "\n\n")
@@ -167,6 +169,8 @@ function renderMarkdownBlocks(source: string): ReactNode[] {
       blocks.push(
         <Pill
           key={`pill-${blocks.length}`}
+          marginTop="sm"
+          marginBottom="sm"
           text={disclaimerMatch[1].trim() || "Disclaimer"}
           variant="warning"
           textTransform="none"

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
@@ -196,7 +196,9 @@ export const DocsTab = ({ examples, exampleProps, sections }: DocsTabProps) => {
           )}
           {example.description && example.description !== "" && (
             <Body margin="md" dark={darkMode}>
-              <MarkdownContent>{example.description}</MarkdownContent>
+              <MarkdownContent dark={darkMode}>
+                {example.description}
+              </MarkdownContent>
             </Body>
           )}
           {/* Code Section */}

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/index.tsx
@@ -151,7 +151,9 @@ const KitShow = () => {
 
           {kit_description && kit_description !== "" && (
             <Body marginTop="sm" marginBottom="md" dark={darkMode}>
-              <MarkdownContent>{kit_description}</MarkdownContent>
+              <MarkdownContent dark={darkMode}>
+                {kit_description}
+              </MarkdownContent>
             </Body>
           )}
 

--- a/playbook-website/app/javascript/site_styles/docs/_markdown.scss
+++ b/playbook-website/app/javascript/site_styles/docs/_markdown.scss
@@ -90,7 +90,7 @@
   code {
     font-family: monospace;
     background: $bg_light;
-    padding: 0rem;
+    padding: 0.1rem 0.3rem;
     margin: 0;
     border: 1px solid $border_light;
     border-radius: 0.25rem;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[PLAY-3024](https://runway.powerhrg.com/backlog_items/PLAY-3024?from=backlog)

Fixes for markdown styling for the website to account for spaces, line breaks, code snippets, etc.


**Screenshots:** Screenshots to visualize your addition/change
<img width="1056" height="864" alt="Screenshot 2026-07-06 at 10 37 16 AM" src="https://github.com/user-attachments/assets/95132084-915d-4d9d-9144-d98629bf18eb" />

<img width="1066" height="522" alt="Screenshot 2026-07-06 at 10 48 32 AM" src="https://github.com/user-attachments/assets/2b8517e4-5ecd-4940-8627-194c6fe50aa5" />


<img width="898" height="595" alt="Screenshot 2026-07-06 at 10 36 55 AM" src="https://github.com/user-attachments/assets/6188c4d5-0589-433d-8ca2-78901d8fa2aa" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.