### PR TITLE
[PLAY-3087] Advanced Table Kit: Column Styling Width Props - Rails

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -89,7 +89,7 @@ kits:
   - name: styling
     description: "Styling per row or column: padding, color, and border."
     parent: advanced_table
-    kit_section: ["Collapsible Trail","Row Styling", "Padding Control using Row Styling", "Column Styling", "Column Styling with Multiple Headers", "Column Styling Background Color", "Column Styling Background Color (Custom)", "Column Styling Background Color with Multiple Headers","Column Styling Individual Cell Background Color", "Padding Control using Column Styling", "Column Group Border Color"]
+    kit_section: ["Collapsible Trail","Row Styling", "Padding Control using Row Styling", "Column Styling", "Column Styling Width", "Column Styling with Multiple Headers", "Column Styling Background Color", "Column Styling Background Color (Custom)", "Column Styling Background Color with Multiple Headers","Column Styling Individual Cell Background Color", "Padding Control using Column Styling", "Column Group Border Color"]
     platforms: *1
     status: stable
     icons_used: true

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/column_layout_helper.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/column_layout_helper.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbAdvancedTable
+    # Mirrors React ColumnLayoutHelper: maps column_styling width keys to inline
+    # styles on header/body cells so columns stay stable when rows expand/collapse.
+    module ColumnLayoutHelper
+      # Converts a Playbook column width value to a CSS length string.
+      # Numbers are treated as pixels; strings are passed through (e.g. "12rem", "200px").
+      def css_length(value)
+        return nil if value.nil? || value == ""
+
+        return "#{value}px" if value.is_a?(Numeric)
+
+        value.to_s
+      end
+
+      # Reads a styling length from column_styling, accepting snake_case or camelCase keys.
+      def read_styling_length(styling, *keys)
+        return nil unless styling.is_a?(Hash)
+
+        keys.each do |key|
+          value = styling[key] || styling[key.to_s] || styling[key.to_sym]
+          return value unless value.nil?
+        end
+        nil
+      end
+
+      # Builds layout styles from a column definition that may include :column_styling.
+      def build_column_layout_styles_from_column(column)
+        return {} unless column.is_a?(Hash)
+
+        styling = column[:column_styling] || column["column_styling"] || {}
+        build_column_layout_styles(styling)
+      end
+
+      # Inline width styles for <th> / <td>. Returns a hash with :width, :min_width,
+      # and/or :max_width (CSS length strings). KitBase converts snake_case keys to
+      # kebab-case CSS properties.
+      #
+      # If only +width+ is set (no min/max), all three are locked to that value.
+      def build_column_layout_styles(styling)
+        return {} unless styling.is_a?(Hash) && styling.present?
+
+        styling_width = read_styling_length(styling, :width, "width")
+        styling_min = read_styling_length(styling, :min_width, "min_width", :minWidth, "minWidth")
+        styling_max = read_styling_length(styling, :max_width, "max_width", :maxWidth, "maxWidth")
+
+        has_width = !styling_width.nil? && styling_width != ""
+        has_min = !styling_min.nil? && styling_min != ""
+        has_max = !styling_max.nil? && styling_max != ""
+
+        width_value = has_width ? styling_width : nil
+        min_value = has_min ? styling_min : nil
+        max_value = has_max ? styling_max : nil
+
+        if has_width && !has_min && !has_max
+          min_value = styling_width
+          max_value = styling_width
+          width_value = styling_width
+        end
+
+        styles = {}
+        width_css = css_length(width_value)
+        min_css = css_length(min_value)
+        max_css = css_length(max_value)
+
+        styles[:width] = width_css if width_css
+        styles[:min_width] = min_css if min_css
+        styles[:max_width] = max_css if max_css
+
+        styles
+      end
+    end
+  end
+end

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -7,6 +7,6 @@ The `columnStyling` prop is an optional item that can be used within `columnDefi
 
 Fixed width: pass `width` only (or TanStack `size` only) and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 
-See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/react#column-styling-width) for the full guide (Playbook ↔ TanStack mapping, floor-only vs bands, and when to use one vs three values).
+See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/styling/react#column-styling-width) for the full guide (Playbook ↔ TanStack mapping, floor-only vs bands, and when to use one vs three values).
 
 `columnStyling` can be used within the columnDefinition of all the columns or some of them, as shown. Each column has its own individual control in this way. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -1,12 +1,9 @@
 The `columnStyling` prop is an optional item that can be used within `columnDefinitions` as shown in the code snippet below. It is an object that has several optional key/value pairs, this doc example highlights the following:
 
-1) `headerAlignment`: This will allow you to control alignment of header content which is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
-2) `cellAlignment`: This will allow you to control alignment of content within all cells in the given column. This is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
-3) `fontColor`: This will allow you to control the font color for a given column.
-
-4) Column width: optional keys on `columnStyling` are `minWidth`, `width`, and `maxWidth` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `minWidth` and bands).
+1. `headerAlignment`: This will allow you to control alignment of header content which is set to right aligned by default. you can set this to `left`, `right` or `center`.
+2. `cellAlignment`: This will allow you to control alignment of content within all cells in the given column. This is set to right aligned by default. you can set this to `left`, `right` or `center`.
+3. `fontColor`: This will allow you to control the font color for a given column.
+4. Column width: optional keys on `columnStyling` are `minWidth`, `width`, and `maxWidth` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `minWidth` and bands).
 
 Fixed width: pass `width` only (or TanStack `size` only) and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.html.erb
@@ -3,6 +3,7 @@
       accessor: "year",
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
+      column_styling: { width: 124 },
     },
     {
       accessor: "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
@@ -7,6 +7,6 @@ The `column_styling` prop is an optional item that can be used within `column_de
 
 Fixed width: pass `width` only and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 
-See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/rails#column-styling-width) for the full guide (floor-only vs bands, and when to use one vs three values).
+See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/styling/rails#column-styling-width) for the full guide (floor-only vs bands, and when to use one vs three values).
 
 `column_styling` can be used within the column_definition of all the columns or some of them, as shown. Each column has its own individual control in this way.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
@@ -1,11 +1,8 @@
 The `column_styling` prop is an optional item that can be used within `column_definitions` as shown in the code snippet below.  It is an object that has several optional key/value pairs, this doc example highlights the following:
 
 1) `header_alignment`: This will allow you to control alignment of header content which is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
 2) `cell_alignment`: This will allow you to control alignment of content within all cells in the given column. This is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
 3) `font_color`: This will allow you to control the font color for a given column.
-
 4) Column width: optional keys on `column_styling` are `min_width`, `width`, and `max_width` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `min_width` and bands).
 
 Fixed width: pass `width` only and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
@@ -6,4 +6,10 @@ The `column_styling` prop is an optional item that can be used within `column_de
 
 3) `font_color`: This will allow you to control the font color for a given column.
 
-`column_styling` can be used within the column_definition of all the columns or some of them, as shown. Each column has its own individual control in this way. 
+4) Column width: optional keys on `column_styling` are `min_width`, `width`, and `max_width` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `min_width` and bands).
+
+Fixed width: pass `width` only and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
+
+See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/rails#column-styling-width) for the full guide (floor-only vs bands, and when to use one vs three values).
+
+`column_styling` can be used within the column_definition of all the columns or some of them, as shown. Each column has its own individual control in this way.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.md
@@ -1,6 +1,6 @@
 AdvancedTable column width is controlled in two equivalent places on each leaf `columnDefinitions` entry. Playbook maps them to inline styles on header and body cells (and forwards numeric values into TanStack Table’s column model).
 
-1) Playbook `columnStyling` and TanStack `ColumnDef` use the same three ideas:
+**1)** Playbook `columnStyling` and TanStack `ColumnDef` use the same three ideas:
 
 - Preferred / target width: `columnStyling` `width` maps to TanStack `size` on the same column object.
 - Minimum width (floor): `columnStyling` `minWidth` maps to TanStack `minSize`.
@@ -10,7 +10,7 @@ Numbers are pixels. You can also pass CSS length strings on `columnStyling` (e.g
 
 If both APIs set the same axis, `columnStyling` wins for that axis when Playbook builds cell styles.
 
-2) Fixed width: set `width` only
+**2)** Fixed width: set `width` only
 
 If you pass only `width` (or only `size`) and do not set `minWidth` / `maxWidth` (or `minSize` / `maxSize`), Playbook treats that as a fixed column: it sets all three to the same value under the hood so you do not have to repeat yourself.
 
@@ -26,7 +26,7 @@ size: 200
 
 Use this when the column should stay one width (e.g. a hierarchy column with expand controls).
 
-3) Floor only: `minWidth` / `minSize`
+**3)** Floor only: `minWidth` / `minSize`
 
 Set only a minimum when the column may grow with the table or content but must not shrink below a baseline (common fix for horizontal “jump” when rows expand):
 
@@ -34,7 +34,7 @@ Set only a minimum when the column may grow with the table or content but must n
 columnStyling: { minWidth: 160 }
 ```
 
-4) Flexible band: min + preferred + max
+**4)** Flexible band: min + preferred + max
 
 Set two or three values when you want a range. CSS uses preferred `width` clamped between `minWidth` and `maxWidth`:
 
@@ -46,7 +46,7 @@ Example from the table below (Attendance): `minWidth: 108`, `width: 124`, `maxWi
 
 You only need all three when you want that band. If min and max are omitted, `width` alone is enough for a fixed column.
 
-5) TanStack band without `columnStyling`
+**5)** TanStack band without `columnStyling`
 
 The Meetings column uses only TanStack fields:
 
@@ -56,7 +56,7 @@ The Meetings column uses only TanStack fields:
 
 Playbook applies the same min / preferred / max idea to cell styles. Setting only `size: 200` would lock all three to 200, same as `width: 200` in `columnStyling`.
 
-6) What the example table shows
+**6)** What the example table shows
 
 - Year (fixed): `columnStyling: { width: 128 }` — locked to 128px.
 - Enrollments (floor): `columnStyling: { minWidth: 160 }` — at least 160px; can grow.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.html.erb
@@ -1,0 +1,41 @@
+<% column_definitions = [
+    {
+      accessor: "year",
+      label: "Year (fixed)",
+      cellAccessors: ["quarter", "month", "day"],
+      # width alone locks min + max to the same value (128px).
+      column_styling: { width: 128 },
+    },
+    {
+      accessor: "newEnrollments",
+      label: "Enrollments (floor)",
+      column_styling: { min_width: 160 },
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Meetings (preferred)",
+      column_styling: { width: 200, min_width: 160, max_width: 240 },
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance (min / pref / max)",
+      column_styling: { min_width: 108, width: 124, max_width: 168 },
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Completion %",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated",
+    },
+] %>
+
+<%= pb_rails("advanced_table", props: { id: "column-styling-width", table_data: @table_data, column_definitions: column_definitions }) do %>
+  <%= pb_rails("advanced_table/table_header", props: { table_id: "column-styling-width", column_definitions: column_definitions }) %>
+  <%= pb_rails("advanced_table/table_body", props: { table_id: "column-styling-width", table_data: @table_data, column_definitions: column_definitions }) %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
@@ -1,0 +1,49 @@
+AdvancedTable column width is controlled on each leaf `column_definitions` entry via `column_styling`. Playbook maps these keys to inline styles on header and body cells.
+
+1) `column_styling` width keys:
+
+- Preferred / target width: `width`
+- Minimum width (floor): `min_width`
+- Maximum width (ceiling): `max_width`
+
+Numbers are pixels. You can also pass CSS length strings (e.g. `"12rem"`, `"200px"`).
+
+2) Fixed width: set `width` only
+
+If you pass only `width` and do not set `min_width` / `max_width`, Playbook treats that as a fixed column: it sets all three to the same value under the hood so you do not have to repeat yourself.
+
+```ruby
+column_styling: { width: 128 }
+# Applied as width, min-width, and max-width: 128px
+```
+
+Use this when the column should stay one width (e.g. a hierarchy column with expand controls).
+
+3) Floor only: `min_width`
+
+Set only a minimum when the column may grow with the table or content but must not shrink below a baseline (common fix for horizontal “jump” when rows expand):
+
+```ruby
+column_styling: { min_width: 160 }
+```
+
+4) Flexible band: min + preferred + max
+
+Set two or three values when you want a range. CSS uses preferred `width` clamped between `min_width` and `max_width`:
+
+- `min_width`: won’t shrink below this.
+- `width`: preferred size when space allows.
+- `max_width`: won’t grow above this.
+
+Example from the table below (Attendance): `min_width: 108`, `width: 124`, `max_width: 168` → preferred 124px, allowed between 108 and 168.
+
+You only need all three when you want that band. If min and max are omitted, `width` alone is enough for a fixed column.
+
+5) What the example table shows
+
+- Year (fixed): `column_styling: { width: 128 }` — locked to 128px.
+- Enrollments (floor): `column_styling: { min_width: 160 }` — at least 160px; can grow.
+- Meetings (preferred): `width` / `min_width` / `max_width` — preferred 200px, between 160–240.
+- Attendance (min / pref / max): all three — preferred 124px, between 108–168.
+
+Grouped columns: put width options on leaf definitions (columns with an `accessor`), not on parent group headers.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
@@ -1,6 +1,6 @@
 AdvancedTable column width is controlled on each leaf `column_definitions` entry via `column_styling`. Playbook maps these keys to inline styles on header and body cells.
 
-1) `column_styling` width keys:
+**1)** `column_styling` width keys:
 
 - Preferred / target width: `width`
 - Minimum width (floor): `min_width`
@@ -8,7 +8,7 @@ AdvancedTable column width is controlled on each leaf `column_definitions` entry
 
 Numbers are pixels. You can also pass CSS length strings (e.g. `"12rem"`, `"200px"`).
 
-2) Fixed width: set `width` only
+**2)** Fixed width: set `width` only
 
 If you pass only `width` and do not set `min_width` / `max_width`, Playbook treats that as a fixed column: it sets all three to the same value under the hood so you do not have to repeat yourself.
 
@@ -19,7 +19,7 @@ column_styling: { width: 128 }
 
 Use this when the column should stay one width (e.g. a hierarchy column with expand controls).
 
-3) Floor only: `min_width`
+**3)** Floor only: `min_width`
 
 Set only a minimum when the column may grow with the table or content but must not shrink below a baseline (common fix for horizontal “jump” when rows expand):
 
@@ -27,7 +27,7 @@ Set only a minimum when the column may grow with the table or content but must n
 column_styling: { min_width: 160 }
 ```
 
-4) Flexible band: min + preferred + max
+**4)** Flexible band: min + preferred + max
 
 Set two or three values when you want a range. CSS uses preferred `width` clamped between `min_width` and `max_width`:
 
@@ -39,7 +39,7 @@ Example from the table below (Attendance): `min_width: 108`, `width: 124`, `max_
 
 You only need all three when you want that band. If min and max are omitted, `width` alone is enough for a fixed column.
 
-5) What the example table shows
+**5)** What the example table shows
 
 - Year (fixed): `column_styling: { width: 128 }` — locked to 128px.
 - Enrollments (floor): `column_styling: { min_width: 160 }` — at least 160px; can grow.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -26,6 +26,7 @@ examples:
   - advanced_table_row_styling: Row Styling
   - advanced_table_padding_control_per_row_rails: Padding Control using Row Styling
   - advanced_table_column_styling_rails: Column Styling
+  - advanced_table_column_styling_width_rails: Column Styling Width
   - advanced_table_column_styling_column_headers_rails: Column Styling with Multiple Headers
   - advanced_table_padding_control_rails: Padding Control using Column Styling
   - advanced_table_background_control_rails: Column Styling Background Color

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "column_layout_helper"
+
 module Playbook
   module PbAdvancedTable
     class TableHeader < Playbook::KitBase
+      include Playbook::PbAdvancedTable::ColumnLayoutHelper
       prop :table_id, type: Playbook::Props::String,
                       default: ""
       prop :column_definitions, type: Playbook::Props::Array,
@@ -164,6 +167,9 @@ module Playbook
       def header_component_info(cell, cell_index, row_index)
         header_id = cell[:accessor].present? ? cell[:accessor] : "header_#{row_index}_#{cell_index}"
         classname = [th_classname(is_first_column: cell_index.zero?), ("last-header-cell" if cell[:is_last_in_group] && cell_index != 0)].compact.join(" ")
+        layout_styles = header_layout_styles(cell)
+        style_hash = layout_styles.dup
+        style_hash[:color] = cell[:header_font_color] if cell[:header_font_color].present?
 
         if has_custom_header_background_color?(cell)
           component_name = "background"
@@ -175,9 +181,8 @@ module Playbook
           component_props[:html_options] = {
             id: header_id,
             colspan: cell[:colspan],
-            style: { color: cell[:header_font_color] },
+            style: style_hash,
           }
-          component_props[:html_options][:style].delete(:color) unless cell[:header_font_color].present?
         else
           component_name = "table/table_header"
           component_props = {
@@ -186,7 +191,7 @@ module Playbook
             classname: classname,
             sort_menu: cell[:accessor] ? cell[:sort_menu] : nil,
           }
-          component_props[:html_options] = { style: { color: cell[:header_font_color] } } if cell[:header_font_color].present?
+          component_props[:html_options] = { style: style_hash } if style_hash.present?
         end
 
         { name: component_name, props: component_props }
@@ -206,6 +211,13 @@ module Playbook
       end
 
     private
+
+      def header_layout_styles(cell)
+        original_def = find_original_column_def_for_cell(cell)
+        return {} unless original_def
+
+        build_column_layout_styles_from_column(original_def)
+      end
 
       # Find the original column definition for a cell
       def find_original_column_def_for_cell(cell)

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "column_layout_helper"
+
 module Playbook
   module PbAdvancedTable
     class TableRow < Playbook::KitBase
+      include Playbook::PbAdvancedTable::ColumnLayoutHelper
       prop :table_id, type: Playbook::Props::String,
                       default: ""
       prop :column_definitions, type: Playbook::Props::Array,
@@ -111,6 +114,7 @@ module Playbook
         column_font_color = cell_font_color(column)
         effective_font_color = column_font_color || font_color
         effective_font_weight = font_weight_value(font_weight)
+        layout_styles = cell_layout_styles(column)
 
         if has_custom_background_color?(column)
           custom_bg_color = cell_background_color(column)
@@ -120,13 +124,13 @@ module Playbook
             tag: "td",
             classname: td_classname(column, index),
           }
-          style_hash = {}
+          style_hash = layout_styles.dup
           style_hash[:color] = effective_font_color if effective_font_color.present?
           style_hash[:"font-weight"] = effective_font_weight if effective_font_weight.present?
           component_props[:html_options] = { style: style_hash } if style_hash.present?
         else
           component_name = "table/table_cell"
-          style_hash = { "background-color": bg_color }
+          style_hash = layout_styles.merge("background-color": bg_color)
           style_hash[:color] = effective_font_color if effective_font_color.present?
           style_hash[:"font-weight"] = effective_font_weight if effective_font_weight.present?
           component_props = {
@@ -231,6 +235,15 @@ module Playbook
       end
 
     private
+
+      def cell_layout_styles(column)
+        return {} unless column[:accessor].present?
+
+        orig_def = find_column_def_by_accessor(column_definitions, column[:accessor])
+        return {} unless orig_def
+
+        build_column_layout_styles_from_column(orig_def)
+      end
 
       def custom_renderer_value(column, index)
         return nil unless column[:accessor].present?

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/column_layout_helper_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/column_layout_helper_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_advanced_table/column_layout_helper"
+
+RSpec.describe Playbook::PbAdvancedTable::ColumnLayoutHelper do
+  let(:helper) do
+    Class.new { include Playbook::PbAdvancedTable::ColumnLayoutHelper }.new
+  end
+
+  describe "#css_length" do
+    it "converts numbers to pixel strings" do
+      expect(helper.css_length(128)).to eq "128px"
+      expect(helper.css_length(128.5)).to eq "128.5px"
+    end
+
+    it "passes strings through" do
+      expect(helper.css_length("12rem")).to eq "12rem"
+      expect(helper.css_length("200px")).to eq "200px"
+    end
+
+    it "returns nil for blank values" do
+      expect(helper.css_length(nil)).to be_nil
+      expect(helper.css_length("")).to be_nil
+    end
+  end
+
+  describe "#build_column_layout_styles" do
+    it "applies min_width, width, and max_width" do
+      styles = helper.build_column_layout_styles(min_width: 108, width: 124, max_width: 168)
+
+      expect(styles).to eq(
+        width: "124px",
+        min_width: "108px",
+        max_width: "168px"
+      )
+    end
+
+    it "locks min and max when only width is set" do
+      styles = helper.build_column_layout_styles(width: 128)
+
+      expect(styles).to eq(
+        width: "128px",
+        min_width: "128px",
+        max_width: "128px"
+      )
+    end
+
+    it "applies floor-only min_width" do
+      styles = helper.build_column_layout_styles(min_width: 160)
+
+      expect(styles).to eq(min_width: "160px")
+    end
+
+    it "accepts camelCase aliases" do
+      styles = helper.build_column_layout_styles(minWidth: 108, width: 124, maxWidth: 168)
+
+      expect(styles).to eq(
+        width: "124px",
+        min_width: "108px",
+        max_width: "168px"
+      )
+    end
+
+    it "supports CSS length strings" do
+      styles = helper.build_column_layout_styles(width: "12rem", min_width: "10rem")
+
+      expect(styles).to eq(
+        width: "12rem",
+        min_width: "10rem"
+      )
+    end
+
+    it "returns an empty hash when styling has no width keys" do
+      expect(helper.build_column_layout_styles(cell_alignment: "left")).to eq({})
+      expect(helper.build_column_layout_styles({})).to eq({})
+      expect(helper.build_column_layout_styles(nil)).to eq({})
+    end
+  end
+
+  describe "#build_column_layout_styles_from_column" do
+    it "reads from column_styling on the column definition" do
+      column = {
+        accessor: "year",
+        column_styling: { width: 128 },
+      }
+
+      expect(helper.build_column_layout_styles_from_column(column)).to eq(
+        width: "128px",
+        min_width: "128px",
+        max_width: "128px"
+      )
+    end
+
+    it "returns empty hash when column_styling is missing" do
+      expect(helper.build_column_layout_styles_from_column(accessor: "year")).to eq({})
+    end
+  end
+end

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_header_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_header_spec.rb
@@ -415,6 +415,9 @@ RSpec.describe Playbook::PbAdvancedTable::TableHeader do
         { accessor: "with_bg", label: "With Background", column_styling: { header_background_color: "success" } },
         { accessor: "with_font", label: "With Font", column_styling: { header_font_color: "white" } },
         { accessor: "with_both", label: "With Both", column_styling: { header_background_color: "error", header_font_color: "white" } },
+        { accessor: "with_width", label: "With Width", column_styling: { width: 128 } },
+        { accessor: "with_width_band", label: "With Width Band", column_styling: { min_width: 108, width: 124, max_width: 168 } },
+        { accessor: "with_bg_and_width", label: "With Bg and Width", column_styling: { header_background_color: "success", width: 200 } },
       ]
     end
     let(:instance) { subject.new(column_definitions: column_definitions) }
@@ -432,6 +435,26 @@ RSpec.describe Playbook::PbAdvancedTable::TableHeader do
         result = instance.header_component_info(cell, 0, 0)
         expect(result[:name]).to eq "table/table_header"
         expect(result[:props][:html_options][:style][:color]).to eq "white"
+      end
+
+      it "applies fixed width styles when only width is set" do
+        cell = { accessor: "with_width", label: "With Width", colspan: 1, sort_menu: nil }
+        result = instance.header_component_info(cell, 0, 0)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "128px",
+          min_width: "128px",
+          max_width: "128px"
+        )
+      end
+
+      it "applies min_width, width, and max_width band styles" do
+        cell = { accessor: "with_width_band", label: "With Width Band", colspan: 1, sort_menu: nil }
+        result = instance.header_component_info(cell, 0, 0)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "124px",
+          min_width: "108px",
+          max_width: "168px"
+        )
       end
     end
 
@@ -456,6 +479,17 @@ RSpec.describe Playbook::PbAdvancedTable::TableHeader do
         cell = { accessor: "with_bg", label: "With Background", colspan: 1, header_background_color: "success" }
         result = instance.header_component_info(cell, 0, 0)
         expect(result[:props][:html_options][:style]).to be_empty
+      end
+
+      it "merges width styles with custom background" do
+        cell = { accessor: "with_bg_and_width", label: "With Bg and Width", colspan: 1, header_background_color: "success" }
+        result = instance.header_component_info(cell, 0, 0)
+        expect(result[:name]).to eq "background"
+        expect(result[:props][:html_options][:style]).to include(
+          width: "200px",
+          min_width: "200px",
+          max_width: "200px"
+        )
       end
     end
 

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
@@ -386,6 +386,9 @@ RSpec.describe Playbook::PbAdvancedTable::TableRow do
         { accessor: "with_bg_and_font", column_styling: { cell_background_color: "success_secondary", font_color: "white" } },
         { accessor: "with_bg_only", column_styling: { cell_background_color: "warning_secondary" } },
         { accessor: "none", column_styling: {} },
+        { accessor: "with_width", column_styling: { width: 128 } },
+        { accessor: "with_width_band", column_styling: { min_width: 108, width: 124, max_width: 168 } },
+        { accessor: "with_bg_and_width", column_styling: { cell_background_color: "warning_secondary", width: 200 } },
       ]
     end
     let(:instance) { subject.new(row: row, depth: 0, column_definitions: column_definitions) }
@@ -421,6 +424,36 @@ RSpec.describe Playbook::PbAdvancedTable::TableRow do
         result = instance.cell_component_info({ accessor: "none" }, 0, nil, nil)
         expect(result[:name]).to eq "table/table_cell"
         expect(result[:props][:html_options][:style]).not_to have_key(:color)
+      end
+    end
+
+    context "with column width styling" do
+      it "applies fixed width styles when only width is set" do
+        result = instance.cell_component_info({ accessor: "with_width" }, 0, nil, nil)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "128px",
+          min_width: "128px",
+          max_width: "128px"
+        )
+      end
+
+      it "applies min_width, width, and max_width band styles" do
+        result = instance.cell_component_info({ accessor: "with_width_band" }, 0, nil, nil)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "124px",
+          min_width: "108px",
+          max_width: "168px"
+        )
+      end
+
+      it "merges width styles with custom background" do
+        result = instance.cell_component_info({ accessor: "with_bg_and_width" }, 0, nil, nil)
+        expect(result[:name]).to eq "background"
+        expect(result[:props][:html_options][:style]).to include(
+          width: "200px",
+          min_width: "200px",
+          max_width: "200px"
+        )
       end
     end
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3087

It adds column width controls to [match React](https://github.com/powerhome/playbook/pull/6182). 

- Add column width controls to React Advanced Table so devs can stabilize column layout (especially the first column) using `column_definitions`, without custom CSS. 
- Add `min_width`, `width`, and `max_width` props for columnStyling. 
  - You can also use CSS strings, not just numbers (e.g., "12rem")
  - If you use numbers, pass these to Tanstack to use with corresponding `size` props.
- Can still use the Tanstack `size`, `min_size`, and `max_size` fields too
- Docs and testing 

There were also some small docs fixes for React as well- formatting of markdown.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1968" height="578" alt="Screenshot 2026-07-21 at 9 39 56 AM" src="https://github.com/user-attachments/assets/0cfe9f3c-ef92-4b63-8aca-a80bcb4ba8d4" />


**How to test?** Steps to confirm the desired behavior:



#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.