### PR TITLE
[PLAY-3122] Remove Icon from Error docs

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_error.html.erb
@@ -1,4 +1,4 @@
 <%= pb_rails("date_picker", props: {
-  error: raw(pb_rails("icon", props: { icon: "warning" }) + " Invalid date. Please pick a valid date."),
+  error: "Invalid date. Please pick a valid date.",
   picker_id: "date-picker-error"
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_error.jsx
@@ -1,14 +1,11 @@
 import React from 'react'
 
 import DatePicker from '../_date_picker'
-import Icon from '../../pb_icon/_icon'
 
 const DatePickerError = (props) => (
   <div>
     <DatePicker
-        error={<>
-          <Icon icon="warning" /> Invalid date. Please pick a valid date.
-        </>}
+        error="Invalid date. Please pick a valid date."
         pickerId="date-picker-error"
         {...props}
     />

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_error.html.erb
@@ -7,6 +7,6 @@
 %>
 
 <%= pb_rails("dropdown", props: {
-  error: raw(pb_rails("icon", props: { icon: "warning" }) + " Please make a valid selection"),
+  error: "Please make a valid selection",
   options: options
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_error.jsx
@@ -1,12 +1,9 @@
 import React, { useState } from 'react'
 import Dropdown from '../../pb_dropdown/_dropdown'
-import Icon from '../../pb_icon/_icon'
 
 const DropdownError = (props) => {
     const [selectedOption, setSelectedOption] = useState()
-    const error = selectedOption?.value ? null : (<>
-        <Icon icon="warning" /> Please make a valid selection
-    </>)
+    const error = selectedOption?.value ? null : "Please make a valid selection"
     const options = [
         {
             label: "United States",

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_error.html.erb
@@ -1,1 +1,1 @@
-<%= pb_rails("file_upload", props: {id: "error",  error: raw(pb_rails("icon", props: { icon: "warning" }) + " Please upload a valid file")}) %>
+<%= pb_rails("file_upload", props: {id: "error",  error: "Please upload a valid file."}) %>

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_error.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import FileUpload from '../_file_upload'
 import List from '../../pb_list/_list'
 import ListItem from '../../pb_list/_list_item'
-import Icon from '../../pb_icon/_icon'
 
 const AcceptedFilesList = ({ files }) => (
   <List>
@@ -19,10 +18,6 @@ const FileUploadError = (props) => {
     setFilesToUpload([...filesToUpload, ...files])
   }
 
-  const error = (<>
-    <Icon icon="warning" /> Please upload a valid file
-  </>)
-
   return (
     <div>
       <AcceptedFilesList
@@ -30,7 +25,7 @@ const FileUploadError = (props) => {
           {...props}
       />
       <FileUpload
-          error={error}
+          error="Please upload a valid file."
           onFilesAccepted={handleOnFilesAccepted}
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_validation.jsx
+++ b/playbook/app/pb_kits/playbook/pb_phone_number_input/docs/_phone_number_input_validation.jsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from "react";
 import Button from '../../pb_button/_button'
 import FixedConfirmationToast from '../../pb_fixed_confirmation_toast/_fixed_confirmation_toast'
 import PhoneNumberInput from '../../pb_phone_number_input/_phone_number_input'
-import Icon from '../../pb_icon/_icon'
 
 const PhoneNumberInputValidation = (props) => {
     const [formErrors, setFormErrors] = useState("");
@@ -16,7 +15,7 @@ const PhoneNumberInputValidation = (props) => {
     // Start with initial error - will be cleared on blur if valid
     const initialError = (
         <>
-            <Icon icon="warning" /> Missing phone number.
+            Missing phone number.
         </>
     );
 

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("select", props: {
-  error: raw(pb_rails("icon", props: { icon: "warning" }) + " Please make a valid selection"),
+  error: "Please make a valid selection",
   id: "select-food-error",
   label: "Favorite Food",
   name: "food",

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_select_error.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Body from '../../pb_body/_body'
 import Select from '../../pb_select/_select'
-import Icon from '../../pb_icon/_icon'
 
 const SelectError = (props) => {
   const options = [
@@ -19,14 +18,10 @@ const SelectError = (props) => {
     },
   ]
 
-  const error = (<>
-    <Icon icon="warning" /> Please make a valid selection
-  </>)
-
   return (
     <div>
       <Select
-          error={error}
+          error="Please make a valid selection"
           label="Favorite Food"
           name="food-error"
           options={options}
@@ -34,7 +29,7 @@ const SelectError = (props) => {
           {...props}
       />
       <Body
-          error={error}
+          error="Please make a valid selection"
           status="negative"
           {...props}
       />

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.html.erb
@@ -4,7 +4,7 @@
     border: true,
     icon: "user"
   },
-  error: raw(pb_rails("icon", props: { icon: "warning" }) + " Please enter a valid email address"),
+  error: "Please enter a valid email address",
   label: "Email Address",
   placeholder: "Enter email address",
   type: "email"

--- a/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_text_input/docs/_text_input_error.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 
 import TextInput from '../_text_input'
-import Icon from '../../pb_icon/_icon'
 
 const TextInputError = (props) => {
   const [email, setEmail] = useState('')
@@ -10,17 +9,11 @@ const TextInputError = (props) => {
     setEmail(target.value)
   }
 
-  const error = (
-    <>
-      <Icon icon="warning" /> Please enter a valid email address
-    </>
-  )
-  
   return (
     <div>
       <TextInput
           addOn={{ icon: 'user', alignment: 'left', border: true }}
-          error={error}
+          error="Please enter a valid email address"
           label="Email Address"
           onChange={handleUpdateEmail}
           placeholder="Enter email address"

--- a/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("textarea", props: {
-  error: raw("#{pb_rails('icon', props: { icon: 'warning' })} This field has an error!"),
+  error: "This field has an error!",
   label: "Label",
   rows: 4
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.jsx
+++ b/playbook/app/pb_kits/playbook/pb_textarea/docs/_textarea_error.jsx
@@ -1,21 +1,15 @@
 import React, {useState} from 'react'
 import Textarea from '../../pb_textarea/_textarea'
-import Icon from '../../pb_icon/_icon'
 
 const TextareaError = (props) => {
   const [value, setValue] = useState('default value text')
   const handleChange = (event) => {
     setValue(event.target.value)
   }
-  const error = (
-    <>
-        <Icon icon="warning" /> This field has an error!
-    </>
-  )
   return (
     <div>
       <Textarea
-          error={error}
+          error="This field has an error!"
           label="Label"
           name="comment"
           onChange={(e)=> handleChange(e)}

--- a/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_error_state.jsx
+++ b/playbook/app/pb_kits/playbook/pb_typeahead/docs/_typeahead_error_state.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 
 import Typeahead from '../_typeahead'
-import Icon from '../../pb_icon/_icon'
 
 const options = [
   { label: 'Orange', value: '#FFA500' },
@@ -11,10 +10,7 @@ const options = [
 ]
 
 const TypeaheadErrorState = (props) => {
-  const error = (<>
-    <Icon icon="warning" /> Please make a valid selection
-  </>)
-  const [errorState, setErrorState] = useState(error);
+  const [errorState, setErrorState] = useState("Please make a valid selection");
   const [searchValue, setSearchValue] = useState(null);
   
   const handleOnChange = (value) => setSearchValue(value)
@@ -23,7 +19,7 @@ const TypeaheadErrorState = (props) => {
       if(searchValue) {
         setErrorState("")
       } else {
-        setErrorState(error)
+        setErrorState("Please make a valid selection")
       }
     }, [searchValue])
   


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3122](https://runway.powerhrg.com/backlog_items/PLAY-3122) removes the Warning Icon from the error messages in our error docs - our design style guide has changed. This PR reverses previous work done to add icons to these docs, largely in PLAY-2043/PLAY-2044 (and a couple others).

**Screenshots:** Screenshots to visualize your addition/change
<img width="1546" height="537" alt="PLAY3112sidebyside" src="https://github.com/user-attachments/assets/7aebb9f7-dd0b-4b5c-b3d0-c336e8ab75d0" />

**How to test?** Steps to confirm the desired behavior:
1. Go to kit pages/error docs for the following kits and compare to prod - no more Warning icon in the error message: Rails and React updated for Date Picker, Dropdown, File Upload, Select, Textarea, Text Input; React updated for Typeahead and Phone Number Input.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.