### PR TITLE
[PLAY-3106] Timestamp kit - Support showTimezone on Updated Variant

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.tsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/_timestamp.tsx
@@ -92,8 +92,8 @@ const Timestamp = (props: TimestampProps): React.ReactElement => {
     const finalUpdatedString = []
     if (shouldShowUser) finalUpdatedString.push(`by ${text}`)
     if (showDate && !showTime) finalUpdatedString.push(`on ${baseDateDisplay()}`)
-    if (showDate && showTime) finalUpdatedString.push(`on ${baseDateDisplay()} at ${timeDisplay}`)
-    if (showTime && !showDate) finalUpdatedString.push(`at ${timeDisplay}`)
+    if (showDate && showTime) finalUpdatedString.push(`on ${baseDateDisplay()} at ${fullTimeDisplay()}`)
+    if (showTime && !showDate) finalUpdatedString.push(`at ${fullTimeDisplay()}`)
     return `Last updated ${finalUpdatedString.join(' ')}`
   }
 

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.html.erb
@@ -28,6 +28,6 @@
   show_date: false,
   show_timezone: true,
   timestamp: DateTime.now,
-  timezone: "Asia/Hong_Kong"
+  timezone: "Asia/Hong_Kong",
   variant: "updated",
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.html.erb
@@ -12,3 +12,22 @@
   variant: "updated",
   show_user: false
 }) %>
+
+<br>
+
+<%= pb_rails("timestamp", props: {
+  show_timezone: true,
+  timestamp: DateTime.now,
+  timezone: "America/New_York",
+  variant: "updated",
+}) %>
+
+<br />
+
+<%= pb_rails("timestamp", props: {
+  show_date: false,
+  show_timezone: true,
+  timestamp: DateTime.now,
+  timezone: "Asia/Hong_Kong"
+  variant: "updated",
+}) %>

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.jsx
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.jsx
@@ -21,6 +21,27 @@ const TimestampUpdated = (props) => {
           variant="updated"
           {...props}
       />
+
+      <br />
+
+      <Timestamp
+          showTimezone
+          timestamp={todaysDate}
+          timezone="America/New_York"
+          variant="updated"
+          {...props}
+      />
+
+      <br />
+
+      <Timestamp
+          showDate={false}
+          showTimezone
+          timestamp={todaysDate}
+          timezone="Asia/Hong_Kong"
+          variant="updated"
+          {...props}
+      />
     </div>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.md
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/docs/_timestamp_updated.md
@@ -3,3 +3,5 @@ Use variant `updated` to show last updated at timestamp.
 This variant can be customized using the optional `showUser`/`show_user` prop to show user as part of the text. When showing the user, pass in the user name using the `text` prop as shown. 
 
 `showUser`/`show_user` is set to false by default. 
+
+This variant can also display timezone when the `showTimezone`/`show_timezone` and `timezone` props are used together as instructed in the Show Timezones example above.

--- a/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.test.js
+++ b/playbook/app/pb_kits/playbook/pb_timestamp/timestamp.test.js
@@ -271,3 +271,45 @@ describe("Timestamp Kit", () => {
     expect(text?.textContent).toEqual("Last updated at 12:00a")
   })
 
+  test("updated variant: shows timezone when showTimezone is enabled", () => {
+    render(
+      <Timestamp
+          data={{ testid: testId }}
+          showTimezone
+          timestamp={new Date()}
+          timezone="America/New_York"
+          variant="updated"
+      />
+    )
+    const text = screen.getByTestId(testId).querySelector(".pb_caption_kit_xs")
+    expect(text?.textContent).toEqual("Last updated on Jan 1 at 12:00a EST")
+  })
+
+  test("updated variant: shows timezone with time only when showDate=false", () => {
+    render(
+      <Timestamp
+          data={{ testid: testId }}
+          showDate={false}
+          showTimezone
+          timestamp={new Date()}
+          timezone="America/New_York"
+          variant="updated"
+      />
+    )
+    const text = screen.getByTestId(testId).querySelector(".pb_caption_kit_xs")
+    expect(text?.textContent).toEqual("Last updated at 12:00a EST")
+  })
+
+  test("updated variant: hides timezone when showTimezone is not provided", () => {
+    render(
+      <Timestamp
+          data={{ testid: testId }}
+          timestamp={new Date()}
+          timezone="America/New_York"
+          variant="updated"
+      />
+    )
+    const text = screen.getByTestId(testId).querySelector(".pb_caption_kit_xs")
+    expect(text?.textContent).toEqual("Last updated on Jan 1 at 12:00a")
+  })
+


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3106](https://runway.powerhrg.com/backlog_items/PLAY-3106) updates Timestamp so the React `updated` variant to be compatible with `showTimezone` and `timezone` props. Rails was already compatible. Adds two additional examples and markdown to the "Last Updated by (Updated Variant)"  doc example for Rails and React to demonstrate this.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1135" height="608" alt="react last updated timestamp" src="https://github.com/user-attachments/assets/76469ab8-f034-4128-a6b8-4c2da9d4eb3d" />
<img width="1144" height="601" alt="rails last updated timestamp" src="https://github.com/user-attachments/assets/68b94552-3b7a-4b5a-8bfc-b3e1976d1d98" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Last Updated by (Updated Variant)" in Rails or React - see two additional examples showing timezone display.
2. Go to the React playground - showTimezone and timezone props work with updated variant.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.