### PR TITLE
[PLAY-3060]Playbook Website: hover nav on collapse

### DIFF
--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -239,7 +239,7 @@ function WebsiteContent() {
             />
             <button
                 aria-label={
-                desktopSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"
+                desktopSidebarCollapsed ? "Expand Sidebar" : "Collapse Sidebar"
               }
                 className="pb--page--sideNav-toggle"
                 onClick={() =>
@@ -258,7 +258,7 @@ function WebsiteContent() {
               <Body
                   color="lighter"
                   marginLeft="xs"
-                  text={desktopSidebarCollapsed ? "" : "Collapse sidebar"}
+                  text={desktopSidebarCollapsed ? "" : "Collapse Sidebar"}
               />
             </button>
           </Layout.Side>

--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -258,12 +258,15 @@ function WebsiteContent() {
                     ? "angle-double-right"
                     : "angle-double-left"
                 }
+                size="lg"
               />
-              <Body
-                  color="lighter"
-                  marginLeft="xs"
-                  text={desktopSidebarCollapsed ? "" : "Collapse Sidebar"}
-              />
+              {!desktopSidebarCollapsed && (
+                <Body
+                    color="lighter"
+                    marginLeft="xs"
+                    text="Collapse Sidebar"
+                />
+              )}
             </button>
           </Layout.Side>
           {kits.length > 0 && <LayoutRight />}

--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -90,8 +90,12 @@ function WebsiteContent() {
     [normalizedPath, location.search, type],
   );
 
+  // Playground defaults to a collapsed sidebar; don't force-expand on other routes
+  // so hover-nav clicks can navigate while keeping the sidebar collapsed.
   useEffect(() => {
-    setDesktopSidebarCollapsed(normalizedPath === "/playground");
+    if (normalizedPath === "/playground") {
+      setDesktopSidebarCollapsed(true);
+    }
   }, [normalizedPath]);
 
   // Keep preference in sync when the URL explicitly sets a platform

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.scss
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.scss
@@ -1,0 +1,68 @@
+@import "playbook-tokens/colors";
+@import "playbook-tokens/spacing";
+
+// Portaled to document.body from the collapsed sidebar hover flyout.
+.pb--page--sideNav-hoverNav {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 1100;
+  min-width: 220px;
+  width: max-content;
+  max-width: min(280px, calc(100vw - var(--website-sidebar-collapsed-width, 64px) - 24px));
+  border-top: 1px solid $border_light;
+  border-right: 1px solid $border_light;
+  border-bottom: 1px solid $border_light;
+  border-left: none;
+  // Clip shadow on the left so it doesn't overlay the sidebar.
+  // Still allow shadow to extend on top/right/bottom when not flush.
+  clip-path: inset(-40px -40px -40px 0);
+
+  &.is-attached-top {
+    border-top: none;
+    clip-path: inset(0 -40px -40px 0);
+  }
+
+  &.is-attached-bottom {
+    border-bottom: none;
+    clip-path: inset(-40px -40px 0 0);
+  }
+
+  &.is-attached-top.is-attached-bottom {
+    border-top: none;
+    border-bottom: none;
+    clip-path: inset(0 -40px 0 0);
+  }
+
+  &.dark {
+    border-top-color: $border_dark;
+    border-right-color: $border_dark;
+    border-bottom-color: $border_dark;
+  }
+
+  &__card {
+    width: 100%;
+  }
+
+  &.is-scrollable &__card {
+    height: 100%;
+    max-height: inherit;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__title {
+    cursor: pointer;
+  }
+
+  &__body {
+    padding-bottom: $space_xs;
+  }
+
+  &.is-scrollable &__body {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+}

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -64,8 +64,10 @@ export const CollapsedHoverNav = ({
     const updatePosition = () => {
       const titleEl = titleRef.current;
       const bodyEl = bodyRef.current;
+      const flyoutEl = flyoutRef.current;
       if (!titleEl || !bodyEl || !anchorEl.isConnected) return;
 
+      const hasSubnav = Boolean(children);
       const anchorRect = anchorEl.getBoundingClientRect();
       const left = getSidebarRight(anchorEl) + HORIZONTAL_GAP;
       const headerBottom = getHeaderBottom(anchorEl);
@@ -74,13 +76,24 @@ export const CollapsedHoverNav = ({
 
       // scrollHeight stays accurate even when the body is already constrained/scrollable.
       const contentHeight = titleEl.offsetHeight + bodyEl.scrollHeight;
+      // Leaf flyouts are title-only; use measured height so card padding is included when centering.
+      const leafHeight = flyoutEl?.offsetHeight || contentHeight;
       const alignedTop = Math.max(anchorRect.top, headerBottom);
 
       let mode: PlacementMode = "align";
       let top = alignedTop;
       let bottom: CSSProperties["bottom"] = "auto";
 
-      if (contentHeight > availableHeight) {
+      if (!hasSubnav) {
+        // Leaf items: vertically center on the hovered nav item.
+        const centeredTop =
+          anchorRect.top + (anchorRect.height - leafHeight) / 2;
+        top = Math.min(
+          Math.max(centeredTop, headerBottom),
+          Math.max(headerBottom, viewportHeight - leafHeight),
+        );
+        mode = "align";
+      } else if (contentHeight > availableHeight) {
         // Taller than space below the header: flush with header + viewport bottom, scroll.
         mode = "scroll";
         top = headerBottom;

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -1,8 +1,7 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Caption, Card, Flex, Nav } from "playbook-ui";
+import { Caption, Card, Nav } from "playbook-ui";
 
-const VIEWPORT_BOTTOM_PADDING = 8;
 const HORIZONTAL_GAP = 0;
 const HEADER_HEIGHT_FALLBACK = 89;
 
@@ -68,10 +67,7 @@ export const CollapsedHoverNav = ({
       const left = getSidebarRight(anchorEl) + HORIZONTAL_GAP;
       const headerBottom = getHeaderBottom(anchorEl);
       const viewportHeight = window.innerHeight;
-      const availableHeight = Math.max(
-        viewportHeight - headerBottom - VIEWPORT_BOTTOM_PADDING,
-        0
-      );
+      const availableHeight = Math.max(viewportHeight - headerBottom, 0);
 
       // scrollHeight stays accurate even when the body is already constrained/scrollable.
       const contentHeight = titleEl.offsetHeight + bodyEl.scrollHeight;
@@ -82,17 +78,15 @@ export const CollapsedHoverNav = ({
       let bottom: CSSProperties["bottom"] = "auto";
 
       if (contentHeight > availableHeight) {
-        // Taller than space below the header: flush with header + bottom of screen, scroll.
+        // Taller than space below the header: flush with header + viewport bottom, scroll.
         mode = "scroll";
         top = headerBottom;
-        bottom = VIEWPORT_BOTTOM_PADDING;
-      } else if (alignedTop + contentHeight > viewportHeight - VIEWPORT_BOTTOM_PADDING) {
-        // Not enough room below the item: attach to bottom, still stay under the header.
+        bottom = 0;
+      } else if (alignedTop + contentHeight > viewportHeight) {
+        // Not enough room below the item: flush with viewport bottom, still under the header.
         mode = "bottom";
-        top = Math.max(
-          headerBottom,
-          viewportHeight - VIEWPORT_BOTTOM_PADDING - contentHeight
-        );
+        top = Math.max(headerBottom, viewportHeight - contentHeight);
+        bottom = 0;
       } else {
         // Default: align with the nav item (or flush under the header if needed).
         mode = "align";
@@ -140,6 +134,9 @@ export const CollapsedHoverNav = ({
 
   if (!anchorEl || typeof document === "undefined") return null;
 
+  const isScrollable = placementMode === "scroll";
+  const hasSubnav = Boolean(children);
+
   return createPortal(
     <div
       onMouseEnter={onMouseEnter}
@@ -153,44 +150,53 @@ export const CollapsedHoverNav = ({
         display="flex"
         flexDirection="column"
         htmlOptions={{
-          style: {
-            height: "100%",
-            maxHeight: "inherit",
-            minHeight: 0,
-          },
+          style: isScrollable
+            ? {
+                height: "100%",
+                maxHeight: "inherit",
+                minHeight: 0,
+              }
+            : undefined,
         }}
-        overflow="hidden"
+        overflow={isScrollable ? "hidden" : "visible"}
         padding="none"
         shadow="deeper"
         width="100%"
       >
         <div ref={titleRef}>
           <Caption
-            borderBottom="default"
+            borderBottom={hasSubnav ? "default" : "none"}
             dark={dark}
             paddingX="sm"
             paddingY="xs"
             text={title}
           />
         </div>
-        <Flex
-          flexGrow={1}
-          htmlOptions={{
-            ref: bodyRef,
-            style: {
-              minHeight: 0,
-              overscrollBehavior: "contain",
-            },
-          }}
-          orientation="column"
-          overflowX="hidden"
-          overflowY={placementMode === "scroll" ? "auto" : "visible"}
-          paddingBottom="xs"
+        <div
+          ref={bodyRef}
+          style={
+            !hasSubnav
+              ? undefined
+              : isScrollable
+                ? {
+                    flex: "1 1 0",
+                    minHeight: 0,
+                    overflowX: "hidden",
+                    overflowY: "auto",
+                    overscrollBehavior: "contain",
+                    paddingBottom: 8,
+                  }
+                : {
+                    paddingBottom: 8,
+                  }
+          }
         >
-          <Nav dark={dark} highlight={false} variant="bold">
-            {children}
-          </Nav>
-        </Flex>
+          {hasSubnav && (
+            <Nav dark={dark} highlight={false} variant="bold">
+              {children}
+            </Nav>
+          )}
+        </div>
       </Card>
     </div>,
     document.body

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Caption, Card, Nav } from "playbook-ui";
+import { Card, Nav, Title } from "playbook-ui";
 
 const HORIZONTAL_GAP = 0;
 const HEADER_HEIGHT_FALLBACK = 89;
@@ -182,12 +182,12 @@ export const CollapsedHoverNav = ({
           style={onTitleClick ? { cursor: "pointer" } : undefined}
           tabIndex={onTitleClick ? 0 : undefined}
         >
-          <Caption
-            borderBottom={hasSubnav ? "default" : "none"}
+          <Title
             dark={dark}
-            paddingX="sm"
+            paddingX="md"
             paddingY="xs"
             text={title}
+            size={4}
           />
         </div>
         <div

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Card, Nav, Title, colors } from "playbook-ui";
+import { Card, Nav, Title } from "playbook-ui";
+import "./CollapsedHoverNav.scss";
 
 const HORIZONTAL_GAP = 0;
 const HEADER_HEIGHT_FALLBACK = 89;
@@ -48,10 +49,8 @@ export const CollapsedHoverNav = ({
   const bodyRef = useRef<HTMLDivElement>(null);
   const [style, setStyle] = useState<CSSProperties>({
     left: -9999,
-    position: "fixed",
     top: 0,
     visibility: "hidden",
-    zIndex: 1100,
   });
   const [placementMode, setPlacementMode] = useState<PlacementMode>("align");
   const [attachedTop, setAttachedTop] = useState(false);
@@ -102,16 +101,9 @@ export const CollapsedHoverNav = ({
       setAttachedBottom(bottom === 0);
       setStyle({
         left,
-        maxHeight: mode === "scroll" ? availableHeight : "none",
-        maxWidth:
-          "min(280px, calc(100vw - var(--website-sidebar-collapsed-width, 64px) - 24px))",
-        minWidth: 220,
-        position: "fixed",
         top,
         bottom,
         visibility: "visible",
-        width: "max-content",
-        zIndex: 1100,
       });
     };
 
@@ -142,44 +134,38 @@ export const CollapsedHoverNav = ({
 
   const isScrollable = placementMode === "scroll";
   const hasSubnav = Boolean(children);
-  const borderColor = dark ? colors.border_dark : colors.border_light;
+  const className = [
+    "pb--page--sideNav-hoverNav",
+    dark ? "dark" : "",
+    isScrollable ? "is-scrollable" : "",
+    attachedTop ? "is-attached-top" : "",
+    attachedBottom ? "is-attached-bottom" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return createPortal(
     <div
+      className={className}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       ref={flyoutRef}
-      style={{
-        ...style,
-        borderBottom: attachedBottom ? "none" : `1px solid ${borderColor}`,
-        borderLeft: "none",
-        borderRight: `1px solid ${borderColor}`,
-        borderTop: attachedTop ? "none" : `1px solid ${borderColor}`,
-        boxSizing: "border-box",
-      }}
+      style={style}
     >
       <Card
         borderNone
         borderRadius="none"
+        className="pb--page--sideNav-hoverNav__card"
         dark={dark}
         display="flex"
         flexDirection="column"
-        htmlOptions={{
-          style: isScrollable
-            ? {
-                height: "100%",
-                maxHeight: "inherit",
-                minHeight: 0,
-              }
-            : undefined,
-        }}
         overflow={isScrollable ? "hidden" : "visible"}
         padding="none"
         shadow="deeper"
         width="100%"
       >
         <div
-          ref={titleRef}
+          className={onTitleClick ? "pb--page--sideNav-hoverNav__title" : undefined}
           onClick={onTitleClick}
           onKeyDown={
             onTitleClick
@@ -191,36 +177,21 @@ export const CollapsedHoverNav = ({
                 }
               : undefined
           }
+          ref={titleRef}
           role={onTitleClick ? "button" : undefined}
-          style={onTitleClick ? { cursor: "pointer" } : undefined}
           tabIndex={onTitleClick ? 0 : undefined}
         >
           <Title
             dark={dark}
             paddingX="md"
             paddingY="xs"
-            text={title}
             size={4}
+            text={title}
           />
         </div>
         <div
+          className={hasSubnav ? "pb--page--sideNav-hoverNav__body" : undefined}
           ref={bodyRef}
-          style={
-            !hasSubnav
-              ? undefined
-              : isScrollable
-                ? {
-                    flex: "1 1 0",
-                    minHeight: 0,
-                    overflowX: "hidden",
-                    overflowY: "auto",
-                    overscrollBehavior: "contain",
-                    paddingBottom: 8,
-                  }
-                : {
-                    paddingBottom: 8,
-                  }
-          }
         >
           {hasSubnav && (
             <Nav dark={dark} highlight={false} variant="bold">

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -160,7 +160,8 @@ export const CollapsedHoverNav = ({
         display="flex"
         flexDirection="column"
         overflow={isScrollable ? "hidden" : "visible"}
-        padding="none"
+        paddingX="none"
+        paddingY="sm"
         shadow="deeper"
         width="100%"
       >

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -11,6 +11,7 @@ type CollapsedHoverNavProps = {
   dark?: boolean;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
+  onTitleClick?: () => void;
   title: string;
 };
 
@@ -39,6 +40,7 @@ export const CollapsedHoverNav = ({
   dark = false,
   onMouseEnter,
   onMouseLeave,
+  onTitleClick,
   title,
 }: CollapsedHoverNavProps) => {
   const flyoutRef = useRef<HTMLDivElement>(null);
@@ -163,7 +165,23 @@ export const CollapsedHoverNav = ({
         shadow="deeper"
         width="100%"
       >
-        <div ref={titleRef}>
+        <div
+          ref={titleRef}
+          onClick={onTitleClick}
+          onKeyDown={
+            onTitleClick
+              ? (event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    onTitleClick();
+                  }
+                }
+              : undefined
+          }
+          role={onTitleClick ? "button" : undefined}
+          style={onTitleClick ? { cursor: "pointer" } : undefined}
+          tabIndex={onTitleClick ? 0 : undefined}
+        >
           <Caption
             borderBottom={hasSubnav ? "default" : "none"}
             dark={dark}

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Card, Nav, Title } from "playbook-ui";
+import { Card, Nav, Title, colors } from "playbook-ui";
 
 const HORIZONTAL_GAP = 0;
 const HEADER_HEIGHT_FALLBACK = 89;
@@ -54,6 +54,8 @@ export const CollapsedHoverNav = ({
     zIndex: 1100,
   });
   const [placementMode, setPlacementMode] = useState<PlacementMode>("align");
+  const [attachedTop, setAttachedTop] = useState(false);
+  const [attachedBottom, setAttachedBottom] = useState(false);
 
   useLayoutEffect(() => {
     if (!anchorEl) return;
@@ -96,6 +98,8 @@ export const CollapsedHoverNav = ({
       }
 
       setPlacementMode(mode);
+      setAttachedTop(top === headerBottom);
+      setAttachedBottom(bottom === 0);
       setStyle({
         left,
         maxHeight: mode === "scroll" ? availableHeight : "none",
@@ -138,15 +142,24 @@ export const CollapsedHoverNav = ({
 
   const isScrollable = placementMode === "scroll";
   const hasSubnav = Boolean(children);
+  const borderColor = dark ? colors.border_dark : colors.border_light;
 
   return createPortal(
     <div
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       ref={flyoutRef}
-      style={style}
+      style={{
+        ...style,
+        borderBottom: attachedBottom ? "none" : `1px solid ${borderColor}`,
+        borderLeft: "none",
+        borderRight: `1px solid ${borderColor}`,
+        borderTop: attachedTop ? "none" : `1px solid ${borderColor}`,
+        boxSizing: "border-box",
+      }}
     >
       <Card
+        borderNone
         borderRadius="none"
         dark={dark}
         display="flex"

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/CollapsedHoverNav.tsx
@@ -1,0 +1,198 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { Caption, Card, Flex, Nav } from "playbook-ui";
+
+const VIEWPORT_BOTTOM_PADDING = 8;
+const HORIZONTAL_GAP = 0;
+const HEADER_HEIGHT_FALLBACK = 89;
+
+type CollapsedHoverNavProps = {
+  anchorEl: HTMLElement | null;
+  children: ReactNode;
+  dark?: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  title: string;
+};
+
+type PlacementMode = "align" | "bottom" | "scroll";
+
+const getSidebarRight = (anchorEl: HTMLElement) => {
+  const sidebar = anchorEl.closest(".pb--page--sideNav") as HTMLElement | null;
+  if (sidebar) {
+    return sidebar.getBoundingClientRect().right;
+  }
+  return anchorEl.getBoundingClientRect().right;
+};
+
+const getHeaderBottom = (anchorEl: HTMLElement) => {
+  const shell = anchorEl.closest(".pb--website-shell") as HTMLElement | null;
+  const raw = getComputedStyle(shell || document.documentElement)
+    .getPropertyValue("--website-header-height")
+    .trim();
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : HEADER_HEIGHT_FALLBACK;
+};
+
+export const CollapsedHoverNav = ({
+  anchorEl,
+  children,
+  dark = false,
+  onMouseEnter,
+  onMouseLeave,
+  title,
+}: CollapsedHoverNavProps) => {
+  const flyoutRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<CSSProperties>({
+    left: -9999,
+    position: "fixed",
+    top: 0,
+    visibility: "hidden",
+    zIndex: 1100,
+  });
+  const [placementMode, setPlacementMode] = useState<PlacementMode>("align");
+
+  useLayoutEffect(() => {
+    if (!anchorEl) return;
+
+    let frameId = 0;
+
+    const updatePosition = () => {
+      const titleEl = titleRef.current;
+      const bodyEl = bodyRef.current;
+      if (!titleEl || !bodyEl || !anchorEl.isConnected) return;
+
+      const anchorRect = anchorEl.getBoundingClientRect();
+      const left = getSidebarRight(anchorEl) + HORIZONTAL_GAP;
+      const headerBottom = getHeaderBottom(anchorEl);
+      const viewportHeight = window.innerHeight;
+      const availableHeight = Math.max(
+        viewportHeight - headerBottom - VIEWPORT_BOTTOM_PADDING,
+        0
+      );
+
+      // scrollHeight stays accurate even when the body is already constrained/scrollable.
+      const contentHeight = titleEl.offsetHeight + bodyEl.scrollHeight;
+      const alignedTop = Math.max(anchorRect.top, headerBottom);
+
+      let mode: PlacementMode = "align";
+      let top = alignedTop;
+      let bottom: CSSProperties["bottom"] = "auto";
+
+      if (contentHeight > availableHeight) {
+        // Taller than space below the header: flush with header + bottom of screen, scroll.
+        mode = "scroll";
+        top = headerBottom;
+        bottom = VIEWPORT_BOTTOM_PADDING;
+      } else if (alignedTop + contentHeight > viewportHeight - VIEWPORT_BOTTOM_PADDING) {
+        // Not enough room below the item: attach to bottom, still stay under the header.
+        mode = "bottom";
+        top = Math.max(
+          headerBottom,
+          viewportHeight - VIEWPORT_BOTTOM_PADDING - contentHeight
+        );
+      } else {
+        // Default: align with the nav item (or flush under the header if needed).
+        mode = "align";
+        top = alignedTop;
+      }
+
+      setPlacementMode(mode);
+      setStyle({
+        left,
+        maxHeight: mode === "scroll" ? availableHeight : "none",
+        maxWidth:
+          "min(280px, calc(100vw - var(--website-sidebar-collapsed-width, 64px) - 24px))",
+        minWidth: 220,
+        position: "fixed",
+        top,
+        bottom,
+        visibility: "visible",
+        width: "max-content",
+        zIndex: 1100,
+      });
+    };
+
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(updatePosition);
+    };
+
+    updatePosition();
+
+    const resizeObserver = new ResizeObserver(scheduleUpdate);
+    if (bodyRef.current) {
+      resizeObserver.observe(bodyRef.current);
+    }
+
+    window.addEventListener("resize", scheduleUpdate);
+    window.addEventListener("scroll", scheduleUpdate, true);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+      window.removeEventListener("scroll", scheduleUpdate, true);
+    };
+  }, [anchorEl, children, title]);
+
+  if (!anchorEl || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      ref={flyoutRef}
+      style={style}
+    >
+      <Card
+        borderRadius="none"
+        dark={dark}
+        display="flex"
+        flexDirection="column"
+        htmlOptions={{
+          style: {
+            height: "100%",
+            maxHeight: "inherit",
+            minHeight: 0,
+          },
+        }}
+        overflow="hidden"
+        padding="none"
+        shadow="deeper"
+        width="100%"
+      >
+        <div ref={titleRef}>
+          <Caption
+            borderBottom="default"
+            dark={dark}
+            paddingX="sm"
+            paddingY="xs"
+            text={title}
+          />
+        </div>
+        <Flex
+          flexGrow={1}
+          htmlOptions={{
+            ref: bodyRef,
+            style: {
+              minHeight: 0,
+              overscrollBehavior: "contain",
+            },
+          }}
+          orientation="column"
+          overflowX="hidden"
+          overflowY={placementMode === "scroll" ? "auto" : "visible"}
+          paddingBottom="xs"
+        >
+          <Nav dark={dark} highlight={false} variant="bold">
+            {children}
+          </Nav>
+        </Flex>
+      </Card>
+    </div>,
+    document.body
+  );
+};

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
@@ -230,16 +230,15 @@ export const TopLevelNavItem = ({
       });
     };
 
-    const hoverHandlers =
-      sidebarCollapsed && children
-        ? {
-            onMouseEnter: (event: { currentTarget: HTMLElement }) => {
-              itemElsRef.current[key] = event.currentTarget;
-              openHoverNav(key);
-            },
-            onMouseLeave: () => scheduleCloseHoverNav(),
-          }
-        : undefined;
+    const hoverHandlers = sidebarCollapsed
+      ? {
+          onMouseEnter: (event: { currentTarget: HTMLElement }) => {
+            itemElsRef.current[key] = event.currentTarget;
+            openHoverNav(key);
+          },
+          onMouseLeave: () => scheduleCloseHoverNav(),
+        }
+      : undefined;
 
     return (
       <NavItem
@@ -286,7 +285,7 @@ export const TopLevelNavItem = ({
       {SideBarNavItems.map(({ name, key, children, leftIcon, link }, i) => {
         return renderTopItems(name, key, children, leftIcon, link, i);
       })}
-      {sidebarCollapsed && hoveredItem?.children && hoveredKey && (
+      {sidebarCollapsed && hoveredItem && hoveredKey && (
         <CollapsedHoverNav
           anchorEl={itemElsRef.current[hoveredKey]}
           dark={dark}
@@ -294,7 +293,9 @@ export const TopLevelNavItem = ({
           onMouseLeave={scheduleCloseHoverNav}
           title={hoveredItem.name}
         >
-          {renderSubmenu(hoveredItem.name, hoveredIndex, updateTopLevelNavFromHover)}
+          {hoveredItem.children
+            ? renderSubmenu(hoveredItem.name, hoveredIndex, updateTopLevelNavFromHover)
+            : null}
         </CollapsedHoverNav>
       )}
     </>

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { NavItem, useCollapsible } from "playbook-ui";
 import { useNavigate, useLocation } from "react-router-dom";
 import { KitsNavItem, kitsType } from "./NavComponents/KitsNavComponent";
 import { SideBarNavItems } from "./MenuData/SidebarNavItems";
 import { OtherNavItems } from "./NavComponents/OtherNavComponent";
+import { CollapsedHoverNav } from "./CollapsedHoverNav";
 
 export const TopLevelNavItem = ({
   dark,
@@ -23,6 +24,44 @@ export const TopLevelNavItem = ({
   const currentURL = location.pathname + location.search;
   //hook into collapsible logic for top level item
   const topLevelCollapsibles = SideBarNavItems.map(() => useCollapsible());
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const itemElsRef = useRef<Record<string, HTMLElement | null>>({});
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearCloseTimeout = () => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+  };
+
+  const openHoverNav = (key: string) => {
+    clearCloseTimeout();
+    setHoveredKey(key);
+  };
+
+  const scheduleCloseHoverNav = () => {
+    clearCloseTimeout();
+    closeTimeoutRef.current = setTimeout(() => {
+      setHoveredKey(null);
+    }, 120);
+  };
+
+  useEffect(() => {
+    if (!sidebarCollapsed) {
+      clearCloseTimeout();
+      setHoveredKey(null);
+    }
+  }, [sidebarCollapsed]);
+
+  useEffect(() => {
+    clearCloseTimeout();
+    setHoveredKey(null);
+  }, [location]);
+
+  useEffect(() => {
+    return () => clearCloseTimeout();
+  }, []);
 
   //logic to make it so no navigation if already on that page(prevent unneeded rerenders)
   const TopLevelLink = (link) => {
@@ -107,6 +146,42 @@ export const TopLevelNavItem = ({
     return currentURL.startsWith(link);
   };
 
+  const renderSubmenu = (name: string, parentIndex: number, updateTopLevelNav: (index: number) => void) => {
+    if (name === "Components") {
+      return (
+        <>
+          {kits.map((link, index) => (
+            <KitsNavItem
+              link={link}
+              key={`kits-nav-item-${index}`}
+              kitIndex={index}
+              collapsibles={collapsibles}
+              category={category}
+              type={type}
+              dark={dark}
+              kit={kit}
+              updateTopLevelNav={updateTopLevelNav}
+              parentIndex={parentIndex}
+            />
+          ))}
+        </>
+      );
+    }
+
+    return (
+      <OtherNavItems
+        name={name}
+        dark={dark}
+        updateTopLevelNav={updateTopLevelNav}
+        parentIndex={parentIndex}
+        getting_started={getting_started}
+        design_guidelines={design_guidelines}
+        whats_new={whats_new}
+        global_props_and_tokens={global_props_and_tokens}
+      />
+    );
+  };
+
   //extract render logic out of return for better performance
   const renderTopItems = (name, key, children, leftIcon, link, i) => {
     const [collapsed] = topLevelCollapsibles[i];
@@ -155,6 +230,17 @@ export const TopLevelNavItem = ({
       });
     };
 
+    const hoverHandlers =
+      sidebarCollapsed && children
+        ? {
+            onMouseEnter: (event: { currentTarget: HTMLElement }) => {
+              itemElsRef.current[key] = event.currentTarget;
+              openHoverNav(key);
+            },
+            onMouseLeave: () => scheduleCloseHoverNav(),
+          }
+        : undefined;
+
     return (
       <NavItem
         active={sidebarCollapsed ? shouldExpandTopLevel(link) : activeTopLevel(link, children)}
@@ -165,6 +251,7 @@ export const TopLevelNavItem = ({
         dark={dark}
         fontSize="small"
         fontWeight="bolder"
+        htmlOptions={hoverHandlers as any}
         iconLeft={leftIcon}
         iconRight={!sidebarCollapsed && children && ["plus", "minus"]}
         key={key}
@@ -174,41 +261,24 @@ export const TopLevelNavItem = ({
         paddingY="xxs"
         text={name}
       >
-        {children && !sidebarCollapsed && (
-          <>
-            {name === "Components" ? (
-              <>
-                {kits.map((link, index) => (
-                  <KitsNavItem
-                    link={link}
-                    key={`kits-nav-item-${index}`}
-                    kitIndex={index}
-                    collapsibles={collapsibles}
-                    category={category}
-                    type={type}
-                    dark={dark}
-                    kit={kit}
-                    updateTopLevelNav={updateTopLevelNav}
-                    parentIndex={i}
-                  />
-                ))}
-              </>
-            ) : (
-              <OtherNavItems
-                name={name}
-                dark={dark}
-                updateTopLevelNav={updateTopLevelNav}
-                parentIndex={i}
-                getting_started={getting_started}
-                design_guidelines={design_guidelines}
-                whats_new={whats_new}
-                global_props_and_tokens={global_props_and_tokens}
-              />
-            )}
-          </>
-        )}
+        {children && !sidebarCollapsed && renderSubmenu(name, i, updateTopLevelNav)}
       </NavItem>
     );
+  };
+
+  const hoveredItem = SideBarNavItems.find((item) => item.key === hoveredKey);
+  const hoveredIndex = SideBarNavItems.findIndex((item) => item.key === hoveredKey);
+
+  const updateTopLevelNavFromHover = (index: number) => {
+    topLevelCollapsibles.forEach((collapsible, i) => {
+      const [, , setCollapsed] = collapsible;
+      if (i !== index) {
+        setCollapsed(true);
+      } else {
+        setCollapsed(false);
+      }
+    });
+    setHoveredKey(null);
   };
 
   return (
@@ -216,6 +286,17 @@ export const TopLevelNavItem = ({
       {SideBarNavItems.map(({ name, key, children, leftIcon, link }, i) => {
         return renderTopItems(name, key, children, leftIcon, link, i);
       })}
+      {sidebarCollapsed && hoveredItem?.children && hoveredKey && (
+        <CollapsedHoverNav
+          anchorEl={itemElsRef.current[hoveredKey]}
+          dark={dark}
+          onMouseEnter={() => openHoverNav(hoveredKey)}
+          onMouseLeave={scheduleCloseHoverNav}
+          title={hoveredItem.name}
+        >
+          {renderSubmenu(hoveredItem.name, hoveredIndex, updateTopLevelNavFromHover)}
+        </CollapsedHoverNav>
+      )}
     </>
   );
 };

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
@@ -291,6 +291,10 @@ export const TopLevelNavItem = ({
           dark={dark}
           onMouseEnter={() => openHoverNav(hoveredKey)}
           onMouseLeave={scheduleCloseHoverNav}
+          onTitleClick={() => {
+            handleComponentsClick(hoveredItem.key, hoveredIndex);
+            setHoveredKey(null);
+          }}
           title={hoveredItem.name}
         >
           {hoveredItem.children

--- a/playbook-website/app/javascript/site_styles/website_new.scss
+++ b/playbook-website/app/javascript/site_styles/website_new.scss
@@ -168,9 +168,10 @@ body.pages.application .pb--website-react-host {
     width: 100%;
 
     &:hover {
-      background: mix($primary, $card_light, 10%);
-      border-color: $primary;
-      color: $primary;
+      background: $bg_light;
+      .pb_body_kit_lighter, .pb_custom_icon {
+        color: $primary !important;
+      }
     }
 
     @media screen and (min-width: #{$screen-lg-min + 1}) {

--- a/playbook-website/app/javascript/site_styles/website_new.scss
+++ b/playbook-website/app/javascript/site_styles/website_new.scss
@@ -161,7 +161,7 @@ body.pages.application .pb--website-react-host {
     cursor: pointer;
     display: none;
     flex: 0 0 auto;
-    height: 32px;
+    height: 40px;
     border: none;
     justify-content: center;
     transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-3060?from=active_sprint)

- Adds a collapsed-sidebar hover nav: hovering a top-level icon opens a flyout with that section’s submenu (or just the label for leaf items like Playground / Icons).
- Positions the flyout flush with the sidebar and the hovered item; pins under the page header and/or to the viewport bottom when needed; full-height menus scroll.
- Title click navigates like the expanded top-level item; submenu clicks navigate without expanding the sidebar.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.