### PR TITLE
[PLAY-3091] Nav Kit: Typing and Playground Fixes

### DIFF
--- a/docs/PLAYGROUND_CONFIG.md
+++ b/docs/PLAYGROUND_CONFIG.md
@@ -115,7 +115,7 @@ The base layer can infer simple things like component name, schema defaults, and
 | Field | Purpose |
 | --- | --- |
 | `template` | JSX template. Use `{{props}}` where enabled props should be inserted and `{{children}}` where editable children should appear. |
-| `children` | Controls the Children editor. Use multiline JSX for kits like `Nav`, `Flex`, or `List`. |
+| `children` | Controls the Children editor. Use multiline JSX for kits like `Nav`, `Flex`, or `List`. Optional `propInjection` can merge targeted props into every matching child tag. |
 | `defaults` | Baseline values for controls. Defaults seed the UI but are not emitted until the prop is enabled, selected by a preset, required, or part of a structure mode. |
 | `groups` | Sections in the props panel. Use camelCase prop names. Props not listed still appear under `Other` unless hidden. |
 | `presets` | Feature pills. Each preset can set `props`, `children`, `structureMode`, or `dataPreset`. |
@@ -123,9 +123,9 @@ The base layer can infer simple things like component name, schema defaults, and
 | `hints` | Info/warning/error banners above the preview. |
 | `hiddenProps` | Props to omit from the props panel. |
 | `requiredProps` | Props that should always be present and non-disableable. Useful for required arrays/data like `treeData`. |
-| `customProps` | Playground-only controls not in the schema, often used for subcomponent props. |
+| `customProps` | Playground-only controls not in the schema, often used for subcomponent props. Prefer the real prop names developers pass (for example `text`, `marginY`) when they do not collide with the parent kit. |
 | `propTargets` | Routes a prop into a template marker other than `{{props}}`. |
-| `propAliases` | Renames a playground prop when emitted, such as `navItemText` -> `text`. |
+| `propAliases` | Renames a playground prop when emitted. Prefer avoiding aliases by using real prop names in `customProps` when possible. |
 | `structureModes` | Alternate templates for the same kit, such as default vs subcomponent usage. |
 | `propSyncOnEnable` | Switches structure/data automatically when a prop is enabled. |
 | `wrapper` | Wraps generated JSX with a function component or setup code. Can be top-level or per structure mode. |
@@ -172,6 +172,40 @@ Use `children.editable` when the user should be able to edit nested JSX.
 Any template that includes `{{children}}` will show the Children editor. If a structure mode does not include `{{children}}`, the editor is hidden for that mode.
 
 This is useful for kits where child rows/items matter, such as `Nav`, `Flex`, `List`, `Overlay`, and subcomponent examples.
+
+### Injecting props into every child (`propInjection`)
+
+Use `children.propInjection` when playground controls should apply to **all** matching child tags inside `{{children}}`, not just a single hard-coded child in the template.
+
+This is opt-in. Kits without `propInjection` are unchanged. Injection only runs when the config sets it, and only for the structure modes listed in `structureModes` (if provided).
+
+```json
+"children": {
+  "editable": true,
+  "default": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />",
+  "propInjection": {
+    "component": "NavItem",
+    "propTarget": "NavItem.props",
+    "structureModes": ["standard"]
+  }
+}
+```
+
+| Field | Purpose |
+| --- | --- |
+| `component` | Tag name to update, such as `NavItem` or `FlexItem`. |
+| `propTarget` | Marker key whose enabled props are injected, usually the same string used in `propTargets` (for example `NavItem.props`). |
+| `structureModes` | Optional allowlist of structure mode keys. When set, injection runs only in those modes. |
+
+How it works:
+
+1. Enabled props routed to `propTarget` are formatted as JSX attributes.
+2. Those attributes are merged onto every `<component ...>` tag in the `{{children}}` string.
+3. Existing child attributes are kept; injected props are appended.
+
+Prefer this over a structure mode that wraps a single `<NavItem{{NavItem.props}} />` when the goal is to demo shared child props across a list.
+
+Example (Nav): controls like `marginY`, `fontSize`, and `iconLeft` use the real NavItem prop names, target `NavItem.props`, and inject into every NavItem in standard mode.
 
 ## Defaults
 
@@ -337,72 +371,98 @@ Each mode can define:
 
 ## Subcomponent Props
 
-When the subcomponent has props but no schema, create playground-only controls with a prefix.
+When the subcomponent has props but no schema, create playground-only controls with `customProps` and route them with `propTargets`.
 
-Example: control one `NavItem` from the Nav playground.
+**Prefer the real prop names developers pass** (`text`, `active`, `marginY`, `iconLeft`) so the props panel matches generated code. Avoid inventing prefixed names like `navItemText` unless the real name collides with a parent kit prop (for example Nav’s own `link` vs NavItem `link`).
+
+### Apply props to every child (preferred for lists)
+
+Use `children.propInjection` so enabled child props merge into every matching tag in `{{children}}`. See [Injecting props into every child](#injecting-props-into-every-child-propinjection).
 
 ```json
 {
-  "structureModes": {
-    "default": "nav_item_props",
-    "modes": {
-      "nav_item_props": {
-        "label": "NavItem Props",
-        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}} />\n  {{children}}\n</Nav>",
-        "children": "<NavItem link=\"#\" text=\"Music\" />",
-        "props": {
-          "navItemText": "Photos",
-          "navItemLink": "#"
-        }
-      }
+  "children": {
+    "editable": true,
+    "default": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />",
+    "propInjection": {
+      "component": "NavItem",
+      "propTarget": "NavItem.props",
+      "structureModes": ["standard"]
     }
   },
   "customProps": {
-    "navItemText": {
-      "type": "string",
+    "text": { "type": "string", "platforms": ["react"] },
+    "active": { "type": "boolean", "platforms": ["react"], "default": false },
+    "marginY": {
+      "type": "enum",
       "platforms": ["react"],
-      "default": "Photos"
-    },
-    "navItemLink": {
-      "type": "string",
-      "platforms": ["react"],
-      "default": "#"
-    },
-    "navItemActive": {
-      "type": "boolean",
-      "platforms": ["react"],
-      "default": false
+      "values": ["none", "xxs", "xs", "sm", "md", "lg", "xl"]
     }
   },
   "propTargets": {
-    "navItemText": "NavItem.props",
-    "navItemLink": "NavItem.props",
-    "navItemActive": "NavItem.props"
-  },
-  "propAliases": {
-    "navItemText": "text",
-    "navItemLink": "link",
-    "navItemActive": "active"
+    "text": "NavItem.props",
+    "active": "NavItem.props",
+    "marginY": "NavItem.props"
   },
   "groups": [
     {
       "name": "NavItem Props",
-      "props": ["navItemText", "navItemLink", "navItemActive"]
+      "props": ["text", "active", "marginY"]
     }
   ]
 }
 ```
 
-Use `propSyncOnEnable` if turning on one of these props should switch to the matching structure:
+No `propAliases` are needed when the playground control name already matches the emitted prop.
+
+### Single hard-coded child in the template
+
+When you need one controlled child (or a parent/child structure like collapsible Nav), put a marker on that tag instead of injecting into all children:
 
 ```json
-"propSyncOnEnable": {
-  "navItemText": { "structureMode": "nav_item_props" },
-  "navItemActive": { "structureMode": "nav_item_props" }
+{
+  "structureModes": {
+    "default": "collapsible",
+    "modes": {
+      "collapsible": {
+        "label": "Collapsible NavItem",
+        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}}>\n    {{children}}\n  </NavItem>\n</Nav>",
+        "children": "<NavItem link=\"#\" text=\"City\" />",
+        "props": {
+          "collapsible": true,
+          "text": "Overview"
+        }
+      }
+    }
+  },
+  "customProps": {
+    "text": { "type": "string", "platforms": ["react"] },
+    "collapsible": { "type": "boolean", "platforms": ["react"], "default": false }
+  },
+  "propTargets": {
+    "text": "NavItem.props",
+    "collapsible": "NavItem.props"
+  }
 }
 ```
 
-This same pattern works for `FlexItem`, `Map.Controls`, `AdvancedTable.Header`, or any child/subcomponent surface.
+Use `propSyncOnEnable` if turning on a prop should switch to that structure:
+
+```json
+"propSyncOnEnable": {
+  "collapsible": { "structureMode": "collapsible" }
+}
+```
+
+### When names collide with the parent kit
+
+If a child prop shares a name with the parent (for example both have `link`), either:
+
+- keep the parent prop on `{{props}}` and set the child value in children JSX / structure mode `props`, or
+- use a mode-specific `propTargets` override so `link` routes to `NavItem.props` only in that mode, or
+- as a last resort, use a prefixed `customProps` key plus `propAliases` (older FlexItem-style pattern).
+
+This same targeting pattern works for `FlexItem`, `Map.Controls`, `AdvancedTable.Header`, or any child/subcomponent surface.
 
 ## Wrappers And State
 
@@ -545,7 +605,7 @@ If the template uses `setInput`, `mapContainerRef`, `mapInstance`, or similar, t
 
 ### If a prop belongs to a child component, use `customProps`
 
-Do not add fake props to `kit.schema.json` just for the playground. Add them under `customProps`, target them with `propTargets`, and rename them with `propAliases`.
+Do not add fake props to `kit.schema.json` just for the playground. Add them under `customProps` and target them with `propTargets`. Prefer real prop names so the panel matches what developers write. Use `propAliases` only when a prefix is required to avoid colliding with the parent kit. To apply the same props to every child in `{{children}}`, use `children.propInjection` (opt-in; other kits are unaffected).
 
 ### If a kit needs required data, use `requiredProps`
 
@@ -576,7 +636,8 @@ Before handing off a playground override:
 - `docs/_playground.json` was regenerated.
 - Presets demonstrate real usage patterns.
 - Required data is in `requiredProps`, not just `defaults`.
-- Subcomponent props use `customProps`, `propTargets`, and `propAliases`.
+- Subcomponent props use `customProps` and `propTargets` with real prop names when possible; use `propAliases` only for name collisions.
+- Shared list-item props use `children.propInjection` when they should apply to every matching child tag.
 - Wrappers define every variable used by the template.
 - Complex children/templates parse as JSX.
 - `git diff --check` is clean.

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/CodeGenerator.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/CodeGenerator.ts
@@ -397,6 +397,23 @@ export const getDefaultChildren = (componentName: string): string => {
   return childrenDefaults[name] ?? "";
 };
 
+export const injectPropsIntoComponentTags = (
+  children: string,
+  componentName: string,
+  propsString: string
+): string => {
+  const trimmedProps = propsString.trim();
+  if (!children || !trimmedProps) return children;
+
+  const tagRegex = new RegExp(`(<${componentName}\\b)([^>]*?)(\\/?>)`, "g");
+  return children.replace(tagRegex, (_match, openTag, existingProps, close) => {
+    const existing = existingProps.trim();
+    return existing
+      ? `${openTag} ${existing} ${trimmedProps}${close}`
+      : `${openTag} ${trimmedProps}${close}`;
+  });
+};
+
 export const needsChildren = (componentName: string): boolean => {
   const name = componentName.toLowerCase();
   const componentsWithChildren = [
@@ -429,7 +446,8 @@ export const generateFromTemplate = ({
   wrapper,
   requiredProps = {},
   statefulProps = [],
-}: GenerateFromTemplateOptions): string => {
+  structureMode = null,
+}: GenerateFromTemplateOptions & { structureMode?: string | null }): string => {
   // Group enabled props by their target marker
   const propsByTarget: Record<string, string[]> = {};
   const requiredPropVariableNames = new Set(
@@ -495,7 +513,23 @@ export const generateFromTemplate = ({
   markers.forEach((marker) => {
     if (marker === "children") {
       // Handle children marker - hide if a hideWhenPropSet prop is enabled
-      const childrenValue = shouldHideChildren ? "" : (children ?? childrenConfig?.default ?? "");
+      let childrenValue = shouldHideChildren ? "" : (children ?? childrenConfig?.default ?? "");
+      const injection = childrenConfig?.propInjection;
+      const injectionModes = injection?.structureModes;
+      const shouldInjectProps =
+        injection &&
+        !shouldHideChildren &&
+        (!injectionModes?.length || (structureMode && injectionModes.includes(structureMode)));
+
+      if (shouldInjectProps) {
+        const injectedProps = propsByTarget[injection.propTarget] || [];
+        childrenValue = injectPropsIntoComponentTags(
+          childrenValue,
+          injection.component,
+          injectedProps.join(" ")
+        );
+      }
+
       result = result.replace(/\{\{children\}\}/g, childrenValue);
     } else {
       const props = propsByTarget[marker] || [];
@@ -582,7 +616,8 @@ export const generateLiveFromTemplate = ({
   wrapper,
   requiredProps: _requiredProps = {},
   statefulProps = [],
-}: Omit<GenerateFromTemplateOptions, "includeImport">): string => {
+  structureMode = null,
+}: Omit<GenerateFromTemplateOptions, "includeImport"> & { structureMode?: string | null }): string => {
   // Do NOT pass requiredProps here. PlaygroundPreview injects them as scope variables
   // (via previewScope → extraScope). Generating `const columnDefinitions = …` in the
   // live code string would (a) duplicate the scope parameter name → SyntaxError in
@@ -602,6 +637,7 @@ export const generateLiveFromTemplate = ({
     wrapper,
     requiredProps: {},
     statefulProps,
+    structureMode,
   });
 
   let body = code.trimEnd();

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/hooks/usePlaygroundState.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/hooks/usePlaygroundState.ts
@@ -519,6 +519,7 @@ export const usePlaygroundState = ({
         wrapper: activeWrapper,
         requiredProps,
         statefulProps: activeStatefulProps,
+        structureMode: activeStructureMode,
       });
     }
     return generateCode({
@@ -545,6 +546,7 @@ export const usePlaygroundState = ({
         wrapper: activeWrapper,
         requiredProps,
         statefulProps: activeStatefulProps,
+        structureMode: activeStructureMode,
       });
     }
     return generateLiveCode({

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/types.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/types.ts
@@ -92,11 +92,19 @@ export const REACT_NODE_PRESETS: ReactNodePreset[] = [
   { label: "Custom JSX", value: "custom" },
 ];
 
+export interface PlaygroundChildrenPropInjection {
+  component: string;
+  propTarget: string;
+  /** When set, injection runs only in these structure mode keys (e.g. `"standard"`). */
+  structureModes?: string[];
+}
+
 export interface PlaygroundChildrenConfig {
   editable: boolean;
   default: string;
   marker?: string;
   hideWhenPropSet?: string[];
+  propInjection?: PlaygroundChildrenPropInjection;
 }
 
 export interface PropCondition {

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/codeGeneration.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/codeGeneration.ts
@@ -250,6 +250,7 @@ export const getLivePreviewCode = (
     wrapper: getActiveWrapper(instance, kit),
     requiredProps: getRequiredCodeProps(kit, instance),
     statefulProps: getActiveStatefulProps(instance, kit),
+    structureMode: instance.structureMode,
   });
   const setupCode = context.setupSnippets.join("\n\n");
 
@@ -530,6 +531,7 @@ const renderInstanceCode = (
       wrapper,
       requiredProps: isLivePreviewRender ? {} : requiredProps,
       statefulProps: getActiveStatefulProps(instance, kit),
+      structureMode: instance.structureMode,
     });
 
     const split = splitSetupFromRenderableCode(rendered);

--- a/playbook/app/pb_kits/playbook/pb_nav/_item.tsx
+++ b/playbook/app/pb_kits/playbook/pb_nav/_item.tsx
@@ -7,7 +7,7 @@ import { globalProps, GlobalProps } from "../utilities/globalProps";
 import Icon from "../pb_icon/_icon";
 import Image from "../pb_image/_image";
 import Collapsible from "../pb_collapsible/_collapsible";
-import { NavChildProps } from "./navTypes";
+import { NavChildProps, SpacingObject } from "./navTypes";
 import { Spacing } from "../types";
 
 type NavItemProps = {
@@ -35,7 +35,7 @@ type NavItemProps = {
   collapsibleTrail?: boolean;
   collapsed?: boolean;
   orientation?: "vertical" | "horizontal";
-  variant?: "normal" | "subtle";
+  variant?: "normal" | "subtle" | "bold";
   margin?: Spacing;
   marginBottom?: Spacing;
   marginTop?: Spacing;
@@ -44,6 +44,7 @@ type NavItemProps = {
   marginX?: Spacing;
   marginY?: Spacing;
   disabled?: boolean;
+  itemSpacing?: SpacingObject;
 } & GlobalProps;
 
 const NavItem = (props: NavItemProps) => {

--- a/playbook/app/pb_kits/playbook/pb_nav/_nav.tsx
+++ b/playbook/app/pb_kits/playbook/pb_nav/_nav.tsx
@@ -22,7 +22,7 @@ type NavProps = {
   orientation?: "vertical" | "horizontal",
   link?: string,
   title?: string,
-  variant?: "normal" | "subtle",
+  variant?: "normal" | "subtle" | "bold",
   itemSpacing?: SpacingObject
 } & GlobalProps
 

--- a/playbook/app/pb_kits/playbook/pb_nav/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_nav/docs/_playground.json
@@ -1,24 +1,22 @@
 {
   "template": "<Nav{{props}}>{{children}}</Nav>",
   "propTargets": {
-    "navItemText": "NavItem.props",
-    "navItemLink": "NavItem.props",
-    "navItemActive": "NavItem.props",
-    "navItemDisabled": "NavItem.props",
-    "navItemIconLeft": "NavItem.props",
-    "navItemIconRight": "NavItem.props",
-    "navItemImageUrl": "NavItem.props",
-    "navItemTarget": "NavItem.props",
-    "navItemFontSize": "NavItem.props",
-    "navItemFontWeight": "NavItem.props",
-    "navItemCollapsible": "NavItem.props",
-    "navItemCollapsed": "NavItem.props",
-    "navItemCollapsibleTrail": "NavItem.props",
-    "navItemHighlightedBorder": "NavItem.props",
-    "navItemMargin": "NavItem.props",
-    "navItemMarginY": "NavItem.props",
-    "navItemPaddingY": "NavItem.props",
-    "navItemOnClick": "NavItem.props"
+    "text": "NavItem.props",
+    "active": "NavItem.props",
+    "disabled": "NavItem.props",
+    "iconLeft": "NavItem.props",
+    "iconRight": "NavItem.props",
+    "imageUrl": "NavItem.props",
+    "target": "NavItem.props",
+    "fontSize": "NavItem.props",
+    "fontWeight": "NavItem.props",
+    "collapsible": "NavItem.props",
+    "collapsed": "NavItem.props",
+    "collapsibleTrail": "NavItem.props",
+    "highlighted_border": "NavItem.props",
+    "margin": "NavItem.props",
+    "marginY": "NavItem.props",
+    "paddingY": "NavItem.props"
   },
   "defaults": {
     "borderless": false,
@@ -27,19 +25,23 @@
     "orientation": "vertical",
     "link": "#",
     "variant": "normal",
-    "navItemText": "Photos",
-    "navItemLink": "#",
-    "navItemActive": false,
-    "navItemDisabled": false,
-    "navItemCollapsible": false,
-    "navItemCollapsed": true,
-    "navItemCollapsibleTrail": false,
-    "navItemHighlightedBorder": true,
-    "navItemOnClick": "() => console.log('Nav item clicked')"
+    "active": false,
+    "disabled": false,
+    "collapsible": false,
+    "collapsed": true,
+    "collapsibleTrail": false,
+    "highlighted_border": true
   },
   "children": {
     "editable": true,
-    "default": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
+    "default": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />",
+    "propInjection": {
+      "component": "NavItem",
+      "propTarget": "NavItem.props",
+      "structureModes": [
+        "standard"
+      ]
+    }
   },
   "groups": [
     {
@@ -69,49 +71,42 @@
     {
       "name": "NavItem Content",
       "props": [
-        "navItemText",
-        "navItemLink",
-        "navItemIconLeft",
-        "navItemIconRight",
-        "navItemImageUrl",
-        "navItemTarget"
+        "text",
+        "iconLeft",
+        "iconRight",
+        "imageUrl",
+        "target"
       ]
     },
     {
       "name": "NavItem State",
       "props": [
-        "navItemActive",
-        "navItemDisabled",
-        "navItemHighlightedBorder"
+        "active",
+        "disabled",
+        "highlighted_border"
       ]
     },
     {
       "name": "NavItem Typography",
       "props": [
-        "navItemFontSize",
-        "navItemFontWeight"
+        "fontSize",
+        "fontWeight"
       ]
     },
     {
       "name": "NavItem Collapsible",
       "props": [
-        "navItemCollapsible",
-        "navItemCollapsed",
-        "navItemCollapsibleTrail"
+        "collapsible",
+        "collapsed",
+        "collapsibleTrail"
       ]
     },
     {
       "name": "NavItem Spacing",
       "props": [
-        "navItemMargin",
-        "navItemMarginY",
-        "navItemPaddingY"
-      ]
-    },
-    {
-      "name": "NavItem Events",
-      "props": [
-        "navItemOnClick"
+        "margin",
+        "marginY",
+        "paddingY"
       ]
     }
   ],
@@ -177,69 +172,63 @@
     },
     {
       "name": "NavItem Icons",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
         "title": "Browse",
-        "navItemActive": true,
-        "navItemIconLeft": "comments-alt",
-        "navItemIconRight": "angle-down",
-        "navItemLink": "#",
-        "navItemText": "Messages"
-      }
+        "active": true,
+        "iconLeft": "comments-alt",
+        "iconRight": "angle-down"
+      },
+      "children": "<NavItem link=\"#\" text=\"Messages\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "NavItem Disabled",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
-        "navItemDisabled": true,
-        "navItemLink": "#",
-        "navItemText": "Disabled item"
-      }
+        "disabled": true
+      },
+      "children": "<NavItem link=\"#\" text=\"Disabled item\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "NavItem Typography",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
-        "navItemFontSize": "small",
-        "navItemFontWeight": "bolder",
-        "navItemLink": "#",
-        "navItemText": "Small bolder item"
-      }
+        "fontSize": "small",
+        "fontWeight": "bolder"
+      },
+      "children": "<NavItem link=\"#\" text=\"Small bolder item\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "NavItem Spacing",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
-        "navItemLink": "#",
-        "navItemMargin": "none",
-        "navItemPaddingY": "xxs",
-        "navItemText": "Tight item"
-      }
+        "margin": "none",
+        "paddingY": "xxs"
+      },
+      "children": "<NavItem link=\"#\" text=\"Tight item\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "Collapsible",
       "structureMode": "collapsible",
       "props": {
-        "navItemActive": true,
-        "navItemCollapsed": false,
-        "navItemCollapsible": true,
-        "navItemIconLeft": "city",
-        "navItemIconRight": "angle-down",
-        "navItemLink": "#",
-        "navItemText": "Overview"
+        "active": true,
+        "collapsed": false,
+        "collapsible": true,
+        "iconLeft": "city",
+        "iconRight": "angle-down",
+        "text": "Overview"
       }
     },
     {
       "name": "Collapsible Trail",
       "structureMode": "collapsible",
       "props": {
-        "navItemCollapsible": true,
-        "navItemCollapsibleTrail": true,
-        "navItemFontWeight": "bolder",
-        "navItemIconLeft": "city",
-        "navItemIconRight": "angle-down",
-        "navItemLink": "#",
-        "navItemText": "Overview"
+        "collapsible": true,
+        "collapsibleTrail": true,
+        "fontWeight": "bolder",
+        "iconLeft": "city",
+        "iconRight": "angle-down",
+        "text": "Overview"
       }
     }
   ],
@@ -250,12 +239,12 @@
         "variant": "normal"
       }
     },
-    "navItemCollapsed": {
-      "requires": "navItemCollapsible",
+    "collapsed": {
+      "requires": "collapsible",
       "structureMode": "collapsible"
     },
-    "navItemCollapsibleTrail": {
-      "requires": "navItemCollapsible",
+    "collapsibleTrail": {
+      "requires": "collapsible",
       "structureMode": "collapsible"
     }
   },
@@ -292,22 +281,22 @@
     },
     "nav_item_icons": {
       "presetName": "NavItem Icons",
-      "message": "NavItem iconLeft and iconRight add icons around the item text.",
+      "message": "NavItem iconLeft and iconRight add icons around the item text. Enabled NavItem props apply to every NavItem in children.",
       "type": "info"
     },
     "nav_item_disabled": {
       "presetName": "NavItem Disabled",
-      "message": "disabled makes the NavItem non-interactive and removes link navigation.",
+      "message": "disabled makes NavItems non-interactive and removes link navigation.",
       "type": "info"
     },
     "nav_item_typography": {
       "presetName": "NavItem Typography",
-      "message": "NavItem fontSize and fontWeight control item label styling.",
+      "message": "NavItem fontSize and fontWeight control item label styling on every NavItem.",
       "type": "info"
     },
     "nav_item_spacing": {
       "presetName": "NavItem Spacing",
-      "message": "NavItem spacing props can tighten or expand individual item layout.",
+      "message": "NavItem margin and paddingY props apply to every NavItem in the list.",
       "type": "info"
     },
     "collapsible": {
@@ -329,79 +318,65 @@
         "template": "<Nav{{props}}>\n  {{children}}\n</Nav>",
         "children": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
       },
-      "nav_item_props": {
-        "label": "NavItem Props",
-        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}} />\n  {{children}}\n</Nav>",
-        "children": "<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />",
-        "props": {
-          "navItemLink": "#",
-          "navItemText": "Primary Item"
-        }
-      },
       "collapsible": {
         "label": "Collapsible NavItem",
-        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}}>\n    {{children}}\n    {null}\n  </NavItem>\n</Nav>",
+        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}}>\n    {{children}}\n  </NavItem>\n</Nav>",
         "children": "<NavItem link=\"#\" text=\"City\" />\n<NavItem link=\"#\" text=\"People\" />\n<NavItem link=\"#\" text=\"Business\" />",
         "props": {
-          "navItemActive": true,
-          "navItemCollapsed": false,
-          "navItemCollapsible": true,
-          "navItemIconLeft": "city",
-          "navItemIconRight": "angle-down",
-          "navItemLink": "#",
-          "navItemText": "Overview"
+          "active": true,
+          "collapsed": false,
+          "collapsible": true,
+          "iconLeft": "city",
+          "iconRight": "angle-down",
+          "link": "#",
+          "text": "Overview"
+        },
+        "propTargets": {
+          "link": "NavItem.props"
         }
       }
     }
   },
   "customProps": {
-    "navItemText": {
+    "text": {
       "type": "string",
       "platforms": [
         "react"
-      ],
-      "default": "Photos"
+      ]
     },
-    "navItemLink": {
-      "type": "string",
-      "platforms": [
-        "react"
-      ],
-      "default": "#"
-    },
-    "navItemActive": {
+    "active": {
       "type": "boolean",
       "platforms": [
         "react"
       ],
       "default": false
     },
-    "navItemDisabled": {
+    "disabled": {
       "type": "boolean",
       "platforms": [
         "react"
       ],
       "default": false
     },
-    "navItemIconLeft": {
+    "iconLeft": {
       "type": "string",
       "platforms": [
         "react"
       ]
     },
-    "navItemIconRight": {
+    "iconRight": {
       "type": "string",
       "platforms": [
         "react"
       ]
     },
-    "navItemImageUrl": {
+    "imageUrl": {
       "type": "string",
       "platforms": [
         "react"
       ]
     },
-    "navItemTarget": {
+    "target": {
       "type": "enum",
       "platforms": [
         "react"
@@ -413,7 +388,7 @@
         "_top"
       ]
     },
-    "navItemFontSize": {
+    "fontSize": {
       "type": "enum",
       "platforms": [
         "react"
@@ -423,7 +398,7 @@
         "small"
       ]
     },
-    "navItemFontWeight": {
+    "fontWeight": {
       "type": "enum",
       "platforms": [
         "react"
@@ -434,35 +409,35 @@
         "bolder"
       ]
     },
-    "navItemCollapsible": {
+    "collapsible": {
       "type": "boolean",
       "platforms": [
         "react"
       ],
       "default": false
     },
-    "navItemCollapsed": {
+    "collapsed": {
       "type": "boolean",
       "platforms": [
         "react"
       ],
       "default": true
     },
-    "navItemCollapsibleTrail": {
+    "collapsibleTrail": {
       "type": "boolean",
       "platforms": [
         "react"
       ],
       "default": false
     },
-    "navItemHighlightedBorder": {
+    "highlighted_border": {
       "type": "boolean",
       "platforms": [
         "react"
       ],
       "default": true
     },
-    "navItemMargin": {
+    "margin": {
       "type": "enum",
       "platforms": [
         "react"
@@ -477,7 +452,7 @@
         "xl"
       ]
     },
-    "navItemMarginY": {
+    "marginY": {
       "type": "enum",
       "platforms": [
         "react"
@@ -492,7 +467,7 @@
         "xl"
       ]
     },
-    "navItemPaddingY": {
+    "paddingY": {
       "type": "enum",
       "platforms": [
         "react"
@@ -505,89 +480,18 @@
         "md",
         "lg",
         "xl"
-      ]
-    },
-    "navItemOnClick": {
-      "type": "function",
-      "platforms": [
-        "react"
       ]
     }
   },
-  "propAliases": {
-    "navItemText": "text",
-    "navItemLink": "link",
-    "navItemActive": "active",
-    "navItemDisabled": "disabled",
-    "navItemIconLeft": "iconLeft",
-    "navItemIconRight": "iconRight",
-    "navItemImageUrl": "imageUrl",
-    "navItemTarget": "target",
-    "navItemFontSize": "fontSize",
-    "navItemFontWeight": "fontWeight",
-    "navItemCollapsible": "collapsible",
-    "navItemCollapsed": "collapsed",
-    "navItemCollapsibleTrail": "collapsibleTrail",
-    "navItemHighlightedBorder": "highlighted_border",
-    "navItemMargin": "margin",
-    "navItemMarginY": "marginY",
-    "navItemPaddingY": "paddingY",
-    "navItemOnClick": "onClick"
-  },
   "propSyncOnEnable": {
-    "navItemText": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemLink": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemActive": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemDisabled": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemIconLeft": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemIconRight": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemImageUrl": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemTarget": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemFontSize": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemFontWeight": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemCollapsible": {
+    "collapsible": {
       "structureMode": "collapsible"
     },
-    "navItemCollapsed": {
+    "collapsed": {
       "structureMode": "collapsible"
     },
-    "navItemCollapsibleTrail": {
+    "collapsibleTrail": {
       "structureMode": "collapsible"
-    },
-    "navItemHighlightedBorder": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemMargin": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemMarginY": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemPaddingY": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemOnClick": {
-      "structureMode": "nav_item_props"
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_nav/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_nav/docs/_playground.overrides.json
@@ -7,234 +7,129 @@
         "template": "<Nav{{props}}>\n  {{children}}\n</Nav>",
         "children": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
       },
-      "nav_item_props": {
-        "label": "NavItem Props",
-        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}} />\n  {{children}}\n</Nav>",
-        "children": "<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />",
-        "props": {
-          "navItemLink": "#",
-          "navItemText": "Primary Item"
-        }
-      },
       "collapsible": {
         "label": "Collapsible NavItem",
-        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}}>\n    {{children}}\n    {null}\n  </NavItem>\n</Nav>",
+        "template": "<Nav{{props}}>\n  <NavItem{{NavItem.props}}>\n    {{children}}\n  </NavItem>\n</Nav>",
         "children": "<NavItem link=\"#\" text=\"City\" />\n<NavItem link=\"#\" text=\"People\" />\n<NavItem link=\"#\" text=\"Business\" />",
         "props": {
-          "navItemActive": true,
-          "navItemCollapsed": false,
-          "navItemCollapsible": true,
-          "navItemIconLeft": "city",
-          "navItemIconRight": "angle-down",
-          "navItemLink": "#",
-          "navItemText": "Overview"
+          "active": true,
+          "collapsed": false,
+          "collapsible": true,
+          "iconLeft": "city",
+          "iconRight": "angle-down",
+          "link": "#",
+          "text": "Overview"
+        },
+        "propTargets": {
+          "link": "NavItem.props"
         }
       }
     }
   },
   "children": {
     "editable": true,
-    "default": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
+    "default": "<NavItem link=\"#\" text=\"Photos\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem active link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />",
+    "propInjection": {
+      "component": "NavItem",
+      "propTarget": "NavItem.props",
+      "structureModes": ["standard"]
+    }
   },
   "customProps": {
-    "navItemText": {
+    "text": {
       "type": "string",
-      "platforms": [
-        "react"
-      ],
-      "default": "Photos"
+      "platforms": ["react"]
     },
-    "navItemLink": {
-      "type": "string",
-      "platforms": [
-        "react"
-      ],
-      "default": "#"
-    },
-    "navItemActive": {
+    "active": {
       "type": "boolean",
-      "platforms": [
-        "react"
-      ],
+      "platforms": ["react"],
       "default": false
     },
-    "navItemDisabled": {
+    "disabled": {
       "type": "boolean",
-      "platforms": [
-        "react"
-      ],
+      "platforms": ["react"],
       "default": false
     },
-    "navItemIconLeft": {
+    "iconLeft": {
       "type": "string",
-      "platforms": [
-        "react"
-      ]
+      "platforms": ["react"]
     },
-    "navItemIconRight": {
+    "iconRight": {
       "type": "string",
-      "platforms": [
-        "react"
-      ]
+      "platforms": ["react"]
     },
-    "navItemImageUrl": {
+    "imageUrl": {
       "type": "string",
-      "platforms": [
-        "react"
-      ]
+      "platforms": ["react"]
     },
-    "navItemTarget": {
+    "target": {
       "type": "enum",
-      "platforms": [
-        "react"
-      ],
-      "values": [
-        "_blank",
-        "_self",
-        "_parent",
-        "_top"
-      ]
+      "platforms": ["react"],
+      "values": ["_blank", "_self", "_parent", "_top"]
     },
-    "navItemFontSize": {
+    "fontSize": {
       "type": "enum",
-      "platforms": [
-        "react"
-      ],
-      "values": [
-        "normal",
-        "small"
-      ]
+      "platforms": ["react"],
+      "values": ["normal", "small"]
     },
-    "navItemFontWeight": {
+    "fontWeight": {
       "type": "enum",
-      "platforms": [
-        "react"
-      ],
-      "values": [
-        "regular",
-        "bold",
-        "bolder"
-      ]
+      "platforms": ["react"],
+      "values": ["regular", "bold", "bolder"]
     },
-    "navItemCollapsible": {
+    "collapsible": {
       "type": "boolean",
-      "platforms": [
-        "react"
-      ],
+      "platforms": ["react"],
       "default": false
     },
-    "navItemCollapsed": {
+    "collapsed": {
       "type": "boolean",
-      "platforms": [
-        "react"
-      ],
+      "platforms": ["react"],
       "default": true
     },
-    "navItemCollapsibleTrail": {
+    "collapsibleTrail": {
       "type": "boolean",
-      "platforms": [
-        "react"
-      ],
+      "platforms": ["react"],
       "default": false
     },
-    "navItemHighlightedBorder": {
+    "highlighted_border": {
       "type": "boolean",
-      "platforms": [
-        "react"
-      ],
+      "platforms": ["react"],
       "default": true
     },
-    "navItemMargin": {
+    "margin": {
       "type": "enum",
-      "platforms": [
-        "react"
-      ],
-      "values": [
-        "none",
-        "xxs",
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl"
-      ]
+      "platforms": ["react"],
+      "values": ["none", "xxs", "xs", "sm", "md", "lg", "xl"]
     },
-    "navItemMarginY": {
+    "marginY": {
       "type": "enum",
-      "platforms": [
-        "react"
-      ],
-      "values": [
-        "none",
-        "xxs",
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl"
-      ]
+      "platforms": ["react"],
+      "values": ["none", "xxs", "xs", "sm", "md", "lg", "xl"]
     },
-    "navItemPaddingY": {
+    "paddingY": {
       "type": "enum",
-      "platforms": [
-        "react"
-      ],
-      "values": [
-        "none",
-        "xxs",
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl"
-      ]
-    },
-    "navItemOnClick": {
-      "type": "function",
-      "platforms": [
-        "react"
-      ]
+      "platforms": ["react"],
+      "values": ["none", "xxs", "xs", "sm", "md", "lg", "xl"]
     }
   },
   "propTargets": {
-    "navItemText": "NavItem.props",
-    "navItemLink": "NavItem.props",
-    "navItemActive": "NavItem.props",
-    "navItemDisabled": "NavItem.props",
-    "navItemIconLeft": "NavItem.props",
-    "navItemIconRight": "NavItem.props",
-    "navItemImageUrl": "NavItem.props",
-    "navItemTarget": "NavItem.props",
-    "navItemFontSize": "NavItem.props",
-    "navItemFontWeight": "NavItem.props",
-    "navItemCollapsible": "NavItem.props",
-    "navItemCollapsed": "NavItem.props",
-    "navItemCollapsibleTrail": "NavItem.props",
-    "navItemHighlightedBorder": "NavItem.props",
-    "navItemMargin": "NavItem.props",
-    "navItemMarginY": "NavItem.props",
-    "navItemPaddingY": "NavItem.props",
-    "navItemOnClick": "NavItem.props"
-  },
-  "propAliases": {
-    "navItemText": "text",
-    "navItemLink": "link",
-    "navItemActive": "active",
-    "navItemDisabled": "disabled",
-    "navItemIconLeft": "iconLeft",
-    "navItemIconRight": "iconRight",
-    "navItemImageUrl": "imageUrl",
-    "navItemTarget": "target",
-    "navItemFontSize": "fontSize",
-    "navItemFontWeight": "fontWeight",
-    "navItemCollapsible": "collapsible",
-    "navItemCollapsed": "collapsed",
-    "navItemCollapsibleTrail": "collapsibleTrail",
-    "navItemHighlightedBorder": "highlighted_border",
-    "navItemMargin": "margin",
-    "navItemMarginY": "marginY",
-    "navItemPaddingY": "paddingY",
-    "navItemOnClick": "onClick"
+    "text": "NavItem.props",
+    "active": "NavItem.props",
+    "disabled": "NavItem.props",
+    "iconLeft": "NavItem.props",
+    "iconRight": "NavItem.props",
+    "imageUrl": "NavItem.props",
+    "target": "NavItem.props",
+    "fontSize": "NavItem.props",
+    "fontWeight": "NavItem.props",
+    "collapsible": "NavItem.props",
+    "collapsed": "NavItem.props",
+    "collapsibleTrail": "NavItem.props",
+    "highlighted_border": "NavItem.props",
+    "margin": "NavItem.props",
+    "marginY": "NavItem.props",
+    "paddingY": "NavItem.props"
   },
   "defaults": {
     "borderless": false,
@@ -243,23 +138,17 @@
     "orientation": "vertical",
     "link": "#",
     "variant": "normal",
-    "navItemText": "Photos",
-    "navItemLink": "#",
-    "navItemActive": false,
-    "navItemDisabled": false,
-    "navItemCollapsible": false,
-    "navItemCollapsed": true,
-    "navItemCollapsibleTrail": false,
-    "navItemHighlightedBorder": true,
-    "navItemOnClick": "() => console.log('Nav item clicked')"
+    "active": false,
+    "disabled": false,
+    "collapsible": false,
+    "collapsed": true,
+    "collapsibleTrail": false,
+    "highlighted_border": true
   },
   "groups": [
     {
       "name": "Nav Content",
-      "props": [
-        "title",
-        "link"
-      ]
+      "props": ["title", "link"]
     },
     {
       "name": "Nav Appearance",
@@ -274,57 +163,27 @@
     },
     {
       "name": "Nav Events",
-      "props": [
-        "onClick"
-      ]
+      "props": ["onClick"]
     },
     {
       "name": "NavItem Content",
-      "props": [
-        "navItemText",
-        "navItemLink",
-        "navItemIconLeft",
-        "navItemIconRight",
-        "navItemImageUrl",
-        "navItemTarget"
-      ]
+      "props": ["text", "iconLeft", "iconRight", "imageUrl", "target"]
     },
     {
       "name": "NavItem State",
-      "props": [
-        "navItemActive",
-        "navItemDisabled",
-        "navItemHighlightedBorder"
-      ]
+      "props": ["active", "disabled", "highlighted_border"]
     },
     {
       "name": "NavItem Typography",
-      "props": [
-        "navItemFontSize",
-        "navItemFontWeight"
-      ]
+      "props": ["fontSize", "fontWeight"]
     },
     {
       "name": "NavItem Collapsible",
-      "props": [
-        "navItemCollapsible",
-        "navItemCollapsed",
-        "navItemCollapsibleTrail"
-      ]
+      "props": ["collapsible", "collapsed", "collapsibleTrail"]
     },
     {
       "name": "NavItem Spacing",
-      "props": [
-        "navItemMargin",
-        "navItemMarginY",
-        "navItemPaddingY"
-      ]
-    },
-    {
-      "name": "NavItem Events",
-      "props": [
-        "navItemOnClick"
-      ]
+      "props": ["margin", "marginY", "paddingY"]
     }
   ],
   "presets": [
@@ -389,69 +248,63 @@
     },
     {
       "name": "NavItem Icons",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
         "title": "Browse",
-        "navItemActive": true,
-        "navItemIconLeft": "comments-alt",
-        "navItemIconRight": "angle-down",
-        "navItemLink": "#",
-        "navItemText": "Messages"
-      }
+        "active": true,
+        "iconLeft": "comments-alt",
+        "iconRight": "angle-down"
+      },
+      "children": "<NavItem link=\"#\" text=\"Messages\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "NavItem Disabled",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
-        "navItemDisabled": true,
-        "navItemLink": "#",
-        "navItemText": "Disabled item"
-      }
+        "disabled": true
+      },
+      "children": "<NavItem link=\"#\" text=\"Disabled item\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "NavItem Typography",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
-        "navItemFontSize": "small",
-        "navItemFontWeight": "bolder",
-        "navItemLink": "#",
-        "navItemText": "Small bolder item"
-      }
+        "fontSize": "small",
+        "fontWeight": "bolder"
+      },
+      "children": "<NavItem link=\"#\" text=\"Small bolder item\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "NavItem Spacing",
-      "structureMode": "nav_item_props",
+      "structureMode": "standard",
       "props": {
-        "navItemLink": "#",
-        "navItemMargin": "none",
-        "navItemPaddingY": "xxs",
-        "navItemText": "Tight item"
-      }
+        "margin": "none",
+        "paddingY": "xxs"
+      },
+      "children": "<NavItem link=\"#\" text=\"Tight item\" />\n<NavItem link=\"#\" text=\"Music\" />\n<NavItem link=\"#\" text=\"Video\" />\n<NavItem link=\"#\" text=\"Files\" />"
     },
     {
       "name": "Collapsible",
       "structureMode": "collapsible",
       "props": {
-        "navItemActive": true,
-        "navItemCollapsed": false,
-        "navItemCollapsible": true,
-        "navItemIconLeft": "city",
-        "navItemIconRight": "angle-down",
-        "navItemLink": "#",
-        "navItemText": "Overview"
+        "active": true,
+        "collapsed": false,
+        "collapsible": true,
+        "iconLeft": "city",
+        "iconRight": "angle-down",
+        "text": "Overview"
       }
     },
     {
       "name": "Collapsible Trail",
       "structureMode": "collapsible",
       "props": {
-        "navItemCollapsible": true,
-        "navItemCollapsibleTrail": true,
-        "navItemFontWeight": "bolder",
-        "navItemIconLeft": "city",
-        "navItemIconRight": "angle-down",
-        "navItemLink": "#",
-        "navItemText": "Overview"
+        "collapsible": true,
+        "collapsibleTrail": true,
+        "fontWeight": "bolder",
+        "iconLeft": "city",
+        "iconRight": "angle-down",
+        "text": "Overview"
       }
     }
   ],
@@ -462,69 +315,24 @@
         "variant": "normal"
       }
     },
-    "navItemCollapsed": {
-      "requires": "navItemCollapsible",
+    "collapsed": {
+      "requires": "collapsible",
       "structureMode": "collapsible"
     },
-    "navItemCollapsibleTrail": {
-      "requires": "navItemCollapsible",
+    "collapsibleTrail": {
+      "requires": "collapsible",
       "structureMode": "collapsible"
     }
   },
   "propSyncOnEnable": {
-    "navItemText": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemLink": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemActive": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemDisabled": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemIconLeft": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemIconRight": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemImageUrl": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemTarget": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemFontSize": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemFontWeight": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemCollapsible": {
+    "collapsible": {
       "structureMode": "collapsible"
     },
-    "navItemCollapsed": {
+    "collapsed": {
       "structureMode": "collapsible"
     },
-    "navItemCollapsibleTrail": {
+    "collapsibleTrail": {
       "structureMode": "collapsible"
-    },
-    "navItemHighlightedBorder": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemMargin": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemMarginY": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemPaddingY": {
-      "structureMode": "nav_item_props"
-    },
-    "navItemOnClick": {
-      "structureMode": "nav_item_props"
     }
   },
   "hints": {
@@ -560,22 +368,22 @@
     },
     "nav_item_icons": {
       "presetName": "NavItem Icons",
-      "message": "NavItem iconLeft and iconRight add icons around the item text.",
+      "message": "NavItem iconLeft and iconRight add icons around the item text. Enabled NavItem props apply to every NavItem in children.",
       "type": "info"
     },
     "nav_item_disabled": {
       "presetName": "NavItem Disabled",
-      "message": "disabled makes the NavItem non-interactive and removes link navigation.",
+      "message": "disabled makes NavItems non-interactive and removes link navigation.",
       "type": "info"
     },
     "nav_item_typography": {
       "presetName": "NavItem Typography",
-      "message": "NavItem fontSize and fontWeight control item label styling.",
+      "message": "NavItem fontSize and fontWeight control item label styling on every NavItem.",
       "type": "info"
     },
     "nav_item_spacing": {
       "presetName": "NavItem Spacing",
-      "message": "NavItem spacing props can tighten or expand individual item layout.",
+      "message": "NavItem margin and paddingY props apply to every NavItem in the list.",
       "type": "info"
     },
     "collapsible": {

--- a/playbook/app/pb_kits/playbook/pb_nav/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_nav/kit.schema.json
@@ -78,7 +78,8 @@
       ],
       "values": [
         "normal",
-        "subtle"
+        "subtle",
+        "bold"
       ],
       "default": "normal"
     },

--- a/playbook/app/pb_kits/playbook/pb_nav/navTypes.ts
+++ b/playbook/app/pb_kits/playbook/pb_nav/navTypes.ts
@@ -19,7 +19,7 @@ export type SpacingObject = {
 
 export type NavChildProps = {
     orientation?: "vertical" | "horizontal";
-    variant?: "normal" | "subtle";
+    variant?: "normal" | "subtle" | "bold";
     itemSpacing?: SpacingObject
     disabled?: boolean
   };


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

1. Fix Nav playground so enabling NavItem props (e.g. spacing) no longer drops item text or only updates the first item
2. Use real NavItem prop names in the playground (marginY, text, iconLeft, etc.) instead of prefixed navItem aliases
3. Add opt-in children.propInjection so targeted props can apply to every matching child tag in {{children}} (Nav only today. Other kits unchanged)
4. Guard NavItem against undefined itemSpacing from parent Nav
5. Document the new pattern in docs/PLAYGROUND_CONFIG.md

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.