### PR TITLE
[PLAY-3140] Upgrades Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -684,6 +684,14 @@
     "category": "Communication"
   },
   {
+    "name": "comment-code",
+    "category": "Communication"
+  },
+  {
+    "name": "comment-plus",
+    "category": "Communication"
+  },
+  {
     "name": "comment-slash",
     "category": "Communication"
   },
@@ -976,6 +984,10 @@
     "category": "Files"
   },
   {
+    "name": "file-music",
+    "category": "Files"
+  },
+  {
     "name": "file-pdf",
     "category": "Files"
   },
@@ -1141,6 +1153,10 @@
   },
   {
     "name": "arrow-pointer",
+    "category": "Interface Core"
+  },
+  {
+    "name": "backspace",
     "category": "Interface Core"
   },
   {
@@ -1908,6 +1924,10 @@
     "category": "Power Products"
   },
   {
+    "name": "circle-product-multi",
+    "category": "Power Products"
+  },
+  {
     "name": "circle-product-roofing",
     "category": "Power Products"
   },
@@ -1949,6 +1969,10 @@
   },
   {
     "name": "product-hardboard-siding",
+    "category": "Power Products"
+  },
+  {
+    "name": "product-multi",
     "category": "Power Products"
   },
   {
@@ -2209,6 +2233,14 @@
   },
   {
     "name": "wand-magic-sparkles",
+    "category": "Technology"
+  },
+  {
+    "name": "wifi-slash",
+    "category": "Technology"
+  },
+  {
+    "name": "wifi",
     "category": "Technology"
   },
   {

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "2.5.0",
-    "@powerhome/playbook-icons-react": "2.5.0",
+    "@powerhome/playbook-icons": "2.6.0",
+    "@powerhome/playbook-icons-react": "2.6.0",
     "@powerhome/power-fonts": "0.0.1",
     "maplibre-gl": "^4.7.1",
     "highcharts": "^11.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,15 +3170,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@2.5.0":
-  version "2.5.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/045d750f92e1f72832b5d283170e976128d78676#045d750f92e1f72832b5d283170e976128d78676"
-  integrity sha512-kRxl8bJNempM0coxHQjMerkjWmEGDgBOxk0cyWLgFgd7EOpnLAnMcv09ZZQFfm02VOAFeirFVU7QeKJLCIIoLw==
+"@powerhome/playbook-icons-react@2.6.0":
+  version "2.6.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/2cd263087b80fbd34b773d47672fdcc2af3351fa#2cd263087b80fbd34b773d47672fdcc2af3351fa"
+  integrity sha512-6XBAfRcwFI4m2s8uUkpSWHFJkOMuFyGNX4qhrSqoYRSLXrjadxxKRs9dUcUWutYKQMFDLmsGjnV3idXu51FOJA==
 
-"@powerhome/playbook-icons@2.5.0":
-  version "2.5.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/a348fc5ed50322813a4a63f0bd20304ee444b653#a348fc5ed50322813a4a63f0bd20304ee444b653"
-  integrity sha512-Xsvbxcq7eWnEYTC5qLjcywZ4+Es+Wg2/5DEQ4vfBMA3oDNIo/Tdvvx14JInY6LOXDILRiwavEbojNcx61o8dtQ==
+"@powerhome/playbook-icons@2.6.0":
+  version "2.6.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/e0990903e51960a94157c4631d4fd2b8f8a7df31#e0990903e51960a94157c4631d4fd2b8f8a7df31"
+  integrity sha512-DkLVPRIcflWS2/3Jvfo5UF9oTIyJO2JPnQaFDoy9XXuD5EWvcj60YfXZ4t5Rk7q0opuYsKR1W4IymV3bqQSgyA==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3140](https://runway.powerhrg.com/backlog_items/PLAY-3040) adds 8 icons and 2 aliases to the playbook-icons repo. https://github.com/powerhome/playbook-icons/pull/66 This release also includes repo updates to generate and package icons for Swift.

**Screenshots:** Screenshots to visualize your addition/change
<img width="568" height="457" alt="react icons" src="https://github.com/user-attachments/assets/58426047-db66-4b9a-a0fe-e9da4c64a04b" />
<img width="866" height="786" alt="icon display" src="https://github.com/user-attachments/assets/576f698f-6089-4574-8012-d70c7a4ce8f5" />

**How to test?** Steps to confirm the desired behavior:
1. Go to /icons page - see icon cards for the 8 new icons (including two new Power Products).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.