### PR TITLE
Update Global Props Docs

### DIFF
--- a/docs/ADDING_GLOBAL_PROPS.md
+++ b/docs/ADDING_GLOBAL_PROPS.md
@@ -66,8 +66,19 @@ Add a Global Props page that demonstrates the prop in a Visual Guide and highlig
 - Add to index page `playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/Data/GlobalPropsCards.ts`.
 - Add to Sidebar `playbook-website/config/global_props_and_tokens.yml`.
 
+## 7. Add Playground Grouping
 
-## 7. Regenerate Metadata
+Playground tabs group global props in the props panel using a hardcoded list. Without an entry, the new prop appears under **Other**.
+
+Update `playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/constants.ts`:
+
+- Add the prop name to an existing group in `GLOBAL_PROP_GROUPS` when it fits (e.g. Padding, Margin, Flexbox).
+- Or add a new `{ name, props }` group when the prop belongs in its own section.
+- Include directional or related variants in the same group when they should appear together.
+
+`groupPropDefinitions()` in `Playground/utils.ts` applies these groups on both the kit Playground tab and the standalone Playground page.
+
+## 8. Regenerate Metadata
 
 Run metadata generation after changing global prop types.
 
@@ -84,7 +95,7 @@ This updates:
 
 If website available-props values are generated from the schema, regenerate them from `playbook-website` as well.
 
-## 8. Final Checklist
+## 9. Final Checklist
 
 - The prop uses approved design-system values.
 - Rails and React generate the same class names.
@@ -95,4 +106,5 @@ If website available-props values are generated from the schema, regenerate them
 - Schema and kit metadata are regenerated.
 - Examples render in Rails and React tested locally doc examples.
 - Global Props page contains information and demos.
+- Playground `GLOBAL_PROP_GROUPS` includes the prop (or a new group) so it is not stuck in Other.
 - Tests cover valid, absent, and invalid values.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Update docs to account fro global props groupings for playgrounds. 