### PR TITLE
[PLAY-3085] Distribution Bar Rails Refactor

### DIFF
--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -210,7 +210,7 @@ kits:
     description: Part-to-whole comparison like a pie chart. Default mode stresses share without raw numbers.
     status: stable
     icons_used: false
-    react_rendered: true
+    react_rendered: false
     enhanced_element_used: false
   - name: legend
     platforms: *1

--- a/playbook/app/entrypoints/playbook-rails-react-bindings.js
+++ b/playbook/app/entrypoints/playbook-rails-react-bindings.js
@@ -3,13 +3,11 @@
 import ComponentRegistry from '../utils/componentRegistry'
 import '../utils/mountComponent'
 
-import DistributionBar from 'kits/pb_distribution_bar/_distribution_bar'
 import MultiLevelSelect from 'kits/pb_multi_level_select/_multi_level_select'
 import Typeahead from 'kits/pb_typeahead/_typeahead'
 import PhoneNumberInput from 'kits/pb_phone_number_input/_phone_number_input'
 
 ComponentRegistry.registerComponents({
-  DistributionBar,
   MultiLevelSelect,
   Typeahead,
   PhoneNumberInput,

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.html.erb
@@ -1,1 +1,8 @@
-<%= react_component('DistributionBar', object.chart_options) %>
+<%= pb_content_tag do %>
+  <% widths_to_percentages.each_with_index do |percentage, index| %>
+    <div
+      class="<%= segment_classname(index) %>"
+      style="width: <%= percentage %>%;"
+    ></div>
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.rb
+++ b/playbook/app/pb_kits/playbook/pb_distribution_bar/distribution_bar.rb
@@ -21,12 +21,9 @@ module Playbook
         end
       end
 
-      def chart_options
-        {
-          size: size,
-          widths: widths,
-          colors: colors,
-        }
+      def segment_classname(index)
+        color = colors[index]
+        ["pb_distribution_width", ("color_#{color}" if color.present?)].compact.join(" ")
       end
     end
   end

--- a/playbook/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/distribution_bar_spec.rb
@@ -15,12 +15,46 @@ RSpec.describe Playbook::PbDistributionBar::DistributionBar do
       .of_type(Playbook::Props::NumberArray)
       .with_default([1])
   }
+  it {
+    is_expected.to define_prop(:colors)
+      .of_type(Playbook::Props::Array)
+      .with_default([])
+  }
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
       expect(subject.new({}).classname).to eq "pb_distribution_bar_lg"
       expect(subject.new(size: "sm").classname).to eq "pb_distribution_bar_sm"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_distribution_bar_lg additional_class"
+    end
+  end
+
+  describe "#widths_to_percentages" do
+    it "converts widths to percentage shares of the total", :aggregate_failures do
+      expect(subject.new(widths: [1]).widths_to_percentages).to eq [100.0]
+      expect(subject.new(widths: [1, 1]).widths_to_percentages).to eq [50.0, 50.0]
+      expect(subject.new(widths: [1, 2, 1]).widths_to_percentages).to eq [25.0, 50.0, 25.0]
+      expect(subject.new(widths: [1, 2, 3, 4]).widths_to_percentages).to eq [10.0, 20.0, 30.0, 40.0]
+    end
+  end
+
+  describe "#segment_classname" do
+    it "returns the base segment class without a color override" do
+      expect(subject.new.segment_classname(0)).to eq "pb_distribution_width"
+    end
+
+    it "appends a color class when a matching color is provided" do
+      bar = subject.new(colors: %w[data_7 data_1 neutral])
+
+      expect(bar.segment_classname(0)).to eq "pb_distribution_width color_data_7"
+      expect(bar.segment_classname(1)).to eq "pb_distribution_width color_data_1"
+      expect(bar.segment_classname(2)).to eq "pb_distribution_width color_neutral"
+    end
+
+    it "omits the color class when no color is set for that index" do
+      bar = subject.new(colors: ["data_7"])
+
+      expect(bar.segment_classname(1)).to eq "pb_distribution_width"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3085](https://runway.powerhrg.com/backlog_items/PLAY-3085?from=active_sprint) refactors the Distribution Bar Rails kit to be "pure" rails instead of react-rendered-rails. There was no reason for it to be react rendered as it is not particularly dynamic (but probably was since many Data Vis elements were initially set up that way).

Current DOM:
```
<div data-pb-react-component="DistributionBar" data-pb-react-props="{&quot;size&quot;:&quot;lg&quot;,&quot;widths&quot;:[1,2,3,4,5,3,3,7],&quot;colors&quot;:[]}" data-dark-mode="false" data-dark="false" data-pb-react-mounted="true"><div class="pb_distribution_bar_lg"><div class="pb_distribution_width" style="width: 3.57143%;"></div><div class="pb_distribution_width" style="width: 7.14286%;"></div><div class="pb_distribution_width" style="width: 10.7143%;"></div><div class="pb_distribution_width" style="width: 14.2857%;"></div><div class="pb_distribution_width" style="width: 17.8571%;"></div><div class="pb_distribution_width" style="width: 10.7143%;"></div><div class="pb_distribution_width" style="width: 10.7143%;"></div><div class="pb_distribution_width" style="width: 25%;"></div></div></div>
```

Updated DOM:
```
<div class="pb_distribution_bar_lg" data-dark-mode="false" data-dark="false">
    <div class="pb_distribution_width" style="width: 3.57%;"></div>
    <div class="pb_distribution_width" style="width: 7.14%;"></div>
    <div class="pb_distribution_width" style="width: 10.71%;"></div>
    <div class="pb_distribution_width" style="width: 14.29%;"></div>
    <div class="pb_distribution_width" style="width: 17.86%;"></div>
    <div class="pb_distribution_width" style="width: 10.71%;"></div>
    <div class="pb_distribution_width" style="width: 10.71%;"></div>
    <div class="pb_distribution_width" style="width: 25.0%;"></div>
</div>
```

**Screenshots:** Screenshots to visualize your addition/change
Current prod screenshot:
<img width="1494" height="962" alt="prod" src="https://github.com/user-attachments/assets/6d3e4331-ed85-4540-a116-388c9014ffff" />
Updated review env:
<img width="1494" height="911" alt="rails db for PR" src="https://github.com/user-attachments/assets/ab147b48-621f-4d00-bf19-8bd1c37c63a3" />

**How to test?** Steps to confirm the desired behavior:
1. Go to [Distribution Bar rails kit page](https://pr6421.playbook.wc.beta.gm.powerapp.cloud/kits/distribution_bar/rails) - see updated kit. Compare to prod.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.