### PR TITLE
[PLAY-3079] Playbook Icons Page - Click to Copy

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/Icons/IconCard.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/Icons/IconCard.tsx
@@ -1,0 +1,52 @@
+  import type { KeyboardEvent, MouseEvent } from 'react'
+import { SelectableCardIcon, Tooltip, usePBCopy } from 'playbook-ui'
+
+type IconCardProps = {
+  iconName: string,
+}
+
+const IconCard = ({ iconName }: IconCardProps) => {
+  const [copied, copyToClipboard] = usePBCopy({ value: iconName, timeout: 1500 })
+
+  const handleCopy = (event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>) => {
+    const selection = window.getSelection()?.toString()
+    if (selection) return
+
+    event.preventDefault()
+    copyToClipboard()
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      handleCopy(event)
+    }
+  }
+
+  return (
+    <Tooltip
+      delay={{ close: 1000 }}
+      forceOpenTooltip={copied}
+      placement="top"
+      showTooltip={false}
+      text="Icon copied"
+    >
+      <SelectableCardIcon
+        className="icon-card"
+        cursor="pointer"
+        htmlOptions={{
+          'aria-label': `Copy ${iconName} to clipboard`,
+          onClick: handleCopy,
+          onKeyDown: handleKeyDown,
+          role: 'button',
+          style: { userSelect: 'text' },
+          tabIndex: 0,
+        }}
+        icon={iconName}
+        onChange={() => {}}
+        titleText={iconName}
+      />
+    </Tooltip>
+  )
+}
+
+export default IconCard

--- a/playbook-website/app/javascript/components/Website/src/components/Icons/IconsIndex.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/Icons/IconsIndex.tsx
@@ -14,9 +14,10 @@ import {
   NavItem,
   SectionSeparator,
   Title,
-  SelectableCardIcon,
   TextInput,
 } from 'playbook-ui'
+
+import IconCard from './IconCard'
 
 type IconCategory = {
   label: string,
@@ -219,11 +220,9 @@ const IconsIndex = ({
                           .slice()
                           .sort((left, right) => left.name.localeCompare(right.name))
                           .map((icon) => (
-                            <SelectableCardIcon
-                              className="icon-card"
-                              icon={icon.name}
+                            <IconCard
+                              iconName={icon.name}
                               key={`${category}-${icon.name}`}
-                              titleText={icon.name}
                             />
                           ))}
                         </div>

--- a/playbook-website/app/javascript/site_styles/_playbook_icons_index.scss
+++ b/playbook-website/app/javascript/site_styles/_playbook_icons_index.scss
@@ -123,7 +123,11 @@
         .pb_icon_kit {
           color: $text_lt_light;
         }
-      }
+        .pb_title_kit {
+            cursor: text;
+            user-select: text;
+        }
+    }
 
     .icon-grid {
         .layout_body {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3079](https://runway.powerhrg.com/backlog_items/PLAY-3079?from=active_sprint) makes Icon cards on the Playbook Icons page (/icons) copyable, as currently in prod you cannot copy the text of the icon name from the Selectable Card Icon which is counterintuitive as a user. This PR: adds the Copy Button hook to the Selectable Card Icon with Tooltip alerting copy upon click or keyboard interaction (tab+enter), allows the user to select the text of the Icon name on the card, and adds a missing onChange to resolve a longstanding console error.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1002" height="638" alt="icon copy" src="https://github.com/user-attachments/assets/58ab1eee-32d7-4530-aa4d-ecdbf1ce68c2" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /icons page and interact with Icon Cards, which are now copyable.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.