### PR TITLE
Fixes for rails metadata examples using jsx

### DIFF
--- a/playbook/scripts/lib/jsx-children-to-erb.mjs
+++ b/playbook/scripts/lib/jsx-children-to-erb.mjs
@@ -1,0 +1,420 @@
+/**
+ * Convert playground JSX children strings into Rails ERB (pb_rails) for AI usage examples.
+ *
+ * Handles common playground patterns: self-closing kits, open/close tags with text or
+ * nested kits, compound Parent.Child tags, and literal `{...}` expressions.
+ * Non-literal JS (handlers, state) is skipped on props; unconvertible trees return null.
+ */
+
+const REACT_TO_RAILS_KIT = {
+  BreadCrumbItem: 'bread_crumbs/bread_crumb_item',
+  FlexItem: 'flex/flex_item',
+  NavItem: 'nav/item',
+  ListItem: 'list/item',
+  ProgressStepItem: 'progress_step/progress_step_item',
+  'Timeline.Item': 'timeline/item',
+  'Timeline.Step': 'timeline/step',
+  'Timeline.Label': 'timeline/label',
+  'Timeline.Detail': 'timeline/detail',
+  'Layout.Side': 'layout/sidebar',
+  'Layout.Body': 'layout/body',
+  'Layout.Header': 'layout/header',
+  'Layout.Footer': 'layout/footer',
+  'Layout.Item': 'layout/item',
+  'Table.Head': 'table/table_head',
+  'Table.Body': 'table/table_body',
+  'Table.Row': 'table/table_row',
+  'Table.Header': 'table/table_header',
+  'Table.Cell': 'table/table_cell',
+  'SelectableList.Item': 'selectable_list/selectable_list_item',
+};
+
+/** Known React-only compounds that have no Rails kit path — fail conversion. */
+const REACT_ONLY_COMPONENTS = new Set([
+  'Layout.Round',
+  'Layout.RoundLabel',
+  'Layout.Game',
+  'Layout.Participant',
+]);
+
+/** Component-specific React → Rails prop renames. `null` drops the prop. */
+const COMPONENT_PROP_ALIASES = {
+  BreadCrumbItem: { href: 'link', component: null },
+  'SelectableList.Item': { label: 'text' },
+};
+
+const DROP_PROPS = new Set([
+  'onChange',
+  'onClick',
+  'onClose',
+  'onSelect',
+  'onBlur',
+  'onFocus',
+  'onKeyDown',
+  'onKeyUp',
+  'onMouseEnter',
+  'onMouseLeave',
+  'key',
+  'ref',
+  'children',
+]);
+
+function pascalToSnake(name) {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+function camelToSnake(name) {
+  return name.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+}
+
+function reactNameToRailsKit(name) {
+  if (REACT_TO_RAILS_KIT[name]) return REACT_TO_RAILS_KIT[name];
+  if (name.includes('.')) {
+    const [parent, child] = name.split('.');
+    return `${pascalToSnake(parent)}/${pascalToSnake(child)}`;
+  }
+  return pascalToSnake(name);
+}
+
+function isHtmlTag(name) {
+  return /^[a-z][a-z0-9]*$/.test(name);
+}
+
+function formatRubyValue(value) {
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') return String(value);
+  if (value === null) return 'nil';
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => formatRubyValue(v)).join(', ')}]`;
+  }
+  if (typeof value === 'object') return formatRubyHash(value);
+  return JSON.stringify(String(value));
+}
+
+function formatRubyHashKey(key) {
+  const raw = String(key);
+  // Identifiers (camelCase or snake_case) → snake_case symbol keys.
+  // Leave labels / paths / spaced keys as quoted hash rockets.
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(raw)) {
+    return `${camelToSnake(raw)}:`;
+  }
+  return `${JSON.stringify(raw)} =>`;
+}
+
+function formatRubyHash(obj) {
+  const parts = Object.entries(obj).map(
+    ([k, v]) => `${formatRubyHashKey(k)} ${formatRubyValue(v)}`
+  );
+  return `{ ${parts.join(', ')} }`;
+}
+
+function formatRailsProps(props) {
+  const parts = Object.entries(props).map(
+    ([name, value]) => `${name}: ${formatRubyValue(value)}`
+  );
+  return parts.length ? ` props: { ${parts.join(', ')} }` : '';
+}
+
+function parseExpressionLiteral(expr) {
+  const trimmed = expr.trim();
+  if (trimmed === 'true') return { ok: true, value: true };
+  if (trimmed === 'false') return { ok: true, value: false };
+  if (trimmed === 'null' || trimmed === 'undefined') return { ok: true, value: null };
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return { ok: true, value: Number(trimmed) };
+  const strMatch = trimmed.match(/^(['"])([\s\S]*)\1$/);
+  if (strMatch) return { ok: true, value: strMatch[2] };
+  return { ok: false };
+}
+
+function readBalanced(s, start, openChar, closeChar) {
+  let depth = 1;
+  let i = start;
+  while (i < s.length && depth > 0) {
+    if (s[i] === openChar) depth += 1;
+    else if (s[i] === closeChar) depth -= 1;
+    if (depth > 0) i += 1;
+  }
+  return i;
+}
+
+function parseAttributes(attrString, componentName) {
+  const props = {};
+  const aliases = COMPONENT_PROP_ALIASES[componentName] || {};
+  let i = 0;
+  const s = attrString;
+
+  while (i < s.length) {
+    while (i < s.length && /\s/.test(s[i])) i += 1;
+    if (i >= s.length) break;
+
+    const nameMatch = s.slice(i).match(/^([A-Za-z_][\w]*)/);
+    if (!nameMatch) break;
+    const reactName = nameMatch[1];
+    i += reactName.length;
+
+    while (i < s.length && /\s/.test(s[i])) i += 1;
+
+    let value = true;
+    if (s[i] === '=') {
+      i += 1;
+      while (i < s.length && /\s/.test(s[i])) i += 1;
+
+      if (s[i] === '"' || s[i] === "'") {
+        const quote = s[i];
+        i += 1;
+        let end = i;
+        while (end < s.length && s[end] !== quote) end += 1;
+        value = s.slice(i, end);
+        i = end + 1;
+      } else if (s[i] === '{') {
+        const end = readBalanced(s, i + 1, '{', '}');
+        const parsed = parseExpressionLiteral(s.slice(i + 1, end));
+        i = end + 1;
+        if (!parsed.ok) continue;
+        value = parsed.value;
+      } else {
+        break;
+      }
+    }
+
+    if (DROP_PROPS.has(reactName)) continue;
+    if (Object.prototype.hasOwnProperty.call(aliases, reactName)) {
+      const aliased = aliases[reactName];
+      if (aliased == null) continue;
+      props[aliased] = value;
+      continue;
+    }
+    props[camelToSnake(reactName)] = value;
+  }
+
+  return props;
+}
+
+/**
+ * @returns {Array<{type:'text',value:string}|{type:'element',name:string,props:object,rawAttrs:string,children:Array,selfClosing:boolean}>}
+ */
+export function parseJsxChildren(input) {
+  const s = input;
+  let i = 0;
+
+  function parseNodes(closeName) {
+    const nodes = [];
+
+    while (i < s.length) {
+      if (s[i] === '<' && s[i + 1] === '/') {
+        const closeMatch = s.slice(i).match(/^<\/([A-Za-z_][\w.]*)\s*>/);
+        if (closeMatch && closeName && closeMatch[1] === closeName) {
+          i += closeMatch[0].length;
+          return nodes;
+        }
+        return nodes;
+      }
+
+      if (s[i] === '<') {
+        const el = parseElement();
+        if (!el) return nodes;
+        nodes.push(el);
+        continue;
+      }
+
+      // Text or `{...}` expression
+      const start = i;
+      while (i < s.length && s[i] !== '<') {
+        if (s[i] === '{') {
+          const before = s.slice(start, i);
+          if (before.trim()) nodes.push({ type: 'text', value: before });
+          const end = readBalanced(s, i + 1, '{', '}');
+          const parsed = parseExpressionLiteral(s.slice(i + 1, end));
+          if (parsed.ok && parsed.value != null) {
+            nodes.push({ type: 'text', value: String(parsed.value) });
+          }
+          i = end + 1;
+          nodes.push(...parseNodes(closeName));
+          return nodes;
+        }
+        i += 1;
+      }
+      const text = s.slice(start, i);
+      if (text.trim()) nodes.push({ type: 'text', value: text });
+    }
+
+    return nodes;
+  }
+
+  function parseElement() {
+    if (s[i] !== '<' || s[i + 1] === '/') return null;
+    i += 1;
+
+    const nameMatch = s.slice(i).match(/^([A-Za-z_][\w.]*)/);
+    if (!nameMatch) return null;
+    const name = nameMatch[1];
+    i += name.length;
+
+    const attrStart = i;
+    let selfClosing = false;
+
+    while (i < s.length) {
+      if (s[i] === '"' || s[i] === "'") {
+        const quote = s[i];
+        i += 1;
+        while (i < s.length && s[i] !== quote) i += 1;
+        i += 1;
+        continue;
+      }
+      if (s[i] === '{') {
+        i = readBalanced(s, i + 1, '{', '}') + 1;
+        continue;
+      }
+      if (s[i] === '/' && s[i + 1] === '>') {
+        selfClosing = true;
+        break;
+      }
+      if (s[i] === '>') break;
+      i += 1;
+    }
+
+    const rawAttrs = s.slice(attrStart, i).replace(/\/\s*$/, '').trim();
+    if (selfClosing) i += 2;
+    else if (s[i] === '>') i += 1;
+
+    const element = {
+      type: 'element',
+      name,
+      props: isHtmlTag(name) ? {} : parseAttributes(rawAttrs, name),
+      rawAttrs,
+      children: [],
+      selfClosing,
+    };
+
+    if (!selfClosing) {
+      element.children = parseNodes(name);
+    }
+
+    return element;
+  }
+
+  return parseNodes(null);
+}
+
+function renderPbRails(kit, props, childrenErb, indent) {
+  const pad = ' '.repeat(indent);
+  const propsStr = formatRailsProps(props);
+  const open = propsStr
+    ? `<%= pb_rails("${kit}",${propsStr}) %>`
+    : `<%= pb_rails("${kit}") %>`;
+  const openBlock = propsStr
+    ? `<%= pb_rails("${kit}",${propsStr}) do %>`
+    : `<%= pb_rails("${kit}") do %>`;
+
+  if (!childrenErb || !childrenErb.trim()) {
+    return `${pad}${open}`;
+  }
+
+  const trimmed = childrenErb.trim();
+  const isSimpleText = !trimmed.includes('\n') && !trimmed.includes('pb_rails');
+
+  if (isSimpleText && trimmed.length < 80) {
+    return `${pad}${openBlock} ${trimmed} <% end %>`;
+  }
+
+  return `${pad}${openBlock}\n${childrenErb}\n${pad}<% end %>`;
+}
+
+function renderNodesToErb(nodes, indent = 0) {
+  const pad = ' '.repeat(indent);
+  const lines = [];
+
+  for (const node of nodes) {
+    if (node.type === 'text') {
+      const text = node.value.replace(/\s+/g, ' ').trim();
+      if (text) lines.push(`${pad}${text}`);
+      continue;
+    }
+
+    if (REACT_ONLY_COMPONENTS.has(node.name)) return null;
+
+    if (isHtmlTag(node.name)) {
+      const attrs = node.rawAttrs ? ` ${node.rawAttrs}` : '';
+      if (node.selfClosing || !node.children.length) {
+        lines.push(`${pad}<${node.name}${attrs} />`);
+      } else {
+        const inner = renderNodesToErb(node.children, indent + 2);
+        if (inner == null) return null;
+        if (!inner.includes('\n') && inner.trim().length < 60) {
+          lines.push(`${pad}<${node.name}${attrs}>${inner.trim()}</${node.name}>`);
+        } else {
+          lines.push(`${pad}<${node.name}${attrs}>`);
+          lines.push(inner);
+          lines.push(`${pad}</${node.name}>`);
+        }
+      }
+      continue;
+    }
+
+    const kit = reactNameToRailsKit(node.name);
+    const childErb = node.children.length
+      ? renderNodesToErb(node.children, indent + 2)
+      : '';
+    if (childErb == null) return null;
+
+    lines.push(renderPbRails(kit, node.props, childErb, indent));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Convert a JSX children string to an ERB fragment.
+ * @returns {string|null}
+ */
+export function jsxChildrenToErb(jsx) {
+  if (typeof jsx !== 'string') return null;
+  const trimmed = jsx.trim();
+  if (!trimmed) return '';
+  if (!trimmed.includes('<')) return trimmed;
+
+  try {
+    const ast = parseJsxChildren(trimmed);
+    if (!ast.length) return null;
+    const erb = renderNodesToErb(ast, 0);
+    if (erb == null || !erb.trim()) return null;
+    if (/<[A-Z][A-Za-z0-9.]*[\s/>]/.test(erb)) return null;
+    return erb;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert SelectableList.Item JSX children into Rails `items` array entries.
+ * @returns {object[]|null}
+ */
+export function selectableListItemsFromJsx(jsx) {
+  if (typeof jsx !== 'string' || !jsx.includes('SelectableList.Item')) return null;
+
+  try {
+    const ast = parseJsxChildren(jsx.trim());
+    const items = ast.filter((n) => n.type === 'element');
+    if (!items.length || items.some((n) => n.name !== 'SelectableList.Item')) {
+      return null;
+    }
+
+    return items.map((node) => {
+      const item = {};
+      if (node.props.text != null) item.text = node.props.text;
+      if (node.props.checked === true) item.checked = true;
+      const inputOptions = {};
+      if (node.props.name != null) inputOptions.name = node.props.name;
+      if (node.props.value != null) inputOptions.value = node.props.value;
+      if (Object.keys(inputOptions).length) item.input_options = inputOptions;
+      return item;
+    });
+  } catch {
+    return null;
+  }
+}
+
+export { REACT_TO_RAILS_KIT, reactNameToRailsKit, camelToSnake, formatRailsProps, formatRubyValue };

--- a/playbook/scripts/lib/jsx-children-to-erb.test.mjs
+++ b/playbook/scripts/lib/jsx-children-to-erb.test.mjs
@@ -1,0 +1,164 @@
+/**
+ * Run with: node --test scripts/lib/jsx-children-to-erb.test.mjs
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  jsxChildrenToErb,
+  selectableListItemsFromJsx,
+} from './jsx-children-to-erb.mjs';
+import { resolvePresetChildren, usageFromPreset } from './slim-playground.mjs';
+
+describe('jsxChildrenToErb', () => {
+  it('converts self-closing kits with string props', () => {
+    const erb = jsxChildrenToErb(
+      '<Caption text="A" />\n<Caption text="B" />\n<Caption text="C" />'
+    );
+    assert.equal(
+      erb,
+      [
+        '<%= pb_rails("caption", props: { text: "A" }) %>',
+        '<%= pb_rails("caption", props: { text: "B" }) %>',
+        '<%= pb_rails("caption", props: { text: "C" }) %>',
+      ].join('\n')
+    );
+  });
+
+  it('converts open tags with text children and prop aliases', () => {
+    const erb = jsxChildrenToErb(
+      '<BreadCrumbItem href="/">Home</BreadCrumbItem><BreadCrumbItem component="span">Settings</BreadCrumbItem>'
+    );
+    assert.match(erb, /pb_rails\("bread_crumbs\/bread_crumb_item", props: \{ link: "\/" \}\)/);
+    assert.match(erb, /pb_rails\("bread_crumbs\/bread_crumb_item"\) do %> Settings/);
+    assert.doesNotMatch(erb, /component/);
+    assert.doesNotMatch(erb, /href/);
+  });
+
+  it('converts compound Parent.Child tags', () => {
+    const erb = jsxChildrenToErb(
+      '<Layout.Side>\n  Side\n</Layout.Side>\n<Layout.Body>\n  Body\n</Layout.Body>'
+    );
+    assert.match(erb, /pb_rails\("layout\/sidebar"\) do %> Side/);
+    assert.match(erb, /pb_rails\("layout\/body"\) do %> Body/);
+  });
+
+  it('unwraps string expression children', () => {
+    const erb = jsxChildrenToErb("<FlexItem>\n  {'1'}\n</FlexItem>");
+    assert.equal(erb, '<%= pb_rails("flex/flex_item") do %> 1 <% end %>');
+  });
+
+  it('skips non-literal expression props', () => {
+    const erb = jsxChildrenToErb(
+      '<TextInput label="First Name" onChange={handleFieldChange} value={formFields.firstName} />'
+    );
+    assert.equal(
+      erb,
+      '<%= pb_rails("text_input", props: { label: "First Name" }) %>'
+    );
+  });
+
+  it('returns null for React-only layout compounds', () => {
+    assert.equal(jsxChildrenToErb('<Layout.Round><Caption text="X" /></Layout.Round>'), null);
+  });
+});
+
+describe('selectableListItemsFromJsx', () => {
+  it('maps Item children to Rails items shape', () => {
+    const items = selectableListItemsFromJsx(
+      '<SelectableList.Item label="Mild" name="spice" value="mild" />\n<SelectableList.Item checked label="Medium" name="spice" value="medium" />'
+    );
+    assert.deepEqual(items, [
+      { text: 'Mild', input_options: { name: 'spice', value: 'mild' } },
+      {
+        text: 'Medium',
+        checked: true,
+        input_options: { name: 'spice', value: 'medium' },
+      },
+    ]);
+  });
+});
+
+describe('resolvePresetChildren', () => {
+  it('respects structure mode children clearing', () => {
+    const playground = {
+      structureModes: {
+        default: 'standard',
+        modes: {
+          standard: { template: '<Radio{{props}} />', children: '' },
+          custom_children: {
+            template: '<Radio{{props}}>\n  {{children}}\n</Radio>',
+            children: '<Title text="Custom" />',
+          },
+        },
+      },
+      children: { default: '<Title text="Custom" />' },
+    };
+    assert.equal(
+      resolvePresetChildren({ structureMode: 'standard', props: {} }, playground),
+      ''
+    );
+    assert.equal(
+      resolvePresetChildren(
+        { structureMode: 'custom_children', children: '<Title text="Custom" />' },
+        playground
+      ),
+      '<Title text="Custom" />'
+    );
+  });
+});
+
+describe('usageFromPreset rails children', () => {
+  it('emits ERB children for flex', () => {
+    const usage = usageFromPreset('flex', 'Flex', {
+      presets: [
+        {
+          name: 'Row',
+          props: { orientation: 'row' },
+          children: '<Caption text="A" />\n<Caption text="B" />',
+        },
+      ],
+    });
+    assert.match(usage.rails.example, /pb_rails\("caption", props: \{ text: "A" \}\)/);
+    assert.doesNotMatch(usage.rails.example, /<Caption/);
+  });
+
+  it('emits items array for selectable_list', () => {
+    const usage = usageFromPreset('selectable_list', 'SelectableList', {
+      presets: [
+        {
+          name: 'Checkbox list',
+          props: { variant: 'checkbox' },
+          children:
+            '<SelectableList.Item label="Mild" name="spice" value="mild" />',
+        },
+      ],
+    });
+    assert.match(usage.rails.example, /items: \[\{ text: "Mild"/);
+    assert.doesNotMatch(usage.rails.example, /do %>/);
+  });
+
+  it('quotes non-identifier hash keys and skips render-prop children', () => {
+    const usage = usageFromPreset('filter', 'Filter', {
+      structureModes: {
+        default: 'single',
+        modes: {
+          single: {
+            children: '({ closePopover }) => (\n  <form />\n)',
+          },
+        },
+      },
+      presets: [
+        {
+          name: 'Single Filter',
+          structureMode: 'single',
+          props: {
+            filters: { 'Full Name': 'John Wick' },
+            minWidth: '360px',
+          },
+        },
+      ],
+    });
+    assert.match(usage.rails.example, /"Full Name" => "John Wick"/);
+    assert.doesNotMatch(usage.rails.example, /do %>/);
+  });
+});

--- a/playbook/scripts/lib/slim-playground.mjs
+++ b/playbook/scripts/lib/slim-playground.mjs
@@ -8,6 +8,12 @@
  * tiny synthetic columnDefinitions/tableData samples agents can copy.
  */
 
+import {
+  formatRubyValue,
+  jsxChildrenToErb,
+  selectableListItemsFromJsx,
+} from './jsx-children-to-erb.mjs';
+
 export const AI_PLAYGROUND_KEYS = [
   'presets',
   'hints',
@@ -257,6 +263,86 @@ function formatConst(name, value) {
 }
 
 /**
+ * Resolve children for a usage example from the active preset / structure mode.
+ * Avoids falling back to playground children.default when the structure mode
+ * explicitly clears children (e.g. radio "standard", selectable_card "normal").
+ */
+function isRenderableChildren(children) {
+  if (typeof children !== 'string') return false;
+  const trimmed = children.trim();
+  if (!trimmed) return false;
+  // Structure modes sometimes store React render-prop factories as "children"
+  if (
+    trimmed.startsWith('(') ||
+    trimmed.startsWith('function') ||
+    /^\(?\{/.test(trimmed) && trimmed.includes('=>')
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function resolvePresetChildren(preset, playground) {
+  if (!preset || typeof preset !== 'object') return '';
+
+  if (typeof preset.children === 'string') {
+    return isRenderableChildren(preset.children) ? preset.children : '';
+  }
+
+  const modeKey = preset.structureMode || playground?.structureModes?.default;
+  const mode = modeKey && playground?.structureModes?.modes?.[modeKey];
+  if (mode && typeof mode.children === 'string') {
+    return isRenderableChildren(mode.children) ? mode.children : '';
+  }
+
+  const template = mode?.template || playground?.template || '';
+  if (
+    template.includes('{{children}}') &&
+    typeof playground?.children?.default === 'string' &&
+    isRenderableChildren(playground.children.default)
+  ) {
+    return playground.children.default;
+  }
+
+  return '';
+}
+
+/** Props that only make sense in React playground examples. */
+const REACT_ONLY_USAGE_PROPS = new Set([
+  'trigger',
+  'onChange',
+  'onClick',
+  'onClose',
+  'onSelect',
+  'render',
+  'renderTrigger',
+]);
+
+function isReactOnlyPropValue(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith('(') ||
+    trimmed.startsWith('function') ||
+    trimmed.includes('=>') ||
+    /<[A-Z]/.test(trimmed)
+  );
+}
+
+function formatRailsPropEntries(props) {
+  return Object.entries(props)
+    .filter(([name, value]) => {
+      if (REACT_ONLY_USAGE_PROPS.has(name)) return false;
+      if (isReactOnlyPropValue(value)) return false;
+      return true;
+    })
+    .map(([name, value]) => {
+      const snake = name.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+      return `${snake}: ${formatRubyValue(value)}`;
+    });
+}
+
+/**
  * Build a short React/Rails usage example from the first playground preset.
  */
 export function usageFromPreset(kitName, pascalName, playground) {
@@ -286,13 +372,8 @@ export function usageFromPreset(kitName, pascalName, playground) {
   const preset = playground?.presets?.[0];
   if (!preset) return null;
 
-  const props = preset.props && typeof preset.props === 'object' ? preset.props : {};
-  const children =
-    typeof preset.children === 'string'
-      ? preset.children
-      : typeof playground?.children?.default === 'string'
-        ? playground.children.default
-        : '';
+  const props = preset.props && typeof preset.props === 'object' ? { ...preset.props } : {};
+  const children = resolvePresetChildren(preset, playground);
 
   const reactPropParts = Object.entries(props).map(([name, value]) => {
     if (typeof value === 'boolean') return value ? name : `${name}={false}`;
@@ -302,21 +383,53 @@ export function usageFromPreset(kitName, pascalName, playground) {
   });
   const reactProps = reactPropParts.length ? ` ${reactPropParts.join(' ')}` : '';
 
-  const railsProps = Object.entries(props)
-    .map(([name, value]) => {
-      const snake = name.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
-      return `${snake}: ${JSON.stringify(value)}`;
-    })
-    .join(', ');
-
   const hasChildren = children.trim().length > 0;
   const reactExample = hasChildren
     ? `<${pascalName}${reactProps}>\n  ${children.trim()}\n</${pascalName}>`
     : `<${pascalName}${reactProps} />`;
 
-  const railsExample = hasChildren
-    ? `<%= pb_rails("${kitName}", props: { ${railsProps} }) do %>\n  ${children.trim()}\n<% end %>`
-    : `<%= pb_rails("${kitName}", props: { ${railsProps || ''} }) %>`;
+  // SelectableList Rails API uses an `items` array, not Item children.
+  let railsExample;
+  let railsNote;
+  if (kitName === 'selectable_list' && hasChildren) {
+    const items = selectableListItemsFromJsx(children);
+    if (items) {
+      const railsPropParts = [
+        ...formatRailsPropEntries(props),
+        `items: ${formatRubyValue(items)}`,
+      ];
+      railsExample = `<%= pb_rails("${kitName}", props: { ${railsPropParts.join(', ')} }) %>`;
+    }
+  }
+
+  if (!railsExample) {
+    const railsPropParts = formatRailsPropEntries(props);
+    const railsProps = railsPropParts.join(', ');
+
+    if (hasChildren) {
+      const erbChildren = jsxChildrenToErb(children);
+      if (erbChildren != null && erbChildren.trim()) {
+        const indented = erbChildren
+          .split('\n')
+          .map((line) => (line.trim() ? `  ${line}` : line))
+          .join('\n');
+        railsExample = railsProps
+          ? `<%= pb_rails("${kitName}", props: { ${railsProps} }) do %>\n${indented}\n<% end %>`
+          : `<%= pb_rails("${kitName}") do %>\n${indented}\n<% end %>`;
+      } else {
+        // Keep a valid Rails wrapper; point agents at React children / docs when JSX can't be mapped.
+        railsExample = railsProps
+          ? `<%= pb_rails("${kitName}", props: { ${railsProps} }) do %>\n  <%# Add kit content here %>\n<% end %>`
+          : `<%= pb_rails("${kitName}") do %>\n  <%# Add kit content here %>\n<% end %>`;
+        railsNote =
+          'Rails children could not be auto-converted from the React playground preset; see kit docs `.html.erb` examples for the correct nested pb_rails content.';
+      }
+    } else {
+      railsExample = railsProps
+        ? `<%= pb_rails("${kitName}", props: { ${railsProps} }) %>`
+        : `<%= pb_rails("${kitName}") %>`;
+    }
+  }
 
   return {
     react: {
@@ -328,6 +441,7 @@ export function usageFromPreset(kitName, pascalName, playground) {
       import: null,
       example: railsExample,
       preset: preset.name || null,
+      ...(railsNote ? { note: railsNote } : {}),
     },
   };
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Fix AI kit schema Rails usage examples so nested content is ERB/pb_rails, not playground JSX (e.g. Flex Captions, NavItems, Table subcomponents).
- Add a JSX→ERB converter used by usageFromPreset, with kit-path mapping, prop aliases, and a SelectableList items: special case.
- Resolve preset children from the active structure mode so kits like Radio/SelectableCard don’t incorrectly inherit JSX children.default.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.