### PR TITLE
[PLAY-3101] Icon kit: Harden custom SVG source loading - Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_icon/icon.rb
+++ b/playbook/app/pb_kits/playbook/pb_icon/icon.rb
@@ -292,15 +292,6 @@ module Playbook
 
     private
 
-      # Loads the SVG markup that #render_svg inlines.
-      #
-      # `asset_path` is resolved by the kit itself from the configured on-disk
-      # icon index, so it is trusted and read directly. A `custom_icon` / `icon`
-      # value may originate from application input, so it is passed through an
-      # allow-listed reader that only reads a file inside the application/engine
-      # or fetches an http(s) URL. It never calls Kernel#open, so a value can
-      # never spawn a subprocess ("|command"), traverse outside the application,
-      # or open an unexpected scheme (file://, ftp://, ...).
       def svg_content
         return File.read(asset_path) if asset_path.present?
 

--- a/playbook/app/pb_kits/playbook/pb_icon/icon.rb
+++ b/playbook/app/pb_kits/playbook/pb_icon/icon.rb
@@ -3,6 +3,7 @@
 require "open-uri"
 require "json"
 require "digest"
+require "pathname"
 
 module Playbook
   module PbIcon
@@ -113,12 +114,9 @@ module Playbook
       end
 
       def render_svg
-        source = asset_path || icon || custom_icon
-        content = if source.to_s.include?("://")
-                    URI.open(source, "User-Agent" => "Playbook-Icon-Kit/1.0 (https://github.com/powerhome/playbook)", &:read) # rubocop:disable Security/Open
-                  else
-                    URI.open(source, &:read) # rubocop:disable Security/Open
-                  end
+        content = svg_content
+        return "" if content.blank?
+
         doc = Nokogiri::XML(content)
         svg = doc.at_css("svg")
         return "" unless svg
@@ -293,6 +291,102 @@ module Playbook
       end
 
     private
+
+      # Loads the SVG markup that #render_svg inlines.
+      #
+      # `asset_path` is resolved by the kit itself from the configured on-disk
+      # icon index, so it is trusted and read directly. A `custom_icon` / `icon`
+      # value may originate from application input, so it is passed through an
+      # allow-listed reader that only reads a file inside the application/engine
+      # or fetches an http(s) URL. It never calls Kernel#open, so a value can
+      # never spawn a subprocess ("|command"), traverse outside the application,
+      # or open an unexpected scheme (file://, ftp://, ...).
+      def svg_content
+        return File.read(asset_path) if asset_path.present?
+
+        read_svg_content(icon || custom_icon)
+      end
+
+      def read_svg_content(source)
+        source = source.to_s
+        return "" if source.blank?
+
+        remote = remote_svg_uri(source)
+        return read_remote_svg(remote) if remote
+
+        path = allowed_svg_path(source)
+        return "" unless path
+
+        path.read
+      end
+
+      def remote_svg_uri(source)
+        uri = URI.parse(source)
+        uri if uri.is_a?(URI::HTTP)
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def read_remote_svg(uri)
+        uri.open("User-Agent" => "Playbook-Icon-Kit/1.0 (https://github.com/powerhome/playbook)", redirect: false, &:read)
+      rescue OpenURI::HTTPError, StandardError
+        ""
+      end
+
+      def allowed_svg_path(source)
+        candidate = Pathname.new(source)
+        candidate = Rails.root.join(candidate) unless candidate.absolute?
+        resolved = candidate.expand_path
+        return nil unless svg_file?(resolved)
+        return nil unless path_within_allowed_root?(resolved)
+
+        resolved
+      end
+
+      # Only ever read real .svg files. This keeps non-svg files that happen to
+      # live inside an allowed root (config/master.key, credentials, .env, ...)
+      # structurally out of the read path rather than relying on the is_svg?
+      # gate to exclude them.
+      def svg_file?(path)
+        path.file? && path.extname.casecmp(".svg").zero?
+      end
+
+      def path_within_allowed_root?(path)
+        real = path.realpath
+        allowed_svg_roots.any? do |root|
+          real == root || real.to_s.start_with?("#{root}#{File::SEPARATOR}")
+        end
+      rescue
+        false
+      end
+
+      # An SVG may live in the host application or in any mounted engine
+      # (Playbook itself, or a host app's component engines), so every loaded
+      # engine root is allowed in addition to Rails.root.
+      def allowed_svg_roots
+        @allowed_svg_roots ||= svg_root_candidates.filter_map { |candidate| real_path(candidate) }.uniq
+      end
+
+      def svg_root_candidates
+        Rails::Engine.descendants
+                     .map { |engine| engine_root(engine) }
+                     .push(Playbook::Engine.root, Rails.root)
+                     .compact
+      end
+
+      def engine_root(engine)
+        engine.root
+      rescue
+        nil
+      end
+
+      def real_path(path)
+        return nil unless path
+
+        Pathname.new(path).realpath
+      rescue
+        nil
+      end
 
       def resolve_alias(icon)
         return icon unless icon_alias_map

--- a/playbook/spec/pb_kits/playbook/kits/icon_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/icon_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "tmpdir"
 require_relative "../../../../app/pb_kits/playbook/pb_icon/icon"
 
 RSpec.describe Playbook::PbIcon::Icon do
@@ -97,6 +98,64 @@ RSpec.describe Playbook::PbIcon::Icon do
       icon = "user"
 
       expect(subject.new(icon: icon).classname).not_to include "color_"
+    end
+  end
+
+  # A custom_icon / icon value can originate from application input, so the SVG
+  # source loader must never treat it as a shell command, a path outside the
+  # application, or a non-http scheme. See #svg_content / #read_svg_content.
+  describe "secure custom SVG loading" do
+    it "reads an SVG that lives inside an allowed root" do
+      svg_path = Playbook::Engine.root.join("app/pb_kits/playbook/utilities/icons/clock.svg").to_s
+
+      expect(subject.new(custom_icon: svg_path).send(:read_svg_content, svg_path)).to include("<svg")
+    end
+
+    it "never executes a shell command supplied as an icon source", :aggregate_failures do
+      Dir.mktmpdir do |dir|
+        sentinel = File.join(dir, "pb_icon_rce_sentinel")
+        payload = "|touch #{sentinel} #.svg"
+
+        result = subject.new(custom_icon: payload).send(:read_svg_content, payload)
+
+        expect(result).to eq("")
+        expect(File).not_to exist(sentinel)
+      end
+    end
+
+    it "refuses to read files outside the allowed roots (path traversal)" do
+      Dir.mktmpdir do |dir|
+        outside_svg = File.join(dir, "secret.svg")
+        File.write(outside_svg, "<svg>secret</svg>")
+
+        expect(subject.new(custom_icon: outside_svg).send(:read_svg_content, outside_svg)).to eq("")
+      end
+    end
+
+    it "reads an SVG from a mounted engine whose root is outside Rails.root" do
+      Dir.mktmpdir do |engine_dir|
+        engine_svg = File.join(engine_dir, "logo.svg")
+        File.write(engine_svg, "<svg>engine</svg>")
+        Class.new(Rails::Engine) { define_singleton_method(:root) { Pathname.new(engine_dir) } }
+
+        expect(subject.new(custom_icon: engine_svg).send(:read_svg_content, engine_svg)).to include("<svg")
+      end
+    end
+
+    it "refuses to read a non-svg file even when it lives inside an allowed root" do
+      Dir.mktmpdir do |engine_dir|
+        secret = File.join(engine_dir, "master.key")
+        File.write(secret, "fake_secret_key_base")
+        Class.new(Rails::Engine) { define_singleton_method(:root) { Pathname.new(engine_dir) } }
+
+        expect(subject.new(custom_icon: secret).send(:read_svg_content, secret)).to eq("")
+      end
+    end
+
+    it "refuses non-http url schemes", :aggregate_failures do
+      %w[file:///etc/passwd ftp://example.com/icon.svg].each do |source|
+        expect(subject.new(custom_icon: source).send(:read_svg_content, source)).to eq("")
+      end
     end
   end
 end


### PR DESCRIPTION
Loads the icon kit's `custom_icon` / `icon` SVG sources through an explicit reader — local `.svg` files resolved to within the host application or a loaded engine root, or `http(s)` URLs — instead of the prior `URI.open`-based loading. Named icons resolved from the on-disk index are unchanged.

Adds unit coverage for the source-loading paths. More context to follow.