### PR TITLE
[GOG-1931] Add ci-kubed-read-token preset for renovate ci-kubed release lookups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "github>powerhome/renovate-config"
+    "github>powerhome/renovate-config",
+    "github>powerhome/renovate-config:ci-kubed-read-token"
   ],
   "prCreation": "not-pending",
   "prConcurrentLimit": 2,


### PR DESCRIPTION
## Summary

playbook's Jenkinsfile pins `powerhome/ci-kubed` (`library 'github.com/powerhome/ci-kubed@...'`), resolved via the `github-releases` datasource by the `ci-kubed-versioning` regex manager (already part of the default preset). Since playbook is a public repo, Mend issues its Renovate job a GitHub App token scoped only to playbook itself, not the rest of the org — so the lookup can't resolve the private `ci-kubed` repo and fails with "Could not resolve to a Repository."

`powerhome/keess` hit the same issue (see <a href="https://github.com/powerhome/keess/pull/121">keess#121</a>) and now has a reusable fix as a preset: `ci-kubed-read-token` (<a href="https://github.com/powerhome/renovate-config/pull/64">powerhome/renovate-config#64</a>). This adds that preset to playbook's `extends`. The `CI_KUBED_READ_TOKEN` secret is already configured at the org level in Mend, so no additional Mend setup is needed here.

## Depends on

- [ ] <a href="https://github.com/powerhome/renovate-config/pull/64">powerhome/renovate-config#64</a> must merge first — the `ci-kubed-read-token` preset doesn't exist on renovate-config's main branch yet, so this PR isn't mergeable until then. Marking as draft for now.

## Context

<a href="https://runway.powerhrg.com/backlog_items/GOG-1931">GOG-1931</a>

## Test plan

- [ ] After merge, trigger a Renovate run and confirm the ci-kubed `github-releases` lookup succeeds with no "Package lookup failures" warning