### PR TITLE
Playbook Website: Default Platform as Rails 

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -12,7 +12,7 @@ class PagesController < ApplicationController
   def application
     @kits = MENU["kits"]
     @dark = cookies[:dark_mode] == "true"
-    @type = params[:platform] || params[:type] || "react"
+    @type = params[:platform] || params[:type] || "rails"
     @kit = params[:name]
     @params = params
 

--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
         _kit_category, components = kit.first
         components.each do |component|
           name_or_parent = component[:parent].presence || component[:name]
-          status_for_type = kit_status_for_platform(component, @type || "react")
+          status_for_type = kit_status_for_platform(component, @type || "rails")
           all_kits.push(name_or_parent) if status_for_type != "beta"
         end
       else
@@ -82,7 +82,7 @@ module ApplicationHelper
             end
     {
       label: label,
-      value: if @type == "react" || @type.nil?
+      value: if @type == "react"
                "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}#{kit == 'advanced_table' ? '?type=react' : '/react'}"
              elsif @type == "swift"
                "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}/swift"

--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -14,6 +14,12 @@ import { PlatformToggle } from "./src/components/PlatformToggle";
 import { useLoaderData, useLocation, useNavigate } from "react-router-dom";
 import { PlatformContext } from "./src/contexts/PlatformContext";
 import { DarkModeProvider, useDarkMode } from "./src/contexts/DarkModeContext";
+import {
+  DEFAULT_PLATFORM,
+  resolvePlatform,
+  syncStoredPlatformFromLocation,
+  writeStoredPlatform,
+} from "./src/helpers/platform";
 
 function WebsiteContent() {
   const {
@@ -77,13 +83,19 @@ function WebsiteContent() {
     "--website-header-height": `${headerHeight}px`,
   } as CSSProperties;
 
-  const platform = useMemo(() => {
-    const pathPlatform = normalizedPath.match(/\/(react|rails|swift)$/)?.[1];
-    const queryPlatform = new URLSearchParams(location.search).get("type");
-    return pathPlatform || queryPlatform || type || "rails";
-  }, [normalizedPath, location.search, type]);
+  const platform = useMemo(
+    () => resolvePlatform(normalizedPath, location.search, type),
+    [normalizedPath, location.search, type],
+  );
+
+  // Keep preference in sync when the URL explicitly sets a platform
+  useEffect(() => {
+    syncStoredPlatformFromLocation(normalizedPath, location.search);
+  }, [normalizedPath, location.search]);
 
   const handlePlatformChange = (nextPlatform: string) => {
+    writeStoredPlatform(nextPlatform);
+
     const isKitDetailRoute =
       /^\/kits\/advanced_table\/[^/]+\/(react|rails|swift)$/.test(
         normalizedPath,
@@ -193,7 +205,7 @@ function WebsiteContent() {
             <Sidebar
               dark={darkMode}
               collapsed={desktopSidebarCollapsed}
-              type={platform || "rails"}
+              type={platform || DEFAULT_PLATFORM}
               category={category}
               kit={kit}
               kits_with_status={kits_with_status || kits}

--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -80,7 +80,7 @@ function WebsiteContent() {
   const platform = useMemo(() => {
     const pathPlatform = normalizedPath.match(/\/(react|rails|swift)$/)?.[1];
     const queryPlatform = new URLSearchParams(location.search).get("type");
-    return pathPlatform || queryPlatform || type || "react";
+    return pathPlatform || queryPlatform || type || "rails";
   }, [normalizedPath, location.search, type]);
 
   const handlePlatformChange = (nextPlatform: string) => {
@@ -193,7 +193,7 @@ function WebsiteContent() {
             <Sidebar
               dark={darkMode}
               collapsed={desktopSidebarCollapsed}
-              type={platform || "react"}
+              type={platform || "rails"}
               category={category}
               kit={kit}
               kits_with_status={kits_with_status || kits}

--- a/playbook-website/app/javascript/components/Website/src/helpers/platform.ts
+++ b/playbook-website/app/javascript/components/Website/src/helpers/platform.ts
@@ -1,0 +1,57 @@
+const PLATFORM_STORAGE_KEY = "playbook-platform";
+export const VALID_PLATFORMS = ["react", "rails", "swift"] as const;
+export const DEFAULT_PLATFORM = "rails" as const;
+
+export type Platform = (typeof VALID_PLATFORMS)[number];
+
+export const isValidPlatform = (
+  value: string | null | undefined,
+): value is Platform => VALID_PLATFORMS.includes(value as Platform);
+
+export const readStoredPlatform = (): Platform | null => {
+  try {
+    const stored = localStorage.getItem(PLATFORM_STORAGE_KEY);
+    return isValidPlatform(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+export const writeStoredPlatform = (platform: string) => {
+  if (!isValidPlatform(platform)) return;
+  try {
+    localStorage.setItem(PLATFORM_STORAGE_KEY, platform);
+  } catch {
+    // Ignore quota / private-mode failures
+  }
+};
+
+export const getPlatformFromPath = (pathname: string): Platform | null => {
+  const match = pathname.match(/\/(react|rails|swift)$/)?.[1];
+  return isValidPlatform(match) ? match : null;
+};
+
+export const getPlatformFromSearch = (search: string): Platform | null => {
+  const type = new URLSearchParams(search).get("type");
+  return isValidPlatform(type) ? type : null;
+};
+
+export const resolvePlatform = (
+  pathname: string,
+  search: string,
+  loaderType?: string,
+): string =>
+  getPlatformFromPath(pathname) ||
+  getPlatformFromSearch(search) ||
+  readStoredPlatform() ||
+  (isValidPlatform(loaderType) ? loaderType : null) ||
+  DEFAULT_PLATFORM;
+
+export const syncStoredPlatformFromLocation = (
+  pathname: string,
+  search: string,
+) => {
+  const explicit =
+    getPlatformFromPath(pathname) || getPlatformFromSearch(search);
+  if (explicit) writeStoredPlatform(explicit);
+};

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.json
@@ -70,10 +70,36 @@
   ],
   "presets": [
     {
-      "name": "Basic list",
+      "name": "Default",
       "props": {
         "label": "Colors",
         "name": "color",
+        "options": [
+          {
+            "label": "Orange",
+            "value": "#FFA500"
+          },
+          {
+            "label": "Red",
+            "value": "#FF0000"
+          },
+          {
+            "label": "Green",
+            "value": "#00FF00"
+          },
+          {
+            "label": "Blue",
+            "value": "#0000FF"
+          }
+        ]
+      }
+    },
+    {
+      "name": "With Pills",
+      "props": {
+        "label": "With Pills",
+        "name": "with_pills",
+        "isMulti": true,
         "options": [
           {
             "label": "Orange",
@@ -229,12 +255,21 @@
     },
     "clearOnContextChange": {
       "requires": "searchContextSelector"
+    },
+    "enablePillReorder": {
+      "requires": "isMulti"
+    },
+    "showPillIndex": {
+      "requires": "isMulti"
+    },
+    "pillDragHandle": {
+      "requires": "isMulti"
     }
   },
   "hints": {
-    "basic_list": {
-      "presetName": "Basic list",
-      "message": "Basic list uses a local options array with label and value keys.",
+    "default": {
+      "presetName": "Default",
+      "message": "Default uses a local options array with label and value keys.",
       "type": "info"
     },
     "count_display": {
@@ -260,6 +295,11 @@
     "creatable_handler": {
       "presetName": "Creatable handler",
       "message": "Creatable handler shows custom option creation, preserved search input, and an onChange handler.",
+      "type": "info"
+    },
+    "with_pills": {
+      "presetName": "With Pills",
+      "message": "With Pills uses multi-select with pills so selected values render as pills.",
       "type": "info"
     }
   },

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.overrides.json
@@ -49,15 +49,29 @@
     },
     {
       "name": "Appearance",
-      "props": ["components", "dark", "marginBottom"]
+      "props": ["components", "dark", "marginBottom", "enablePillReorder", "showPillIndex", "pillDragHandle"]
     }
   ],
   "presets": [
     {
-      "name": "Basic list",
+      "name": "Default",
       "props": {
         "label": "Colors",
         "name": "color",
+        "options": [
+          { "label": "Orange", "value": "#FFA500" },
+          { "label": "Red", "value": "#FF0000" },
+          { "label": "Green", "value": "#00FF00" },
+          { "label": "Blue", "value": "#0000FF" }
+        ]
+      }
+    },
+    {
+      "name": "With Pills",
+      "props": {
+        "label": "With Pills",
+        "name": "with_pills",
+        "isMulti": true,
         "options": [
           { "label": "Orange", "value": "#FFA500" },
           { "label": "Red", "value": "#FF0000" },
@@ -145,12 +159,15 @@
     "requiredIndicator": { "requires": "label" },
     "validation": { "requires": { "required": true } },
     "optionsByContext": { "requires": "searchContextSelector" },
-    "clearOnContextChange": { "requires": "searchContextSelector" }
+    "clearOnContextChange": { "requires": "searchContextSelector" },
+    "enablePillReorder": { "requires": "isMulti" },
+    "showPillIndex": { "requires": "isMulti" },
+    "pillDragHandle": { "requires": "isMulti" }
   },
   "hints": {
-    "basic_list": {
-      "presetName": "Basic list",
-      "message": "Basic list uses a local options array with label and value keys.",
+    "default": {
+      "presetName": "Default",
+      "message": "Default uses a local options array with label and value keys.",
       "type": "info"
     },
     "count_display": {
@@ -176,6 +193,11 @@
     "creatable_handler": {
       "presetName": "Creatable handler",
       "message": "Creatable handler shows custom option creation, preserved search input, and an onChange handler.",
+      "type": "info"
+    },
+    "with_pills": {
+      "presetName": "With Pills",
+      "message": "With Pills uses multi-select with pills so selected values render as pills.",
       "type": "info"
     }
   }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Add playground config for new draggable pills functionality 
- Since Power is a Rails shop, default website platform is now Rails
- Persist each developer’s platform choice in localStorage (playbook-platform)
- Platform resolve/storage helpers into src/helpers/platform.ts

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.