### PR TITLE
Add /worldcup page

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -107,7 +107,8 @@ class PagesController < ApplicationController
     on_guides    = request.path.include?("guides")
     on_icons     = request.path.include?("icons")
     on_playground = request.path.include?("playground")
-    on_home = !@kit.present? && !on_changelog && !on_guides && !on_icons && !on_playground
+    on_worldcup = request.path.include?("worldcup")
+    on_home = !@kit.present? && !on_changelog && !on_guides && !on_icons && !on_playground && !on_worldcup
 
     # Changelog — needed on changelog page AND as part of the general /kits.json payload
     # (the Changelog React component loads via ComponentsLoader which fetches /kits.json).
@@ -197,6 +198,11 @@ class PagesController < ApplicationController
         playground_kits: playground_kits,
         global_props_schema: global_props_schema,
       }
+      return
+    end
+
+    if on_worldcup && request.format.json?
+      render json: worldcup_json_payload
       return
     end
 
@@ -680,5 +686,30 @@ private
 
   def page_not_found
     redirect_to root_path, flash: { error: "The kit (#{params[:name]}) was not found." }
+  end
+
+  def worldcup_json_payload
+    Rails.cache.fetch("worldcup_json", expires_in: 60.seconds) do
+      matches = fetch_remote_json("https://wheniskickoff.com/data/v1/matches.json")
+      teams = fetch_remote_json("https://wheniskickoff.com/data/v1/teams.json")
+
+      {
+        matches: matches,
+        teams: teams,
+        updated_at: matches.dig("meta", "generated"),
+      }
+    end
+  rescue
+    { error: "Could not load World Cup data" }
+  end
+
+  def fetch_remote_json(url)
+    uri = URI(url)
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+      http.request(Net::HTTP::Get.new(uri))
+    end
+    raise "HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
   end
 end

--- a/playbook-website/app/javascript/components/Website/src/app.tsx
+++ b/playbook-website/app/javascript/components/Website/src/app.tsx
@@ -18,6 +18,7 @@ import GettingStarted from './pages/GettingStarted'
 import DesignGuidelines from './pages/DesignGuidelines'
 import GuidePage from './pages/GuidePage'
 import Playground from './pages/Playground'
+import WorldCup from './pages/WorldCup'
 import Color from './pages/DesignGuidelines/Color'
 import Spacing from './pages/DesignGuidelines/Spacing'
 import Typography from './pages/DesignGuidelines/Typography'
@@ -127,6 +128,7 @@ const router = createBrowserRouter(
         loader={PlaygroundLoader}
         path="playground"
       />
+      <Route element={<WorldCup />} path="worldcup" />
       <Route
         element={<Changelog />}
         loader={ComponentsLoader}

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/WorldCupBracket.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/WorldCupBracket.tsx
@@ -1,0 +1,56 @@
+import { Layout, Caption, SectionSeparator } from "playbook-ui"
+
+import { BRACKET_ROUNDS } from "./bracketConfig"
+import { resolveMatchParticipants } from "./matchUtils"
+import type { ApiMatch, ApiTeam, ResolvedParticipant } from "./types"
+
+type WorldCupBracketProps = {
+  matchesByNum: Map<number, ApiMatch>
+  teamsByCode: Map<string, ApiTeam>
+}
+
+const BracketParticipant = (participant: ResolvedParticipant) => (
+  <Layout.Participant
+    avatar={participant.avatar}
+    name={participant.name}
+    points={participant.points}
+    rank={participant.rank}
+    self={participant.self}
+    territory={participant.territory}
+    winner={participant.winner}
+  />
+)
+
+const WorldCupBracket = ({ matchesByNum, teamsByCode }: WorldCupBracketProps) => (
+  <Layout layout="bracket">
+    {BRACKET_ROUNDS.flatMap((round) => [
+      <Layout.RoundLabel key={`${round.label}-label`}>
+        <Caption>{round.label}</Caption>
+        <SectionSeparator marginY="sm" />
+      </Layout.RoundLabel>,
+      <Layout.Round
+        key={`${round.label}-round`}
+        marginBottom={
+          round.label === "Final" ? undefined : { xs: "md", sm: "md" }
+        }
+      >
+        {round.matchNums.map((matchNum) => {
+          const [home, away] = resolveMatchParticipants(
+            matchNum,
+            matchesByNum,
+            teamsByCode
+          )
+
+          return (
+            <Layout.Game key={matchNum}>
+              <BracketParticipant {...home} />
+              <BracketParticipant {...away} />
+            </Layout.Game>
+          )
+        })}
+      </Layout.Round>,
+    ])}
+  </Layout>
+)
+
+export default WorldCupBracket

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/bracketConfig.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/bracketConfig.ts
@@ -1,0 +1,34 @@
+import type { BracketRound } from "./types"
+
+// Match numbers in bracket tree order (pairs feed into the next round).
+export const BRACKET_ROUNDS: BracketRound[] = [
+  {
+    label: "Round of 32",
+    matchNums: [73, 76, 75, 78, 84, 83, 82, 81, 74, 77, 79, 80, 87, 86, 85, 88],
+  },
+  {
+    label: "Round of 16",
+    matchNums: [89, 90, 93, 94, 91, 92, 95, 96],
+  },
+  {
+    label: "Quarterfinals",
+    matchNums: [97, 98, 99, 100],
+  },
+  {
+    label: "Semifinals",
+    matchNums: [101, 102],
+  },
+  {
+    label: "Final",
+    matchNums: [104],
+  },
+]
+
+// When the API has not yet filled home/away, derive from feeder match winners.
+export const FEEDER_MATCHES: Record<number, [number, number]> = {
+  101: [97, 98],
+  102: [99, 100],
+  104: [101, 102],
+}
+
+export const WORLDCUP_DATA_URL = "/worldcup.json"

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/index.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+import { Body, Button, Flex, LoadingInline, Title } from "playbook-ui"
+
+import WorldCupBracket from "./WorldCupBracket"
+import { useWorldCupData } from "./useWorldCupData"
+import "./styles.scss"
+
+const formatUpdatedAt = (iso: string | null) => {
+  if (!iso) return null
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    })
+  } catch {
+    return null
+  }
+}
+
+export default function WorldCup() {
+  const state = useWorldCupData()
+  const updatedAt =
+    state.status === "ready" ? formatUpdatedAt(state.data.updatedAt) : null
+
+  return (
+    <div className="worldcup-page">
+      <Flex
+        align="stretch"
+        columnGap="none"
+        flexDirection="column"
+        paddingBottom="md"
+        paddingTop="md"
+        paddingX="md"
+        rowGap="sm"
+      >
+        <Title size={2} tag="h1" text="2026 FIFA World Cup Bracket" />
+        <Body color="light">
+          Knockout results loaded on visit — refresh the page for the latest scores.
+          Built with Playbook&apos;s{" "}
+          <a href="/kits/layout/react#layout_bracket">Layout bracket</a> variant.
+          {" "}
+          Data from{" "}
+          <a href="https://wheniskickoff.com/data/" rel="noreferrer" target="_blank">
+            When Is Kickoff
+          </a>
+          .
+        </Body>
+        {updatedAt && (
+          <Body color="light" text={`Last updated ${updatedAt}`} />
+        )}
+      </Flex>
+
+      <div className="worldcup-page__bracket">
+        {state.status === "loading" && (
+          <Flex alignItems="center" justifyContent="center" padding="xl">
+            <LoadingInline />
+          </Flex>
+        )}
+
+        {state.status === "error" && (
+          <Flex
+            align="center"
+            columnGap="sm"
+            flexDirection="column"
+            padding="xl"
+            rowGap="sm"
+          >
+            <Body color="error" text={state.message} />
+            <Button onClick={state.retry} text="Try again" variant="secondary" />
+          </Flex>
+        )}
+
+        {state.status === "ready" && (
+          <WorldCupBracket
+            matchesByNum={state.data.matchesByNum}
+            teamsByCode={state.data.teamsByCode}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/matchUtils.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/matchUtils.ts
@@ -1,0 +1,104 @@
+import { FEEDER_MATCHES } from "./bracketConfig"
+import { flagUrl, isUnitedStates } from "./teamFlags"
+import type { ApiMatch, ApiTeam, ResolvedParticipant } from "./types"
+
+const TBD: ResolvedParticipant = {
+  avatar: "",
+  name: "TBD",
+  points: "",
+  rank: "",
+  territory: "",
+}
+
+const isFinished = (match?: ApiMatch) =>
+  match?.status === "FINISHED" &&
+  match.score_home != null &&
+  match.score_away != null
+
+export const getWinnerCode = (match?: ApiMatch): string | null => {
+  if (!isFinished(match) || !match) return null
+  if (match.score_home! > match.score_away!) return match.home
+  if (match.score_away! > match.score_home!) return match.away
+  return null
+}
+
+const participantFromCode = (
+  code: string | null | undefined,
+  name: string | undefined,
+  teamsByCode: Map<string, ApiTeam>,
+  match: ApiMatch | undefined,
+  side: "home" | "away"
+): ResolvedParticipant => {
+  if (!code && !name) return TBD
+
+  const team = code ? teamsByCode.get(code) : undefined
+  const displayName = name || team?.name || "TBD"
+  const finished = isFinished(match)
+  const score =
+    side === "home" ? match?.score_home : match?.score_away
+  const homeWins = finished && match!.score_home! > match!.score_away!
+  const awayWins = finished && match!.score_away! > match!.score_home!
+  const winner = side === "home" ? homeWins : awayWins
+
+  return {
+    avatar: flagUrl(code),
+    name: displayName,
+    points: finished && score != null ? String(score) : "",
+    rank: team ? `Group ${team.group}` : "",
+    territory: team?.confederation || "",
+    winner: winner || undefined,
+    self: isUnitedStates(code, displayName) || undefined,
+  }
+}
+
+export const resolveMatchParticipants = (
+  matchNum: number,
+  matchesByNum: Map<number, ApiMatch>,
+  teamsByCode: Map<string, ApiTeam>
+): [ResolvedParticipant, ResolvedParticipant] => {
+  const match = matchesByNum.get(matchNum)
+
+  if (match?.home && match?.away) {
+    return [
+      participantFromCode(match.home, match.home_name, teamsByCode, match, "home"),
+      participantFromCode(match.away, match.away_name, teamsByCode, match, "away"),
+    ]
+  }
+
+  const feeders = FEEDER_MATCHES[matchNum]
+  if (!feeders) {
+    return [TBD, TBD]
+  }
+
+  const [feederA, feederB] = feeders
+  const feederMatchA = matchesByNum.get(feederA)
+  const feederMatchB = matchesByNum.get(feederB)
+  const winnerA = getWinnerCode(feederMatchA)
+  const winnerB = getWinnerCode(feederMatchB)
+
+  const sideA = winnerA
+    ? participantFromCode(
+        winnerA,
+        winnerA === feederMatchA?.home
+          ? feederMatchA.home_name
+          : feederMatchA?.away_name,
+        teamsByCode,
+        match,
+        "home"
+      )
+    : TBD
+
+  const sideB = winnerB
+    ? participantFromCode(
+        winnerB,
+        winnerB === feederMatchB?.home
+          ? feederMatchB.home_name
+          : feederMatchB?.away_name,
+        teamsByCode,
+        match,
+        "away"
+      )
+    : TBD
+
+  return [sideA, sideB]
+}

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/styles.scss
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/styles.scss
@@ -1,0 +1,8 @@
+@import "playbook-tokens/spacing";
+
+.worldcup-page {
+  &__bracket {
+    overflow-x: auto;
+    padding: 0 $space_md $space_lg;
+  }
+}

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/teamFlags.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/teamFlags.ts
@@ -1,0 +1,43 @@
+const FIFA_TO_FLAG: Record<string, string> = {
+  ARG: "ar",
+  AUS: "au",
+  AUT: "at",
+  BEL: "be",
+  BIH: "ba",
+  BRA: "br",
+  CAN: "ca",
+  CPV: "cv",
+  COL: "co",
+  CIV: "ci",
+  CRO: "hr",
+  COD: "cd",
+  ECU: "ec",
+  EGY: "eg",
+  ENG: "gb-eng",
+  FRA: "fr",
+  GHA: "gh",
+  GER: "de",
+  JPN: "jp",
+  MAR: "ma",
+  MEX: "mx",
+  NED: "nl",
+  NOR: "no",
+  PAR: "py",
+  POR: "pt",
+  RSA: "za",
+  SEN: "sn",
+  ESP: "es",
+  SUI: "ch",
+  SWE: "se",
+  USA: "us",
+  DZA: "dz",
+}
+
+export const flagUrl = (code?: string | null) => {
+  if (!code) return ""
+  const iso = FIFA_TO_FLAG[code]
+  return iso ? `https://flagcdn.com/w80/${iso}.png` : ""
+}
+
+export const isUnitedStates = (code?: string | null, name?: string) =>
+  code === "USA" || name === "United States"

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/types.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/types.ts
@@ -1,0 +1,37 @@
+export type ApiMatch = {
+  num: number
+  date: string
+  time_utc?: string
+  home: string | null
+  away: string | null
+  home_name?: string
+  away_name?: string
+  phase: string
+  status?: string
+  score_home?: number
+  score_away?: number
+  datetime_utc?: string
+  label?: string
+}
+
+export type ApiTeam = {
+  code: string
+  name: string
+  group: string
+  confederation: string
+}
+
+export type BracketRound = {
+  label: string
+  matchNums: number[]
+}
+
+export type ResolvedParticipant = {
+  avatar: string
+  name: string
+  points: string
+  rank: string
+  territory: string
+  winner?: boolean
+  self?: boolean
+}

--- a/playbook-website/app/javascript/components/Website/src/pages/WorldCup/useWorldCupData.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/WorldCup/useWorldCupData.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react"
+
+import { WORLDCUP_DATA_URL } from "./bracketConfig"
+import type { ApiMatch, ApiTeam } from "./types"
+
+type WorldCupData = {
+  matchesByNum: Map<number, ApiMatch>
+  teamsByCode: Map<string, ApiTeam>
+  updatedAt: string | null
+}
+
+type WorldCupState =
+  | { status: "loading" }
+  | { status: "error"; message: string; retry: () => void }
+  | { status: "ready"; data: WorldCupData }
+
+let sessionCache: WorldCupData | null = null
+
+const parsePayload = async (): Promise<WorldCupData> => {
+  if (sessionCache) {
+    return sessionCache
+  }
+
+  const response = await fetch(WORLDCUP_DATA_URL)
+
+  if (!response.ok) {
+    throw new Error("Could not load World Cup data")
+  }
+
+  const json = await response.json()
+
+  if (json.error) {
+    throw new Error(json.error)
+  }
+
+  sessionCache = {
+    matchesByNum: new Map<number, ApiMatch>(
+      (json.matches.data as ApiMatch[]).map((match) => [match.num, match])
+    ),
+    teamsByCode: new Map<string, ApiTeam>(
+      (json.teams.data as ApiTeam[]).map((team) => [team.code, team])
+    ),
+    updatedAt: json.updated_at ?? json.matches?.meta?.generated ?? null,
+  }
+
+  return sessionCache
+}
+
+export const useWorldCupData = (): WorldCupState => {
+  const [state, setState] = useState<WorldCupState>({ status: "loading" })
+
+  const load = useCallback(async () => {
+    setState({ status: "loading" })
+
+    try {
+      const data = await parsePayload()
+      setState({ status: "ready", data })
+    } catch (error) {
+      sessionCache = null
+      setState({
+        status: "error",
+        message:
+          error instanceof Error ? error.message : "Could not load World Cup data",
+        retry: () => {
+          sessionCache = null
+          load()
+        },
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  return state
+}

--- a/playbook-website/config/routes.rb
+++ b/playbook-website/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get "kits/:name",                          to: "pages#application"
   get "kit_category/:category",              to: "pages#application"
   get "playground",                          to: "pages#application"
+  get "worldcup",                            to: "pages#application"
   get "icons",                               to: "pages#application"
   get "changelog/:variant",                  to: "pages#application"
   get "changelog",                           to: "pages#application"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Makes a /worldcup page for fun!

**Screenshots:** Screenshots to visualize your addition/change
<img width="2560" height="1324" alt="Screenshot 2026-07-09 at 9 19 04 AM" src="https://github.com/user-attachments/assets/fd831f0a-d148-4927-a2e3-8e94641b1e93" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.