### PR TITLE
[PLAY-3092] Update PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,6 @@
 - [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
 - [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
 - [ ] **TESTS** I have added test coverage to my code.
+- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
 - [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
 - [ ] **RC** I have added an `inactive RC` label if not an active RC.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Updated PR checkout - will now contain a checklist item for Playground metadata + testing. Also using this PR to test the agentic-pr-review GitHub action.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to open a PR - a sixth item (4th in list) will be in the checklist at the bottom of the pre-filled PR description. 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.