### PR TITLE
[PLAY-3071] Dropdown Options Sectioning Docs

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_grouped_options.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_grouped_options.html.erb
@@ -1,0 +1,67 @@
+<%
+  sections = [
+    {
+      title: "Profile",
+      items: [
+        { label: "View Profile", value: "profile", id: "profile" },
+        { label: "Account Settings", value: "settings", id: "settings" },
+      ],
+    },
+    {
+      title: "Workspace",
+      items: [
+        { label: "Projects", value: "projects", id: "projects" },
+        { label: "Billing", value: "billing", id: "billing" },
+      ],
+    },
+    {
+      title: "Support",
+      items: [
+        { label: "Help Center", value: "help", id: "help" },
+        { label: "Contact Support", value: "contact", id: "contact" },
+      ],
+    },
+  ]
+
+  options = sections.flat_map { |section| section[:items] }
+%>
+
+<%= pb_rails("dropdown", props: { label: "Grouped Options", margin_bottom: "md", options: options }) do %>
+  <%= pb_rails("dropdown/dropdown_trigger") %>
+  <%= pb_rails("dropdown/dropdown_container") do %>
+    <% sections.each do |section| %>
+
+      <%= pb_rails("caption", props: {
+        text: section[:title],
+        color: "light",
+        padding_x: "xs",
+        padding_y: "xs"
+      }) %>
+
+      <%= pb_rails("section_separator") %>
+
+      <% section[:items].each do |option| %>
+        <%= pb_rails("dropdown/dropdown_option", props: { option: option }) %>
+      <% end %>
+
+    <% end %>
+  <% end %>
+<% end %>
+
+
+<%= pb_rails("dropdown", props: { label: "Grouped Options Minimalist", options: options, separators: false }) do %>
+  <%= pb_rails("dropdown/dropdown_trigger") %>
+  <%= pb_rails("dropdown/dropdown_container") do %>
+    <% sections.each do |section| %>
+
+      <%= pb_rails("section_separator", props: { padding_y: "xs" }) do %>
+        <%= pb_rails("caption", props: { text: section[:title], padding_x: "xs" }) %>
+      <% end %>
+
+      <% section[:items].each do |option| %>
+        <%= pb_rails("dropdown/dropdown_option", props: { option: option }) %>
+      <% end %>
+
+    <% end %>
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_grouped_options.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_grouped_options.jsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import Dropdown from '../_dropdown'
+import Caption from '../../pb_caption/_caption'
+import SectionSeparator from '../../pb_section_separator/_section_separator'
+
+const DropdownGroupedOptions = (props) => {
+
+  const sections = [
+    {
+      title: "Profile",
+      items: [
+        { label: "View Profile", value: "profile", id: "profile" },
+        { label: "Account Settings", value: "settings", id: "settings" },
+      ],
+    },
+    {
+      title: "Workspace",
+      items: [
+        { label: "Projects", value: "projects", id: "projects" },
+        { label: "Billing", value: "billing", id: "billing" },
+      ],
+    },
+    {
+      title: "Support",
+      items: [
+        { label: "Help Center", value: "help", id: "help" },
+        { label: "Contact Support", value: "support", id: "support" },
+      ],
+    },
+  ]
+  const options = sections.flatMap((section) => section.items)
+
+  return (
+    <div>
+      <Dropdown
+          label="Grouped Options"
+          marginBottom="md"
+          options={options}
+          {...props}
+      >
+        <Dropdown.Trigger />
+        <Dropdown.Container>
+          {sections.map((section) => (
+            <React.Fragment key={section.title}>
+              <Caption
+                  color="light"
+                  padding="xs"
+              >
+                {section.title}
+              </Caption>
+              <SectionSeparator />
+
+              {section.items.map((option) => (
+                <Dropdown.Option
+                    key={option.id}
+                    option={option}
+                />
+              ))}
+            </React.Fragment>
+          ))}
+        </Dropdown.Container>
+      </Dropdown>
+      <Dropdown
+          label="Grouped Options Minimalist"
+          options={options}
+          separators={false}
+          {...props}
+      >
+        <Dropdown.Trigger />
+        <Dropdown.Container>
+          {sections.map((section) => (
+            <React.Fragment key={section.title}>
+              <SectionSeparator
+                  paddingY="xs"
+              >
+                <Caption paddingX="xs">
+                  {section.title}
+                </Caption>
+              </SectionSeparator>
+
+              {section.items.map((option) => (
+                <Dropdown.Option
+                    key={option.id}
+                    option={option}
+                />
+              ))}
+            </React.Fragment>
+          ))}
+        </Dropdown.Container>
+      </Dropdown>
+    </div>
+  )
+}
+
+export default DropdownGroupedOptions

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_grouped_options.md
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_grouped_options.md
@@ -1,0 +1,1 @@
+Customize the Dropdown Container to organize options into distinct, labeled sections.

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/example.yml
@@ -36,6 +36,7 @@ examples:
   - dropdown_quickpick_with_date_pickers_default_rails: Quick Pick with Date Pickers (Default Value)
   - dropdown_required_indicator: Required Indicator
   - dropdown_disabled: Disabled Input
+  - dropdown_grouped_options: Grouped Options
   - dropdown_custom_event_type: Custom Event Type
 
   react:
@@ -77,3 +78,4 @@ examples:
   - dropdown_quickpick_with_date_pickers: Quick Pick Variant with Date Pickers
   - dropdown_required_indicator: Required Indicator
   - dropdown_disabled: Disabled Input
+  - dropdown_grouped_options: Grouped Options

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/index.js
@@ -36,3 +36,4 @@ export { default as DropdownRequiredIndicator } from "./_dropdown_required_indic
 export { default as DropdownDisabledOption } from "./_dropdown_disabled_option.jsx";
 export { default as DropdownCustomDisplayDisabledOption } from "./_dropdown_custom_display_disabled_option.jsx";
 export { default as DropdownDisabled } from "./_dropdown_disabled.jsx";
+export { default as DropdownGroupedOptions } from "./_dropdown_grouped_options.jsx";


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3066](https://runway.powerhrg.com/backlog_items/PLAY-3071?from=active_sprint) adds Dropdown docs demonstrating how to create Grouped Options/Sections in the dropdown menu for Rails and React.

**Screenshots:** Screenshots to visualize your addition/change
<img width="691" height="409" alt="doc 1" src="https://github.com/user-attachments/assets/d6e55b3a-28a8-4741-8d73-6fa205bc4b0c" />
<img width="700" height="528" alt="doc 2" src="https://github.com/user-attachments/assets/69acda0b-d422-4ebf-bf09-e6a182ca5493" />
<img width="696" height="610" alt="doc 3" src="https://github.com/user-attachments/assets/3ef2b66a-724a-48db-9afa-90cc65326103" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Dropdown kit "Grouped Options" doc examples ([rails](https://pr6412.playbook.wc.beta.gm.powerapp.cloud/kits/dropdown/rails#dropdown_grouped_options), [react](https://pr6412.playbook.wc.beta.gm.powerapp.cloud/kits/dropdown/react#dropdown_grouped_options)) and to see two examples in action.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.