### PR TITLE
[PLAY-3113] MetaData: Fix parser for global props

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/AvailableProps/globalProps.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/AvailableProps/globalProps.tsx
@@ -1,8 +1,18 @@
 import React from 'react'
 import { Body, Card, Table, Title } from 'playbook-ui'
 import globalPropsValues from './globalPropsValues'
+import { formatPropNameForPlatform } from '../../helpers/platform'
 
-const GlobalProps = ({ darkMode }) => {
+type GlobalPropsType = {
+  darkMode: boolean,
+  platform?: string
+}
+
+const GlobalProps = ({ darkMode, platform = 'react' }: GlobalPropsType) => {
+  const platformProps = globalPropsValues.filter(
+    (prop) => !prop.platforms || prop.platforms.includes(platform)
+  )
+
   return (
     <>
       <Card.Body
@@ -23,7 +33,7 @@ const GlobalProps = ({ darkMode }) => {
             </tr>
           </thead>
           <tbody>
-            {globalPropsValues.map((prop) => (
+            {platformProps.map((prop) => (
               <>
                 <tr>
                   <td>
@@ -31,7 +41,7 @@ const GlobalProps = ({ darkMode }) => {
                         dark={darkMode}
                         size={4}
                         tag="h4"
-                        text={prop.prop}
+                        text={formatPropNameForPlatform(prop.prop, platform)}
                     />
                   </td>
                   <td>

--- a/playbook-website/app/javascript/components/Website/src/components/AvailableProps/globalPropsValues.ts
+++ b/playbook-website/app/javascript/components/Website/src/components/AvailableProps/globalPropsValues.ts
@@ -9,317 +9,380 @@ const globalPropsValues = [
   {
     prop: "alignContent",
     type: "union",
-    values: '"start" | "end" | "center" | "spaceBetween" | "spaceAround" | "spaceEvenly"'
+    values: '"start" | "end" | "center" | "spaceBetween" | "spaceAround" | "spaceEvenly"',
+    platforms: ["react","rails"]
   },
   {
     prop: "alignItems",
     type: "union",
-    values: '"start" | "end" | "center" | "flexStart" | "flexEnd" | "stretch" | "baseline"'
+    values: '"start" | "end" | "center" | "flexStart" | "flexEnd" | "stretch" | "baseline"',
+    platforms: ["react","rails"]
   },
   {
     prop: "alignSelf",
     type: "union",
-    values: '"start" | "end" | "center" | "auto" | "stretch" | "baseline"'
+    values: '"start" | "end" | "center" | "auto" | "stretch" | "baseline"',
+    platforms: ["react","rails"]
   },
   {
     prop: "border",
     type: "union",
-    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"'
+    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"',
+    platforms: ["react","rails"]
   },
   {
     prop: "borderBottom",
     type: "union",
-    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"'
+    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"',
+    platforms: ["react","rails"]
   },
   {
     prop: "borderLeft",
     type: "union",
-    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"'
+    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"',
+    platforms: ["react","rails"]
   },
   {
     prop: "borderRadius",
     type: "union",
-    values: '"none" | "xs" | "sm" | "md" | "lg" | "xl" | "rounded"'
+    values: '"none" | "xs" | "sm" | "md" | "lg" | "xl" | "rounded"',
+    platforms: ["react","rails"]
   },
   {
     prop: "borderRight",
     type: "union",
-    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"'
+    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"',
+    platforms: ["react","rails"]
   },
   {
     prop: "borderTop",
     type: "union",
-    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"'
+    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"',
+    platforms: ["react","rails"]
   },
   {
     prop: "borderX",
     type: "union",
-    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"'
+    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"',
+    platforms: ["react","rails"]
   },
   {
     prop: "borderY",
     type: "union",
-    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"'
+    values: '"none" | "default" | "active" | "default_thick" | "default_thicker" | "active_thick" | "active_thicker"',
+    platforms: ["react","rails"]
   },
   {
     prop: "bottom",
     type: "union",
-    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"'
+    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"',
+    platforms: ["react","rails"]
   },
   {
     prop: "columnGap",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "cursor",
     type: "union",
-    values: '"auto" | "default" | "none" | "contextMenu" | "help" | "pointer" | "progress" | "wait" | "cell"'
+    values: '"auto" | "default" | "none" | "contextMenu" | "help" | "pointer" | "progress" | "wait" | "cell"',
+    platforms: ["react","rails"]
   },
   {
     prop: "dark",
     type: "boolean",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "display",
     type: "union",
-    values: '"none" | "flex" | "inline_flex" | "inline" | "inline_block" | "block" | "grid"'
+    values: '"none" | "flex" | "inline_flex" | "inline" | "inline_block" | "block" | "grid"',
+    platforms: ["react","rails"]
   },
   {
     prop: "flex",
     type: "union",
-    values: '"auto" | "initial" | "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "none"'
+    values: '"auto" | "initial" | "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "none"',
+    platforms: ["react","rails"]
   },
   {
     prop: "flexDirection",
     type: "union",
-    values: '"row" | "column" | "rowReverse" | "columnReverse"'
+    values: '"row" | "column" | "rowReverse" | "columnReverse"',
+    platforms: ["react","rails"]
   },
   {
     prop: "flexGrow",
     type: "union",
-    values: '"0" | "1"'
+    values: '"0" | "1"',
+    platforms: ["react","rails"]
   },
   {
     prop: "flexShrink",
     type: "union",
-    values: '"0" | "1"'
+    values: '"0" | "1"',
+    platforms: ["react","rails"]
   },
   {
     prop: "flexWrap",
     type: "union",
-    values: '"wrap" | "nowrap" | "wrapReverse"'
+    values: '"wrap" | "nowrap" | "wrapReverse"',
+    platforms: ["react","rails"]
   },
   {
     prop: "gap",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "groupHover",
     type: "boolean",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "height",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "hover",
     type: "object",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "inset",
     type: "boolean",
-    values: []
+    values: [],
+    platforms: ["react"]
   },
   {
     prop: "justifyContent",
     type: "union",
-    values: '"start" | "end" | "center" | "spaceBetween" | "spaceAround" | "spaceEvenly"'
+    values: '"start" | "end" | "center" | "spaceBetween" | "spaceAround" | "spaceEvenly"',
+    platforms: ["react","rails"]
   },
   {
     prop: "justifySelf",
     type: "union",
-    values: '"start" | "end" | "center" | "auto" | "stretch"'
+    values: '"start" | "end" | "center" | "auto" | "stretch"',
+    platforms: ["react","rails"]
   },
   {
     prop: "left",
     type: "union",
-    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"'
+    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"',
+    platforms: ["react","rails"]
   },
   {
     prop: "lineHeight",
     type: "union",
-    values: '"loosest" | "looser" | "loose" | "normal" | "tight" | "tighter" | "tightest"'
+    values: '"loosest" | "looser" | "loose" | "normal" | "tight" | "tighter" | "tightest"',
+    platforms: ["react","rails"]
   },
   {
     prop: "margin",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "marginBottom",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "marginLeft",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "marginRight",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "marginTop",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "marginX",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "marginY",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "maxHeight",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "maxWidth",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "minHeight",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "minWidth",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "numberSpacing",
     type: "union",
-    values: '"tabular"'
+    values: '"tabular"',
+    platforms: ["react","rails"]
   },
   {
     prop: "order",
     type: "union",
-    values: '"none" | "first" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12"'
+    values: '"none" | "first" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12"',
+    platforms: ["react","rails"]
   },
   {
     prop: "overflow",
     type: "union",
-    values: '"scroll" | "visible" | "hidden" | "auto"'
+    values: '"scroll" | "visible" | "hidden" | "auto"',
+    platforms: ["react","rails"]
   },
   {
     prop: "overflowX",
     type: "union",
-    values: '"scroll" | "visible" | "hidden" | "auto"'
+    values: '"scroll" | "visible" | "hidden" | "auto"',
+    platforms: ["react","rails"]
   },
   {
     prop: "overflowY",
     type: "union",
-    values: '"scroll" | "visible" | "hidden" | "auto"'
+    values: '"scroll" | "visible" | "hidden" | "auto"',
+    platforms: ["react","rails"]
   },
   {
     prop: "padding",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "paddingBottom",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "paddingLeft",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "paddingRight",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "paddingTop",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "paddingX",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "paddingY",
     type: "union",
-    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"'
+    values: '"none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "auto" | "initial" | "inherit"',
+    platforms: ["react","rails"]
   },
   {
     prop: "position",
     type: "union",
-    values: '"relative" | "absolute" | "fixed" | "sticky" | "static"'
+    values: '"relative" | "absolute" | "fixed" | "sticky" | "static"',
+    platforms: ["react","rails"]
   },
   {
     prop: "right",
     type: "union",
-    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"'
+    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"',
+    platforms: ["react","rails"]
   },
   {
     prop: "rowGap",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "shadow",
     type: "union",
-    values: '"none" | "deep" | "deeper" | "deepest"'
+    values: '"none" | "deep" | "deeper" | "deepest"',
+    platforms: ["react","rails"]
   },
   {
     prop: "textAlign",
     type: "union",
-    values: '"start" | "end" | "left" | "right" | "center" | "justify" | "justifyAll" | "matchParent"'
+    values: '"start" | "end" | "left" | "right" | "center" | "justify" | "justifyAll" | "matchParent"',
+    platforms: ["react","rails"]
   },
   {
     prop: "top",
     type: "union",
-    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"'
+    values: '"xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl"',
+    platforms: ["react","rails"]
   },
   {
     prop: "truncate",
     type: "union",
-    values: '"none" | "1" | "2" | "3" | "4" | "5"'
+    values: '"none" | "1" | "2" | "3" | "4" | "5"',
+    platforms: ["react","rails"]
   },
   {
     prop: "verticalAlign",
     type: "union",
-    values: '"baseline" | "super" | "top" | "middle" | "bottom" | "sub" | "text-top" | "text-bottom"'
+    values: '"baseline" | "super" | "top" | "middle" | "bottom" | "sub" | "text-top" | "text-bottom"',
+    platforms: ["react","rails"]
   },
   {
     prop: "width",
     type: "string",
-    values: []
+    values: [],
+    platforms: ["react","rails"]
   },
   {
     prop: "zIndex",
     type: "union",
-    values: '"1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "max"'
+    values: '"1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "max"',
+    platforms: ["react","rails"]
   }
 ];
 

--- a/playbook-website/app/javascript/components/Website/src/components/AvailableProps/globalPropsValues.ts
+++ b/playbook-website/app/javascript/components/Website/src/components/AvailableProps/globalPropsValues.ts
@@ -14,7 +14,12 @@ const globalPropsValues = [
   {
     prop: "alignItems",
     type: "union",
-    values: '"start" | "end" | "center"'
+    values: '"start" | "end" | "center" | "flexStart" | "flexEnd" | "stretch" | "baseline"'
+  },
+  {
+    prop: "alignSelf",
+    type: "union",
+    values: '"start" | "end" | "center" | "auto" | "stretch" | "baseline"'
   },
   {
     prop: "border",
@@ -77,6 +82,11 @@ const globalPropsValues = [
     values: []
   },
   {
+    prop: "display",
+    type: "union",
+    values: '"none" | "flex" | "inline_flex" | "inline" | "inline_block" | "block" | "grid"'
+  },
+  {
     prop: "flex",
     type: "union",
     values: '"auto" | "initial" | "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11" | "12" | "none"'
@@ -85,6 +95,16 @@ const globalPropsValues = [
     prop: "flexDirection",
     type: "union",
     values: '"row" | "column" | "rowReverse" | "columnReverse"'
+  },
+  {
+    prop: "flexGrow",
+    type: "union",
+    values: '"0" | "1"'
+  },
+  {
+    prop: "flexShrink",
+    type: "union",
+    values: '"0" | "1"'
   },
   {
     prop: "flexWrap",
@@ -120,6 +140,11 @@ const globalPropsValues = [
     prop: "justifyContent",
     type: "union",
     values: '"start" | "end" | "center" | "spaceBetween" | "spaceAround" | "spaceEvenly"'
+  },
+  {
+    prop: "justifySelf",
+    type: "union",
+    values: '"start" | "end" | "center" | "auto" | "stretch"'
   },
   {
     prop: "left",

--- a/playbook-website/app/javascript/components/Website/src/helpers/platform.ts
+++ b/playbook-website/app/javascript/components/Website/src/helpers/platform.ts
@@ -39,6 +39,21 @@ export const writeStoredPlatform = (platform: string) => {
   }
 };
 
+/**
+ * Prop names are camelCase in React and snake_case in Rails. Only names differ —
+ * Rails keeps camelCase prop *values* (e.g. justify_content: "spaceBetween").
+ */
+export const formatPropNameForPlatform = (
+  propName: string,
+  platform: string,
+): string =>
+  platform === "rails"
+    ? propName
+        .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+        .replace(/-/g, "_")
+        .toLowerCase()
+    : propName;
+
 export const getPlatformFromPath = (pathname: string): Platform | null => {
   const match = pathname.match(
     /^\/kits\/(?:advanced_table\/)?[^/]+\/(react|rails|swift)$/,

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/constants.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/constants.ts
@@ -37,11 +37,16 @@ export const GLOBAL_PROP_GROUPS: Array<{ name: string; props: string[] }> = [
   {
     name: "Flexbox",
     props: [
+      "display",
       "flex",
       "flexDirection",
       "flexWrap",
+      "flexGrow",
+      "flexShrink",
       "justifyContent",
+      "justifySelf",
       "alignItems",
+      "alignSelf",
       "alignContent",
       "gap",
       "columnGap",

--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/PropsTab.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/PropsTab.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Nav, NavItem, SectionSeparator } from "playbook-ui";
 import globalPropsValues from "../../../components/AvailableProps/globalPropsValues";
 import { useDarkMode } from "../../../contexts/DarkModeContext";
+import { formatPropNameForPlatform } from "../../../helpers/platform";
 interface PropsTabProps {
   availableProps?: string;
   platform?: string;
@@ -24,14 +25,6 @@ export const PropsTab = ({ availableProps, platform = "react" }: PropsTabProps) 
   // Parse the schema JSON
   const schema = JSON.parse(availableProps);
 
-  const formatPropName = (propName: string) =>
-    platform === "rails"
-      ? propName
-          .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-          .replace(/-/g, "_")
-          .toLowerCase()
-      : propName;
-  
   // Extract props from our kit.schema.json format
   // Schema structure: { $schema, name, description, platforms, props: {...}, globalProps, usage }
   const props = schema.props && typeof schema.props === 'object' ? schema.props : schema;
@@ -48,7 +41,7 @@ export const PropsTab = ({ availableProps, platform = "react" }: PropsTabProps) 
     const isForPlatform = platforms.length === 0 || platforms.includes(platform);
     
     if (!isGlobalProp && isForPlatform) {
-      kitProps[formatPropName(propName)] = prop;
+      kitProps[formatPropNameForPlatform(propName, platform)] = prop;
     }
   }
 
@@ -75,7 +68,7 @@ export const PropsTab = ({ availableProps, platform = "react" }: PropsTabProps) 
         </Card.Body>
         <SectionSeparator dark={darkMode} />
         {showKitTab && <KitProps kitPropsValues={kitProps} darkMode={darkMode} />}
-        {!showKitTab && <GlobalProps darkMode={darkMode} />}
+        {!showKitTab && <GlobalProps darkMode={darkMode} platform={platform} />}
       </Card>
     </Flex>
   );

--- a/playbook-website/scripts/generate-global-props-values.mjs
+++ b/playbook-website/scripts/generate-global-props-values.mjs
@@ -47,11 +47,13 @@ function generate() {
     .map(([name, prop]) => {
       const type = getTypeFromSchema(prop);
       const values = formatValues(prop);
-      
+      const platforms = prop.platforms || ['react', 'rails'];
+
       return `  {
     prop: "${name}",
     type: "${type}",
-    values: ${values}
+    values: ${values},
+    platforms: ${JSON.stringify(platforms)}
   }`;
     });
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/docs/_playground.json
@@ -12,6 +12,7 @@
     "fullWidthCell": false,
     "inlineRowLoading": false,
     "loading": false,
+    "maxHeight": "auto",
     "responsive": "scroll",
     "scrollBarNone": false,
     "selectableRows": false,

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/kit.schema.json
@@ -125,7 +125,8 @@
     "maxHeight": {
       "type": "enum",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ],
       "values": [
         "auto",
@@ -136,7 +137,8 @@
         "xl",
         "xxl",
         "xxxl"
-      ]
+      ],
+      "default": "auto"
     },
     "onRowToggleClick": {
       "type": "function",

--- a/playbook/app/pb_kits/playbook/pb_avatar/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_avatar/docs/_playground.json
@@ -2,6 +2,7 @@
   "template": "<Avatar{{props}} />",
   "propTargets": {},
   "defaults": {
+    "dark": false,
     "grayscale": false,
     "imageAlt": "",
     "name": "",

--- a/playbook/app/pb_kits/playbook/pb_avatar/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_avatar/kit.schema.json
@@ -17,8 +17,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "grayscale": {
       "type": "boolean",

--- a/playbook/app/pb_kits/playbook/pb_card/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_card/docs/_playground.json
@@ -7,6 +7,7 @@
   "defaults": {
     "background": "none",
     "borderNone": false,
+    "borderRadius": "md",
     "draggableItem": false,
     "dragHandle": true,
     "selected": false,

--- a/playbook/app/pb_kits/playbook/pb_card/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_card/kit.schema.json
@@ -66,7 +66,8 @@
     "borderRadius": {
       "type": "enum",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ],
       "values": [
         "xs",
@@ -76,7 +77,8 @@
         "xl",
         "none",
         "rounded"
-      ]
+      ],
+      "default": "md"
     },
     "dragId": {
       "type": "string",

--- a/playbook/app/pb_kits/playbook/pb_currency/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_currency/docs/_playground.json
@@ -4,6 +4,7 @@
   "defaults": {
     "abbreviate": false,
     "align": "left",
+    "dark": false,
     "decimals": "default",
     "emphasized": true,
     "label": "Balance",

--- a/playbook/app/pb_kits/playbook/pb_currency/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_currency/kit.schema.json
@@ -38,8 +38,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "decimals": {
       "type": "enum",

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_playground.json
@@ -3,6 +3,7 @@
   "propTargets": {},
   "defaults": {
     "allowInput": false,
+    "dark": false,
     "defaultDate": "",
     "disableInput": false,
     "enableTime": false,

--- a/playbook/app/pb_kits/playbook/pb_date_picker/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/kit.schema.json
@@ -25,8 +25,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "defaultDate": {
       "type": "string",
@@ -339,6 +341,13 @@
       "type": "boolean",
       "default": false
     },
+    "position": {
+      "platforms": [
+        "rails"
+      ],
+      "type": "string",
+      "default": "auto"
+    },
     "startDateId": {
       "platforms": [
         "rails"
@@ -373,6 +382,13 @@
       ],
       "type": "string",
       "default": ""
+    },
+    "cursor": {
+      "platforms": [
+        "rails"
+      ],
+      "type": "string",
+      "default": "pointer"
     }
   },
   "globalProps": true,

--- a/playbook/app/pb_kits/playbook/pb_date_range_inline/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_date_range_inline/docs/_playground.json
@@ -3,6 +3,7 @@
   "propTargets": {},
   "defaults": {
     "align": "left",
+    "dark": false,
     "size": "sm",
     "showCurrentYear": false
   },

--- a/playbook/app/pb_kits/playbook/pb_date_range_inline/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_date_range_inline/kit.schema.json
@@ -23,8 +23,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "endDate": {
       "type": "Date",

--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/docs/_playground.json
@@ -1,7 +1,9 @@
 {
   "template": "<DateRangeStacked{{props}} />",
   "propTargets": {},
-  "defaults": {},
+  "defaults": {
+    "dark": false
+  },
   "groups": [
     {
       "name": "Content",

--- a/playbook/app/pb_kits/playbook/pb_date_range_stacked/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_date_range_stacked/kit.schema.json
@@ -10,8 +10,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "endDate": {
       "type": "Date",

--- a/playbook/app/pb_kits/playbook/pb_date_stacked/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_date_stacked/docs/_playground.json
@@ -4,6 +4,7 @@
   "defaults": {
     "align": "left",
     "bold": false,
+    "dark": false,
     "size": "sm",
     "reverse": false,
     "showCurrentYear": false

--- a/playbook/app/pb_kits/playbook/pb_date_stacked/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_date_stacked/kit.schema.json
@@ -31,8 +31,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "date": {
       "type": "Date",

--- a/playbook/app/pb_kits/playbook/pb_date_time/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_date_time/kit.schema.json
@@ -80,6 +80,13 @@
       ],
       "type": "string",
       "default": "America/New_York"
+    },
+    "dark": {
+      "platforms": [
+        "rails"
+      ],
+      "type": "boolean",
+      "default": false
     }
   },
   "globalProps": true,

--- a/playbook/app/pb_kits/playbook/pb_date_time_stacked/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_date_time_stacked/docs/_playground.json
@@ -2,6 +2,7 @@
   "template": "<DateTimeStacked{{props}} />",
   "propTargets": {},
   "defaults": {
+    "dark": false,
     "showCurrentYear": false
   },
   "groups": [

--- a/playbook/app/pb_kits/playbook/pb_date_time_stacked/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_date_time_stacked/kit.schema.json
@@ -23,8 +23,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "timeZone": {
       "type": "string",

--- a/playbook/app/pb_kits/playbook/pb_date_year_stacked/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_date_year_stacked/docs/_playground.json
@@ -2,7 +2,8 @@
   "template": "<DateYearStacked{{props}} />",
   "propTargets": {},
   "defaults": {
-    "align": "left"
+    "align": "left",
+    "dark": false
   },
   "groups": [
     {

--- a/playbook/app/pb_kits/playbook/pb_date_year_stacked/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_date_year_stacked/kit.schema.json
@@ -23,8 +23,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "date": {
       "type": "Date",

--- a/playbook/app/pb_kits/playbook/pb_filter/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_filter/docs/_playground.json
@@ -3,6 +3,7 @@
   "propTargets": {},
   "defaults": {
     "background": true,
+    "minWidth": "360px",
     "placement": "bottom-start",
     "double": false,
     "filters": {
@@ -10,7 +11,6 @@
       "City": "San Francisco"
     },
     "isCollapsed": false,
-    "minWidth": "360px",
     "onCollapse": "() => {}",
     "onSortChange": "() => {}",
     "popoverProps": {},

--- a/playbook/app/pb_kits/playbook/pb_filter/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_filter/kit.schema.json
@@ -37,14 +37,17 @@
     "maxHeight": {
       "type": "string",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "minWidth": {
       "type": "string",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": "auto"
     },
     "onCollapse": {
       "type": "function",

--- a/playbook/app/pb_kits/playbook/pb_flex/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_flex/kit.schema.json
@@ -116,19 +116,22 @@
     "gap": {
       "type": "SizeType | SizeResponsiveType",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "rowGap": {
       "type": "SizeType | SizeResponsiveType",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "columnGap": {
       "type": "SizeType | SizeResponsiveType",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "wrap": {

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/docs/_playground.json
@@ -2,6 +2,7 @@
   "template": "<HomeAddressStreet{{props}} />",
   "propTargets": {},
   "defaults": {
+    "dark": false,
     "preserveCase": false,
     "emphasis": "street",
     "newWindow": false,

--- a/playbook/app/pb_kits/playbook/pb_home_address_street/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_home_address_street/kit.schema.json
@@ -31,8 +31,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "preserveCase": {
       "type": "boolean",

--- a/playbook/app/pb_kits/playbook/pb_icon/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_icon/docs/_playground.json
@@ -2,6 +2,7 @@
   "template": "<Icon{{props}} />",
   "propTargets": {},
   "defaults": {
+    "border": false,
     "fixedWidth": true,
     "inverse": false,
     "listItem": false,

--- a/playbook/app/pb_kits/playbook/pb_icon/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_icon/kit.schema.json
@@ -8,10 +8,23 @@
   ],
   "props": {
     "border": {
-      "type": "boolean | BorderPropValue",
+      "type": "enum",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "values": [
+        false,
+        true,
+        "none",
+        "default",
+        "active",
+        "default_thick",
+        "active_thick",
+        "default_thicker",
+        "active_thicker"
+      ],
+      "default": false
     },
     "color": {
       "type": "string",
@@ -168,11 +181,11 @@
   "usage": {
     "react": {
       "import": "import { Icon } from 'playbook-ui'",
-      "example": "<Icon flip=\"horizontal\" pull=\"left\"></Icon>"
+      "example": "<Icon border=\"false\" flip=\"horizontal\"></Icon>"
     },
     "rails": {
       "import": null,
-      "example": "<%= pb_rails(\"icon\", props: { flip: \"horizontal\", pull: \"left\" }) %>"
+      "example": "<%= pb_rails(\"icon\", props: { border: \"false\", flip: \"horizontal\" }) %>"
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_layout/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_layout/docs/_playground.json
@@ -4,6 +4,7 @@
   "defaults": {
     "collapse": "xs",
     "full": false,
+    "position": "left",
     "responsive": false,
     "size": {
       "react": "sm",

--- a/playbook/app/pb_kits/playbook/pb_layout/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_layout/kit.schema.json
@@ -39,12 +39,14 @@
     "position": {
       "type": "enum",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ],
       "values": [
         "left",
         "right"
-      ]
+      ],
+      "default": "left"
     },
     "responsive": {
       "type": "boolean",

--- a/playbook/app/pb_kits/playbook/pb_list/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_list/docs/_playground.json
@@ -3,6 +3,7 @@
   "propTargets": {},
   "defaults": {
     "borderless": false,
+    "dark": false,
     "enableDrag": false,
     "layout": "",
     "ordered": false,

--- a/playbook/app/pb_kits/playbook/pb_list/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_list/kit.schema.json
@@ -18,8 +18,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "enableDrag": {
       "type": "boolean",

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/docs/_playground.json
@@ -4,6 +4,7 @@
   "defaults": {
     "align": "left",
     "color": "light",
+    "dark": false,
     "text": "Loading",
     "variant": "dotted"
   },

--- a/playbook/app/pb_kits/playbook/pb_loading_inline/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_loading_inline/kit.schema.json
@@ -39,8 +39,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "text": {
       "type": "string",

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_playground.json
@@ -2,6 +2,7 @@
   "template": "<PhoneNumberInput{{props}} />",
   "propTargets": {},
   "defaults": {
+    "dark": false,
     "disabled": false,
     "error": "",
     "hiddenInputs": false,

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/kit.schema.json
@@ -10,8 +10,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "disabled": {
       "type": "boolean",

--- a/playbook/app/pb_kits/playbook/pb_popover/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_popover/kit.schema.json
@@ -56,6 +56,27 @@
       ],
       "default": "noop"
     },
+    "position": {
+      "platforms": [
+        "rails"
+      ],
+      "type": "enum",
+      "values": [
+        "top",
+        "bottom",
+        "left",
+        "right",
+        "top-start",
+        "top-end",
+        "bottom-start",
+        "bottom-end",
+        "right-start",
+        "right-end",
+        "left-start",
+        "left-end"
+      ],
+      "default": "left"
+    },
     "triggerElementId": {
       "platforms": [
         "rails"
@@ -65,17 +86,48 @@
       "platforms": [
         "rails"
       ]
+    },
+    "maxHeight": {
+      "platforms": [
+        "rails"
+      ]
+    },
+    "maxWidth": {
+      "platforms": [
+        "rails"
+      ]
+    },
+    "minWidth": {
+      "platforms": [
+        "rails"
+      ]
+    },
+    "minHeight": {
+      "platforms": [
+        "rails"
+      ]
+    },
+    "width": {
+      "platforms": [
+        "rails"
+      ]
+    },
+    "zIndex": {
+      "platforms": [
+        "rails"
+      ],
+      "type": "string"
     }
   },
   "globalProps": true,
   "usage": {
     "react": {
       "import": "import { Popover } from 'playbook-ui'",
-      "example": "<Popover closeOnClick=\"outside\"></Popover>"
+      "example": "<Popover closeOnClick=\"outside\" position=\"top\"></Popover>"
     },
     "rails": {
       "import": null,
-      "example": "<%= pb_rails(\"popover\", props: { close_on_click: \"outside\" }) %>"
+      "example": "<%= pb_rails(\"popover\", props: { close_on_click: \"outside\", position: \"top\" }) %>"
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/docs/_playground.json
@@ -5,8 +5,8 @@
     "align": "left",
     "muted": false,
     "variant": "default",
-    "percent": "50",
-    "width": "100%"
+    "width": "100%",
+    "percent": "50"
   },
   "groups": [
     {

--- a/playbook/app/pb_kits/playbook/pb_progress_simple/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_progress_simple/kit.schema.json
@@ -72,8 +72,10 @@
     "width": {
       "type": "string",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": "100%"
     }
   },
   "globalProps": true,

--- a/playbook/app/pb_kits/playbook/pb_section_separator/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/docs/_playground.json
@@ -3,6 +3,7 @@
   "propTargets": {},
   "defaults": {
     "color": "default",
+    "dark": false,
     "lineStyle": "solid",
     "orientation": "horizontal",
     "variant": "card"

--- a/playbook/app/pb_kits/playbook/pb_section_separator/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_section_separator/kit.schema.json
@@ -22,8 +22,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "lineStyle": {
       "type": "enum",

--- a/playbook/app/pb_kits/playbook/pb_skeleton_loading/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_skeleton_loading/docs/_playground.json
@@ -2,12 +2,13 @@
   "template": "<SkeletonLoading{{props}} />",
   "propTargets": {},
   "defaults": {
-    "stack": 1,
-    "color": "default",
+    "height": "16px",
+    "width": "100%",
     "borderRadius": "sm",
     "gap": "xxs",
-    "height": "16px",
-    "width": "100%"
+    "stack": 1,
+    "color": "default",
+    "dark": false
   },
   "groups": [
     {

--- a/playbook/app/pb_kits/playbook/pb_skeleton_loading/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_skeleton_loading/kit.schema.json
@@ -10,26 +10,53 @@
     "height": {
       "type": "string",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": "16px"
     },
     "width": {
       "type": "string",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": "100%"
     },
     "borderRadius": {
-      "type": "string",
+      "type": "enum",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "values": [
+        "none",
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "rounded"
+      ],
+      "default": "sm"
     },
     "gap": {
-      "type": "Sizes | \"none\"",
+      "type": "enum",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "values": [
+        "none",
+        "xxs",
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "xxl"
+      ],
+      "default": "xxs"
     },
     "stack": {
       "type": "number",
@@ -54,19 +81,21 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     }
   },
   "globalProps": true,
   "usage": {
     "react": {
       "import": "import { SkeletonLoading } from 'playbook-ui'",
-      "example": "<SkeletonLoading color=\"default\"></SkeletonLoading>"
+      "example": "<SkeletonLoading borderRadius=\"none\" gap=\"none\"></SkeletonLoading>"
     },
     "rails": {
       "import": null,
-      "example": "<%= pb_rails(\"skeleton_loading\", props: { color: \"default\" }) %>"
+      "example": "<%= pb_rails(\"skeleton_loading\", props: { border_radius: \"none\", gap: \"none\" }) %>"
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_time_picker/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_time_picker/docs/_playground.json
@@ -2,6 +2,7 @@
   "template": "<TimePicker{{props}} />",
   "propTargets": {},
   "defaults": {
+    "dark": false,
     "disabled": false,
     "label": "Time Picker",
     "required": false,

--- a/playbook/app/pb_kits/playbook/pb_time_picker/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_time_picker/kit.schema.json
@@ -10,8 +10,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "defaultTime": {
       "type": "string",

--- a/playbook/app/pb_kits/playbook/pb_time_range_inline/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_time_range_inline/docs/_playground.json
@@ -4,6 +4,7 @@
   "defaults": {
     "alignment": "left",
     "size": "sm",
+    "dark": false,
     "icon": false,
     "timezone": false
   },

--- a/playbook/app/pb_kits/playbook/pb_time_range_inline/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_time_range_inline/kit.schema.json
@@ -35,8 +35,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "icon": {
       "type": "boolean",

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_playground.json
@@ -3,6 +3,7 @@
   "propTargets": {},
   "defaults": {
     "align": "left",
+    "dark": false,
     "timezone": "America/New_York",
     "showCurrentYear": false,
     "showDate": true,

--- a/playbook/app/pb_kits/playbook/pb_timestamp/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/kit.schema.json
@@ -23,8 +23,10 @@
     "dark": {
       "type": "boolean",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": false
     },
     "text": {
       "type": "string",

--- a/playbook/app/pb_kits/playbook/pb_tooltip/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_tooltip/kit.schema.json
@@ -24,7 +24,8 @@
     "height": {
       "type": "string",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "icon": {
@@ -44,25 +45,29 @@
     "maxHeight": {
       "type": "string",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "maxWidth": {
       "type": "string",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "minHeight": {
       "type": "string",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "minWidth": {
       "type": "string",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "placement": {
@@ -74,7 +79,8 @@
     "position": {
       "type": "enum",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ],
       "values": [
         "absolute",
@@ -90,7 +96,8 @@
     "width": {
       "type": "string",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ]
     },
     "showTooltip": {
@@ -104,6 +111,13 @@
       "platforms": [
         "react"
       ]
+    },
+    "dark": {
+      "platforms": [
+        "rails"
+      ],
+      "type": "boolean",
+      "default": false
     },
     "delayOpen": {
       "platforms": [

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_playground.json
@@ -7,6 +7,7 @@
     "disabled": false,
     "error": "",
     "inputDisplay": "pills",
+    "marginBottom": "sm",
     "pillColor": "primary",
     "required": false,
     "requiredIndicator": false,

--- a/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/kit.schema.json
@@ -108,7 +108,8 @@
     "marginBottom": {
       "type": "enum",
       "platforms": [
-        "react"
+        "react",
+        "rails"
       ],
       "values": [
         "none",
@@ -118,7 +119,8 @@
         "md",
         "lg",
         "xl"
-      ]
+      ],
+      "default": "sm"
     },
     "pillColor": {
       "type": "enum",

--- a/playbook/app/pb_kits/playbook/utilities/global-props.schema.json
+++ b/playbook/app/pb_kits/playbook/utilities/global-props.schema.json
@@ -54,11 +54,29 @@
       "values": [
         "start",
         "end",
-        "center"
+        "center",
+        "flexStart",
+        "flexEnd",
+        "stretch",
+        "baseline"
       ],
       "responsive": true,
       "description": "Align items.",
       "example": "alignItems=\"start\" or alignItems={{ default: \"start\", md: \"end\" }}"
+    },
+    "alignSelf": {
+      "type": "enum | responsive",
+      "values": [
+        "start",
+        "end",
+        "center",
+        "auto",
+        "stretch",
+        "baseline"
+      ],
+      "responsive": true,
+      "description": "Align self.",
+      "example": "alignSelf=\"start\" or alignSelf={{ default: \"start\", md: \"end\" }}"
     },
     "border": {
       "type": "enum",
@@ -184,6 +202,21 @@
       "description": "Dark.",
       "default": false
     },
+    "display": {
+      "type": "enum | responsive",
+      "values": [
+        "none",
+        "flex",
+        "inline_flex",
+        "inline",
+        "inline_block",
+        "block",
+        "grid"
+      ],
+      "responsive": true,
+      "description": "CSS display.",
+      "example": "display=\"none\" or display={{ default: \"none\", md: \"flex\" }}"
+    },
     "flex": {
       "type": "enum | responsive",
       "values": [
@@ -220,6 +253,26 @@
       "description": "Flex direction.",
       "example": "flexDirection=\"row\" or flexDirection={{ default: \"row\", md: \"column\" }}"
     },
+    "flexGrow": {
+      "type": "enum | responsive",
+      "values": [
+        0,
+        1
+      ],
+      "responsive": true,
+      "description": "Flex grow.",
+      "example": "flexGrow=\"0\" or flexGrow={{ default: \"0\", md: \"1\" }}"
+    },
+    "flexShrink": {
+      "type": "enum | responsive",
+      "values": [
+        0,
+        1
+      ],
+      "responsive": true,
+      "description": "Flex shrink.",
+      "example": "flexShrink=\"0\" or flexShrink={{ default: \"0\", md: \"1\" }}"
+    },
     "flexWrap": {
       "type": "enum | responsive",
       "values": [
@@ -244,6 +297,19 @@
       "responsive": true,
       "description": "Justify multi-line content.",
       "example": "justifyContent=\"start\" or justifyContent={{ default: \"start\", md: \"end\" }}"
+    },
+    "justifySelf": {
+      "type": "enum | responsive",
+      "values": [
+        "start",
+        "end",
+        "center",
+        "auto",
+        "stretch"
+      ],
+      "responsive": true,
+      "description": "Justify self.",
+      "example": "justifySelf=\"start\" or justifySelf={{ default: \"start\", md: \"end\" }}"
     },
     "lineHeight": {
       "type": "enum",

--- a/playbook/app/pb_kits/playbook/utilities/global-props.schema.json
+++ b/playbook/app/pb_kits/playbook/utilities/global-props.schema.json
@@ -37,6 +37,10 @@
   "props": {
     "alignContent": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "start",
         "end",
@@ -51,6 +55,10 @@
     },
     "alignItems": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "start",
         "end",
@@ -66,6 +74,10 @@
     },
     "alignSelf": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "start",
         "end",
@@ -80,6 +92,10 @@
     },
     "border": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "default",
@@ -93,6 +109,10 @@
     },
     "borderTop": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "default",
@@ -106,6 +126,10 @@
     },
     "borderBottom": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "default",
@@ -119,6 +143,10 @@
     },
     "borderLeft": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "default",
@@ -132,6 +160,10 @@
     },
     "borderRight": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "default",
@@ -145,6 +177,10 @@
     },
     "borderX": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "default",
@@ -158,6 +194,10 @@
     },
     "borderY": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "default",
@@ -171,6 +211,10 @@
     },
     "borderRadius": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xs",
@@ -184,6 +228,10 @@
     },
     "cursor": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "auto",
         "default",
@@ -199,11 +247,19 @@
     },
     "dark": {
       "type": "boolean",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "description": "Dark.",
       "default": false
     },
     "display": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "flex",
@@ -219,6 +275,10 @@
     },
     "flex": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "auto",
         "initial",
@@ -243,6 +303,10 @@
     },
     "flexDirection": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "row",
         "column",
@@ -255,6 +319,10 @@
     },
     "flexGrow": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         0,
         1
@@ -265,6 +333,10 @@
     },
     "flexShrink": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         0,
         1
@@ -275,6 +347,10 @@
     },
     "flexWrap": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "wrap",
         "nowrap",
@@ -286,6 +362,10 @@
     },
     "justifyContent": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "start",
         "end",
@@ -300,6 +380,10 @@
     },
     "justifySelf": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "start",
         "end",
@@ -313,6 +397,10 @@
     },
     "lineHeight": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "loosest",
         "looser",
@@ -326,6 +414,10 @@
     },
     "marginRight": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -345,6 +437,10 @@
     },
     "marginLeft": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -364,6 +460,10 @@
     },
     "marginTop": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -383,6 +483,10 @@
     },
     "marginBottom": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -402,6 +506,10 @@
     },
     "marginX": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -421,6 +529,10 @@
     },
     "marginY": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -440,6 +552,10 @@
     },
     "margin": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -459,36 +575,64 @@
     },
     "width": {
       "type": "string",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "description": "CSS width."
     },
     "minWidth": {
       "type": "string",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "description": "Minimum width."
     },
     "maxWidth": {
       "type": "string",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "description": "Maximum width."
     },
     "gap": {
       "type": "string | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "responsive": true,
       "description": "Gap.",
       "example": "gap=\"md\" or gap={{ default: \"md\", md: \"lg\" }}"
     },
     "columnGap": {
       "type": "string | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "responsive": true,
       "description": "Column gap.",
       "example": "columnGap=\"md\" or columnGap={{ default: \"md\", md: \"lg\" }}"
     },
     "rowGap": {
       "type": "string | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "responsive": true,
       "description": "Row gap.",
       "example": "rowGap=\"md\" or rowGap={{ default: \"md\", md: \"lg\" }}"
     },
     "numberSpacing": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "tabular"
       ],
@@ -496,6 +640,10 @@
     },
     "order": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "first",
@@ -518,6 +666,10 @@
     },
     "overflowX": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "scroll",
         "visible",
@@ -528,6 +680,10 @@
     },
     "overflowY": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "scroll",
         "visible",
@@ -538,6 +694,10 @@
     },
     "overflow": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "scroll",
         "visible",
@@ -548,6 +708,10 @@
     },
     "paddingRight": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -567,6 +731,10 @@
     },
     "paddingLeft": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -586,6 +754,10 @@
     },
     "paddingTop": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -605,6 +777,10 @@
     },
     "paddingBottom": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -624,6 +800,10 @@
     },
     "paddingX": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -643,6 +823,10 @@
     },
     "paddingY": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -662,6 +846,10 @@
     },
     "padding": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "xxs",
@@ -681,6 +869,10 @@
     },
     "position": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "relative",
         "absolute",
@@ -692,6 +884,10 @@
     },
     "shadow": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         "deep",
@@ -702,6 +898,10 @@
     },
     "textAlign": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "start",
         "end",
@@ -718,6 +918,10 @@
     },
     "truncate": {
       "type": "enum",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "none",
         1,
@@ -730,6 +934,10 @@
     },
     "verticalAlign": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "baseline",
         "super",
@@ -746,6 +954,10 @@
     },
     "zIndex": {
       "type": "enum | responsive",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         1,
         2,
@@ -765,6 +977,10 @@
     },
     "top": {
       "type": "enum | object",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "xxs",
         "xs",
@@ -778,11 +994,18 @@
     },
     "inset": {
       "type": "boolean",
+      "platforms": [
+        "react"
+      ],
       "description": "Inset.",
       "default": false
     },
     "right": {
       "type": "enum | object",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "xxs",
         "xs",
@@ -796,6 +1019,10 @@
     },
     "bottom": {
       "type": "enum | object",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "xxs",
         "xs",
@@ -809,6 +1036,10 @@
     },
     "left": {
       "type": "enum | object",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "values": [
         "xxs",
         "xs",
@@ -822,18 +1053,34 @@
     },
     "height": {
       "type": "string",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "description": "CSS height."
     },
     "maxHeight": {
       "type": "string",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "description": "Maximum height."
     },
     "minHeight": {
       "type": "string",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "description": "Minimum height."
     },
     "hover": {
       "type": "object",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "properties": {
         "shadow": {
           "type": "enum",
@@ -870,6 +1117,10 @@
     },
     "groupHover": {
       "type": "boolean",
+      "platforms": [
+        "react",
+        "rails"
+      ],
       "default": false,
       "description": "Group hover."
     }

--- a/playbook/scripts/generate-ai-metadata.mjs
+++ b/playbook/scripts/generate-ai-metadata.mjs
@@ -26,7 +26,6 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { getGlobalPropNames } from './lib/global-props-parser.mjs';
 
 // =============================================================================
 // CONFIGURATION
@@ -40,13 +39,11 @@ const CONFIG = {
   excludedDirs: ['docs', 'utilities'],
 };
 
-const GLOBAL_PROPS = getGlobalPropNames();
-['aria', 'data', 'htmlOptions', 'id', 'className', 'children', 'key', 'ref'].forEach(p => GLOBAL_PROPS.add(p));
-
 /**
- * When parsing a kit `type XProps = { ... }` block, skip only structural globals that
- * should not be duplicated into kit.schema.json. Do **not** use the full GLOBAL_PROPS set
- * here — kits often redeclare names from `& GlobalProps` with a narrower type (e.g. maxHeight).
+ * When parsing kit prop definitions (React `type XProps` or Rails `prop :name`),
+ * skip only structural globals that should not be duplicated into kit.schema.json.
+ * Do **not** skip the full GlobalProps set — kits often redeclare those names with a
+ * narrower type (e.g. Flex alignSelf, maxHeight).
  */
 const KIT_TYPE_BLOCK_SKIP_PROPS = new Set([
   'aria',
@@ -422,7 +419,7 @@ function parseRuby(filePath) {
 
   for (const [, name, body] of content.matchAll(propRegex)) {
     const camelName = snakeToCamel(name);
-    if (GLOBAL_PROPS.has(camelName)) continue;
+    if (KIT_TYPE_BLOCK_SKIP_PROPS.has(camelName)) continue;
 
     const prop = { platforms: ['rails'] };
 

--- a/playbook/scripts/generate-global-props-metadata.mjs
+++ b/playbook/scripts/generate-global-props-metadata.mjs
@@ -18,7 +18,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { TypeRegistry, parseTypeDefinitions, parsePropsFromBlock, PATHS } from './lib/global-props-parser.mjs';
+import { TypeRegistry, parseTypeDefinitions, parseObjectTypes, parsePropsFromBlock, readTypeFiles, PATHS } from './lib/global-props-parser.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -146,8 +146,8 @@ function generateDescription(propName) {
   
   // Pattern: alignX, justifyX
   if ((lower[0] === 'align' || lower[0] === 'justify') && parts.length > 1) {
-    const axis = lower[1] === 'content' ? 'multi-line ' : (lower[1] === 'self' ? 'self ' : '');
-    return `${capitalize(lower[0])} ${axis}${lower[1] === 'items' ? 'items' : lower[1]}.`;
+    const target = lower[1] === 'content' ? 'multi-line content' : lower[1];
+    return `${capitalize(lower[0])} ${target}.`;
   }
   
   // Pattern: rowX, columnX (rowGap, columnGap)
@@ -179,9 +179,10 @@ function generateDescription(propName) {
 
 function generateExample(propName, isResponsive, values) {
   if (!isResponsive) return null;
-  
-  const val = values?.[0] || 'md';
-  return `${propName}="${val}" or ${propName}={{ default: "${val}", md: "${values?.[1] || 'lg'}" }}`;
+
+  // Destructured defaults (rather than ||) so falsy enum values like 0 survive
+  const [base = 'md', responsive = 'lg'] = values ?? [];
+  return `${propName}="${base}" or ${propName}={{ default: "${base}", md: "${responsive}" }}`;
 }
 
 // =============================================================================
@@ -190,24 +191,19 @@ function generateExample(propName, isResponsive, values) {
 
 function parseSourceFiles() {
   const registry = new TypeRegistry();
-  const typeFiles = ['sizes.ts', 'display.ts', 'base.ts', 'spacing.ts'];
+  const content = fs.readFileSync(PATHS.globalPropsTs, 'utf8');
+  const sources = [...readTypeFiles(), content];
 
-  // Parse type files
-  for (const file of typeFiles) {
-    const filePath = path.join(PATHS.typesDir, file);
-    if (fs.existsSync(filePath)) {
-      parseTypeDefinitions(fs.readFileSync(filePath, 'utf8'), registry);
-    }
+  // Register aliases from every source before resolving any prop types
+  for (const source of sources) {
+    parseTypeDefinitions(source, registry);
   }
 
-  // Parse globalProps.ts
-  const content = fs.readFileSync(PATHS.globalPropsTs, 'utf8');
-  parseTypeDefinitions(content, registry);
-
-  // Extract object-style types
+  // Extract object-style types from every source, since types used by GlobalProps
+  // (e.g. Display) may be declared in a type file rather than inline
   const typeProps = {};
-  for (const [, name, block] of content.matchAll(/type\s+(\w+)\s*=\s*\{([^}]+)\}/g)) {
-    typeProps[name] = parsePropsFromBlock(block, registry);
+  for (const source of sources) {
+    parseObjectTypes(source, registry, typeProps);
   }
 
   // Handle Hover = Shadow & { ... }

--- a/playbook/scripts/generate-global-props-metadata.mjs
+++ b/playbook/scripts/generate-global-props-metadata.mjs
@@ -27,8 +27,36 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // =============================================================================
 
 const TOKENS_DIR = path.resolve(__dirname, '../app/pb_kits/playbook/tokens');
+const RAILS_LIB_DIR = path.resolve(__dirname, '../lib/playbook');
 const OUTPUT_PATH = path.resolve(__dirname, '../app/pb_kits/playbook/utilities/global-props.schema.json');
 const SCHEMA_VERSION = 'https://playbook.powerapp.cloud/schemas/global-props-schema.json';
+
+// =============================================================================
+// PLATFORM DETECTION
+// =============================================================================
+
+const snakeToCamel = (s) => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+
+/**
+ * Rails exposes each global prop as `base.prop :name` in the mixins under lib/playbook
+ * that KitBase includes. Props absent here are React-only (e.g. inset, which Rails
+ * expresses as a hash key on top/right/bottom/left rather than its own prop).
+ */
+function parseRailsGlobalProps() {
+  const railsProps = new Set();
+  if (!fs.existsSync(RAILS_LIB_DIR)) return railsProps;
+
+  for (const file of fs.readdirSync(RAILS_LIB_DIR)) {
+    if (!file.endsWith('.rb')) continue;
+
+    const content = fs.readFileSync(path.join(RAILS_LIB_DIR, file), 'utf8');
+    for (const [, name] of content.matchAll(/base\.prop\s+:(\w+)/g)) {
+      railsProps.add(snakeToCamel(name));
+    }
+  }
+
+  return railsProps;
+}
 
 // =============================================================================
 // SCSS PARSING
@@ -236,6 +264,9 @@ function buildSchema() {
   const responsiveProps = detectResponsiveProps();
   const spacingTokens = parseSpacingTokens();
   const breakpoints = parseBreakpoints();
+  const railsProps = parseRailsGlobalProps();
+
+  const platformsFor = (name) => railsProps.has(name) ? ['react', 'rails'] : ['react'];
 
   // Build props
   const props = {};
@@ -250,6 +281,7 @@ function buildSchema() {
 
       props[name] = {
         type,
+        platforms: platformsFor(name),
         ...(def.values?.length && { values: def.values }),
         ...(isResponsive && { responsive: true }),
         description: generateDescription(name),
@@ -267,6 +299,7 @@ function buildSchema() {
     }
     props.hover = {
       type: 'object',
+      platforms: platformsFor('hover'),
       properties: hoverProps,
       description: generateDescription('hover'),
       example: 'hover={{ shadow: "deep", scale: "sm" }}',
@@ -276,6 +309,7 @@ function buildSchema() {
   // Add groupHover
   props.groupHover = {
     type: 'boolean',
+    platforms: platformsFor('groupHover'),
     default: false,
     description: generateDescription('groupHover'),
   };

--- a/playbook/scripts/lib/global-props-parser.mjs
+++ b/playbook/scripts/lib/global-props-parser.mjs
@@ -36,19 +36,20 @@ const stripQuotes = (s) => s.slice(1, -1);
 const dedupe = (arr) => [...new Set(arr)];
 
 /**
- * Split a union type by | while respecting nested braces/parens.
- * e.g., "A | B | { x: number }" -> ["A", "B", "{ x: number }"]
+ * Split a type expression on a top-level operator, respecting nested braces/parens.
+ * e.g., splitTopLevel("A | B | { x: number }", '|') -> ["A", "B", "{ x: number }"]
+ *       splitTopLevel('A & ("a" | "b")', '&') -> ["A", '("a" | "b")']
  */
-function splitUnionType(str) {
+function splitTopLevel(str, operator) {
   const parts = [];
   let current = '';
   let depth = 0;
-  
+
   for (const char of str) {
     if ('{(<'.includes(char)) depth++;
     if ('})>'.includes(char)) depth--;
-    
-    if (char === '|' && depth === 0) {
+
+    if (char === operator && depth === 0) {
       if (current.trim()) parts.push(current.trim());
       current = '';
     } else {
@@ -58,6 +59,34 @@ function splitUnionType(str) {
   
   if (current.trim()) parts.push(current.trim());
   return parts;
+}
+
+const splitUnionType = (str) => splitTopLevel(str, '|');
+
+/**
+ * Remove parens that wrap an entire expression, e.g. '("a" | "b")' -> '"a" | "b"'.
+ * Parens that only wrap part of the expression are left alone.
+ */
+function stripOuterParens(str) {
+  let expr = str.trim();
+
+  while (expr.startsWith('(') && expr.endsWith(')')) {
+    let depth = 0;
+    let wrapsWholeExpr = true;
+
+    for (let i = 0; i < expr.length; i++) {
+      if (expr[i] === '(') depth++;
+      else if (expr[i] === ')' && --depth === 0 && i < expr.length - 1) {
+        wrapsWholeExpr = false;
+        break;
+      }
+    }
+
+    if (!wrapsWholeExpr) break;
+    expr = expr.slice(1, -1).trim();
+  }
+
+  return expr;
 }
 
 /**
@@ -95,7 +124,8 @@ export class TypeRegistry {
    */
   resolve(typeExpr, visited = new Set()) {
     if (!typeExpr) return null;
-    typeExpr = typeExpr.trim();
+    typeExpr = stripOuterParens(typeExpr);
+    if (!typeExpr) return null;
     
     // Circular reference guard
     if (visited.has(typeExpr)) return null;
@@ -107,14 +137,20 @@ export class TypeRegistry {
       return typeof def === 'string' ? this.resolve(def, visited) : def;
     }
     
-    // Intersection type: A & B (combine values from both)
-    if (typeExpr.includes('&') && !typeExpr.includes('|')) {
-      return this.#resolveIntersection(typeExpr, visited);
+    // Indexed access on a const array: typeof BitValues[number]
+    const indexedAccess = typeExpr.match(/^typeof\s+(\w+)\s*\[\s*number\s*\]$/);
+    if (indexedAccess) {
+      return this.resolve(indexedAccess[1], visited);
     }
     
-    // Union type: A | B | C
-    if (typeExpr.includes('|')) {
+    // Union type: A | B | C (checked first so `A & ("a" | "b")` reads as an intersection)
+    if (splitTopLevel(typeExpr, '|').length > 1) {
       return this.#resolveUnion(typeExpr, visited);
+    }
+    
+    // Intersection type: A & B (combine values from both)
+    if (splitTopLevel(typeExpr, '&').length > 1) {
+      return this.#resolveIntersection(typeExpr, visited);
     }
     
     // Literal types
@@ -134,7 +170,7 @@ export class TypeRegistry {
 
   /** Resolve an intersection type like Alignment & Space (combine values) */
   #resolveIntersection(intersectionExpr, visited) {
-    const parts = intersectionExpr.split('&').map(p => p.trim()).filter(Boolean);
+    const parts = splitTopLevel(intersectionExpr, '&');
     const allValues = [];
     
     for (const part of parts) {
@@ -214,7 +250,14 @@ export class TypeRegistry {
 export function parseTypeDefinitions(content, registry) {
   // Type aliases: type Foo = "a" | "b" | ...
   // Keep this separate from object-style type parsing so multiline unions resolve to every approved value.
-  const typeRegex = /(?:export\s+)?type\s+(\w+)\s*=\s*((?:(?!\n\s*(?:export\s+)?type\s+\w+\s*=).)+?)(?=\n\s*(?:export\s+)?type\s+\w+\s*=|\n\s*(?:export\s+)?const\s+\w+\s*=|$)/gs;
+  // Generic declarations (`type Callback<T, K> = ...`) act as boundaries but are not captured,
+  // otherwise the preceding alias swallows them and resolves to nonsense.
+  const TYPE_DECL = String.raw`(?:export\s+)?type\s+\w+\s*(?:<[^>]*>)?\s*=`;
+  const CONST_DECL = String.raw`(?:export\s+)?const\s+\w+\s*=`;
+  const typeRegex = new RegExp(
+    String.raw`(?:export\s+)?type\s+(\w+)\s*=\s*((?:(?!\n\s*${TYPE_DECL}).)+?)(?=\n\s*${TYPE_DECL}|\n\s*${CONST_DECL}|$)`,
+    'gs'
+  );
   for (const [, name, expr] of content.matchAll(typeRegex)) {
     const normalized = expr.trim().replace(/;\s*$/, '');
     if (!normalized.startsWith('{') && !normalized.includes('{')) {
@@ -228,6 +271,29 @@ export function parseTypeDefinitions(content, registry) {
     const values = valuesStr.split(',').map(v => parseLiteral(v.trim()));
     registry.register(name, { type: 'enum', values });
   }
+}
+
+/**
+ * Extract object-style type definitions (`type Foo = { bar?: Type }`) into `target`,
+ * keyed by type name. Definitions spread across files are merged.
+ *
+ * The registry must already hold every alias these blocks reference, so run
+ * parseTypeDefinitions over all sources first.
+ */
+export function parseObjectTypes(content, registry, target = {}) {
+  for (const [, name, block] of content.matchAll(/type\s+(\w+)\s*=\s*\{([^}]+)\}/g)) {
+    target[name] = { ...target[name], ...parsePropsFromBlock(block, registry) };
+  }
+
+  return target;
+}
+
+/** Read the type files that globalProps.ts imports from. */
+export function readTypeFiles() {
+  return TYPE_FILES
+    .map(file => path.join(PATHS.typesDir, file))
+    .filter(filePath => fs.existsSync(filePath))
+    .map(filePath => fs.readFileSync(filePath, 'utf8'));
 }
 
 /**
@@ -262,27 +328,22 @@ export function parsePropsFromBlock(block, registry) {
  */
 export function parseGlobalProps() {
   const registry = new TypeRegistry();
-  
-  // 1. Parse imported type files (sizes, display, etc.)
-  for (const file of TYPE_FILES) {
-    const filePath = path.join(PATHS.typesDir, file);
-    if (fs.existsSync(filePath)) {
-      parseTypeDefinitions(fs.readFileSync(filePath, 'utf8'), registry);
-    }
-  }
-  
-  // 2. Parse globalProps.ts
   const content = fs.readFileSync(PATHS.globalPropsTs, 'utf8');
-  parseTypeDefinitions(content, registry);
   
-  // 3. Extract object-style type definitions: type Foo = { bar?: Type }
-  const typeProps = {};
-  const objectTypeRegex = /type\s+(\w+)\s*=\s*\{([^}]+)\}/g;
-  for (const [, name, block] of content.matchAll(objectTypeRegex)) {
-    typeProps[name] = parsePropsFromBlock(block, registry);
+  // 1. Register aliases from the imported type files (sizes, display, etc.) and globalProps.ts
+  const sources = [...readTypeFiles(), content];
+  for (const source of sources) {
+    parseTypeDefinitions(source, registry);
   }
   
-  // 4. Handle Hover = Shadow & { ... } inheritance
+  // 2. Extract object-style type definitions from every source, since types used by
+  //    GlobalProps (e.g. Display) may be declared in a type file rather than inline
+  const typeProps = {};
+  for (const source of sources) {
+    parseObjectTypes(source, registry, typeProps);
+  }
+  
+  // 3. Handle Hover = Shadow & { ... } inheritance
   const hoverMatch = content.match(/type\s+Hover\s*=\s*Shadow\s*&\s*\{([^}]+)\}/);
   if (hoverMatch && typeProps['Shadow']) {
     typeProps['Hover'] = {
@@ -291,7 +352,7 @@ export function parseGlobalProps() {
     };
   }
   
-  // 5. Find which types make up GlobalProps
+  // 4. Find which types make up GlobalProps
   const globalPropsMatch = content.match(/export\s+type\s+GlobalProps\s*=\s*([^;]+)/);
   const memberTypes = globalPropsMatch
     ? globalPropsMatch[1]
@@ -300,7 +361,7 @@ export function parseGlobalProps() {
         .filter(t => t && !t.includes(':'))
     : [];
   
-  // 6. Collect all prop names and definitions
+  // 5. Collect all prop names and definitions
   const globalPropNames = new Set();
   const globalPropDefs = {};
   
@@ -314,7 +375,7 @@ export function parseGlobalProps() {
     }
   }
   
-  // 7. Always include hover props
+  // 6. Always include hover props
   globalPropNames.add('hover');
   globalPropNames.add('groupHover');
   


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-3113?from=backlog)

- The global props schema was missing props (display, alignSelf, justifySelf, flexGrow, flexShrink), and the Global Props tab on kit pages always showed React camelCase even when viewing Rails.
- This PR fixes the schema generator so those props are included, then updates the kit props UI so Rails users see the right names and only the props that actually exist in Rails.

**Schema / generator**
- Fixed the global props parser so it can read object types from types/*.ts (this is why display was missing), resolve typeof BitValues[number] (needed for flexGrow / flexShrink), and handle parenthesized unions like Alignment & ("auto" | "stretch") (alignSelf / justifySelf).
- alignItems also picks up its full value set now (flexStart, flexEnd, stretch, baseline).
- Stopped the kit schema generator from dropping Rails kit props just because they share a name with a global prop. Flex’s align_self (and similar kit-level props like gap) show up correctly again.
- Annotated each global prop with a platforms list, derived from the Rails mixins in lib/playbook/. Today that means inset is React-only; everything else is both.

**Kit show page / playground**
- Global Props tab converts names for Rails (alignSelf to align_self) using the same helper as kit props.
- Global Props tab filters by platform, so Rails no longer lists react olny props like inset.
- Added the newly restored props to the playground’s Flexbox group so they don’t land under Other.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.