### PR TITLE
[PLAY-3124] Select Kit: Color Consistency - Rails & React

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/_select.scss
+++ b/playbook/app/pb_kits/playbook/pb_select/_select.scss
@@ -18,6 +18,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-height: 45px;
+    &:has(option[value=""]:checked) {
+      color: $input_text_default;
+    }
     @media (hover:hover) {
       &:hover, &:active, &:focus {
         background-color: $input_background_state;
@@ -170,6 +173,9 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    &:has(option[value=""]:checked) {
+      color: $input_text_default_dark;
+    }
     @media (hover:hover) {
       &:hover, &:active, &:focus {
         background-color: $input_background_state_dark;


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3124

Set empty value option (`blank_selection` or `include_blank` placeholder) to a grey to match other input placeholder font color.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1994" height="538" alt="Screenshot 2026-08-12 at 1 56 43 PM" src="https://github.com/user-attachments/assets/afcdda4e-04e5-42fd-a384-1a7bb19ccc6f" />
<img width="1945" height="267" alt="Screenshot 2026-08-12 at 1 52 18 PM" src="https://github.com/user-attachments/assets/81d0da9d-b3e6-4963-badc-aad4bf2fc230" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /kits/select/rails#select_blank

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.