### PR TITLE
[PLAY-3087] and [PLAY-3097] Advanced Table Rails: Column Styling Width Props and Pinned Row Bottom Prop

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
+++ b/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
@@ -62,6 +62,13 @@ export const ComponentShowLoader = async ({
     url = `/kits/${params.name}/${platform}.json`;
   }
 
+  // Forward query params (e.g. ?sort=) so Rails ERB examples can re-render
+  // with params["sort"] after the SPA migration. Without this, sort_menu demos
+  // stay static because examples are prerendered into the JSON payload.
+  if (requestUrl.search) {
+    url = `${url}${requestUrl.search}`;
+  }
+
   const response = await fetch(url);
   const data = await response.json();
   return data;

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/DocsTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import {
   Body,
   Flex,
@@ -34,6 +35,7 @@ interface DocsTabProps {
 
 export const DocsTab = ({ examples, exampleProps, sections }: DocsTabProps) => {
   const { platform } = usePlatform();
+  const location = useLocation();
   const codeLanguage: "erb" | "swift" | "tsx" =
     platform === "rails" ? "erb" : platform === "swift" ? "swift" : "tsx";
   const { darkMode } = useDarkMode();
@@ -190,7 +192,10 @@ export const DocsTab = ({ examples, exampleProps, sections }: DocsTabProps) => {
             </Tooltip>
           </Flex>
           {platform === "rails" ? (
-            <LiveExampleRails html={example.rendered ?? ""} />
+            <LiveExampleRails
+              key={`${example.example_key}${location.search}`}
+              html={example.rendered ?? ""}
+            />
           ) : (
             <LiveExample code={example.source} exampleProps={exampleProps} />
           )}

--- a/playbook-website/config/menu.yml
+++ b/playbook-website/config/menu.yml
@@ -89,7 +89,7 @@ kits:
   - name: styling
     description: "Styling per row or column: padding, color, and border."
     parent: advanced_table
-    kit_section: ["Collapsible Trail","Row Styling", "Padding Control using Row Styling", "Column Styling", "Column Styling with Multiple Headers", "Column Styling Background Color", "Column Styling Background Color (Custom)", "Column Styling Background Color with Multiple Headers","Column Styling Individual Cell Background Color", "Padding Control using Column Styling", "Column Group Border Color"]
+    kit_section: ["Collapsible Trail","Row Styling", "Padding Control using Row Styling", "Column Styling", "Column Styling Width", "Column Styling with Multiple Headers", "Column Styling Background Color", "Column Styling Background Color (Custom)", "Column Styling Background Color with Multiple Headers","Column Styling Individual Cell Background Color", "Padding Control using Column Styling", "Column Group Border Color"]
     platforms: *1
     status: stable
     icons_used: true

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/column_layout_helper.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/column_layout_helper.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Playbook
+  module PbAdvancedTable
+    # Mirrors React ColumnLayoutHelper: maps column_styling width keys to inline
+    # styles on header/body cells so columns stay stable when rows expand/collapse.
+    module ColumnLayoutHelper
+      # Converts a Playbook column width value to a CSS length string.
+      # Numbers are treated as pixels; strings are passed through (e.g. "12rem", "200px").
+      def css_length(value)
+        return nil if value.nil? || value == ""
+
+        return "#{value}px" if value.is_a?(Numeric)
+
+        value.to_s
+      end
+
+      # Reads a styling length from column_styling, accepting snake_case or camelCase keys.
+      def read_styling_length(styling, *keys)
+        return nil unless styling.is_a?(Hash)
+
+        keys.each do |key|
+          value = styling[key] || styling[key.to_s] || styling[key.to_sym]
+          return value unless value.nil?
+        end
+        nil
+      end
+
+      # Builds layout styles from a column definition that may include :column_styling.
+      def build_column_layout_styles_from_column(column)
+        return {} unless column.is_a?(Hash)
+
+        styling = column[:column_styling] || column["column_styling"] || {}
+        build_column_layout_styles(styling)
+      end
+
+      # Inline width styles for <th> / <td>. Returns a hash with :width, :min_width,
+      # and/or :max_width (CSS length strings). KitBase converts snake_case keys to
+      # kebab-case CSS properties.
+      #
+      # If only +width+ is set (no min/max), all three are locked to that value.
+      def build_column_layout_styles(styling)
+        return {} unless styling.is_a?(Hash) && styling.present?
+
+        styling_width = read_styling_length(styling, :width, "width")
+        styling_min = read_styling_length(styling, :min_width, "min_width", :minWidth, "minWidth")
+        styling_max = read_styling_length(styling, :max_width, "max_width", :maxWidth, "maxWidth")
+
+        has_width = !styling_width.nil? && styling_width != ""
+        has_min = !styling_min.nil? && styling_min != ""
+        has_max = !styling_max.nil? && styling_max != ""
+
+        width_value = has_width ? styling_width : nil
+        min_value = has_min ? styling_min : nil
+        max_value = has_max ? styling_max : nil
+
+        if has_width && !has_min && !has_max
+          min_value = styling_width
+          max_value = styling_width
+          width_value = styling_width
+        end
+
+        styles = {}
+        width_css = css_length(width_value)
+        min_css = css_length(min_value)
+        max_css = css_length(max_value)
+
+        styles[:width] = width_css if width_css
+        styles[:min_width] = min_css if min_css
+        styles[:max_width] = max_css if max_css
+
+        styles
+      end
+    end
+  end
+end

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -7,6 +7,6 @@ The `columnStyling` prop is an optional item that can be used within `columnDefi
 
 Fixed width: pass `width` only (or TanStack `size` only) and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 
-See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/react#column-styling-width) for the full guide (Playbook ↔ TanStack mapping, floor-only vs bands, and when to use one vs three values).
+See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/styling/react#column-styling-width) for the full guide (Playbook ↔ TanStack mapping, floor-only vs bands, and when to use one vs three values).
 
 `columnStyling` can be used within the columnDefinition of all the columns or some of them, as shown. Each column has its own individual control in this way. 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling.md
@@ -1,12 +1,9 @@
 The `columnStyling` prop is an optional item that can be used within `columnDefinitions` as shown in the code snippet below. It is an object that has several optional key/value pairs, this doc example highlights the following:
 
-1) `headerAlignment`: This will allow you to control alignment of header content which is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
-2) `cellAlignment`: This will allow you to control alignment of content within all cells in the given column. This is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
-3) `fontColor`: This will allow you to control the font color for a given column.
-
-4) Column width: optional keys on `columnStyling` are `minWidth`, `width`, and `maxWidth` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `minWidth` and bands).
+1. `headerAlignment`: This will allow you to control alignment of header content which is set to right aligned by default. you can set this to `left`, `right` or `center`.
+2. `cellAlignment`: This will allow you to control alignment of content within all cells in the given column. This is set to right aligned by default. you can set this to `left`, `right` or `center`.
+3. `fontColor`: This will allow you to control the font color for a given column.
+4. Column width: optional keys on `columnStyling` are `minWidth`, `width`, and `maxWidth` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `minWidth` and bands).
 
 Fixed width: pass `width` only (or TanStack `size` only) and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.html.erb
@@ -3,6 +3,7 @@
       accessor: "year",
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
+      column_styling: { width: 124 },
     },
     {
       accessor: "newEnrollments",

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
@@ -7,6 +7,6 @@ The `column_styling` prop is an optional item that can be used within `column_de
 
 Fixed width: pass `width` only and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
 
-See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/rails#column-styling-width) for the full guide (floor-only vs bands, and when to use one vs three values).
+See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/styling/rails#column-styling-width) for the full guide (floor-only vs bands, and when to use one vs three values).
 
 `column_styling` can be used within the column_definition of all the columns or some of them, as shown. Each column has its own individual control in this way.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
@@ -1,11 +1,8 @@
 The `column_styling` prop is an optional item that can be used within `column_definitions` as shown in the code snippet below.  It is an object that has several optional key/value pairs, this doc example highlights the following:
 
 1) `header_alignment`: This will allow you to control alignment of header content which is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
 2) `cell_alignment`: This will allow you to control alignment of content within all cells in the given column. This is set to right aligned by default. you can set this to `left`, `right` or `center`.
-
 3) `font_color`: This will allow you to control the font color for a given column.
-
 4) Column width: optional keys on `column_styling` are `min_width`, `width`, and `max_width` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `min_width` and bands).
 
 Fixed width: pass `width` only and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_rails.md
@@ -6,4 +6,10 @@ The `column_styling` prop is an optional item that can be used within `column_de
 
 3) `font_color`: This will allow you to control the font color for a given column.
 
-`column_styling` can be used within the column_definition of all the columns or some of them, as shown. Each column has its own individual control in this way. 
+4) Column width: optional keys on `column_styling` are `min_width`, `width`, and `max_width` (numbers = pixels; CSS strings allowed). This example sets `width` on Year for a fixed hierarchy column (see the width doc for `min_width` and bands).
+
+Fixed width: pass `width` only and Playbook sets min and max to the same value automatically — you do not need all three for an exact width.
+
+See [Column Styling: Width](https://playbook.powerapp.cloud/kits/advanced_table/rails#column-styling-width) for the full guide (floor-only vs bands, and when to use one vs three values).
+
+`column_styling` can be used within the column_definition of all the columns or some of them, as shown. Each column has its own individual control in this way.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width.md
@@ -1,6 +1,6 @@
 AdvancedTable column width is controlled in two equivalent places on each leaf `columnDefinitions` entry. Playbook maps them to inline styles on header and body cells (and forwards numeric values into TanStack Table’s column model).
 
-1) Playbook `columnStyling` and TanStack `ColumnDef` use the same three ideas:
+**1)** Playbook `columnStyling` and TanStack `ColumnDef` use the same three ideas:
 
 - Preferred / target width: `columnStyling` `width` maps to TanStack `size` on the same column object.
 - Minimum width (floor): `columnStyling` `minWidth` maps to TanStack `minSize`.
@@ -10,7 +10,7 @@ Numbers are pixels. You can also pass CSS length strings on `columnStyling` (e.g
 
 If both APIs set the same axis, `columnStyling` wins for that axis when Playbook builds cell styles.
 
-2) Fixed width: set `width` only
+**2)** Fixed width: set `width` only
 
 If you pass only `width` (or only `size`) and do not set `minWidth` / `maxWidth` (or `minSize` / `maxSize`), Playbook treats that as a fixed column: it sets all three to the same value under the hood so you do not have to repeat yourself.
 
@@ -26,7 +26,7 @@ size: 200
 
 Use this when the column should stay one width (e.g. a hierarchy column with expand controls).
 
-3) Floor only: `minWidth` / `minSize`
+**3)** Floor only: `minWidth` / `minSize`
 
 Set only a minimum when the column may grow with the table or content but must not shrink below a baseline (common fix for horizontal “jump” when rows expand):
 
@@ -34,7 +34,7 @@ Set only a minimum when the column may grow with the table or content but must n
 columnStyling: { minWidth: 160 }
 ```
 
-4) Flexible band: min + preferred + max
+**4)** Flexible band: min + preferred + max
 
 Set two or three values when you want a range. CSS uses preferred `width` clamped between `minWidth` and `maxWidth`:
 
@@ -46,7 +46,7 @@ Example from the table below (Attendance): `minWidth: 108`, `width: 124`, `maxWi
 
 You only need all three when you want that band. If min and max are omitted, `width` alone is enough for a fixed column.
 
-5) TanStack band without `columnStyling`
+**5)** TanStack band without `columnStyling`
 
 The Meetings column uses only TanStack fields:
 
@@ -56,7 +56,7 @@ The Meetings column uses only TanStack fields:
 
 Playbook applies the same min / preferred / max idea to cell styles. Setting only `size: 200` would lock all three to 200, same as `width: 200` in `columnStyling`.
 
-6) What the example table shows
+**6)** What the example table shows
 
 - Year (fixed): `columnStyling: { width: 128 }` — locked to 128px.
 - Enrollments (floor): `columnStyling: { minWidth: 160 }` — at least 160px; can grow.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.html.erb
@@ -1,0 +1,41 @@
+<% column_definitions = [
+    {
+      accessor: "year",
+      label: "Year (fixed)",
+      cellAccessors: ["quarter", "month", "day"],
+      # width alone locks min + max to the same value (128px).
+      column_styling: { width: 128 },
+    },
+    {
+      accessor: "newEnrollments",
+      label: "Enrollments (floor)",
+      column_styling: { min_width: 160 },
+    },
+    {
+      accessor: "scheduledMeetings",
+      label: "Meetings (preferred)",
+      column_styling: { width: 200, min_width: 160, max_width: 240 },
+    },
+    {
+      accessor: "attendanceRate",
+      label: "Attendance (min / pref / max)",
+      column_styling: { min_width: 108, width: 124, max_width: 168 },
+    },
+    {
+      accessor: "completedClasses",
+      label: "Completed",
+    },
+    {
+      accessor: "classCompletionRate",
+      label: "Completion %",
+    },
+    {
+      accessor: "graduatedStudents",
+      label: "Graduated",
+    },
+] %>
+
+<%= pb_rails("advanced_table", props: { id: "column-styling-width", table_data: @table_data, column_definitions: column_definitions }) do %>
+  <%= pb_rails("advanced_table/table_header", props: { table_id: "column-styling-width", column_definitions: column_definitions }) %>
+  <%= pb_rails("advanced_table/table_body", props: { table_id: "column-styling-width", table_data: @table_data, column_definitions: column_definitions }) %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
@@ -1,0 +1,49 @@
+AdvancedTable column width is controlled on each leaf `column_definitions` entry via `column_styling`. Playbook maps these keys to inline styles on header and body cells.
+
+1) `column_styling` width keys:
+
+- Preferred / target width: `width`
+- Minimum width (floor): `min_width`
+- Maximum width (ceiling): `max_width`
+
+Numbers are pixels. You can also pass CSS length strings (e.g. `"12rem"`, `"200px"`).
+
+2) Fixed width: set `width` only
+
+If you pass only `width` and do not set `min_width` / `max_width`, Playbook treats that as a fixed column: it sets all three to the same value under the hood so you do not have to repeat yourself.
+
+```ruby
+column_styling: { width: 128 }
+# Applied as width, min-width, and max-width: 128px
+```
+
+Use this when the column should stay one width (e.g. a hierarchy column with expand controls).
+
+3) Floor only: `min_width`
+
+Set only a minimum when the column may grow with the table or content but must not shrink below a baseline (common fix for horizontal “jump” when rows expand):
+
+```ruby
+column_styling: { min_width: 160 }
+```
+
+4) Flexible band: min + preferred + max
+
+Set two or three values when you want a range. CSS uses preferred `width` clamped between `min_width` and `max_width`:
+
+- `min_width`: won’t shrink below this.
+- `width`: preferred size when space allows.
+- `max_width`: won’t grow above this.
+
+Example from the table below (Attendance): `min_width: 108`, `width: 124`, `max_width: 168` → preferred 124px, allowed between 108 and 168.
+
+You only need all three when you want that band. If min and max are omitted, `width` alone is enough for a fixed column.
+
+5) What the example table shows
+
+- Year (fixed): `column_styling: { width: 128 }` — locked to 128px.
+- Enrollments (floor): `column_styling: { min_width: 160 }` — at least 160px; can grow.
+- Meetings (preferred): `width` / `min_width` / `max_width` — preferred 200px, between 160–240.
+- Attendance (min / pref / max): all three — preferred 124px, between 108–168.
+
+Grouped columns: put width options on leaf definitions (columns with an `accessor`), not on parent group headers.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_column_styling_width_rails.md
@@ -1,6 +1,6 @@
 AdvancedTable column width is controlled on each leaf `column_definitions` entry via `column_styling`. Playbook maps these keys to inline styles on header and body cells.
 
-1) `column_styling` width keys:
+**1)** `column_styling` width keys:
 
 - Preferred / target width: `width`
 - Minimum width (floor): `min_width`
@@ -8,7 +8,7 @@ AdvancedTable column width is controlled on each leaf `column_definitions` entry
 
 Numbers are pixels. You can also pass CSS length strings (e.g. `"12rem"`, `"200px"`).
 
-2) Fixed width: set `width` only
+**2)** Fixed width: set `width` only
 
 If you pass only `width` and do not set `min_width` / `max_width`, Playbook treats that as a fixed column: it sets all three to the same value under the hood so you do not have to repeat yourself.
 
@@ -19,7 +19,7 @@ column_styling: { width: 128 }
 
 Use this when the column should stay one width (e.g. a hierarchy column with expand controls).
 
-3) Floor only: `min_width`
+**3)** Floor only: `min_width`
 
 Set only a minimum when the column may grow with the table or content but must not shrink below a baseline (common fix for horizontal “jump” when rows expand):
 
@@ -27,7 +27,7 @@ Set only a minimum when the column may grow with the table or content but must n
 column_styling: { min_width: 160 }
 ```
 
-4) Flexible band: min + preferred + max
+**4)** Flexible band: min + preferred + max
 
 Set two or three values when you want a range. CSS uses preferred `width` clamped between `min_width` and `max_width`:
 
@@ -39,7 +39,7 @@ Example from the table below (Attendance): `min_width: 108`, `width: 124`, `max_
 
 You only need all three when you want that band. If min and max are omitted, `width` alone is enough for a fixed column.
 
-5) What the example table shows
+**5)** What the example table shows
 
 - Year (fixed): `column_styling: { width: 128 }` — locked to 128px.
 - Enrollments (floor): `column_styling: { min_width: 160 }` — at least 160px; can grow.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both_rails.html.erb
@@ -19,8 +19,8 @@
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
       sort_menu: [
-        { item: "Year", link: "?sort=year_asc#pinned_rows_top_table", active: params["sort"] == "year_asc", direction: "asc" },
-        { item: "Year", link: "?sort=year_desc#pinned_rows_top_table", active: params["sort"] == "year_desc", direction: "desc" }
+        { item: "Year", link: "?sort=year_asc#pinned_rows_both_table", active: params["sort"] == "year_asc", direction: "asc" },
+        { item: "Year", link: "?sort=year_desc#pinned_rows_both_table", active: params["sort"] == "year_desc", direction: "desc" }
       ],
     },
     {
@@ -49,9 +49,9 @@
     }
 ] %>
 
-<% pinned_rows = { top: ["8"] } %>
+<% pinned_rows = { top: ["8"], bottom: ["1"] } %>
 
-<%= pb_rails("advanced_table", props: { id: "pinned_rows_top_table", table_data: @table_data_with_id, column_definitions: column_definitions, max_height: "xs", pinned_rows: pinned_rows, responsive: "none", table_props: { sticky: true }}) do %>
-  <%= pb_rails("advanced_table/table_header", props: { table_id: "pinned_rows_top_table", column_definitions: column_definitions }) %>
-  <%= pb_rails("advanced_table/table_body", props: { table_id: "pinned_rows_top_table", table_data: @table_data_with_id, column_definitions: column_definitions, pinned_rows: pinned_rows }) %>
+<%= pb_rails("advanced_table", props: { id: "pinned_rows_both_table", table_data: @table_data_with_id, column_definitions: column_definitions, max_height: "xs", pinned_rows: pinned_rows, responsive: "none", table_props: { sticky: true }}) do %>
+  <%= pb_rails("advanced_table/table_header", props: { table_id: "pinned_rows_both_table", column_definitions: column_definitions }) %>
+  <%= pb_rails("advanced_table/table_body", props: { table_id: "pinned_rows_both_table", table_data: @table_data_with_id, column_definitions: column_definitions, pinned_rows: pinned_rows }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_both_rails.md
@@ -1,0 +1,1 @@
+This code snippet demonstrates `pinned_rows` taking a hash with an array of row ids to both the `top` and `bottom` keys.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom_rails.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom_rails.html.erb
@@ -19,8 +19,8 @@
       label: "Year",
       cellAccessors: ["quarter", "month", "day"],
       sort_menu: [
-        { item: "Year", link: "?sort=year_asc#pinned_rows_top_table", active: params["sort"] == "year_asc", direction: "asc" },
-        { item: "Year", link: "?sort=year_desc#pinned_rows_top_table", active: params["sort"] == "year_desc", direction: "desc" }
+        { item: "Year", link: "?sort=year_asc#pinned_rows_bottom_table", active: params["sort"] == "year_asc", direction: "asc" },
+        { item: "Year", link: "?sort=year_desc#pinned_rows_bottom_table", active: params["sort"] == "year_desc", direction: "desc" }
       ],
     },
     {
@@ -49,9 +49,9 @@
     }
 ] %>
 
-<% pinned_rows = { top: ["8"] } %>
+<% pinned_rows = { bottom: ["8"] } %>
 
-<%= pb_rails("advanced_table", props: { id: "pinned_rows_top_table", table_data: @table_data_with_id, column_definitions: column_definitions, max_height: "xs", pinned_rows: pinned_rows, responsive: "none", table_props: { sticky: true }}) do %>
-  <%= pb_rails("advanced_table/table_header", props: { table_id: "pinned_rows_top_table", column_definitions: column_definitions }) %>
-  <%= pb_rails("advanced_table/table_body", props: { table_id: "pinned_rows_top_table", table_data: @table_data_with_id, column_definitions: column_definitions, pinned_rows: pinned_rows }) %>
+<%= pb_rails("advanced_table", props: { id: "pinned_rows_bottom_table", table_data: @table_data_with_id, column_definitions: column_definitions, max_height: "xs", pinned_rows: pinned_rows, responsive: "none", table_props: { sticky: true }}) do %>
+  <%= pb_rails("advanced_table/table_header", props: { table_id: "pinned_rows_bottom_table", column_definitions: column_definitions }) %>
+  <%= pb_rails("advanced_table/table_body", props: { table_id: "pinned_rows_bottom_table", table_data: @table_data_with_id, column_definitions: column_definitions, pinned_rows: pinned_rows }) %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_bottom_rails.md
@@ -1,0 +1,1 @@
+This code snippet demonstrates `pinned_rows` taking a hash with an array of row ids to the `bottom` key.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_advanced_table_pinned_rows_rails.md
@@ -1,7 +1,7 @@
-Use the `pinned_rows` prop to pin specific rows to the top of an Advanced Table. Pinned rows will remain at the top when scrolling through table data and will not change position if sorting is used.
+Use the `pinned_rows` prop to pin specific rows to the top or bottom of an Advanced Table. Pinned rows will remain at the top or bottom when scrolling through table data and will not change position if sorting is used.
 
 **NOTE:**
 - Sticky header required: Pinned rows must be used with `sticky: true` via `table_props` (works with both responsive and non-responsive tables)
 - Row ids required: Each object within the `table_data` array must contain a unique `id` in order to attach an id to all Rows for this to function.
-- `pinned_rows` takes a hash with a `top` key containing an array of row ids, as shown in the code snippet below.
-- For expandable rows, use the parent id in `pinned_rows[:top]`; all its children will automatically be pinned with it. If a child id is passed without the parent being pinned, nothing will be pinned.
+- `pinned_rows` takes a hash with a `top` and/or `bottom` key containing an array of row ids, as shown in the code snippet below.
+- For expandable rows, use the parent id in `pinned_rows[:top]` or `pinned_rows[:bottom]`; all its children will automatically be pinned with it. If a child id is passed without the parent being pinned, nothing will be pinned.

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -30,6 +30,7 @@ examples:
   - advanced_table_row_styling: Row Styling
   - advanced_table_padding_control_per_row_rails: Padding Control using Row Styling
   - advanced_table_column_styling_rails: Column Styling
+  - advanced_table_column_styling_width_rails: Column Styling Width
   - advanced_table_column_styling_column_headers_rails: Column Styling with Multiple Headers
   - advanced_table_padding_control_rails: Padding Control using Column Styling
   - advanced_table_background_control_rails: Column Styling Background Color

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/example.yml
@@ -9,7 +9,9 @@ examples:
   - advanced_table_table_props: Table Props
   - advanced_table_sticky_header_rails: Sticky Header
   - advanced_table_table_props_sticky_header: Sticky Header for Responsive Table
-  - advanced_table_pinned_rows_rails: Pinned Rows
+  - advanced_table_pinned_rows_rails: Pinned Rows (Top)
+  - advanced_table_pinned_rows_bottom_rails: Pinned Rows (Bottom)
+  - advanced_table_pinned_rows_both_rails: Pinned Rows (Both)
   - advanced_table_beta_sort: Enable Sorting
   - advanced_table_responsive: Responsive Tables
   - advanced_table_custom_cell_rails: Custom Components for Cells

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/index.js
@@ -356,23 +356,40 @@ export default class PbAdvancedTable extends PbEnhancedElement {
   }
 
   /**
-   * Recompute sticky top for visible pinned rows so collapsed rows don't leave a gap.
+   * Recompute sticky top/bottom for visible pinned rows so collapsed rows don't leave a gap.
    * Call after expand/collapse and on load.
    */
   static updatePinnedRowsStickyTops(advancedTableWrapper) {
-    const pinnedTbody = advancedTableWrapper?.querySelector("tbody.pinned-rows-tbody");
-    if (!pinnedTbody) return;
-
-    const pinnedRows = Array.from(pinnedTbody.querySelectorAll("tr.pinned-row"));
-    const visibleRows = pinnedRows.filter(
-      (tr) => tr.style.display !== "none" && tr.offsetParent !== null
-    );
-
     const headerOffset =
       "calc(var(--advanced-table-header-height, 44px) + var(--advanced-table-action-bar-height, 0px))";
-    visibleRows.forEach((tr, index) => {
-      tr.style.top = `calc(${headerOffset} + 2.5em * ${index})`;
-    });
+
+    const pinnedTopTbody = advancedTableWrapper?.querySelector("tbody.pinned-rows-tbody");
+    if (pinnedTopTbody) {
+      const pinnedRows = Array.from(pinnedTopTbody.querySelectorAll("tr.pinned-row"));
+      const visibleRows = pinnedRows.filter(
+        (tr) => tr.style.display !== "none" && tr.offsetParent !== null
+      );
+
+      visibleRows.forEach((tr, index) => {
+        tr.style.top = `calc(${headerOffset} + 2.5em * ${index})`;
+        tr.style.bottom = "";
+      });
+    }
+
+    const pinnedBottomTbody = advancedTableWrapper?.querySelector(
+      "tbody.pinned-rows-tbody-bottom"
+    );
+    if (pinnedBottomTbody) {
+      const pinnedRows = Array.from(pinnedBottomTbody.querySelectorAll("tr.pinned-row"));
+      const visibleRows = pinnedRows.filter(
+        (tr) => tr.style.display !== "none" && tr.offsetParent !== null
+      );
+
+      visibleRows.forEach((tr, index) => {
+        tr.style.bottom = `calc(2.5em * ${visibleRows.length - 1 - index})`;
+        tr.style.top = "";
+      });
+    }
   }
 
   hideCloseIcon() {

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_body.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_body.html.erb
@@ -1,16 +1,28 @@
 <% table_data = object.table_data || [] %>
 <% if object.has_pinned_rows? %>
-  <%= pb_content_tag(:tbody, class: "pinned-rows-tbody") do %>
-    <% next_index = 0 %>
-    <% object.pinned_root_rows.each do |root_info| %>
-      <% row_output, next_index = object.render_row_and_children(root_info[:row], object.column_definitions, root_info[:depth], root_info[:depth] > 0, root_info[:ancestor_ids] || [], root_info[:ancestor_ids]&.first, immediate_parent_row_id: object.row_id_for(root_info[:parent_row]), is_pinned_row: true, pinned_index: next_index, initial_table_data_attributes: root_info[:depth].to_i > 0 ? object.pinned_root_initial_data_attributes(root_info) : nil) %>
-      <%= row_output %>
+  <% if object.has_pinned_top_rows? %>
+    <%= pb_content_tag(:tbody, class: "pinned-rows-tbody") do %>
+      <% next_index = 0 %>
+      <% object.pinned_top_root_rows.each do |root_info| %>
+        <% row_output, next_index = object.render_row_and_children(root_info[:row], object.column_definitions, root_info[:depth], root_info[:depth] > 0, root_info[:ancestor_ids] || [], root_info[:ancestor_ids]&.first, immediate_parent_row_id: object.row_id_for(root_info[:parent_row]), is_pinned_row: true, pinned_index: next_index, pinned_position: "top", initial_table_data_attributes: root_info[:depth].to_i > 0 ? object.pinned_root_initial_data_attributes(root_info) : nil) %>
+        <%= row_output %>
+      <% end %>
     <% end %>
   <% end %>
   <%= pb_content_tag(:tbody) do %>
     <% table_data.each do |row| %>
       <% result = object.render_row_and_children(row, object.column_definitions, 0, false, skip_pinned_ids: object.pinned_ids_set) %>
       <%= result.is_a?(Array) ? result[0] : result %>
+    <% end %>
+  <% end %>
+  <% if object.has_pinned_bottom_rows? %>
+    <%= pb_content_tag(:tbody, class: "pinned-rows-tbody-bottom") do %>
+      <% next_index = 0 %>
+      <% bottom_total = object.pinned_bottom_row_count %>
+      <% object.pinned_bottom_root_rows.each do |root_info| %>
+        <% row_output, next_index = object.render_row_and_children(root_info[:row], object.column_definitions, root_info[:depth], root_info[:depth] > 0, root_info[:ancestor_ids] || [], root_info[:ancestor_ids]&.first, immediate_parent_row_id: object.row_id_for(root_info[:parent_row]), is_pinned_row: true, pinned_index: next_index, pinned_position: "bottom", pinned_bottom_total: bottom_total, initial_table_data_attributes: root_info[:depth].to_i > 0 ? object.pinned_root_initial_data_attributes(root_info) : nil) %>
+        <%= row_output %>
+      <% end %>
     <% end %>
   <% end %>
 <% else %>

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_body.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_body.rb
@@ -46,7 +46,7 @@ module Playbook
         end.compact
       end
 
-      def render_row_and_children(row, column_definitions, current_depth, first_parent_child, ancestor_ids = [], top_parent_id = nil, additional_classes: "", table_data_attributes: {}, immediate_parent_row_id: nil, is_pinned_row: false, pinned_index: nil, skip_pinned_ids: nil, initial_table_data_attributes: nil)
+      def render_row_and_children(row, column_definitions, current_depth, first_parent_child, ancestor_ids = [], top_parent_id = nil, additional_classes: "", table_data_attributes: {}, immediate_parent_row_id: nil, is_pinned_row: false, pinned_index: nil, skip_pinned_ids: nil, initial_table_data_attributes: nil, pinned_position: "top", pinned_bottom_total: nil)
         if skip_pinned_ids && row_id_for(row) && skip_pinned_ids.include?(row_id_for(row).to_s)
           return is_pinned_row ? [ActiveSupport::SafeBuffer.new, pinned_index] : ActiveSupport::SafeBuffer.new
         end
@@ -71,10 +71,11 @@ module Playbook
         # Subrow header if applicable
         if is_first_child_of_subrow && enable_toggle_expansion == "all"
           subrow_props = { row: row, column_definitions: leaf_columns, depth: current_depth, subrow_header: subrow_headers_arr[current_depth - 1], collapsible_trail: collapsible_trail, classname: "toggle-content", responsive: responsive, subrow_data_attributes: subrow_data_attributes, last_row: last_row, immediate_parent_row_id: immediate_parent_row_id }
-          if is_pinned_row && next_pinned_index
+          if is_pinned_row && !next_pinned_index.nil?
             subrow_props[:is_pinned_row] = true
+            subrow_props[:pinned_position] = pinned_position.to_s
             subrow_props[:pinned_index] = next_pinned_index
-            subrow_props[:html_options] = { style: build_pinned_row_style(next_pinned_index, background: "var(--pb_table_sticky_bg, #f5f5f5)") }
+            subrow_props[:html_options] = { style: build_pinned_row_style(next_pinned_index, background: "var(--pb_table_sticky_bg, #f5f5f5)", position: pinned_position, bottom_total: pinned_bottom_total) }
             next_pinned_index += 1
           end
           output << pb_rails("advanced_table/table_subrow_header", props: subrow_props)
@@ -92,11 +93,12 @@ module Playbook
 
         # Additional class and data attributes needed for toggle logic
         row_props = { table_id: table_id, row: row, column_definitions: leaf_columns, depth: current_depth, collapsible_trail: collapsible_trail, classname: additional_classes, table_data_attributes: current_data_attributes, responsive: responsive, loading: loading, selectable_rows: selectable_rows, row_id: row[:id], enable_toggle_expansion: enable_toggle_expansion, row_styling: row_styling, last_row: last_row, immediate_parent_row_id: immediate_parent_row_id, inline_row_loading: inline_row_loading, full_width_cell: full_width_cell }
-        if is_pinned_row && next_pinned_index
+        if is_pinned_row && !next_pinned_index.nil?
           row_props[:is_pinned_row] = true
+          row_props[:pinned_position] = pinned_position.to_s
           row_props[:pinned_index] = next_pinned_index
           row_bg = (row_styling || []).find { |s| s[:row_id].to_s == row_id_for(row).to_s }&.[](:background_color) || "white"
-          row_props[:html_options] = { style: build_pinned_row_style(next_pinned_index, background: row_bg) }
+          row_props[:html_options] = { style: build_pinned_row_style(next_pinned_index, background: row_bg, position: pinned_position, bottom_total: pinned_bottom_total) }
           next_pinned_index += 1
         end
         output << pb_rails("advanced_table/table_row", props: row_props)
@@ -134,6 +136,8 @@ module Playbook
             child_opts = { additional_classes: "toggle-content", table_data_attributes: child_data_attributes, immediate_parent_row_id: row[:id] }
             child_opts[:is_pinned_row] = is_pinned_row
             child_opts[:pinned_index] = next_pinned_index if is_pinned_row
+            child_opts[:pinned_position] = pinned_position if is_pinned_row
+            child_opts[:pinned_bottom_total] = pinned_bottom_total if is_pinned_row
             child_opts[:skip_pinned_ids] = skip_pinned_ids if skip_pinned_ids
 
             child_output, next_pinned_index = render_row_and_children(child_row, column_definitions, current_depth + 1, is_first_child, new_ancestor_ids, top_parent_id, **child_opts)
@@ -187,17 +191,16 @@ module Playbook
       end
 
       def pinned_top_ids
-        return [] if pinned_rows.nil? || !pinned_rows.respond_to?(:[])
+        pinned_ids_for(:top)
+      end
 
-        top = pinned_rows["top"] || pinned_rows[:top]
-        Array(top).map(&:to_s)
+      def pinned_bottom_ids
+        pinned_ids_for(:bottom)
       end
 
       def pinned_ids_set
-        return Set.new if pinned_top_ids.blank?
-
         set = Set.new
-        pinned_root_rows.each do |root|
+        (pinned_top_root_rows + pinned_bottom_root_rows).each do |root|
           collect_row_and_descendant_ids(root[:row], set)
         end
         set
@@ -207,6 +210,10 @@ module Playbook
         id = row_id_for(row)
         set.add(id.to_s) if id
         row_children_for(row)&.each { |child| collect_row_and_descendant_ids(child, set) }
+      end
+
+      def count_row_and_descendants(row)
+        1 + Array(row_children_for(row)).sum { |child| count_row_and_descendants(child) }
       end
 
       def find_row_by_id(data, id, depth: 0, ancestor_ids: [], parent_row: nil)
@@ -220,21 +227,55 @@ module Playbook
         nil
       end
 
-      def pinned_root_rows
+      def pinned_top_root_rows
         return [] if pinned_top_ids.blank?
 
         pinned_top_ids.filter_map { |id| find_row_by_id(table_data, id) }
       end
 
+      # Alias kept for existing call sites / specs
+      alias pinned_root_rows pinned_top_root_rows
+
+      def pinned_bottom_root_rows
+        return [] if pinned_bottom_ids.blank?
+
+        pinned_bottom_ids.filter_map { |id| find_row_by_id(table_data, id) }
+      end
+
+      def pinned_bottom_row_count
+        pinned_bottom_root_rows.sum { |root| count_row_and_descendants(root[:row]) }
+      end
+
+      def has_pinned_top_rows?
+        pinned_top_root_rows.any?
+      end
+
+      def has_pinned_bottom_rows?
+        pinned_bottom_root_rows.any?
+      end
+
       def has_pinned_rows?
-        pinned_root_rows.any?
+        has_pinned_top_rows? || has_pinned_bottom_rows?
       end
 
       # Build inline style for sticky pinned row (matches React). Pass via html_options so the tr gets the attribute.
-      def build_pinned_row_style(pinned_index, background: "white")
-        header_offset = "calc(var(--advanced-table-header-height, 44px) + var(--advanced-table-action-bar-height, 0px))"
-        row_offset = "calc(2.5em * #{pinned_index})"
-        "position: sticky; top: calc(#{header_offset} + #{row_offset}); z-index: 3; background: #{background};"
+      def build_pinned_row_style(pinned_index, background: "white", position: "top", bottom_total: nil)
+        if position.to_s == "bottom"
+          offset_index = bottom_total ? [bottom_total - 1 - pinned_index, 0].max : pinned_index
+          "position: sticky; bottom: calc(2.5em * #{offset_index}); z-index: 3; background: #{background};"
+        else
+          header_offset = "calc(var(--advanced-table-header-height, 44px) + var(--advanced-table-action-bar-height, 0px))"
+          row_offset = "calc(2.5em * #{pinned_index})"
+          "position: sticky; top: calc(#{header_offset} + #{row_offset}); z-index: 3; background: #{background};"
+        end
+      end
+
+      def pinned_ids_for(position)
+        return [] if pinned_rows.nil? || !pinned_rows.respond_to?(:[])
+
+        key = position.to_s
+        ids = pinned_rows[key] || pinned_rows[key.to_sym]
+        Array(ids).map(&:to_s)
       end
 
       def pinned_root_initial_data_attributes(root_info)

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_body.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_body.rb
@@ -212,10 +212,6 @@ module Playbook
         row_children_for(row)&.each { |child| collect_row_and_descendant_ids(child, set) }
       end
 
-      def count_row_and_descendants(row)
-        1 + Array(row_children_for(row)).sum { |child| count_row_and_descendants(child) }
-      end
-
       def find_row_by_id(data, id, depth: 0, ancestor_ids: [], parent_row: nil)
         id_str = id.to_s
         Array(data).each do |row|
@@ -243,7 +239,7 @@ module Playbook
       end
 
       def pinned_bottom_row_count
-        pinned_bottom_root_rows.sum { |root| count_row_and_descendants(root[:row]) }
+        pinned_bottom_root_rows.size
       end
 
       def has_pinned_top_rows?

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_header.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "column_layout_helper"
+
 module Playbook
   module PbAdvancedTable
     class TableHeader < Playbook::KitBase
+      include Playbook::PbAdvancedTable::ColumnLayoutHelper
       prop :table_id, type: Playbook::Props::String,
                       default: ""
       prop :column_definitions, type: Playbook::Props::Array,
@@ -164,6 +167,9 @@ module Playbook
       def header_component_info(cell, cell_index, row_index)
         header_id = cell[:accessor].present? ? cell[:accessor] : "header_#{row_index}_#{cell_index}"
         classname = [th_classname(is_first_column: cell_index.zero?), ("last-header-cell" if cell[:is_last_in_group] && cell_index != 0)].compact.join(" ")
+        layout_styles = header_layout_styles(cell)
+        style_hash = layout_styles.dup
+        style_hash[:color] = cell[:header_font_color] if cell[:header_font_color].present?
 
         if has_custom_header_background_color?(cell)
           component_name = "background"
@@ -175,9 +181,8 @@ module Playbook
           component_props[:html_options] = {
             id: header_id,
             colspan: cell[:colspan],
-            style: { color: cell[:header_font_color] },
+            style: style_hash,
           }
-          component_props[:html_options][:style].delete(:color) unless cell[:header_font_color].present?
         else
           component_name = "table/table_header"
           component_props = {
@@ -186,7 +191,7 @@ module Playbook
             classname: classname,
             sort_menu: cell[:accessor] ? cell[:sort_menu] : nil,
           }
-          component_props[:html_options] = { style: { color: cell[:header_font_color] } } if cell[:header_font_color].present?
+          component_props[:html_options] = { style: style_hash } if style_hash.present?
         end
 
         { name: component_name, props: component_props }
@@ -206,6 +211,13 @@ module Playbook
       end
 
     private
+
+      def header_layout_styles(cell)
+        original_def = find_original_column_def_for_cell(cell)
+        return {} unless original_def
+
+        build_column_layout_styles_from_column(original_def)
+      end
 
       # Find the original column definition for a cell
       def find_original_column_def_for_cell(cell)

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
@@ -39,6 +39,9 @@ module Playbook
                              default: false
       prop :is_pinned_row, type: Playbook::Props::Boolean,
                            default: false
+      prop :pinned_position, type: Playbook::Props::Enum,
+                             values: %w[top bottom],
+                             default: "top"
       prop :pinned_index, type: Playbook::Props::Numeric,
                           default: nil
       prop :html_options, type: Playbook::Props::HashProp,
@@ -53,6 +56,7 @@ module Playbook
       def classname
         classes = ["pb_table_tr", "pb-bg-row-white", subrow_depth_classname]
         classes << "pinned-row" if is_pinned_row
+        classes << "pinned-row-bottom" if is_pinned_row && pinned_position.to_s == "bottom"
         classes.reject!(&:blank?)
         generate_classname(*classes, separator: " ")
       end

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_row.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "column_layout_helper"
+
 module Playbook
   module PbAdvancedTable
     class TableRow < Playbook::KitBase
+      include Playbook::PbAdvancedTable::ColumnLayoutHelper
       prop :table_id, type: Playbook::Props::String,
                       default: ""
       prop :column_definitions, type: Playbook::Props::Array,
@@ -117,6 +120,7 @@ module Playbook
         column_font_color = cell_font_color(column)
         effective_font_color = column_font_color || font_color
         effective_font_weight = font_weight_value(font_weight)
+        layout_styles = cell_layout_styles(column)
 
         if has_custom_background_color?(column)
           custom_bg_color = cell_background_color(column)
@@ -126,13 +130,13 @@ module Playbook
             tag: "td",
             classname: td_classname(column, index),
           }
-          style_hash = {}
+          style_hash = layout_styles.dup
           style_hash[:color] = effective_font_color if effective_font_color.present?
           style_hash[:"font-weight"] = effective_font_weight if effective_font_weight.present?
           component_props[:html_options] = { style: style_hash } if style_hash.present?
         else
           component_name = "table/table_cell"
-          style_hash = { "background-color": bg_color }
+          style_hash = layout_styles.merge("background-color": bg_color)
           style_hash[:color] = effective_font_color if effective_font_color.present?
           style_hash[:"font-weight"] = effective_font_weight if effective_font_weight.present?
           component_props = {
@@ -237,6 +241,15 @@ module Playbook
       end
 
     private
+
+      def cell_layout_styles(column)
+        return {} unless column[:accessor].present?
+
+        orig_def = find_column_def_by_accessor(column_definitions, column[:accessor])
+        return {} unless orig_def
+
+        build_column_layout_styles_from_column(orig_def)
+      end
 
       def custom_renderer_value(column, index)
         return nil unless column[:accessor].present?

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/table_subrow_header.rb
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/table_subrow_header.rb
@@ -21,6 +21,9 @@ module Playbook
                         default: "scroll"
       prop :is_pinned_row, type: Playbook::Props::Boolean,
                            default: false
+      prop :pinned_position, type: Playbook::Props::Enum,
+                             values: %w[top bottom],
+                             default: "top"
       prop :pinned_index, type: Playbook::Props::Numeric,
                           default: nil
       prop :html_options, type: Playbook::Props::HashProp,
@@ -33,6 +36,7 @@ module Playbook
       def classname
         classes = ["pb_table_tr", "bg-silver", "pb_subrow_header", subrow_depth_classname]
         classes << "pinned-row" if is_pinned_row
+        classes << "pinned-row-bottom" if is_pinned_row && pinned_position.to_s == "bottom"
         generate_classname(*classes, separator: " ")
       end
 

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/column_layout_helper_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/column_layout_helper_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative "../../../../app/pb_kits/playbook/pb_advanced_table/column_layout_helper"
+
+RSpec.describe Playbook::PbAdvancedTable::ColumnLayoutHelper do
+  let(:helper) do
+    Class.new { include Playbook::PbAdvancedTable::ColumnLayoutHelper }.new
+  end
+
+  describe "#css_length" do
+    it "converts numbers to pixel strings" do
+      expect(helper.css_length(128)).to eq "128px"
+      expect(helper.css_length(128.5)).to eq "128.5px"
+    end
+
+    it "passes strings through" do
+      expect(helper.css_length("12rem")).to eq "12rem"
+      expect(helper.css_length("200px")).to eq "200px"
+    end
+
+    it "returns nil for blank values" do
+      expect(helper.css_length(nil)).to be_nil
+      expect(helper.css_length("")).to be_nil
+    end
+  end
+
+  describe "#build_column_layout_styles" do
+    it "applies min_width, width, and max_width" do
+      styles = helper.build_column_layout_styles(min_width: 108, width: 124, max_width: 168)
+
+      expect(styles).to eq(
+        width: "124px",
+        min_width: "108px",
+        max_width: "168px"
+      )
+    end
+
+    it "locks min and max when only width is set" do
+      styles = helper.build_column_layout_styles(width: 128)
+
+      expect(styles).to eq(
+        width: "128px",
+        min_width: "128px",
+        max_width: "128px"
+      )
+    end
+
+    it "applies floor-only min_width" do
+      styles = helper.build_column_layout_styles(min_width: 160)
+
+      expect(styles).to eq(min_width: "160px")
+    end
+
+    it "accepts camelCase aliases" do
+      styles = helper.build_column_layout_styles(minWidth: 108, width: 124, maxWidth: 168)
+
+      expect(styles).to eq(
+        width: "124px",
+        min_width: "108px",
+        max_width: "168px"
+      )
+    end
+
+    it "supports CSS length strings" do
+      styles = helper.build_column_layout_styles(width: "12rem", min_width: "10rem")
+
+      expect(styles).to eq(
+        width: "12rem",
+        min_width: "10rem"
+      )
+    end
+
+    it "returns an empty hash when styling has no width keys" do
+      expect(helper.build_column_layout_styles(cell_alignment: "left")).to eq({})
+      expect(helper.build_column_layout_styles({})).to eq({})
+      expect(helper.build_column_layout_styles(nil)).to eq({})
+    end
+  end
+
+  describe "#build_column_layout_styles_from_column" do
+    it "reads from column_styling on the column definition" do
+      column = {
+        accessor: "year",
+        column_styling: { width: 128 },
+      }
+
+      expect(helper.build_column_layout_styles_from_column(column)).to eq(
+        width: "128px",
+        min_width: "128px",
+        max_width: "128px"
+      )
+    end
+
+    it "returns empty hash when column_styling is missing" do
+      expect(helper.build_column_layout_styles_from_column(accessor: "year")).to eq({})
+    end
+  end
+end

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_body_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_body_spec.rb
@@ -316,6 +316,28 @@ RSpec.describe Playbook::PbAdvancedTable::TableBody do
       end
     end
 
+    describe "#pinned_bottom_ids" do
+      it "returns empty array when pinned_rows is nil or empty" do
+        expect(subject.new({}).pinned_bottom_ids).to eq []
+        expect(subject.new(pinned_rows: {}).pinned_bottom_ids).to eq []
+      end
+
+      it "returns bottom ids from symbol key" do
+        instance = subject.new(pinned_rows: { bottom: %w[row_1 row_2] })
+        expect(instance.pinned_bottom_ids).to eq %w[row_1 row_2]
+      end
+
+      it "returns bottom ids from string key" do
+        instance = subject.new(pinned_rows: { "bottom" => ["totals"] })
+        expect(instance.pinned_bottom_ids).to eq %w[totals]
+      end
+
+      it "stringifies id values" do
+        instance = subject.new(pinned_rows: { bottom: [123, :totals] })
+        expect(instance.pinned_bottom_ids).to eq %w[123 totals]
+      end
+    end
+
     describe "#row_id_for" do
       let(:instance) { subject.new({}) }
 
@@ -389,15 +411,88 @@ RSpec.describe Playbook::PbAdvancedTable::TableBody do
       end
     end
 
+    describe "#pinned_bottom_root_rows" do
+      let(:table_data) do
+        [
+          { id: "totals", name: "Totals" },
+          { id: "row_1", name: "Row 1" },
+        ]
+      end
+
+      it "returns empty array when no bottom pinned_rows" do
+        instance = subject.new(table_data: table_data, pinned_rows: { top: ["totals"] })
+        expect(instance.pinned_bottom_root_rows).to eq []
+      end
+
+      it "returns root info hashes for each bottom pinned id found in table_data" do
+        instance = subject.new(table_data: table_data, pinned_rows: { bottom: ["totals"] })
+        rows = instance.pinned_bottom_root_rows
+        expect(rows.length).to eq 1
+        expect(rows.first[:row][:id]).to eq "totals"
+        expect(rows.first[:depth]).to eq 0
+      end
+    end
+
+    describe "#pinned_ids_set" do
+      let(:table_data) do
+        [
+          { id: "top_row", name: "Top", children: [{ id: "top_child", name: "Top Child" }] },
+          { id: "middle", name: "Middle" },
+          { id: "bottom_row", name: "Bottom" },
+        ]
+      end
+
+      it "includes top and bottom pinned ids and their descendants" do
+        instance = subject.new(
+          table_data: table_data,
+          pinned_rows: { top: ["top_row"], bottom: ["bottom_row"] }
+        )
+        expect(instance.pinned_ids_set).to eq Set.new(%w[top_row top_child bottom_row])
+      end
+    end
+
+    describe "#pinned_bottom_row_count" do
+      let(:table_data) do
+        [
+          { id: "a", name: "A", children: [{ id: "a1", name: "A1" }, { id: "a2", name: "A2" }] },
+          { id: "b", name: "B" },
+        ]
+      end
+
+      it "counts pinned bottom roots and descendants" do
+        instance = subject.new(table_data: table_data, pinned_rows: { bottom: %w[a b] })
+        expect(instance.pinned_bottom_row_count).to eq 4
+      end
+    end
+
     describe "#has_pinned_rows?" do
       it "returns false when no pinned rows" do
         instance = subject.new(table_data: [{ id: "1" }])
         expect(instance.has_pinned_rows?).to be false
       end
 
-      it "returns true when pinned_root_rows is non-empty" do
+      it "returns true when top pinned_root_rows is non-empty" do
         instance = subject.new(table_data: [{ id: "totals" }], pinned_rows: { top: ["totals"] })
         expect(instance.has_pinned_rows?).to be true
+        expect(instance.has_pinned_top_rows?).to be true
+        expect(instance.has_pinned_bottom_rows?).to be false
+      end
+
+      it "returns true when bottom pinned rows are present" do
+        instance = subject.new(table_data: [{ id: "totals" }], pinned_rows: { bottom: ["totals"] })
+        expect(instance.has_pinned_rows?).to be true
+        expect(instance.has_pinned_top_rows?).to be false
+        expect(instance.has_pinned_bottom_rows?).to be true
+      end
+
+      it "returns true when both top and bottom pinned rows are present" do
+        instance = subject.new(
+          table_data: [{ id: "1" }, { id: "2" }],
+          pinned_rows: { top: ["1"], bottom: ["2"] }
+        )
+        expect(instance.has_pinned_rows?).to be true
+        expect(instance.has_pinned_top_rows?).to be true
+        expect(instance.has_pinned_bottom_rows?).to be true
       end
     end
 
@@ -412,12 +507,27 @@ RSpec.describe Playbook::PbAdvancedTable::TableBody do
         expect(style).to include("2.5em * 0")
         expect(style).to include("z-index: 3")
         expect(style).to include("background: white")
+        expect(style).to include("top:")
+        expect(style).not_to include("bottom:")
       end
 
       it "uses custom background when given" do
         style = instance.build_pinned_row_style(1, background: "#f0f0f0")
         expect(style).to include("background: #f0f0f0")
         expect(style).to include("2.5em * 1")
+      end
+
+      it "returns bottom sticky style for bottom position" do
+        style = instance.build_pinned_row_style(0, position: "bottom", bottom_total: 3)
+        expect(style).to include("position: sticky")
+        expect(style).to include("bottom: calc(2.5em * 2)")
+        expect(style).to include("z-index: 3")
+        expect(style).not_to include("top:")
+      end
+
+      it "places the last bottom pinned row at bottom 0" do
+        style = instance.build_pinned_row_style(2, position: "bottom", bottom_total: 3)
+        expect(style).to include("bottom: calc(2.5em * 0)")
       end
     end
   end

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_body_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_body_spec.rb
@@ -459,9 +459,14 @@ RSpec.describe Playbook::PbAdvancedTable::TableBody do
         ]
       end
 
-      it "counts pinned bottom roots and descendants" do
+      it "counts initially visible bottom roots only (collapsed descendants excluded)" do
         instance = subject.new(table_data: table_data, pinned_rows: { bottom: %w[a b] })
-        expect(instance.pinned_bottom_row_count).to eq 4
+        expect(instance.pinned_bottom_row_count).to eq 2
+      end
+
+      it "still counts a single expandable root as one for first paint" do
+        instance = subject.new(table_data: table_data, pinned_rows: { bottom: ["a"] })
+        expect(instance.pinned_bottom_row_count).to eq 1
       end
     end
 

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_header_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_header_spec.rb
@@ -415,6 +415,9 @@ RSpec.describe Playbook::PbAdvancedTable::TableHeader do
         { accessor: "with_bg", label: "With Background", column_styling: { header_background_color: "success" } },
         { accessor: "with_font", label: "With Font", column_styling: { header_font_color: "white" } },
         { accessor: "with_both", label: "With Both", column_styling: { header_background_color: "error", header_font_color: "white" } },
+        { accessor: "with_width", label: "With Width", column_styling: { width: 128 } },
+        { accessor: "with_width_band", label: "With Width Band", column_styling: { min_width: 108, width: 124, max_width: 168 } },
+        { accessor: "with_bg_and_width", label: "With Bg and Width", column_styling: { header_background_color: "success", width: 200 } },
       ]
     end
     let(:instance) { subject.new(column_definitions: column_definitions) }
@@ -432,6 +435,26 @@ RSpec.describe Playbook::PbAdvancedTable::TableHeader do
         result = instance.header_component_info(cell, 0, 0)
         expect(result[:name]).to eq "table/table_header"
         expect(result[:props][:html_options][:style][:color]).to eq "white"
+      end
+
+      it "applies fixed width styles when only width is set" do
+        cell = { accessor: "with_width", label: "With Width", colspan: 1, sort_menu: nil }
+        result = instance.header_component_info(cell, 0, 0)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "128px",
+          min_width: "128px",
+          max_width: "128px"
+        )
+      end
+
+      it "applies min_width, width, and max_width band styles" do
+        cell = { accessor: "with_width_band", label: "With Width Band", colspan: 1, sort_menu: nil }
+        result = instance.header_component_info(cell, 0, 0)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "124px",
+          min_width: "108px",
+          max_width: "168px"
+        )
       end
     end
 
@@ -456,6 +479,17 @@ RSpec.describe Playbook::PbAdvancedTable::TableHeader do
         cell = { accessor: "with_bg", label: "With Background", colspan: 1, header_background_color: "success" }
         result = instance.header_component_info(cell, 0, 0)
         expect(result[:props][:html_options][:style]).to be_empty
+      end
+
+      it "merges width styles with custom background" do
+        cell = { accessor: "with_bg_and_width", label: "With Bg and Width", colspan: 1, header_background_color: "success" }
+        result = instance.header_component_info(cell, 0, 0)
+        expect(result[:name]).to eq "background"
+        expect(result[:props][:html_options][:style]).to include(
+          width: "200px",
+          min_width: "200px",
+          max_width: "200px"
+        )
       end
     end
 

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Playbook::PbAdvancedTable::TableRow do
       .with_values("all", "header", "none")
   }
   it { is_expected.to define_boolean_prop(:inline_row_loading).with_default(false) }
+  it { is_expected.to define_boolean_prop(:is_pinned_row).with_default(false) }
+
+  it {
+    is_expected.to define_enum_prop(:pinned_position)
+      .with_default("top")
+      .with_values("top", "bottom")
+  }
   it { is_expected.to define_boolean_prop(:full_width_cell).with_default(false) }
 
   describe "#classname" do
@@ -44,6 +51,20 @@ RSpec.describe Playbook::PbAdvancedTable::TableRow do
       it "does not include depth class for root rows" do
         instance = subject.new(row: {}, depth: 0)
         expect(instance.classname).not_to include "depth-sub-row"
+      end
+    end
+
+    context "pinned rows" do
+      it "adds pinned-row class when is_pinned_row is true" do
+        instance = subject.new(row: {}, depth: 0, is_pinned_row: true)
+        expect(instance.classname).to include "pinned-row"
+        expect(instance.classname).not_to include "pinned-row-bottom"
+      end
+
+      it "adds pinned-row-bottom class for bottom pinned rows" do
+        instance = subject.new(row: {}, depth: 0, is_pinned_row: true, pinned_position: "bottom")
+        expect(instance.classname).to include "pinned-row"
+        expect(instance.classname).to include "pinned-row-bottom"
       end
     end
 

--- a/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
+++ b/playbook/spec/pb_kits/playbook/pb_advanced_table/table_row_spec.rb
@@ -408,6 +408,9 @@ RSpec.describe Playbook::PbAdvancedTable::TableRow do
         { accessor: "with_bg_and_font", column_styling: { cell_background_color: "success_secondary", font_color: "white" } },
         { accessor: "with_bg_only", column_styling: { cell_background_color: "warning_secondary" } },
         { accessor: "none", column_styling: {} },
+        { accessor: "with_width", column_styling: { width: 128 } },
+        { accessor: "with_width_band", column_styling: { min_width: 108, width: 124, max_width: 168 } },
+        { accessor: "with_bg_and_width", column_styling: { cell_background_color: "warning_secondary", width: 200 } },
       ]
     end
     let(:instance) { subject.new(row: row, depth: 0, column_definitions: column_definitions) }
@@ -443,6 +446,36 @@ RSpec.describe Playbook::PbAdvancedTable::TableRow do
         result = instance.cell_component_info({ accessor: "none" }, 0, nil, nil)
         expect(result[:name]).to eq "table/table_cell"
         expect(result[:props][:html_options][:style]).not_to have_key(:color)
+      end
+    end
+
+    context "with column width styling" do
+      it "applies fixed width styles when only width is set" do
+        result = instance.cell_component_info({ accessor: "with_width" }, 0, nil, nil)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "128px",
+          min_width: "128px",
+          max_width: "128px"
+        )
+      end
+
+      it "applies min_width, width, and max_width band styles" do
+        result = instance.cell_component_info({ accessor: "with_width_band" }, 0, nil, nil)
+        expect(result[:props][:html_options][:style]).to include(
+          width: "124px",
+          min_width: "108px",
+          max_width: "168px"
+        )
+      end
+
+      it "merges width styles with custom background" do
+        result = instance.cell_component_info({ accessor: "with_bg_and_width" }, 0, nil, nil)
+        expect(result[:name]).to eq "background"
+        expect(result[:props][:html_options][:style]).to include(
+          width: "200px",
+          min_width: "200px",
+          max_width: "200px"
+        )
       end
     end
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
This PR combines two Rails Advanced Table PRs for combined alpha testing - see tickets/PRs for detailed descriptions. 
[PLAY-3097](https://runway.powerhrg.com/backlog_items/PLAY-3097?from=active_sprint) Advanced Table: Pin Row to Bottom - Rails [playbook PR](https://github.com/powerhome/playbook/pull/6425)
[PLAY-3087](https://runway.powerhrg.com/backlog_items/PLAY-3087?from=active_sprint) Advanced Table Kit: Column Styling Width Props - Rails [playbook PR](https://github.com/powerhome/playbook/pull/6420)

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
See each PR's testing notes.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.