### PR TITLE
[PLAY-3098] Playbook Website: Using Tokens Page

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/Data/TokenCards.ts
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/Data/TokenCards.ts
@@ -1,5 +1,12 @@
 export const TokenCards = [
   {
+    title: "Using Tokens",
+    description:
+      "How to import and use Playbook CSS token exports in React, Sass, and Ruby.",
+    icon: "code",
+    link: "/tokens/using_tokens",
+  },
+  {
     title: "Animation",
     description:
       "Predefined duration and easing values for consistent motion effects.",

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/UsingTokens.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/UsingTokens.tsx
@@ -121,7 +121,12 @@ const UsingTokens = () => {
           <Body text="JS maps import from playbook-ui. Ruby helpers are available for colors; other token sets will follow." />
           <PropsExamplesTable
             firstColumnBold={false}
-            headers={["Token Set", "JS", "Ruby", "Values"]}
+            headers={[
+              "Token Set",
+              <div key="js" style={{ width: 360 }}>JS</div>,
+              "Ruby",
+              "Values",
+            ]}
             rows={TOKEN_EXPORTS.map(({ tokenSet, jsImport, rubyAccess, valuesPath }) => [
               <Title key={`${jsImport}-set`} size={4}>{tokenSet}</Title>,
               <ExampleCodeCard

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/UsingTokens.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/UsingTokens.tsx
@@ -1,0 +1,243 @@
+import { Link } from "react-router-dom";
+import { Body, Caption, Card, Flex, Title } from "playbook-ui";
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+import {
+  SyntaxHighlightedCode,
+  type SyntaxLanguage,
+} from "../../../SyntaxHighlightedCode";
+
+type TokenExportRow = {
+  tokenSet: string;
+  jsImport: string;
+  sassImport: string;
+  rubyAccess?: string;
+  valuesPath: string;
+};
+
+const TOKEN_EXPORTS: TokenExportRow[] = [
+  {
+    tokenSet: "Border Radius",
+    jsImport: "borderRadius",
+    sassImport: "playbook-ui/dist/tokens/border_radius",
+    valuesPath: "/tokens/border_radius",
+  },
+  {
+    tokenSet: "Colors",
+    jsImport: "colors",
+    sassImport: "playbook-ui/dist/tokens/colors",
+    rubyAccess: "Playbook::Tokens.colors",
+    valuesPath: "/tokens/colors",
+  },
+  {
+    tokenSet: "Line Height",
+    jsImport: "lineHeight",
+    sassImport: "playbook-ui/dist/tokens/line_height",
+    valuesPath: "/tokens/line_height",
+  },
+  {
+    tokenSet: "Opacity",
+    jsImport: "opacity",
+    sassImport: "playbook-ui/dist/tokens/opacity",
+    valuesPath: "/tokens/opacity",
+  },
+  {
+    tokenSet: "Positioning",
+    jsImport: "positioning",
+    sassImport: "playbook-ui/dist/tokens/positioning",
+    valuesPath: "/tokens/position",
+  },
+  {
+    tokenSet: "Scale",
+    jsImport: "scale",
+    sassImport: "playbook-ui/dist/tokens/scale",
+    valuesPath: "/tokens/scale",
+  },
+  {
+    tokenSet: "Screen Sizes",
+    jsImport: "screenSizes",
+    sassImport: "playbook-ui/dist/tokens/screen_sizes",
+    valuesPath: "/tokens/screen_sizes",
+  },
+  {
+    tokenSet: "Shadows",
+    jsImport: "shadows",
+    sassImport: "playbook-ui/dist/tokens/shadows",
+    valuesPath: "/tokens/shadow",
+  },
+  {
+    tokenSet: "Spacing",
+    jsImport: "spacing",
+    sassImport: "playbook-ui/dist/tokens/spacing",
+    valuesPath: "/tokens/spacing",
+  },
+  {
+    tokenSet: "Typography",
+    jsImport: "typography",
+    sassImport: "playbook-ui/dist/tokens/typography",
+    valuesPath: "/tokens/typography",
+  },
+];
+
+const REACT_EXAMPLE = `import { colors, spacing } from "playbook-ui"
+
+<div
+  style={{
+    color: colors.error,
+    marginLeft: spacing.space_xs,
+    padding: spacing.space_sm,
+  }}
+>
+  Token-styled content
+</div>`;
+
+const RAILS_SASS_EXAMPLE = `@import "playbook-ui/dist/tokens/spacing";
+@import "playbook-ui/dist/tokens/colors";
+
+.my-panel {
+  padding: $space_sm;
+  color: $primary;
+}`;
+
+const RUBY_EXAMPLE = `Playbook::Tokens.colors[:input_text_error]
+# => "#DA0014"
+
+Playbook::Tokens.colors.status_text_primary
+# => "#0056CF"`;
+
+type DocCodeSnippetProps = {
+  code: string;
+  label: string;
+  language: SyntaxLanguage;
+};
+
+const DocCodeSnippet = ({ code, label, language }: DocCodeSnippetProps) => (
+  <Card borderNone borderRadius="md" padding="none" width="100%">
+    <Caption color="lighter" paddingBottom="xs" text={label} />
+    <SyntaxHighlightedCode code={code} language={language} />
+  </Card>
+);
+
+const UsingTokens = () => {
+  return (
+    <ShowPage
+      description="Playbook exports CSS tokens for use outside of kit properties. They can be used in custom CSS, inline styles, and Rails helpers. Prefer to use Global Props on kits when you can. Reach for token exports when you need the raw values."
+      pageType="tokens"
+      title="Using Tokens"
+    >
+      <Flex flexDirection="column" gap="xl" width="100%">
+        <Flex flexDirection="column" gap="sm" id="available-js-exports" width="100%">
+          <Title size={2} text="Available JS Exports" />
+          <Body text="Import these maps from playbook-ui. Each links to the full value reference." />
+          <PropsExamplesTable
+            firstColumnBold={false}
+            headers={["Token Set", "Import Name", "Values"]}
+            rows={TOKEN_EXPORTS.map(({ tokenSet, jsImport, valuesPath }) => [
+              <Title key={`${jsImport}-set`} size={4}>{tokenSet}</Title>,
+              <ExampleCodeCard
+                key={`${jsImport}-import`}
+                id={`js-export-${jsImport}`}
+                text={jsImport}
+              />,
+              <Link key={`${jsImport}-values`} to={valuesPath}>
+                View Tokens
+              </Link>,
+            ])}
+          />
+        </Flex>
+
+        <Flex flexDirection="column" gap="sm" id="use-in-react-or-tsx" width="100%">
+          <Title size={2} text="Use in React or TSX" />
+          <Body text="Import token maps and apply them as inline styles or in custom components." />
+          <DocCodeSnippet
+            code={REACT_EXAMPLE}
+            label="REACT / TSX"
+            language="tsx"
+          />
+        </Flex>
+
+        <Flex flexDirection="column" gap="sm" id="available-rails-exports" width="100%">
+          <Title size={2} text="Available Rails Exports" />
+          <Body text="Import these partials into Sass for stylesheet variables. Ruby helper access is available for colors only." />
+          <PropsExamplesTable
+            firstColumnBold={false}
+            headers={["Token Set", "Sass Import", "Ruby", "Values"]}
+            rows={TOKEN_EXPORTS.map(({ tokenSet, sassImport, rubyAccess, valuesPath, jsImport }) => [
+              <Title key={`${jsImport}-rails-set`} size={4}>{tokenSet}</Title>,
+              <ExampleCodeCard
+                key={`${jsImport}-sass`}
+                id={`sass-export-${jsImport}`}
+                text={sassImport}
+              />,
+              rubyAccess ? (
+                <ExampleCodeCard
+                  key={`${jsImport}-ruby`}
+                  id={`ruby-export-${jsImport}`}
+                  text={rubyAccess}
+                />
+              ) : (
+                "—"
+              ),
+              <Link key={`${jsImport}-rails-values`} to={valuesPath}>
+                View Tokens
+              </Link>,
+            ])}
+          />
+        </Flex>
+
+        <Flex flexDirection="column" gap="sm" id="use-in-rails" width="100%">
+          <Title size={2} text="Use in Rails" />
+          <Body text="In Rails apps, import Playbook token partials into your Sass and use $variables in stylesheets." />
+          <DocCodeSnippet
+            code={RAILS_SASS_EXAMPLE}
+            label="SCSS"
+            language="scss"
+          />
+        </Flex>
+
+        <Flex flexDirection="column" gap="sm" id="use-in-ruby-colors" width="100%">
+          <Title size={2} text="Use in Ruby (colors)" />
+          <Body text="When you need color values in Ruby (helpers, presenters, etc.), use Playbook::Tokens. Other token sets are not yet exposed; use Sass or JS exports instead." />
+          <DocCodeSnippet
+            code={RUBY_EXAMPLE}
+            label="RAILS"
+            language="ruby"
+          />
+        </Flex>
+
+        <Flex flexDirection="column" gap="sm" id="tokens-vs-global-props" width="100%">
+          <Title size={2} text="Tokens vs Global Props" />
+          <PropsExamplesTable
+            firstColumnBold={false}
+            headers={["Need", "Use"]}
+            rows={[
+              [
+                "Spacing or color on a Playbook component",
+                <Link key="global-props" to="/global_props">Global Props</Link>,
+              ],
+              [
+                "Custom CSS in a Rails app",
+                "Token Sass imports (Use in Rails)",
+              ],
+              [
+                "Inline styles or custom React UI",
+                "JS token exports (Use in React / TSX)",
+              ],
+              [
+                "Color values in Ruby code",
+                "Playbook::Tokens (colors only)",
+              ],
+              [
+                "Override theme defaults",
+                <Link key="how-to-theme" to="/guides/getting_started/how_to_theme">How to Theme</Link>,
+              ],
+            ]}
+          />
+        </Flex>
+      </Flex>
+    </ShowPage>
+  );
+};
+
+export default UsingTokens;

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/UsingTokens.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/UsingTokens.tsx
@@ -11,7 +11,6 @@ import {
 type TokenExportRow = {
   tokenSet: string;
   jsImport: string;
-  sassImport: string;
   rubyAccess?: string;
   valuesPath: string;
 };
@@ -20,62 +19,52 @@ const TOKEN_EXPORTS: TokenExportRow[] = [
   {
     tokenSet: "Border Radius",
     jsImport: "borderRadius",
-    sassImport: "playbook-ui/dist/tokens/border_radius",
     valuesPath: "/tokens/border_radius",
   },
   {
     tokenSet: "Colors",
     jsImport: "colors",
-    sassImport: "playbook-ui/dist/tokens/colors",
     rubyAccess: "Playbook::Tokens.colors",
     valuesPath: "/tokens/colors",
   },
   {
     tokenSet: "Line Height",
     jsImport: "lineHeight",
-    sassImport: "playbook-ui/dist/tokens/line_height",
     valuesPath: "/tokens/line_height",
   },
   {
     tokenSet: "Opacity",
     jsImport: "opacity",
-    sassImport: "playbook-ui/dist/tokens/opacity",
     valuesPath: "/tokens/opacity",
   },
   {
     tokenSet: "Positioning",
     jsImport: "positioning",
-    sassImport: "playbook-ui/dist/tokens/positioning",
     valuesPath: "/tokens/position",
   },
   {
     tokenSet: "Scale",
     jsImport: "scale",
-    sassImport: "playbook-ui/dist/tokens/scale",
     valuesPath: "/tokens/scale",
   },
   {
     tokenSet: "Screen Sizes",
     jsImport: "screenSizes",
-    sassImport: "playbook-ui/dist/tokens/screen_sizes",
     valuesPath: "/tokens/screen_sizes",
   },
   {
     tokenSet: "Shadows",
     jsImport: "shadows",
-    sassImport: "playbook-ui/dist/tokens/shadows",
     valuesPath: "/tokens/shadow",
   },
   {
     tokenSet: "Spacing",
     jsImport: "spacing",
-    sassImport: "playbook-ui/dist/tokens/spacing",
     valuesPath: "/tokens/spacing",
   },
   {
     tokenSet: "Typography",
     jsImport: "typography",
-    sassImport: "playbook-ui/dist/tokens/typography",
     valuesPath: "/tokens/typography",
   },
 ];
@@ -127,19 +116,28 @@ const UsingTokens = () => {
       title="Using Tokens"
     >
       <Flex flexDirection="column" gap="xl" width="100%">
-        <Flex flexDirection="column" gap="sm" id="available-js-exports" width="100%">
-          <Title size={2} text="Available JS Exports" />
-          <Body text="Import these maps from playbook-ui. Each links to the full value reference." />
+        <Flex flexDirection="column" gap="sm" id="available-token-exports" width="100%">
+          <Title size={2} text="Available Token Exports" />
+          <Body text="JS maps import from playbook-ui. Ruby helpers are available for colors; other token sets will follow." />
           <PropsExamplesTable
             firstColumnBold={false}
-            headers={["Token Set", "Import Name", "Values"]}
-            rows={TOKEN_EXPORTS.map(({ tokenSet, jsImport, valuesPath }) => [
+            headers={["Token Set", "JS", "Ruby", "Values"]}
+            rows={TOKEN_EXPORTS.map(({ tokenSet, jsImport, rubyAccess, valuesPath }) => [
               <Title key={`${jsImport}-set`} size={4}>{tokenSet}</Title>,
               <ExampleCodeCard
-                key={`${jsImport}-import`}
+                key={`${jsImport}-js`}
                 id={`js-export-${jsImport}`}
-                text={jsImport}
+                text={`import { ${jsImport} } from "playbook-ui"`}
               />,
+              rubyAccess ? (
+                <ExampleCodeCard
+                  key={`${jsImport}-ruby`}
+                  id={`ruby-export-${jsImport}`}
+                  text={rubyAccess}
+                />
+              ) : (
+                "—"
+              ),
               <Link key={`${jsImport}-values`} to={valuesPath}>
                 View Tokens
               </Link>,
@@ -157,48 +155,9 @@ const UsingTokens = () => {
           />
         </Flex>
 
-        <Flex flexDirection="column" gap="sm" id="available-rails-exports" width="100%">
-          <Title size={2} text="Available Rails Exports" />
-          <Body text="Import these partials into Sass for stylesheet variables. Ruby helper access is available for colors only." />
-          <PropsExamplesTable
-            firstColumnBold={false}
-            headers={["Token Set", "Sass Import", "Ruby", "Values"]}
-            rows={TOKEN_EXPORTS.map(({ tokenSet, sassImport, rubyAccess, valuesPath, jsImport }) => [
-              <Title key={`${jsImport}-rails-set`} size={4}>{tokenSet}</Title>,
-              <ExampleCodeCard
-                key={`${jsImport}-sass`}
-                id={`sass-export-${jsImport}`}
-                text={sassImport}
-              />,
-              rubyAccess ? (
-                <ExampleCodeCard
-                  key={`${jsImport}-ruby`}
-                  id={`ruby-export-${jsImport}`}
-                  text={rubyAccess}
-                />
-              ) : (
-                "—"
-              ),
-              <Link key={`${jsImport}-rails-values`} to={valuesPath}>
-                View Tokens
-              </Link>,
-            ])}
-          />
-        </Flex>
-
-        <Flex flexDirection="column" gap="sm" id="use-in-rails" width="100%">
-          <Title size={2} text="Use in Rails" />
-          <Body text="In Rails apps, import Playbook token partials into your Sass and use $variables in stylesheets." />
-          <DocCodeSnippet
-            code={RAILS_SASS_EXAMPLE}
-            label="SCSS"
-            language="scss"
-          />
-        </Flex>
-
         <Flex flexDirection="column" gap="sm" id="use-in-ruby-colors" width="100%">
           <Title size={2} text="Use in Ruby (colors)" />
-          <Body text="When you need color values in Ruby (helpers, presenters, etc.), use Playbook::Tokens. Other token sets are not yet exposed; use Sass or JS exports instead." />
+          <Body text="When you need color values in Ruby (helpers, presenters, etc.), use Playbook::Tokens. Note: other token sets are not yet exposed." />
           <DocCodeSnippet
             code={RUBY_EXAMPLE}
             label="RAILS"
@@ -217,10 +176,6 @@ const UsingTokens = () => {
                 <Link key="global-props" to="/global_props">Global Props</Link>,
               ],
               [
-                "Custom CSS in a Rails app",
-                "Token Sass imports (Use in Rails)",
-              ],
-              [
                 "Inline styles or custom React UI",
                 "JS token exports (Use in React / TSX)",
               ],
@@ -233,6 +188,16 @@ const UsingTokens = () => {
                 <Link key="how-to-theme" to="/guides/getting_started/how_to_theme">How to Theme</Link>,
               ],
             ]}
+          />
+        </Flex>
+
+        <Flex flexDirection="column" gap="sm" id="sass-variables-optional" width="100%">
+          <Title size={2} text="Sass variables (optional)" />
+          <Body text="Most Power apps already load Playbook’s bundled CSS and won’t need this. If you’re writing custom SCSS and want token values as $variables, you can import individual partials from playbook-ui/dist/tokens." />
+          <DocCodeSnippet
+            code={RAILS_SASS_EXAMPLE}
+            label="SCSS"
+            language="scss"
           />
         </Flex>
       </Flex>

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex.tsx
@@ -18,6 +18,7 @@ import Transition from "./Examples/Transition";
 import Typography from "./Examples/Typography";
 import Colors from "./Examples/Colors";
 import Spacing from "./Examples/Spacing";
+import UsingTokens from "./Examples/UsingTokens";
 
 const COMPONENT_MAP = {
   animation: Animation,
@@ -37,6 +38,7 @@ const COMPONENT_MAP = {
   titles: Titles,
   transition: Transition,
   typography: Typography,
+  using_tokens: UsingTokens,
   vertical_align: VerticalAlign,
   z_index: ZIndex,
 };

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/TokensIndex.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/TokensIndex.tsx
@@ -46,10 +46,18 @@ const Tokens = () => {
         maxWidth="lg"
       >
         <Title size={1} text="Tokens" marginBottom="sm" />
-        <Body text="Tokens are reusable values that define core design elements like colors, typography, and spacing. They provide consistency across components and Global Props, ensuring scalable and cohesive design throughout the application." />
+        <Body>
+          Tokens are reusable values that define core design elements like colors, typography, and spacing. They provide consistency across components and Global Props, ensuring scalable and cohesive design throughout the application. See{" "}
+          <RouterLink to="/tokens/using_tokens">Using Tokens</RouterLink>
+          {" "}for how to import and consume token exports in React and Rails.
+        </Body>
         <Layout layout="collection" marginY="xl" paddingBottom="xl">
           <Layout.Body>
-            {TokenCards.sort((a, b) => a.title.localeCompare(b.title)).map(({ title, description, link, icon }) => (
+            {TokenCards.sort((a, b) => {
+              if (a.link === "/tokens/using_tokens") return -1;
+              if (b.link === "/tokens/using_tokens") return 1;
+              return a.title.localeCompare(b.title);
+            }).map(({ title, description, link, icon }) => (
               <RouterLink key={title} to={link} style={linkStyle}>
                 <Card padding="none" hover={{ shadow: "deep" }} flex={1}>
                   <Background backgroundColor="light">

--- a/playbook-website/app/javascript/components/Website/src/components/SyntaxHighlightedCode.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/SyntaxHighlightedCode.tsx
@@ -7,7 +7,8 @@ export type SyntaxLanguage =
   | "tsx"
   | "markup"
   | "erb"
-  | "ruby";
+  | "ruby"
+  | "scss";
 
 type SyntaxHighlightedCodeProps = {
   code: string;

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/NavComponents/OtherNavComponent.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/NavComponents/OtherNavComponent.tsx
@@ -86,13 +86,18 @@ export const OtherNavItems = ({
 
   const tokensMenu =
     global_props_and_tokens?.tokens
-      ?.map((item: Record<string, any>) => ({
+      ?.map((item: string) => ({
         name: item
           .replace(/_/g, " ")
           .replace(/\b\w/g, (char: string) => char.toUpperCase()),
         link: createLink(`/tokens/${item}`),
+        itemKey: item,
       }))
-      .sort((a, b) => a.name.localeCompare(b.name)) || [];
+      .sort((a, b) => {
+        if (a.itemKey === "using_tokens") return -1;
+        if (b.itemKey === "using_tokens") return 1;
+        return a.name.localeCompare(b.name);
+      }) || [];
 
   if (name === "Global Props") {
     menuItems = globalPropsMenu;

--- a/playbook-website/app/javascript/components/Website/src/pages/DesignGuidelines/Color.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/DesignGuidelines/Color.tsx
@@ -27,8 +27,9 @@ const Color = () => {
           
           <Body marginBottom="md">
             For all our Color Tokens refer to{" "}
-            <a href="https://playbook.powerapp.cloud/tokens/colors">Colors</a> in{" "}
-            <a href="https://playbook.powerapp.cloud/tokens">Tokens</a>
+            <a href="/tokens/colors">Colors</a> in{" "}
+            <a href="/tokens">Tokens</a>. For using color exports in React or Rails, see{" "}
+            <a href="/tokens/using_tokens">Using Tokens</a>.
           </Body>
 
           <Title text="Index" size={4} marginBottom="sm" />

--- a/playbook-website/app/views/guides/design_guidelines/color.md
+++ b/playbook-website/app/views/guides/design_guidelines/color.md
@@ -4,7 +4,7 @@ description: As a design system primarily used for business software application
 icon: palette
 ---
 
-For all our Color Tokens refer to [Colors](https://playbook.powerapp.cloud/tokens/colors) in [Tokens](https://playbook.powerapp.cloud/tokens)
+For all our Color Tokens refer to [Colors](/tokens/colors) in [Tokens](/tokens). For using color exports in React or Rails, see [Using Tokens](/tokens/using_tokens).
 
 #### Index
 

--- a/playbook-website/app/views/guides/getting_started/how_to_theme.md
+++ b/playbook-website/app/views/guides/getting_started/how_to_theme.md
@@ -4,7 +4,7 @@ description: You can customize and theme Playbook components by setting your own
 icon: wrench
 ---
 
-For a comprehensive overview of our tokens, refer to the [Tokens](https://playbook.powerapp.cloud/tokens) or review our [variables](https://github.com/powerhome/playbook/tree/master/playbook/app/pb_kits/playbook/tokens).
+For a comprehensive overview of our tokens, refer to the [Tokens](/tokens) page, [Using Tokens](/tokens/using_tokens) for export usage in React and Rails, or review our [variables](https://github.com/powerhome/playbook/tree/master/playbook/app/pb_kits/playbook/tokens).
 
 #### Index
 

--- a/playbook-website/config/global_props_and_tokens.yml
+++ b/playbook-website/config/global_props_and_tokens.yml
@@ -35,6 +35,7 @@ global_props:
   - border
 
 tokens:
+  - using_tokens
   - animation
   - border_radius
   - colors


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3098

Show how to use Playbook tokens in React, Rails Sass, and Ruby helpers. 

**Screenshots:** Screenshots to visualize your addition/change
<img width="975" height="1033" alt="Screenshot 2026-08-11 at 11 20 01 AM" src="https://github.com/user-attachments/assets/287a22b3-0cc3-4e38-9364-bb285ec5c482" />
<img width="974" height="944" alt="Screenshot 2026-08-11 at 11 20 11 AM" src="https://github.com/user-attachments/assets/4018bd32-85bf-4ef2-bc1d-1d7f2505b2ff" />
<img width="981" height="322" alt="Screenshot 2026-08-11 at 11 20 17 AM" src="https://github.com/user-attachments/assets/311a1786-a018-4515-87dc-cf70319123d2" />

**How to test?** Steps to confirm the desired behavior:
1. Go to /tokens/using_tokens

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.