### PR TITLE
[PLAY-3116] Playbook Website - React Inputs Reset When Viewing Code

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleReact.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/LiveExamples/LiveExampleReact.tsx
@@ -20,6 +20,10 @@ import {
 // Pull in all Playbook React exports so we don't have to specify individual imports
 import * as PB from "playbook-ui";
 
+// Module-level so PBrest stays stable across re-renders (avoids remounting live previews).
+// Rename Date so it does not shadow the global Date constructor.
+const { Date: FormattedDate, ...PBrest } = PB as any;
+
 /**
  * NOTE:
  * This component renders a live code example using react-live.
@@ -135,8 +139,6 @@ const LiveExample: React.FC<LiveExampleProps> = ({
 }) => {
   const prepared = useMemo(() => prepareCode(code), [code]);
   const { darkMode } = useDarkMode();
-  // prevent Date kit from shadowing the global Date constructor. Do FormattedDate like we do in the docs
-  const { Date: FormattedDate, ...PBrest } = PB as any;
 
   // Check if Date is imported with an alias (e.g., "Date as DateKit")
   const dateAlias = useMemo(() => parseDateAlias(code), [code]);
@@ -238,7 +240,7 @@ const LiveExample: React.FC<LiveExampleProps> = ({
       baseScope[dateAlias] = FormattedDate;
     }
     return baseScope;
-  }, [thirdParty, mergedExampleProps, PBrest, FormattedDate, dateAlias, darkMode]);
+  }, [thirdParty, mergedExampleProps, dateAlias, darkMode]);
 
   // Handle clicks to prevent href="#" navigation (only preventDefault, not stopPropagation)
   const handleContainerClick = useCallback((e: React.MouseEvent) => {


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3116

Clicking Show Code made React throw away live examples and build a fresh one - like refreshing the page for that little demo. Anything you’d typed was gone (especially true for inputs).

Fix this bug so it doesn't re-render. Stabilize the playbook-ui scope passed to react-live so Show Code re-renders do not remount live previews and clear input values.

**How to test?** Steps to confirm the desired behavior:
1. Go to text input for React
2. Type in the text box
3. Click Show Code
4. You should not see it reset

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.