### PR TITLE
Textarea docs: update error message with raw element syntax

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("textarea", props: {
-  error: raw(pb_rails("icon", props: { icon: "warning" }) + " This field has an error!"),
+  error: raw("#{pb_rails('icon', props: { icon: 'warning' })} This field has an error!"),
   label: "Label",
   rows: 4
 }) %>


### PR DESCRIPTION
**What does this PR do?**
This PR updates the textarea with raw element error syntax to complain with rubocop. The current docs syntax raises this offense: 

```
Errors on modified lines:
[Rubocop] Style/StringConcatenation: Prefer string interpolation to string 
concatenation. (https://rubystyle.guide#string-interpolation)

```

I got this rubocop error on [INC-3178](https://github.com/powerhome/nitro-web/pull/60519/changes#diff-6ca340f4e1aec3bad8ba1d967e68fe5f16c8a030ce7ee7d99489138382149c53R13) and the above suggestion is applied there =)

Rubocop reference:  https://docs.rubocop.org/rubocop/latest/cops_style.html#stylestringconcatenation