### PR TITLE
Playbook Website: Fixes for Pagination Doc in Rails

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -281,10 +281,21 @@ class PagesController < ApplicationController
     return nil unless example_path.exist?
 
     erb_content = example_path.read
-    view_context.render(inline: erb_content)
+    html = view_context.render(inline: erb_content)
+    rewrite_prerendered_example_urls(html)
   rescue => e
     Rails.logger.error("Error rendering Rails example #{example_key}: #{e.message}")
     nil
+  end
+
+  # Examples are prerendered into the SPA JSON payload. Helpers like
+  # will_paginate inherit format=json into hrefs. We must strip it so clicks stay on
+  # the HTML docs page (ComponentShowLoader already forwards query params).
+  # Mostly for pagination docs examples.
+  def rewrite_prerendered_example_urls(html)
+    return html if html.blank?
+
+    html.to_s.gsub(/(href=["'])([^"']+)\.json(\?[^"']*)?(["'])/, '\1\2\3\4')
   end
 
   def get_description(example)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Fixes for the issue where clicking the page buttons in the Rails Pagination docs served AT JSON instead of rerendering the page. 

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.