### PR TITLE
[PLAY-3090] Update Restrictions for Agentic PR Review

### DIFF
--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -1,16 +1,16 @@
 name: Agentic PR Review
 
 # Runs automatically on:
-#  - PR opened (including drafts) from org-member branches in this repo (not forks)
-#  - PR marked ready for review (draft -> ready) under the same constraints
+#  - PR opened (including drafts) from a branch in this repo (not forks)
+#  - PR marked ready for review (draft -> ready)
 #  - `agentic-review` label (re-)applied for a manual rerun on same-repo PRs
-#  - PR comment containing @playbook-pr-review from an org member
+#  - PR comment containing @playbook-pr-review from an org member / collaborator
 #
 # Never runs when the PR carries the `agentic-review-opt-out` label.
 #
-# This is a public repo. Unlike private repos, issue comments are open to anyone,
-# so comment-triggered runs require org membership. Fork PRs are excluded because
-# they cannot safely use repository secrets.
+# This is a public repo. Comment triggers require org membership (or collaborator).
+# Same-repo PRs already imply push access; author_association is NOT required for
+# pull_request events (it often reports CONTRIBUTOR even for org members).
 on:
   pull_request:
     types: [opened, ready_for_review, labeled]
@@ -29,32 +29,22 @@ jobs:
   agentic-review:
     name: PR Review
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'agentic-review-opt-out') &&
-      !contains(github.event.issue.labels.*.name, 'agentic-review-opt-out') &&
       (
+        github.event_name == 'pull_request' &&
+        !contains(github.event.pull_request.labels.*.name, 'agentic-review-opt-out') &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          (
-            (
-              (
-                github.event.action == 'opened' ||
-                github.event.action == 'ready_for_review'
-              ) &&
-              contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association)
-            ) ||
-            (
-              github.event.action == 'labeled' &&
-              github.event.label.name == 'agentic-review'
-            )
-          )
-        ) ||
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
-          contains(github.event.comment.body, '@playbook-pr-review') &&
-          contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
+          github.event.action == 'opened' ||
+          github.event.action == 'ready_for_review' ||
+          (github.event.action == 'labeled' && github.event.label.name == 'agentic-review')
         )
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        !contains(github.event.issue.labels.*.name, 'agentic-review-opt-out') &&
+        contains(github.event.comment.body, '@playbook-pr-review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -52,15 +52,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          http_code="$(
-            gh api -i "orgs/${GITHUB_REPOSITORY_OWNER}/members/${GITHUB_ACTOR}" \
-              2>/dev/null | head -n1 | awk '{print $2}'
-          )"
-
-          if [[ "${http_code}" != "204" ]]; then
+          if gh api "orgs/${GITHUB_REPOSITORY_OWNER}/members/${GITHUB_ACTOR}" --silent; then
+            echo "Confirmed ${GITHUB_ACTOR} is a ${GITHUB_REPOSITORY_OWNER} org member"
+          else
             echo "skip=true" >> "${GITHUB_OUTPUT}"
-            echo "Skipping agentic review: ${GITHUB_ACTOR} is not a visible ${GITHUB_REPOSITORY_OWNER} org member (HTTP ${http_code:-unknown})"
-            exit 0
+            echo "Skipping agentic review: ${GITHUB_ACTOR} is not a visible ${GITHUB_REPOSITORY_OWNER} org member"
           fi
 
       - name: Check eligibility

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -10,7 +10,9 @@ name: Agentic PR Review
 #
 # This is a public repo. Comment triggers require org membership (or collaborator).
 # Same-repo PRs already imply push access; author_association is NOT required for
-# pull_request events (it often reports CONTRIBUTOR even for org members).
+# pull_request open/ready events (it often reports CONTRIBUTOR even for org members).
+# Bot-authored PRs (e.g. Dependabot) are skipped on auto open/ready to avoid quota burn;
+# label and @playbook-pr-review remain available as manual overrides.
 on:
   pull_request:
     types: [opened, ready_for_review, labeled]
@@ -34,9 +36,17 @@ jobs:
         !contains(github.event.pull_request.labels.*.name, 'agentic-review-opt-out') &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         (
-          github.event.action == 'opened' ||
-          github.event.action == 'ready_for_review' ||
-          (github.event.action == 'labeled' && github.event.label.name == 'agentic-review')
+          (
+            (
+              github.event.action == 'opened' ||
+              github.event.action == 'ready_for_review'
+            ) &&
+            github.event.pull_request.user.type != 'Bot'
+          ) ||
+          (
+            github.event.action == 'labeled' &&
+            github.event.label.name == 'agentic-review'
+          )
         )
       ) ||
       (

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -1,7 +1,7 @@
 name: Agentic PR Review
 
 # Manual triggers only:
-#  - `agentic-review` label applied by a powerhome org member (same-repo PRs)
+#  - `agentic-review` label on a same-repo PR (requires triage/write to apply labels)
 #  - PR comment containing @nitro-pr-review from a powerhome org member
 on:
   pull_request:
@@ -35,33 +35,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Create GitHub App token
-        id: app_token
-        if: github.event_name == 'pull_request'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_ID }}
-          private-key: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Verify labeler is a powerhome org member
-        id: org_gate
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-        run: |
-          set -euo pipefail
-
-          if gh api "orgs/${GITHUB_REPOSITORY_OWNER}/members/${GITHUB_ACTOR}" --silent; then
-            echo "Confirmed ${GITHUB_ACTOR} is a ${GITHUB_REPOSITORY_OWNER} org member"
-          else
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-            echo "Skipping agentic review: ${GITHUB_ACTOR} is not a visible ${GITHUB_REPOSITORY_OWNER} org member"
-          fi
-
       - name: Check eligibility
         id: eligibility
-        if: steps.org_gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -95,9 +70,7 @@ jobs:
 
       - name: Run agentic PR review
         timeout-minutes: 15
-        if: |
-          steps.org_gate.outputs.skip != 'true' &&
-          steps.eligibility.outputs.skip != 'true'
+        if: steps.eligibility.outputs.skip != 'true'
         uses: powerhome/github-actions-workflows/agentic-pr-review@3f92012ed22b3c6f4cf2a1272d170fc01a5b75f4 # main
         with:
           app-id: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_ID }}

--- a/.github/workflows/agentic-pr-review.yml
+++ b/.github/workflows/agentic-pr-review.yml
@@ -1,21 +1,11 @@
 name: Agentic PR Review
 
-# Runs automatically on:
-#  - PR opened (including drafts) from a branch in this repo (not forks)
-#  - PR marked ready for review (draft -> ready)
-#  - `agentic-review` label (re-)applied for a manual rerun on same-repo PRs
-#  - PR comment containing @playbook-pr-review from an org member / collaborator
-#
-# Never runs when the PR carries the `agentic-review-opt-out` label.
-#
-# This is a public repo. Comment triggers require org membership (or collaborator).
-# Same-repo PRs already imply push access; author_association is NOT required for
-# pull_request open/ready events (it often reports CONTRIBUTOR even for org members).
-# Bot-authored PRs (e.g. Dependabot) are skipped on auto open/ready to avoid quota burn;
-# label and @playbook-pr-review remain available as manual overrides.
+# Manual triggers only:
+#  - `agentic-review` label applied by a powerhome org member (same-repo PRs)
+#  - PR comment containing @nitro-pr-review from a powerhome org member
 on:
   pull_request:
-    types: [opened, ready_for_review, labeled]
+    types: [labeled]
   issue_comment:
     types: [created]
 
@@ -33,33 +23,49 @@ jobs:
     if: |
       (
         github.event_name == 'pull_request' &&
-        !contains(github.event.pull_request.labels.*.name, 'agentic-review-opt-out') &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        (
-          (
-            (
-              github.event.action == 'opened' ||
-              github.event.action == 'ready_for_review'
-            ) &&
-            github.event.pull_request.user.type != 'Bot'
-          ) ||
-          (
-            github.event.action == 'labeled' &&
-            github.event.label.name == 'agentic-review'
-          )
-        )
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'agentic-review' &&
+        github.event.pull_request.head.repo.full_name == github.repository
       ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        !contains(github.event.issue.labels.*.name, 'agentic-review-opt-out') &&
-        contains(github.event.comment.body, '@playbook-pr-review') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        contains(github.event.comment.body, '@nitro-pr-review') &&
+        contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: app_token
+        if: github.event_name == 'pull_request'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_ID }}
+          private-key: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Verify labeler is a powerhome org member
+        id: org_gate
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          http_code="$(
+            gh api -i "orgs/${GITHUB_REPOSITORY_OWNER}/members/${GITHUB_ACTOR}" \
+              2>/dev/null | head -n1 | awk '{print $2}'
+          )"
+
+          if [[ "${http_code}" != "204" ]]; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "Skipping agentic review: ${GITHUB_ACTOR} is not a visible ${GITHUB_REPOSITORY_OWNER} org member (HTTP ${http_code:-unknown})"
+            exit 0
+          fi
+
       - name: Check eligibility
         id: eligibility
+        if: steps.org_gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -93,7 +99,9 @@ jobs:
 
       - name: Run agentic PR review
         timeout-minutes: 15
-        if: steps.eligibility.outputs.skip != 'true'
+        if: |
+          steps.org_gate.outputs.skip != 'true' &&
+          steps.eligibility.outputs.skip != 'true'
         uses: powerhome/github-actions-workflows/agentic-pr-review@3f92012ed22b3c6f4cf2a1272d170fc01a5b75f4 # main
         with:
           app-id: ${{ secrets.AGENTIC_REVIEW_GITHUB_APP_ID }}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3090](https://runway.powerhrg.com/backlog_items/PLAY-3090?from=active_sprint) quick follow up after initial live testing:
- bot review will only be triggered manually by adding `agentic-review` label or by commenting on the PR (this PR changes the trigger back to `nitro-pr-review` from temporary `playbook-pr-review` since that is the bots name.
- the bot will not listen to comments by unauthorized users (see ignored comment below) and only authorized users for a specific PR can add labels (a member outside the org can add labels but if it's not their PR they cannot).
- we are removing auto-bot review upon PR opening (draft or ready) and moving a PR from draft to review - too noisy for this repo, we have lots of small PRs that don't require bot.

**Screenshots:** Screenshots to visualize your addition/change
N/A

**How to test?** Steps to confirm the desired behavior:
1. I have tested on this PR and will test on a follow up once this is merged to confirm restrictions loosened and workflow runs as expected on a follow up PR. 

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.