### PR TITLE
[PLAY-2991] Flatten RTE 'focus' Variant Top Corners Under Toolbar

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_rich_text_editor.scss
@@ -40,7 +40,7 @@
     trix-toolbar {
       display: none;
     }
-    :not(.focused-editor) {
+    trix-editor:not(.focused-editor) {
       border-top-left-radius: $border_rad_heavier !important;
       border-top-right-radius: $border_rad_heavier !important;
     }

--- a/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
+++ b/playbook/app/pb_kits/playbook/pb_rich_text_editor/_tiptap_styles.scss
@@ -339,8 +339,8 @@
   .pb_rich_text_editor_advanced_container.toolbar-active {
     .ProseMirror {
       border-top: none;
-      border-top-left-radius: initial;
-      border-top-right-radius: initial;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-2991

Use `border-top: 0` instead of `border-top: initial`

**Screenshots:** Screenshots to visualize your addition/change
<img width="816" height="302" alt="Screenshot 2026-07-09 at 8 32 38 AM" src="https://github.com/user-attachments/assets/a852e2d0-ed8c-4ab9-9c23-5e4d8927fb89" />

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.