### PR TITLE
[PLAY-3086] Playbook Website: Extend Code Example Background and Update Schema Generator

### DIFF
--- a/playbook-website/app/javascript/site_styles/website_new.scss
+++ b/playbook-website/app/javascript/site_styles/website_new.scss
@@ -76,6 +76,9 @@ body.pages.application .pb--website-react-host {
   pre.highlight {
     padding: 44px 24px;
     margin: 0;
+    width: max-content;
+    min-width: 100%;
+    box-sizing: border-box;
   }
   .highlight {
     background: $bg_dark;

--- a/playbook/app/pb_kits/playbook/pb_background/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_background/kit.schema.json
@@ -14,7 +14,7 @@
       ]
     },
     "backgroundColor": {
-      "type": "ResponsiveProp<BackgroundColors> | BackgroundColors",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"
@@ -85,7 +85,7 @@
       "default": "light"
     },
     "backgroundSize": {
-      "type": "ResponsiveProp<BackgroundSizes> | BackgroundSizes",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"
@@ -106,7 +106,7 @@
       "default": null
     },
     "backgroundRepeat": {
-      "type": "ResponsiveProp<BackgroundRepeat> | BackgroundRepeat",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"

--- a/playbook/app/pb_kits/playbook/pb_card/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_card/kit.schema.json
@@ -8,7 +8,7 @@
   ],
   "props": {
     "background": {
-      "type": "BackgroundColors | ProductColors | \"none\"",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"

--- a/playbook/app/pb_kits/playbook/pb_icon_circle/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_icon_circle/kit.schema.json
@@ -44,8 +44,16 @@
         "rails"
       ],
       "values": [
-        0,
-        "default"
+        "default",
+        "royal",
+        "blue",
+        "purple",
+        "teal",
+        "red",
+        "yellow",
+        "orange",
+        "green",
+        "lighter"
       ],
       "default": "default"
     },
@@ -61,11 +69,11 @@
   "usage": {
     "react": {
       "import": "import { IconCircle } from 'playbook-ui'",
-      "example": "<IconCircle size=\"base\" variant=\"0\"></IconCircle>"
+      "example": "<IconCircle size=\"base\" variant=\"default\"></IconCircle>"
     },
     "rails": {
       "import": null,
-      "example": "<%= pb_rails(\"icon_circle\", props: { size: \"base\", variant: \"0\" }) %>"
+      "example": "<%= pb_rails(\"icon_circle\", props: { size: \"base\", variant: \"default\" }) %>"
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_icon_stat_value/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_icon_stat_value/kit.schema.json
@@ -69,7 +69,7 @@
       ]
     },
     "variant": {
-      "type": "\"default\"",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"
@@ -82,8 +82,8 @@
         "teal",
         "red",
         "yellow",
-        "green",
-        "orange"
+        "orange",
+        "green"
       ],
       "default": "default"
     }

--- a/playbook/app/pb_kits/playbook/pb_message/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_message/kit.schema.json
@@ -78,7 +78,7 @@
       "default": "America/New_York"
     },
     "alignTimestamp": {
-      "type": "string",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/docs/_playground.json
@@ -14,6 +14,7 @@
     "placeholder": "Start typing...",
     "variant": "multi",
     "wrapped": false,
+    "pillColor": "primary",
     "selectedIds": [
       "talent1",
       "initiative1"

--- a/playbook/app/pb_kits/playbook/pb_multi_level_select/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_multi_level_select/kit.schema.json
@@ -145,10 +145,11 @@
       "default": false
     },
     "pillColor": {
+      "type": "enum",
       "platforms": [
+        "react",
         "rails"
       ],
-      "type": "enum",
       "values": [
         "primary",
         "neutral",

--- a/playbook/app/pb_kits/playbook/pb_pill/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_pill/kit.schema.json
@@ -8,7 +8,7 @@
   ],
   "props": {
     "size": {
-      "type": "\"sm\"",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"

--- a/playbook/app/pb_kits/playbook/pb_progress_step/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_progress_step/kit.schema.json
@@ -36,7 +36,7 @@
       "default": false
     },
     "variant": {
-      "type": "string",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"
@@ -48,7 +48,7 @@
       "default": "default"
     },
     "color": {
-      "type": "string",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"

--- a/playbook/app/pb_kits/playbook/pb_timeline/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_timeline/kit.schema.json
@@ -8,7 +8,7 @@
   ],
   "props": {
     "orientation": {
-      "type": "string",
+      "type": "enum",
       "platforms": [
         "react",
         "rails"

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.json
@@ -7,6 +7,7 @@
     "disabled": false,
     "error": "",
     "inputDisplay": "pills",
+    "pillColor": "primary",
     "required": false,
     "requiredIndicator": false,
     "clearOnContextChange": true,

--- a/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
@@ -120,6 +120,38 @@
         "xl"
       ]
     },
+    "pillColor": {
+      "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
+      "values": [
+        "primary",
+        "neutral",
+        "success",
+        "warning",
+        "error",
+        "info",
+        "data_1",
+        "data_2",
+        "data_3",
+        "data_4",
+        "data_5",
+        "data_6",
+        "data_7",
+        "data_8",
+        "windows",
+        "siding",
+        "roofing",
+        "doors",
+        "gutters",
+        "solar",
+        "insulation",
+        "accessories"
+      ],
+      "default": "primary"
+    },
     "onChange": {
       "type": "any",
       "platforms": [
@@ -278,37 +310,6 @@
       "platforms": [
         "rails"
       ]
-    },
-    "pillColor": {
-      "platforms": [
-        "rails"
-      ],
-      "type": "enum",
-      "values": [
-        "primary",
-        "neutral",
-        "success",
-        "warning",
-        "error",
-        "info",
-        "data_1",
-        "data_2",
-        "data_3",
-        "data_4",
-        "data_5",
-        "data_6",
-        "data_7",
-        "data_8",
-        "windows",
-        "siding",
-        "roofing",
-        "doors",
-        "gutters",
-        "solar",
-        "insulation",
-        "accessories"
-      ],
-      "default": "primary"
     },
     "wrapped": {
       "platforms": [

--- a/playbook/scripts/generate-ai-metadata.mjs
+++ b/playbook/scripts/generate-ai-metadata.mjs
@@ -259,7 +259,7 @@ function parseTypeString(typeStr, imports = new Map()) {
 
   // Union of literals: "a" | "b" | "c"
   if (typeStr.includes('|')) {
-    const parts = typeStr.split('|').map(p => p.trim());
+    const parts = typeStr.split('|').map(p => p.trim()).filter(Boolean);
     const isAllLiterals = parts.every(p => 
       isQuoted(p) || p === 'null' || p === 'undefined' || !isNaN(Number(p)) || p === '""'
     );
@@ -271,6 +271,14 @@ function parseTypeString(typeStr, imports = new Map()) {
       return { type: 'enum', values };
     }
     return { type: typeStr };
+  }
+
+  // Single string/number literal: → enum with one value
+  if (isQuoted(typeStr)) {
+    return { type: 'enum', values: [stripQuotes(typeStr)] };
+  }
+  if (typeStr !== '' && !isNaN(Number(typeStr))) {
+    return { type: 'enum', values: [Number(typeStr)] };
   }
 
   // Primitives
@@ -332,7 +340,8 @@ function parseTypeBlock(block, imports = new Map()) {
     } else {
       // Update depth for continuation lines
       depth += (trimmed.match(/\{/g) || []).length - (trimmed.match(/\}/g) || []).length;
-      if (currentProp && depth > 0) {
+      // Continue object types (depth > 0) and multiline unions (lines starting with |)
+      if (currentProp && (depth > 0 || trimmed.startsWith('|'))) {
         currentType += ' ' + trimmed.replace(/,\s*$/, '');
       }
     }
@@ -454,8 +463,22 @@ function mergeProps(react, rails) {
       merged[name] = {
         type: r.type || rb.type,
         platforms: ['react', 'rails'],
-        ...(r.values || rb.values) && { values: r.values || rb.values },
       };
+
+      // Prefer React values (current display preference). Fall back to Rails 
+      // when React looks truncated to a single literal that exists in a longer Rails enum 
+      // (e.g. multiline union parse failure: ["default"] vs full Rails enum list).
+      // This logic should probably eventually be updated in a better way than this.
+      const rValues = r.values || [];
+      const rbValues = rb.values || [];
+      if (rValues.length || rbValues.length) {
+        const reactLooksTruncated =
+          rValues.length === 1 &&
+          rbValues.length > 1 &&
+          rbValues.includes(rValues[0]);
+        merged[name].values = reactLooksTruncated || !rValues.length ? rbValues : rValues;
+        if (r.type === 'enum' || rb.type === 'enum') merged[name].type = 'enum';
+      }
       
       const rd = r.default, rbd = rb.default;
       if (rd !== undefined || rbd !== undefined) {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3086](https://runway.powerhrg.com/backlog_items/PLAY-3086) addresses two Playbook Website only issues:
- it extends the dark code background width to expand for doc examples with horizontal scroll
- it updates the schema generator to handle some edge cases/atypical prop type layouts and correctly display props/types in the Kit Props tables. The updates caused schema changes in several kits (a few examples highlighted in screenshot section below, where current prod on left updated on right for all side-by-sides)

**Screenshots:** Screenshots to visualize your addition/change 
Expanded Code Background
<img width="1625" height="976" alt="at table props code snippet side by side" src="https://github.com/user-attachments/assets/0666b914-f540-4672-88ca-f9130ffdb4f7" />
Schema Generator update
Pill - type corrected to union for entries with one value
<img width="1603" height="931" alt="pill side by side" src="https://github.com/user-attachments/assets/eee54333-1208-4376-b54d-35663815efd3" />
Icon Stat Value - type corrected to union for entries with multiple values (but only one on the first line in the kit file)
<img width="1645" height="977" alt="icon stat value side by side" src="https://github.com/user-attachments/assets/06cd6722-a5e6-47fe-b507-4cd5a09de8ca" />
Icon Circle - type corrected to union for entries with multiple values (but only one on the first line in the kit file) and removes "0" value when the value line starts with a bar "|"
<img width="1677" height="839" alt="icon circle side by side" src="https://github.com/user-attachments/assets/fd115ea4-7540-42d7-9618-ac3f283bbf2f" />
Typeahead - pillColor prop makes it onto kit prop table now
<img width="1664" height="1005" alt="typeahead side by side" src="https://github.com/user-attachments/assets/a4123373-6fe8-44b0-94c1-1e6f41e83048" />

**How to test?** Steps to confirm the desired behavior:
1. Go to a doc example with a long horizontal line (ex. Advanced Table Rails docs) - open a code snippet and scroll to the right, the dark background will extend.
2. Go to the kit prop table for each of the updated kit schemas - compare to prod and see improved accuracy. Look at kit files to see what was causing the difference.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.