### PR TITLE
[PLAY-3001] Allow ViewComponent to have Flexible Versioning

### DIFF
--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 5.2.4.5)
       actionview (>= 5.2.4.5)
       activesupport (>= 5.2.4.5)
-      view_component (= 2.83.0)
+      view_component (>= 2.83.0, < 5.0)
       vite_rails
 
 GEM

--- a/playbook/Gemfile.lock
+++ b/playbook/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 5.2.4.5)
       actionview (>= 5.2.4.5)
       activesupport (>= 5.2.4.5)
-      view_component (= 2.83.0)
+      view_component (>= 2.83.0, < 5.0)
       vite_rails
 
 GEM

--- a/playbook/lib/playbook/engine.rb
+++ b/playbook/lib/playbook/engine.rb
@@ -11,7 +11,7 @@ module Playbook
       g.test_framework :rspec
     end
 
-    config.view_component.render_monkey_patch_enabled = false
+    config.view_component.render_monkey_patch_enabled = false if config.view_component.respond_to?(:render_monkey_patch_enabled=)
 
     if config.respond_to?(:assets)
       config.assets.paths ||= []

--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack", ">= 5.2.4.5"
   s.add_dependency "actionview", ">= 5.2.4.5"
   s.add_dependency "activesupport", ">= 5.2.4.5"
-  s.add_dependency "view_component", "2.83.0"
+  s.add_dependency "view_component", ">= 2.83.0", "< 5.0"
   s.add_dependency "vite_rails"
 
   s.add_development_dependency "brakeman", "7.0.0"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3001](https://runway.powerhrg.com/backlog_items/PLAY-3001?from=backlog) makes ViewComponent a flexible dependency (>= 2.83.0, <5.0). Part of Playbook VC resolution effort to unblock Nitro Rails upgrade. This PR did not require additional Playbook website or kit adjustments (since just made flexible, not upgraded).

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to Playbook website - everything should load as expected.
2. Go to Nitro alpha - same.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.