### PR TITLE
[PLAY-3099] Pill kit: Smaller Size

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
@@ -1,14 +1,18 @@
 @import "../tokens/spacing";
 @import "../tokens/colors";
 @import "../tokens/opacity";
+@import "../tokens/typography";
 @import "../pb_body/body";
 
 $pb_pill_height: 22px;
+$pb_pill_height_sm: 17px;
 
 // Base styles for all pill variations
 @each $color_name, $color_value in $status_color_text {
   .pb_pill_kit_#{$color_name}_lowercase,
-  .pb_pill_kit_#{$color_name}_none {
+  .pb_pill_kit_#{$color_name}_none,
+  .pb_pill_kit_#{$color_name}_lowercase_sm,
+  .pb_pill_kit_#{$color_name}_none_sm {
     display: inline-flex;
     justify-content: center;
     align-items: center;
@@ -26,11 +30,28 @@ $pb_pill_height: 22px;
 
 // Text transform specific styles
 @each $color_name, $color_value in $status_color_text {
-  .pb_pill_kit_#{$color_name}_lowercase {
+  .pb_pill_kit_#{$color_name}_lowercase,
+  .pb_pill_kit_#{$color_name}_lowercase_sm {
     text-transform: lowercase;
   }
 
-  .pb_pill_kit_#{$color_name}_none {
+  .pb_pill_kit_#{$color_name}_none,
+  .pb_pill_kit_#{$color_name}_none_sm {
     text-transform: none;
+  }
+}
+
+// Small size styles
+@each $color_name, $color_value in $status_color_text {
+  .pb_pill_kit_#{$color_name}_lowercase_sm,
+  .pb_pill_kit_#{$color_name}_none_sm {
+    height: $pb_pill_height_sm;
+    padding: 0 $space_xs;
+    border-radius: $pb_pill_height_sm/2;
+
+    .pb_pill_text {
+      font-size: $font_smallest !important;
+      line-height: 1.7;
+    }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { render, screen } from '../utilities/test-utils'
+import Pill from './_pill'
+
+const testId = 'pill'
+
+test('should render classname', () => {
+  render(
+    <Pill
+        data={{ testid: testId }}
+        text="test"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass('pb_pill_kit_neutral_lowercase')
+})
+
+test('displays text content', () => {
+  render(
+    <Pill
+        data={{ testid: testId }}
+        text="test"
+    />
+  )
+
+  const text = screen.getByText('test')
+  expect(text).toBeInTheDocument()
+})
+
+test('displays variant', () => {
+  render(
+    <Pill
+        data={{ testid: testId }}
+        text="test"
+        variant="success"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass('pb_pill_kit_success_lowercase')
+})
+
+test('displays size sm', () => {
+  render(
+    <Pill
+        data={{ testid: testId }}
+        size="sm"
+        text="test"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass('pb_pill_kit_neutral_lowercase_sm')
+})
+
+test('displays textTransform none', () => {
+  render(
+    <Pill
+        data={{ testid: testId }}
+        text="TEST"
+        textTransform="none"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass('pb_pill_kit_neutral_none')
+})
+
+test('displays size sm with variant and textTransform', () => {
+  render(
+    <Pill
+        data={{ testid: testId }}
+        size="sm"
+        text="Success"
+        textTransform="none"
+        variant="success"
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  expect(kit).toHaveClass('pb_pill_kit_success_none_sm')
+})

--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.tsx
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.tsx
@@ -11,6 +11,7 @@ type PillProps = {
   data?: {[key: string]: string},
   htmlOptions?: {[key: string]: string | number | boolean | (() => void)},
   id?: string,
+  size?: "sm",
   text: string,
   variant?: "success" | "warning" | "error" | "info" | "neutral" | "primary",
   textTransform?: "none" | "lowercase"
@@ -23,6 +24,7 @@ const Pill = (props: PillProps) => {
     data = {},
     htmlOptions = {},
     id,
+    size,
     text,
     variant = 'neutral',
     textTransform = 'lowercase',
@@ -31,7 +33,7 @@ const Pill = (props: PillProps) => {
   const ariaProps = buildAriaProps(aria)
   const dataProps = buildDataProps(data)
   const htmlProps = buildHtmlProps(htmlOptions)
-  const classes = classnames(buildCss('pb_pill_kit', variant, textTransform), globalProps(props), className)
+  const classes = classnames(buildCss('pb_pill_kit', variant, textTransform, size || ''), globalProps(props), className)
 
   return (
     <div

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.html.erb
@@ -1,0 +1,1 @@
+<%= pb_rails("pill", props: { size: "sm", text: "Small" }) %>

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.jsx
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Pill from '../_pill'
+
+const PillSize = (props) => {
+  return (
+    <div>
+      <Pill
+          size="sm"
+          text="small"
+          {...props}
+      />
+    </div>
+  )
+}
+
+export default PillSize

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.md
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.md
@@ -1,0 +1,1 @@
+Set pill size to small wtih `size: "sm"` / `size="sm"`.

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.md
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_size.md
@@ -1,1 +1,1 @@
-Set pill size to small wtih `size: "sm"` / `size="sm"`.
+Set pill size to small with `size: "sm"` / `size="sm"`.

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_playground.json
@@ -24,6 +24,7 @@
       "name": "Appearance",
       "props": [
         "variant",
+        "size",
         "textTransform"
       ]
     }
@@ -44,6 +45,16 @@
         "text": "Primary",
         "variant": "primary",
         "textTransform": "none"
+      },
+      "children": ""
+    },
+    {
+      "name": "Small",
+      "props": {
+        "text": "small",
+        "size": "sm",
+        "variant": "neutral",
+        "textTransform": "lowercase"
       },
       "children": ""
     },

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_playground.overrides.json
@@ -11,7 +11,7 @@
     },
     {
       "name": "Appearance",
-      "props": ["variant", "textTransform"]
+      "props": ["variant", "size", "textTransform"]
     }
   ],
   "presets": [
@@ -30,6 +30,16 @@
         "text": "Primary",
         "variant": "primary",
         "textTransform": "none"
+      },
+      "children": ""
+    },
+    {
+      "name": "Small",
+      "props": {
+        "text": "small",
+        "size": "sm",
+        "variant": "neutral",
+        "textTransform": "lowercase"
       },
       "children": ""
     },

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/example.yml
@@ -3,6 +3,7 @@ examples:
   rails:
   - pill_default: Default
   - pill_variants: Variants
+  - pill_size: Size
   - pill_example: Example
  
   
@@ -10,6 +11,7 @@ examples:
   react:
   - pill_default: Default
   - pill_variants: Variants
+  - pill_size: Size
   - pill_example: Example
 
   swift:

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/index.js
@@ -1,3 +1,4 @@
 export { default as PillDefault } from './_pill_default.jsx'
 export { default as PillVariants } from './_pill_variants.jsx'
 export { default as PillExample } from './_pill_example.jsx'
+export { default as PillSize } from './_pill_size.jsx'

--- a/playbook/app/pb_kits/playbook/pb_pill/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_pill/kit.schema.json
@@ -7,6 +7,17 @@
     "rails"
   ],
   "props": {
+    "size": {
+      "type": "\"sm\"",
+      "platforms": [
+        "react",
+        "rails"
+      ],
+      "values": [
+        "sm"
+      ],
+      "default": null
+    },
     "text": {
       "type": "string",
       "platforms": [
@@ -47,11 +58,11 @@
   "usage": {
     "react": {
       "import": "import { Pill } from 'playbook-ui'",
-      "example": "<Pill variant=\"success\" textTransform=\"none\"></Pill>"
+      "example": "<Pill size=\"sm\" variant=\"success\"></Pill>"
     },
     "rails": {
       "import": null,
-      "example": "<%= pb_rails(\"pill\", props: { variant: \"success\", text_transform: \"none\" }) %>"
+      "example": "<%= pb_rails(\"pill\", props: { size: \"sm\", variant: \"success\" }) %>"
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_pill/pill.rb
+++ b/playbook/app/pb_kits/playbook/pb_pill/pill.rb
@@ -4,6 +4,9 @@ module Playbook
   module PbPill
     class Pill < Playbook::KitBase
       prop :text
+      prop :size, type: Playbook::Props::Enum,
+                  values: ["sm", nil],
+                  default: nil
       prop :variant, type: Playbook::Props::Enum,
                      values: %w[success warning error info neutral primary],
                      default: "neutral"
@@ -12,7 +15,7 @@ module Playbook
                             default: "lowercase"
 
       def classname
-        generate_classname("pb_pill_kit", variant, text_transform)
+        generate_classname("pb_pill_kit", variant, text_transform, size)
       end
 
       def display_text

--- a/playbook/spec/pb_kits/playbook/kits/pill_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/pill_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Playbook::PbPill::Pill do
 
   it { is_expected.to define_prop(:text) }
   it {
+    is_expected.to define_enum_prop(:size)
+      .with_default(nil)
+      .with_values("sm", nil)
+  }
+  it {
     is_expected.to define_enum_prop(:variant)
       .with_default("neutral")
       .with_values("neutral", "success", "warning", "error", "info", "primary")
@@ -16,6 +21,8 @@ RSpec.describe Playbook::PbPill::Pill do
       expect(subject.new({}).classname).to eq "pb_pill_kit_neutral_lowercase"
       expect(subject.new(dark: true).classname).to eq "pb_pill_kit_neutral_lowercase dark"
       expect(subject.new(classname: "additional_class").classname).to eq "pb_pill_kit_neutral_lowercase additional_class"
+      expect(subject.new(size: "sm").classname).to eq "pb_pill_kit_neutral_lowercase_sm"
+      expect(subject.new(size: "sm", variant: "success", text_transform: "none").classname).to eq "pb_pill_kit_success_none_sm"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3099](https://runway.powerhrg.com/backlog_items/PLAY-3099) introduces a new size prop and style to the Pill kit. A smaller pill matches the appearance and API set up of the [small Form Pill](https://playbook.powerapp.cloud/kits/form_pill/react#form_pill_size). This PR also adds a jest test suite for the kit which did not have one previously.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1352" height="452" alt="PR doc" src="https://github.com/user-attachments/assets/b25c2dcf-77b4-4ec2-90b5-12ba073f226f" />
<img width="613" height="313" alt="dom" src="https://github.com/user-attachments/assets/73427ff0-d778-43c9-a5eb-35e813598631" />

**How to test?** Steps to confirm the desired behavior:
1. Go to Pill kit "Size" doc ex to see small pill. Can evaluate appearance of different variants in the Playground.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.