### PR TITLE
[PLAY-3104] Typeahead Reset to Default Preparation - `data-default-value` and :set

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
@@ -590,3 +590,43 @@ test(':set updates values; :set after :clear restores', async () => {
   ).map((input) => input.value)
   expect(hiddenValues).toEqual(['#FFA500', '#00FF00'])
 })
+
+test(':set calls onChange but does not dispatch result-option-select', async () => {
+  const handleChange = jest.fn()
+  const selectHandler = jest.fn()
+
+  document.addEventListener(
+    'pb-typeahead-kit-set-side-effects-typeahead-result-option-select',
+    selectHandler,
+  )
+
+  render(
+    <Typeahead
+        data={{ testid: 'set-side-effects-test' }}
+        id="set-side-effects-typeahead"
+        isMulti
+        onChange={handleChange}
+        options={options}
+    />
+  )
+
+  await act(async () => {
+    document.dispatchEvent(
+      new CustomEvent('pb-typeahead-kit-set-side-effects-typeahead:set', {
+        detail: [options[0], options[1]],
+      }),
+    )
+  })
+
+  await waitFor(() => {
+    expect(screen.getByTestId('set-side-effects-test').querySelectorAll('.pb_form_pill_kit')).toHaveLength(2)
+  })
+
+  expect(handleChange).toHaveBeenCalled()
+  expect(selectHandler).not.toHaveBeenCalled()
+
+  document.removeEventListener(
+    'pb-typeahead-kit-set-side-effects-typeahead-result-option-select',
+    selectHandler,
+  )
+})

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
@@ -500,8 +500,54 @@ test('publishes data-default-value from initial defaultValue', () => {
 
   expect(screen.getByTestId('default-stamp-test')).toHaveAttribute(
     'data-default-value',
-    JSON.stringify([options[0], options[1]]),
+    JSON.stringify([
+      { label: 'Orange', value: '#FFA500' },
+      { label: 'Red', value: '#FF0000' },
+    ]),
   )
+})
+
+test('data-default-value only includes label and value', () => {
+  render(
+    <Typeahead
+        data={{ testid: 'slim-default-test' }}
+        defaultValue={[
+          {
+            label: 'Orange',
+            value: '#FFA500',
+            imageUrl: 'https://example.com/orange.png',
+            meta: { nested: true },
+          },
+        ]}
+        id="slim-default-typeahead"
+        isMulti
+        options={options}
+    />
+  )
+
+  expect(screen.getByTestId('slim-default-test')).toHaveAttribute(
+    'data-default-value',
+    JSON.stringify([{ label: 'Orange', value: '#FFA500' }]),
+  )
+})
+
+test('omits data-default-value when serialization fails', () => {
+  const circular = { label: 'Broken' }
+  circular.value = circular
+
+  render(
+    <Typeahead
+        data={{ testid: 'bad-default-test' }}
+        defaultValue={[circular]}
+        id="bad-default-typeahead"
+        isMulti
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId('bad-default-test')
+  expect(kit).toBeInTheDocument()
+  expect(kit).not.toHaveAttribute('data-default-value')
 })
 
 test(':set updates values; :set after :clear restores', async () => {

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '../utilities/test-utils'
+import { render, screen, fireEvent, waitFor, act } from '../utilities/test-utils'
 import Typeahead from './_typeahead'
 
 const options = [
@@ -485,4 +485,62 @@ test('pill reorder commit dispatches custom event on drop', () => {
     'pb-typeahead-kit-reorder-event-typeahead-result-option-reorder',
     reorderHandler,
   )
+})
+
+test('publishes data-default-value from initial defaultValue', () => {
+  render(
+    <Typeahead
+        data={{ testid: 'default-stamp-test' }}
+        defaultValue={[options[0], options[1]]}
+        id="default-stamp-typeahead"
+        isMulti
+        options={options}
+    />
+  )
+
+  expect(screen.getByTestId('default-stamp-test')).toHaveAttribute(
+    'data-default-value',
+    JSON.stringify([options[0], options[1]]),
+  )
+})
+
+test(':set updates values; :set after :clear restores', async () => {
+  render(
+    <Typeahead
+        data={{ testid: 'set-event-test' }}
+        defaultValue={[options[0]]}
+        id="set-event-typeahead"
+        isMulti
+        name="products"
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId('set-event-test')
+  expect(kit.querySelectorAll('.pb_form_pill_kit')).toHaveLength(1)
+
+  await act(async () => {
+    document.dispatchEvent(new CustomEvent('pb-typeahead-kit-set-event-typeahead:clear'))
+  })
+  await waitFor(() => expect(kit.querySelectorAll('.pb_form_pill_kit')).toHaveLength(0))
+
+  await act(async () => {
+    document.dispatchEvent(
+      new CustomEvent('pb-typeahead-kit-set-event-typeahead:set', {
+        detail: [options[0], options[2]],
+      }),
+    )
+  })
+
+  await waitFor(() => {
+    const pills = kit.querySelectorAll('.pb_form_pill_kit')
+    expect(pills).toHaveLength(2)
+    expect(pills[0]).toHaveTextContent('Orange')
+    expect(pills[1]).toHaveTextContent('Green')
+  })
+
+  const hiddenValues = Array.from(
+    kit.querySelectorAll('input[type="hidden"][name="products"]'),
+  ).map((input) => input.value)
+  expect(hiddenValues).toEqual(['#FFA500', '#00FF00'])
 })

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -216,12 +216,24 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(
     // Create a ref to access React Select instance
     const selectRef = useRef<any>(null)
 
-    // Mount-time stamp for smart Defaults (:clear → read → :set). Not updated on selection change.
+    // Mount-time data-default-value for smart Defaults (:clear → read → :set).
+    // Only label/value, with try/catch so non-serializable extras never block mount.
     const [dataDefaultValue] = useState(() => {
       const defaultValue = props.defaultValue
       if (defaultValue == null) return undefined
       const options = Array.isArray(defaultValue) ? defaultValue : [defaultValue]
-      return options.length ? JSON.stringify(options) : undefined
+      if (!options.length) return undefined
+
+      try {
+        return JSON.stringify(
+          options.map((option: SelectValueType) => ({
+            label: option?.label,
+            value: option?.value,
+          })),
+        )
+      } catch {
+        return undefined
+      }
     })
 
     const dialogCtx = useContext(DialogContext)

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -216,6 +216,14 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(
     // Create a ref to access React Select instance
     const selectRef = useRef<any>(null)
 
+    // Mount-time stamp for smart Defaults (:clear → read → :set). Not updated on selection change.
+    const [dataDefaultValue] = useState(() => {
+      const defaultValue = props.defaultValue
+      if (defaultValue == null) return undefined
+      const options = Array.isArray(defaultValue) ? defaultValue : [defaultValue]
+      return options.length ? JSON.stringify(options) : undefined
+    })
+
     const dialogCtx = useContext(DialogContext)
 
     const kitContainerRef = useRef<HTMLDivElement>(null)
@@ -710,6 +718,7 @@ const resolvedLoadOptions =
         {...htmlProps}
         aria-busy={asyncLoading ? "true" : "false"}
         className={classnames(classes, inlineClass)}
+        {...(dataDefaultValue ? { "data-default-value": dataDefaultValue } : {})}
         data-pb-typeahead-loading={asyncLoading ? "true" : "false"}
     >
       <Tag

--- a/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/_typeahead.tsx
@@ -215,6 +215,8 @@ const Typeahead = forwardRef<HTMLInputElement, TypeaheadProps>(
 
     // Create a ref to access React Select instance
     const selectRef = useRef<any>(null)
+    // True while :set is applying so handleOnChange skips click-only side effects.
+    const isProgrammaticSetRef = useRef(false)
 
     // Mount-time data-default-value for smart Defaults (:clear → read → :set).
     // Only label/value, with try/catch so non-serializable extras never block mount.
@@ -534,6 +536,7 @@ const resolvedLoadOptions =
           }
         : {}),
       styles: mergedSelectStyles,
+      isProgrammaticSetRef,
     }
 
     const [contextValue, setContextValue] = useState("")
@@ -645,6 +648,8 @@ const resolvedLoadOptions =
       _data: SelectValueType,
       {action, option, removedValue}: TagOnChangeValues,
     ) => {
+      const isProgrammaticSet = isProgrammaticSetRef.current
+
       if (onChange) {
         const isReactHookForm = onChange.toString().includes("target")
         if (isReactHookForm) {
@@ -654,19 +659,19 @@ const resolvedLoadOptions =
         }
       }
 
-      // Reset form submitted state when a selection is made (this is all for react rendered rails kit)
-      if (action === "select-option" || action === "create-option") {
+      // User-selection side effects — skipped for programmatic :set restores
+      if (!isProgrammaticSet && (action === "select-option" || action === "create-option")) {
         setFormSubmitted(false)
         // Mark that user has made a selection to disable default value focus behavior
         setHasUserSelected(true)
       }
 
       // If a value is selected/created and we're preserving input on blur, clear the input
-      if ((action === "select-option" || action === "create-option") && preserveSearchInput) {
+      if (!isProgrammaticSet && (action === "select-option" || action === "create-option") && preserveSearchInput) {
         setInputValue("")
       }
 
-      if (action === "select-option" || action === "create-option") {
+      if (!isProgrammaticSet && (action === "select-option" || action === "create-option")) {
         if (selectProps.onMultiValueClick && option)
           selectProps.onMultiValueClick(option)
         const multiValueClearEvent = new CustomEvent(

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
@@ -1,16 +1,32 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { components } from 'react-select'
 
-type IndicatorsContainerProps = {
-  children: React.ReactNode,
+// Always mounted — ClearIndicator unmounts when empty, so :set after :clear lives here.
+const IndicatorsContainer = (props: any): React.ReactElement => {
+  const { selectProps, setValue } = props
+
+  useEffect(() => {
+    if (!selectProps?.id) return
+
+    const handleSet = (event: Event) => {
+      const detail = (event as CustomEvent).detail
+      const value = selectProps.isMulti
+        ? (Array.isArray(detail) ? detail : [detail]).filter(Boolean)
+        : (Array.isArray(detail) ? detail[0] : detail) ?? null
+      setValue(value, 'select-option')
+    }
+
+    const eventName = `pb-typeahead-kit-${selectProps.id}:set`
+    document.addEventListener(eventName, handleSet)
+    return () => document.removeEventListener(eventName, handleSet)
+  }, [setValue, selectProps?.id, selectProps?.isMulti])
+
+  return (
+    <components.IndicatorsContainer
+        className="text_input_indicators"
+        {...props}
+    />
+  )
 }
-
-
-const IndicatorsContainer = (props: IndicatorsContainerProps): React.ReactElement => (
-  <components.IndicatorsContainer
-      className="text_input_indicators"
-      {...props}
-  />
-)
 
 export default IndicatorsContainer

--- a/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/components/IndicatorsContainer.tsx
@@ -13,13 +13,20 @@ const IndicatorsContainer = (props: any): React.ReactElement => {
       const value = selectProps.isMulti
         ? (Array.isArray(detail) ? detail : [detail]).filter(Boolean)
         : (Array.isArray(detail) ? detail[0] : detail) ?? null
-      setValue(value, 'select-option')
+
+      const programmaticSetRef = selectProps.isProgrammaticSetRef
+      if (programmaticSetRef) programmaticSetRef.current = true
+      try {
+        setValue(value, 'select-option')
+      } finally {
+        if (programmaticSetRef) programmaticSetRef.current = false
+      }
     }
 
     const eventName = `pb-typeahead-kit-${selectProps.id}:set`
     document.addEventListener(eventName, handleSet)
     return () => document.removeEventListener(eventName, handleSet)
-  }, [setValue, selectProps?.id, selectProps?.isMulti])
+  }, [setValue, selectProps?.id, selectProps?.isMulti, selectProps?.isProgrammaticSetRef])
 
   return (
     <components.IndicatorsContainer

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.html.erb
@@ -10,6 +10,7 @@
 <%= pb_rails("typeahead", props: { id: "typeahead-pills-example1", default_options: [options.first], options: options, label: "Products", name: :foo, pills: true }) %>
 
 <%= pb_rails("button", props: {id: "clear-pills", text: "Clear All Options", variant: "secondary"}) %>
+<%= pb_rails("button", props: {id: "set-pills", text: "Restore Default Options", variant: "secondary"}) %>
 
 <!-- This section is an example of the available JavaScript event hooks -->
 <%= javascript_tag defer: "defer" do %>
@@ -27,5 +28,11 @@
 
   document.querySelector('#clear-pills').addEventListener('click', function() {
     document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example1:clear'))
+  })
+
+  document.querySelector('#set-pills').addEventListener('click', function() {
+    document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example1:set', {
+      detail: [{ label: 'Windows', value: '#FFA500' }]
+    }))
   })
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
@@ -25,7 +25,7 @@ The same rule regarding the `id` prop applies to publishing JS events. The examp
 
 `pb-typeahead-kit-typeahead-pills-example1:clear` event to clear all options.
 
-`pb-typeahead-kit-typeahead-pills-example1:set` event to set options. Pass `detail` as `[{ label, value }, ...]` (or a single object for single-select):
+`pb-typeahead-kit-typeahead-pills-example1:set` event to set options without treating it as a user click (no `result-option-select`). Pass `detail` as `[{ label, value }, ...]` (or a single object for single-select):
 
 ```js
 document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example1:set', {

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
@@ -8,6 +8,8 @@ You can also pass `default_options` which will populate the initial pill selecti
 
 `default_options: [{ label: 'Windows', value: '#FFA500' }]`
 
+When present, the kit root is stamped with `data-default-value` (JSON of those initial options) for restore-after-clear via `:set`.
+
 #### Rails: Subscribing to JS Events
 
 JavaScript events are triggered based on actions you take within the kit such as selection, removal and clearing.
@@ -22,3 +24,11 @@ This kit utilizes a default `id` prop named `react-select-input`. It is **highly
 The same rule regarding the `id` prop applies to publishing JS events. The examples below will use the unique `id` prop named `typeahead-pills-example1`:
 
 `pb-typeahead-kit-typeahead-pills-example1:clear` event to clear all options.
+
+`pb-typeahead-kit-typeahead-pills-example1:set` event to set options. Pass `detail` as `[{ label, value }, ...]` (or a single object for single-select):
+
+```js
+document.dispatchEvent(new CustomEvent('pb-typeahead-kit-typeahead-pills-example1:set', {
+  detail: [{ label: 'Windows', value: '#FFA500' }]
+}))
+```

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_with_pills.md
@@ -8,7 +8,7 @@ You can also pass `default_options` which will populate the initial pill selecti
 
 `default_options: [{ label: 'Windows', value: '#FFA500' }]`
 
-When present, the kit root is stamped with `data-default-value` (JSON of those initial options) for restore-after-clear via `:set`.
+When present, the kit root gets `data-default-value` (JSON of `{ label, value }` only) for restore-after-clear via `:set`. Extra option fields are omitted; if serialization fails, the attribute is left off so the kit still mounts.
 
 #### Rails: Subscribing to JS Events
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3104

Add typeahead :set event to restore selections after clear. 

Set up for smart reset defaults in nitro_search_playbook_filter:

- IndicatorsContainer.tsx — listens for :set and calls react-select setValue (lives here because ClearIndicator unmounts when empty)
- _typeahead.tsx — stamps data-default-value on the kit root from initial defaultValue / default_options

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.