### PR TITLE
[PLAY-3147] Upgrades Playbook Icons

### DIFF
--- a/playbook-website/app/assets/icons.json
+++ b/playbook-website/app/assets/icons.json
@@ -1460,6 +1460,10 @@
     "category": "Interface Core"
   },
   {
+    "name": "square-list",
+    "category": "Interface Core"
+  },
+  {
     "name": "square-plus",
     "category": "Interface Core"
   },

--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-draw": "^1.4.1",
-    "@powerhome/playbook-icons": "2.6.0",
-    "@powerhome/playbook-icons-react": "2.6.0",
+    "@powerhome/playbook-icons": "2.7.0",
+    "@powerhome/playbook-icons-react": "2.7.0",
     "@powerhome/power-fonts": "0.0.1",
     "maplibre-gl": "^4.7.1",
     "highcharts": "^11.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,15 +3170,15 @@
   resolved "https://npm.powerapp.cloud/@powerhome/eslint-config/-/eslint-config-0.1.0.tgz#f1e1151481f51421186ba8caad99fadb24b1fe51"
   integrity sha512-8e5DRgnKPbJ+ofAtqjUPZTxcgHg/TVf52WeNqAGBUXSS4QWHemL6fj1n/YHfAIvx3aMUhFwrw2lUNofUocgK3A==
 
-"@powerhome/playbook-icons-react@2.6.0":
-  version "2.6.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/2cd263087b80fbd34b773d47672fdcc2af3351fa#2cd263087b80fbd34b773d47672fdcc2af3351fa"
-  integrity sha512-6XBAfRcwFI4m2s8uUkpSWHFJkOMuFyGNX4qhrSqoYRSLXrjadxxKRs9dUcUWutYKQMFDLmsGjnV3idXu51FOJA==
+"@powerhome/playbook-icons-react@2.7.0":
+  version "2.7.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons-react/-/47586cff3eff7fb4b743dbc39fdc6fb1f86e285f#47586cff3eff7fb4b743dbc39fdc6fb1f86e285f"
+  integrity sha512-iyDdkyqYMCkq1utB0UBsDvj1cVMofgL6ymETqWEEeiqX5KGlyErmf0wY5LCI6Hp0DnXdgMejrQhbJmIJJkIsWA==
 
-"@powerhome/playbook-icons@2.6.0":
-  version "2.6.0"
-  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/e0990903e51960a94157c4631d4fd2b8f8a7df31#e0990903e51960a94157c4631d4fd2b8f8a7df31"
-  integrity sha512-DkLVPRIcflWS2/3Jvfo5UF9oTIyJO2JPnQaFDoy9XXuD5EWvcj60YfXZ4t5Rk7q0opuYsKR1W4IymV3bqQSgyA==
+"@powerhome/playbook-icons@2.7.0":
+  version "2.7.0"
+  resolved "https://npm.powerapp.cloud/@powerhome/playbook-icons/-/ca2086130fa627cf5ebe315b0a009b2a322f8623#ca2086130fa627cf5ebe315b0a009b2a322f8623"
+  integrity sha512-n++M1zjmtLLL1B9lmFflvbdz1DeoEyI/ebCIVSBHg9Q2WGfbmUlxh23I16FMGDKMRJRu6PrmJd4PfdWaX02RGQ==
 
 "@powerhome/power-fonts@0.0.1":
   version "0.0.1"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3147](https://runway.powerhrg.com/backlog_items/PLAY-3147) adds one icon to the playbook-icons repo. https://github.com/powerhome/playbook-icons/pull/67

**Screenshots:** Screenshots to visualize your addition/change
<img width="357" height="428" alt="react kit page" src="https://github.com/user-attachments/assets/292164ee-57f0-4ee0-9dbf-2f5ed1526c87" />
<img width="795" height="530" alt="icon page" src="https://github.com/user-attachments/assets/8a4aa602-1828-4698-b901-706f6f4d597e" />


**How to test?** Steps to confirm the desired behavior:
1. Go to /icons page - see icon card for square-list in Interface-Core category


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.