### PR TITLE
[PLAY-3136] Upgrade vite_ruby to 3.8.0

### DIFF
--- a/playbook-website/Gemfile
+++ b/playbook-website/Gemfile
@@ -12,6 +12,7 @@ gem "rails", "~> 7.2.2.1"
 gem "turbo-rails", "~> 1.4.0"
 gem "puma", "~> 6.4.2"
 gem "vite_rails"
+gem "vite_ruby", "3.8.0"
 # Make Compatible with Ruby 3.1.0 Upgrade
 gem "psych", "< 4"
 gem "bootsnap", ">= 1.1.0", require: false

--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     debug_inspector (1.2.0)
     diff-lcs (1.4.4)
     drb (2.2.3)
-    dry-cli (1.1.0)
+    dry-cli (1.4.1)
     erubi (1.13.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
@@ -192,8 +192,8 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.9)
-    rack-proxy (0.7.7)
+    rack (2.2.23)
+    rack-proxy (0.8.3)
       rack
     rack-session (1.0.2)
       rack (< 3)
@@ -324,7 +324,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (4.0.1)
-    zeitwerk (2.6.17)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   aarch64-linux
@@ -368,6 +368,7 @@ DEPENDENCIES
   turbo-rails (~> 1.4.0)
   tzinfo-data
   vite_rails
+  vite_ruby (= 3.8.0)
   web-console
   will_paginate
 

--- a/playbook/Gemfile
+++ b/playbook/Gemfile
@@ -7,5 +7,6 @@ git_source(:github) do |repo_name|
 end
 
 gem "vite_rails"
+gem "vite_ruby", "3.8.0"
 
 gemspec

--- a/playbook/Gemfile.lock
+++ b/playbook/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.4.4)
-    dry-cli (1.0.0)
+    dry-cli (1.4.1)
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -124,8 +124,8 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
-    rack (2.2.9)
-    rack-proxy (0.7.7)
+    rack (2.2.23)
+    rack-proxy (0.8.3)
       rack
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -216,7 +216,7 @@ GEM
     vite_rails (3.0.17)
       railties (>= 5.1, < 8)
       vite_ruby (~> 3.0, >= 3.2.2)
-    vite_ruby (3.6.0)
+    vite_ruby (3.8.0)
       dry-cli (>= 0.7, < 2)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
@@ -224,7 +224,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (3.3.1)
-    zeitwerk (2.6.13)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   ruby
@@ -240,6 +240,7 @@ DEPENDENCIES
   rubocop-performance (~> 1.11.5)
   tzinfo-data (= 1.2018.9)
   vite_rails
+  vite_ruby (= 3.8.0)
   will_paginate (= 3.3.1)
 
 BUNDLED WITH


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Upgrade and pin vite_ruby to 3.8.0

