### PR TITLE
[PLAY-3053] Advanced Table: Pin Row to Bottom - React

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -53,7 +53,7 @@ kits:
   - name: row_interaction
     description: Select, expand, subrows, pinning; row highlights and bulk actions.
     parent: advanced_table
-    kit_section: ["Expanded Control", "Expand by Depth", "SubRow Headers", "Enable Toggle Expansion", "Cascade Collapse", "Pinned Rows", "Selectable Rows", "Selectable Rows (No Subrows)", "Selectable Rows (With Actions)", "Selectable Rows (No Actions Bar)"]
+    kit_section: ["Expanded Control", "Expand by Depth", "SubRow Headers", "Enable Toggle Expansion", "Cascade Collapse", "Pinned Rows (Top)", "Pinned Rows (Bottom)", "Pinned Rows (Both)", "Selectable Rows", "Selectable Rows (No Subrows)", "Selectable Rows (With Actions)", "Selectable Rows (No Actions Bar)"]
     platforms: *1
     status: stable
     icons_used: true

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/RegularTableView.tsx
@@ -162,20 +162,26 @@ export const RegularTableView = ({
   );
 
   // Row pinning
-  function PinnedRow({ row }: { row: Row<any> }) {
+  function PinnedRow({ row, position }: { row: Row<any>; position: 'top' | 'bottom' }) {
     const customRowStyle = getRowStyle(rowStyling, row);
+    const bottomRowsCount = table.getBottomRows().length;
+
     return (
       <tr
-          className={classnames(
-            `pinned-row`,
-          )}
+          className={classnames('pinned-row', {
+            'pinned-row-bottom': position === 'bottom',
+          })}
           style={{
             backgroundColor: customRowStyle?.backgroundColor ? customRowStyle?.backgroundColor : 'white',
             color: customRowStyle?.fontColor,
             position: 'sticky',
             top:
-              row.getIsPinned() === 'top'
-                  ? `${row.getPinnedIndex() * rowHeight + headerHeight + actionBarHeight}px`
+            position === 'top'
+                ? `${row.getPinnedIndex() * rowHeight + headerHeight + actionBarHeight}px`
+                : undefined,
+            bottom:
+              position === 'bottom'
+                  ? `${(bottomRowsCount - 1 - row.getPinnedIndex()) * rowHeight}px`
                   : undefined,
             zIndex: '3',
             fontWeight: getFontWeight(customRowStyle),
@@ -201,6 +207,7 @@ export const RegularTableView = ({
     <>
       {pinnedRows && table.getTopRows().map((row: Row<GenericObject>) => (
         <PinnedRow key={row.id}
+            position="top"
             row={row}
         />
       ))}
@@ -274,6 +281,12 @@ export const RegularTableView = ({
           </React.Fragment>
         );
       })}
+      {pinnedRows && table.getBottomRows().map((row: Row<GenericObject>) => (
+        <PinnedRow key={row.id}
+            position="bottom"
+            row={row}
+        />
+      ))}
     </>
   );
 }

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Hooks/useTableState.ts
@@ -72,6 +72,7 @@ export function useTableState({
   const [localColumnVisibility, setLocalColumnVisibility] = useState({});
   const [localRowPinning, setLocalRowPinning] = useState<RowPinningState>({
     top: [],
+    bottom: [],
   });
   // Manage local state to preserve current page index when inlineRowLoading is enabled so it does not boot table to page 1
   // We can extend this for more usecases, but for now scoping it only for inlineRowLoading
@@ -235,22 +236,26 @@ export function useTableState({
   // Handle row pinning changes
     useEffect(() => {
     const topPins = pinnedRows?.value?.top ?? [];
-    if (topPins.length === 0) {
-      onRowPinningChange({ top: [] });
-      return;
-    }
+    const bottomPins = pinnedRows?.value?.bottom ?? [];
+    
     const rows = table.getRowModel().rows;
     const collectAllDescendantIds = (subs: Row<GenericObject>[]): string[] =>
       subs.flatMap(r => [r.id, ...collectAllDescendantIds(r.subRows)]);
-    const allPinned: string[] = [];
-    topPins.forEach(id => {
-      const parent = rows.find(r => r.id === id && r.depth === 0);
-      if (parent) {
-        allPinned.push(parent.id, ...collectAllDescendantIds(parent.subRows));
-      }
+    const expandPins = (ids: string[]): string[] => {
+      const allPinned: string[] = [];
+      ids.forEach(id => {
+        const parent = rows.find(r => r.id === id && r.depth === 0);
+        if (parent) {
+          allPinned.push(parent.id, ...collectAllDescendantIds(parent.subRows));
+        }
+      });
+      return allPinned;
+    };
+    onRowPinningChange({
+      top: expandPins(topPins),
+      bottom: expandPins(bottomPins),
     });
-    onRowPinningChange({ top: allPinned });
-  }, [table, pinnedRows?.value?.top?.join(',')]);
+  }, [table, pinnedRows?.value?.top?.join(','), pinnedRows?.value?.bottom?.join(',')]);
 
   // Set pagination state when pagination is enabled
   useEffect(() => {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -747,6 +747,9 @@
   // Row Pinning - React uses inline style; Rails passes same style via html_options from table_body
   .pinned-row {
     box-shadow: 0 4px 10px 0 rgba($shadow, 0.16) !important;
+    &.pinned-row-bottom {
+      box-shadow: 0 -3px 8px 0 rgba($shadow, 0.1) !important;
+    }
   }
 
   // For Rails, we can't target the &:last-child since collapsed rows are display: none;

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/advanced_table.test.jsx
@@ -696,7 +696,7 @@ test("customRenderer prop functions as expected", () => {
   expect(pill).toBeInTheDocument()
 })
 
-test("pinnedRows prop renders pinned rows at top", () => {
+test("pinnedRows prop renders top pinned rows at top", () => {
   const pinnedRowsControl = {
     value: { top: ["1", "3"] },
     onChange: jest.fn()
@@ -719,6 +719,31 @@ test("pinnedRows prop renders pinned rows at top", () => {
   const firstPinnedRow = pinnedRows[0]
   expect(firstPinnedRow).toHaveStyle("position: sticky")
   expect(firstPinnedRow).toHaveStyle("background-color: white")
+})
+
+test("pinnedRows prop renders bottom pinned rows at bottom", () => {
+  const pinnedRowsControl = {
+    value: { bottom: ["1", "3"] },
+    onChange: jest.fn()
+  }
+
+  render(
+    <AdvancedTable
+        columnDefinitions={columnDefinitions}
+        data={{ testid: testId }}
+        pinnedRows={pinnedRowsControl}
+        tableData={MOCK_DATA_WITH_ID}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  const pinnedRows = kit.querySelectorAll(".pinned-row-bottom")
+  
+  expect(pinnedRows).toHaveLength(2)
+  
+  const lastPinnedRow = pinnedRows[0]
+  expect(lastPinnedRow).toHaveStyle("position: sticky")
+  expect(lastPinnedRow).toHaveStyle("background-color: white")
 })
 
 test("columnStyling.headerAlignment aligns header as expected", () => {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import AdvancedTable from '../_advanced_table'
 import MOCK_DATA_WITH_ID from "./advanced_table_mock_data_with_id.json"
+import Caption from "../../pb_caption/_caption"
 
 const AdvancedTableRowPinning = (props) => {
   const columnDefinitions = [
@@ -35,14 +36,30 @@ const AdvancedTableRowPinning = (props) => {
     },
   ]
 
-  const [pinnedRows, setPinnedRows] = useState({top: ["8"]})
+  const [pinnedRowsTop, setPinnedRowsTop] = useState({top: ["8"]})
+  const [pinnedRowsBottom, setPinnedRowsBottom] = useState({bottom: ["8"]})
 
   return (
     <div>
+      <Caption text="Pinned Rows Top" />
       <AdvancedTable
           columnDefinitions={columnDefinitions}
           maxHeight="xs"
-          pinnedRows={{value: pinnedRows, onChange: setPinnedRows}}
+          pinnedRows={{value: pinnedRowsTop, onChange: setPinnedRowsTop}}
+          tableData={MOCK_DATA_WITH_ID}
+          tableProps={{sticky: true}}
+          {...props}
+      >
+        <AdvancedTable.Header enableSorting />
+        <AdvancedTable.Body />
+      </AdvancedTable>
+      <Caption marginTop="md"
+          text="Pinned Rows Bottom"
+      />
+      <AdvancedTable
+          columnDefinitions={columnDefinitions}
+          maxHeight="xs"
+          pinnedRows={{value: pinnedRowsBottom, onChange: setPinnedRowsBottom}}
           tableData={MOCK_DATA_WITH_ID}
           tableProps={{sticky: true}}
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import AdvancedTable from '../_advanced_table'
 import MOCK_DATA_WITH_ID from "./advanced_table_mock_data_with_id.json"
 
-const AdvancedTableRowPinning = (props) => {
+const AdvancedTableRowPinningBoth = (props) => {
   const columnDefinitions = [
     {
       accessor: "year",
@@ -35,7 +35,7 @@ const AdvancedTableRowPinning = (props) => {
     },
   ]
 
-  const [pinnedRows, setPinnedRows] = useState({top: ["8"]})
+  const [pinnedRows, setPinnedRows] = useState({top: ["8"], bottom: ["1"]})
 
   return (
     <div>
@@ -54,4 +54,4 @@ const AdvancedTableRowPinning = (props) => {
   )
 }
 
-export default AdvancedTableRowPinning
+export default AdvancedTableRowPinningBoth

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both_react.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both_react.md
@@ -1,0 +1,1 @@
+This code snippet demonstrates `pinnedRows` taking an array of row ids to both the `top` and `bottom` properties.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom.jsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import AdvancedTable from '../_advanced_table'
 import MOCK_DATA_WITH_ID from "./advanced_table_mock_data_with_id.json"
 
-const AdvancedTableRowPinning = (props) => {
+const AdvancedTableRowPinningBottom = (props) => {
   const columnDefinitions = [
     {
       accessor: "year",
@@ -35,7 +35,7 @@ const AdvancedTableRowPinning = (props) => {
     },
   ]
 
-  const [pinnedRows, setPinnedRows] = useState({top: ["8"]})
+  const [pinnedRows, setPinnedRows] = useState({bottom: ["8"]})
 
   return (
     <div>
@@ -54,4 +54,4 @@ const AdvancedTableRowPinning = (props) => {
   )
 }
 
-export default AdvancedTableRowPinning
+export default AdvancedTableRowPinningBottom

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom_react.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom_react.md
@@ -1,0 +1,1 @@
+This code snippet demonstrates `pinnedRows` taking an array of row ids to the `bottom` property.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_react.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_react.md
@@ -3,5 +3,5 @@ Use the `pinnedRows` prop to pin specific rows to the top or bottom of an Advanc
 **NOTE:** 
 - Sticky header required: Pinned rows must be used with `sticky: true` via `tableProps` (works with both responsive and non-responsive tables)
 - Row ids required: Each object within the `tableData` Array must contain a unique id in order to attach an id to all Rows for this to function. 
-- `pinnedRows` takes an array of row ids to the `top` or `bottom` property as shown in the code snippet below (both can be used on the same table).
+- `pinnedRows` takes an array of row ids to the `top` or `bottom` property, or both. `top` is shown in the code snippet below.
 - For expandable rows, use the parent id in `pinnedRows`, all its children will automatically be pinned with it. If id for a child is passed in without parent being pinned, nothing will be pinned. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_react.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_react.md
@@ -1,7 +1,7 @@
-Use the `pinnedRows` prop to pin specific rows to the top of an Advanced Table. Pinned rows will remain at the top when scrolling through table data and will not change position if sorting is used.
+Use the `pinnedRows` prop to pin specific rows to the top or bottom of an Advanced Table. Pinned rows will remain at the top or bottom when scrolling through table data and will not change position if sorting is used.
 
 **NOTE:** 
 - Sticky header required: Pinned rows must be used with `sticky: true` via `tableProps` (works with both responsive and non-responsive tables)
 - Row ids required: Each object within the `tableData` Array must contain a unique id in order to attach an id to all Rows for this to function. 
-- `pinnedRows` takes an array of row ids to the `top` property as shown in the code snippet below. 
+- `pinnedRows` takes an array of row ids to the `top` or `bottom` property as shown in the code snippet below (both can be used on the same table).
 - For expandable rows, use the parent id in `pinnedRows`, all its children will automatically be pinned with it. If id for a child is passed in without parent being pinned, nothing will be pinned. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -89,5 +89,4 @@ examples:
   - advanced_table_column_styling_background_multi: Column Styling Background Color with Multiple Headers
   - advanced_table_padding_control: Padding Control using Column Styling
   - advanced_table_column_border_color: Column Group Border Color
-  - advanced_table_fullscreen: Fullscreen
   - advanced_table_infinite_scroll: Infinite Scroll

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -67,7 +67,9 @@ examples:
   - advanced_table_column_headers_custom_cell: Multi-Header Columns with Custom Cells
   - advanced_table_column_headers_vertical_border: Multi-Header Columns with Vertical Borders
   - advanced_table_no_subrows: Table with No Subrows or Expansion
-  - advanced_table_pinned_rows: Pinned Rows
+  - advanced_table_pinned_rows: Pinned Rows (Top)
+  - advanced_table_pinned_rows_bottom: Pinned Rows (Bottom)
+  - advanced_table_pinned_rows_both: Pinned Rows (Both)
   - advanced_table_selectable_rows: Selectable Rows
   - advanced_table_selectable_rows_no_subrows_react: Selectable Rows (No Subrows)
   - advanced_table_selectable_rows_actions: Selectable Rows (With Actions)

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/index.js
@@ -53,3 +53,5 @@ export { default as AdvancedTableColumnStylingBackgroundMulti } from './_advance
 export { default as AdvancedTableColumnStylingBackgroundCustom } from './_advanced_table_column_styling_background_custom.jsx'
 export { default as AdvancedTableCascadeCollapse } from './_advanced_table_cascade_collapse.jsx'
 export { default as AdvancedTableSortParentOnly } from './_advanced_table_sort_parent_only.jsx'
+export { default as AdvancedTablePinnedRowsBottom } from './_advanced_table_pinned_rows_bottom.jsx'
+export { default as AdvancedTablePinnedRowsBoth } from './_advanced_table_pinned_rows_both.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3053](https://runway.powerhrg.com/backlog_items/PLAY-3053?from=active_sprint) adds a Bottom Pinned Rows option to the existing Pinned Rows logic for the React Advanced Table kit. The bottom option works by itself or along with the top option on the same table. The box-shadow effect is slightly less than the top rows have. See doc example and [CSB with alpha](https://codesandbox.io/p/devbox/play-3039-advanced-table-rowstyling-fontweight-forked-nlj3gc?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) to explore. 
This PR also removed the last reference to the Advanced Table FullScreen doc example (leftover from PLAY-3007).

**Screenshots:** Screenshots to visualize your addition/change

<img width="1354" height="938" alt="three docs" src="https://github.com/user-attachments/assets/0de4a5ab-4017-416b-85e5-f8aae3257b46" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the 3 Pinned Rows doc examples (top, bottom, and both) or [CSB with Alpha](https://codesandbox.io/p/devbox/play-3039-advanced-table-rowstyling-fontweight-forked-nlj3gc?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) to see new prop option in action.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.