### PR TITLE
[PLAY-3110] Height Global Props: Add 100% and 100vh Values

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/Height.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/Height.tsx
@@ -15,15 +15,18 @@ const Height = () => {
     'xl': '1280px',
     'xxl': '1440px',
     'xxxl': '1920px',
+    '100%': '100%',
+    '100vh': '100vh',
   }
 
   const VisualGuideCard = () => {
     return (
       <Background
           className="height-global"
+          height="xxxl"
           width="100%"
       >
-        <Flex justify="between" orientation="row">
+        <Flex height="100%" justify="between" orientation="row">
           {Object.keys(SIZES).map((size: string) => (
             <Background
                 backgroundColor="primary"
@@ -163,6 +166,20 @@ const Height = () => {
               <Flex gap="xs" wrap><ValueCardWithTooltip text="xxxl" tooltipText="1920px"/></Flex>,
               <ExampleCodeCard id="height-xxxl-rails" text='height: "xxxl"' />,
               <ExampleCodeCard id="height-xxxl-react" text='height="xxxl"' />,
+            ],
+            [
+              "100%",
+              <ExampleCodeCard text="string" copyIcon={false} />,
+              <Flex gap="xs" wrap><ExampleCodeCard text="100%" copyIcon={false} /></Flex>,
+              <ExampleCodeCard id="height-100-rails" text='height: "100%"' />,
+              <ExampleCodeCard id="height-100-react" text='height="100%"' />,
+            ],
+            [
+              "100vh",
+              <ExampleCodeCard text="string" copyIcon={false} />,
+              <Flex gap="xs" wrap><ExampleCodeCard text="100vh" copyIcon={false} /></Flex>,
+              <ExampleCodeCard id="height-100vh-rails" text='height: "100vh"' />,
+              <ExampleCodeCard id="height-100vh-react" text='height="100vh"' />,
             ],
           ]}
         />

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/MaxHeight.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/MaxHeight.tsx
@@ -15,6 +15,8 @@ const MaxHeight = () => {
     'xl': '1280px',
     'xxl': '1440px',
     'xxxl': '1920px',
+    '100%': '100%',
+    '100vh': '100vh',
   }
 
   const VisualGuideCard = () => {
@@ -24,7 +26,7 @@ const MaxHeight = () => {
           overflow="auto"
           width="100%"
       >
-        <Flex justify="between" orientation="row">
+        <Flex height="100%" justify="between" orientation="row">
           {Object.keys(SIZES).map((size: string) => (
             <Background
                 backgroundColor="primary"
@@ -163,6 +165,20 @@ const MaxHeight = () => {
               <Flex gap="xs" wrap><ValueCardWithTooltip text="xxxl" tooltipText="1920px"/></Flex>,
               <ExampleCodeCard id="max-height-xxxl-rails" text='max_height: "xxxl"' />,
               <ExampleCodeCard id="max-height-xxxl-react" text='maxHeight="xxxl"' />,
+            ],
+            [
+              "100%",
+              <ExampleCodeCard text="string" copyIcon={false} />,
+              <Flex gap="xs" wrap><ExampleCodeCard text="100%" copyIcon={false} /></Flex>,
+              <ExampleCodeCard id="max-height-100-rails" text='max_height: "100%"' />,
+              <ExampleCodeCard id="max-height-100-react" text='maxHeight="100%"' />,
+            ],
+            [
+              "100vh",
+              <ExampleCodeCard text="string" copyIcon={false} />,
+              <Flex gap="xs" wrap><ExampleCodeCard text="100vh" copyIcon={false} /></Flex>,
+              <ExampleCodeCard id="max-height-100vh-rails" text='max_height: "100vh"' />,
+              <ExampleCodeCard id="max-height-100vh-react" text='maxHeight="100vh"' />,
             ],
           ]}
         />

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/MinHeight.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/MinHeight.tsx
@@ -15,6 +15,8 @@ const MinHeight = () => {
     'xl': '1280px',
     'xxl': '1440px',
     'xxxl': '1920px',
+    '100%': '100%',
+    '100vh': '100vh',
   }
 
   const VisualGuideCard = () => {
@@ -24,7 +26,7 @@ const MinHeight = () => {
           overflow="auto"
           width="100%"
       >
-        <Flex justify="between" orientation="row">
+        <Flex height="100%" justify="between" orientation="row">
           {Object.keys(SIZES).map((size: string) => (
             <Background
                 backgroundColor="primary"
@@ -163,6 +165,20 @@ const MinHeight = () => {
               <Flex gap="xs" wrap><ValueCardWithTooltip text="xxxl" tooltipText="1920px"/></Flex>,
               <ExampleCodeCard id="min-height-xxxl-rails" text='min_height: "xxxl"' />,
               <ExampleCodeCard id="min-height-xxxl-react" text='minHeight="xxxl"' />,
+            ],
+            [
+              "100%",
+              <ExampleCodeCard text="string" copyIcon={false} />,
+              <Flex gap="xs" wrap><ExampleCodeCard text="100%" copyIcon={false} /></Flex>,
+              <ExampleCodeCard id="min-height-100-rails" text='min_height: "100%"' />,
+              <ExampleCodeCard id="min-height-100-react" text='minHeight="100%"' />,
+            ],
+            [
+              "100vh",
+              <ExampleCodeCard text="string" copyIcon={false} />,
+              <Flex gap="xs" wrap><ExampleCodeCard text="100vh" copyIcon={false} /></Flex>,
+              <ExampleCodeCard id="min-height-100vh-rails" text='min_height: "100vh"' />,
+              <ExampleCodeCard id="min-height-100vh-react" text='minHeight="100vh"' />,
             ],
           ]}
         />

--- a/playbook/app/pb_kits/playbook/tokens/_height.scss
+++ b/playbook/app/pb_kits/playbook/tokens/_height.scss
@@ -7,6 +7,8 @@ $height_lg: 1024px !default;
 $height_xl: 1280px !default;
 $height_2xl: 1440px !default;
 $height_3xl: 1920px !default;
+$height_100_percent: 100% !default;
+$height_100vh: 100vh !default;
 $heights: (
   height_auto: $height_auto,
   height_xs: $height_xs,
@@ -15,5 +17,7 @@ $heights: (
   height_lg: $height_lg,
   height_xl: $height_xl,
   height_xxl: $height_2xl,
-  height_xxxl: $height_3xl
+  height_xxxl: $height_3xl,
+  height_100_percent: $height_100_percent,
+  height_100vh: $height_100vh
 );

--- a/playbook/app/pb_kits/playbook/utilities/globalProps.ts
+++ b/playbook/app/pb_kits/playbook/utilities/globalProps.ts
@@ -315,6 +315,8 @@ const filterClassName = (value: string): string => {
   }
 };
 
+const HEIGHT_PROP_VALUES = ["auto", "xs", "sm", "md", "lg", "xl", "xxl", "xxxl", "100%", "100vh"]
+
 const BORDER_PROP_VALUES: BorderPropValue[] = [
   "none",
   "default",
@@ -537,24 +539,21 @@ const PROP_CATEGORIES: {[key:string]: (props: {[key: string]: any}) => string} =
     }
   },
   minHeightProps: ({ minHeight }: MinHeight) => {
-    const heightValues = ["auto", "xs", "sm", "md", "lg", "xl", "xxl", "xxxl"]
-    if (heightValues.includes(minHeight)) {
+    if (HEIGHT_PROP_VALUES.includes(minHeight)) {
       let css = ''
       css += minHeight ? `min_height_${filterClassName(minHeight)} ` : ''
       return css.trimEnd()
     }
   },
   maxHeightProps: ({ maxHeight }: MaxHeight) => {
-    const heightValues = ["auto", "xs", "sm", "md", "lg", "xl", "xxl", "xxxl"]
-    if (heightValues.includes(maxHeight)) {
+    if (HEIGHT_PROP_VALUES.includes(maxHeight)) {
       let css = ''
       css += maxHeight ? `max_height_${filterClassName(maxHeight)} ` : ''
       return css.trimEnd()
     }
   },
   heightProps: ({ height }: Height) => {
-    const heightValues = ["auto", "xs", "sm", "md", "lg", "xl", "xxl", "xxxl"]
-    if (heightValues.includes(height)) {
+    if (HEIGHT_PROP_VALUES.includes(height)) {
       let css = ''
       css += height ? `height_${filterClassName(height)} ` : ''
       return css.trimEnd()
@@ -742,15 +741,24 @@ const PROP_CATEGORIES: {[key:string]: (props: {[key: string]: any}) => string} =
 
 const PROP_INLINE_CATEGORIES: {[key:string]: (props: {[key: string]: any}) => {[key: string]: any}} = {
   heightProps: ({ height }: Height) => {
-    return height ? { height } : {};
+    if (height && !HEIGHT_PROP_VALUES.includes(height)) {
+      return { height }
+    }
+    return {}
   },
 
   maxHeightProps: ({ maxHeight }: MaxHeight) => {
-    return maxHeight ? { maxHeight } : {};
+    if (maxHeight && !HEIGHT_PROP_VALUES.includes(maxHeight)) {
+      return { maxHeight }
+    }
+    return {}
   },
 
   minHeightProps: ({ minHeight }: MinHeight) => {
-    return minHeight ? { minHeight } : {};
+    if (minHeight && !HEIGHT_PROP_VALUES.includes(minHeight)) {
+      return { minHeight }
+    }
+    return {}
   },
 
   gridTemplateColumnsProps: ({ gridTemplateColumns }: GridTemplateColumns) => {

--- a/playbook/app/pb_kits/playbook/utilities/test/globalProps/height.test.js
+++ b/playbook/app/pb_kits/playbook/utilities/test/globalProps/height.test.js
@@ -7,21 +7,24 @@ import Flex from '../../../pb_flex/_flex'
 import Link from '../../../pb_link/_link'
 import Badge from '../../../pb_badge/_badge'
 
-const validHeightValues = ['auto', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl']
+const validHeightValues = ['auto', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', '100%', '100vh']
+const heightClassName = (v) => `height_${v.replace('%', '_percent')}`
+const minHeightClassName = (v) => `min_height_${v.replace('%', '_percent')}`
+const maxHeightClassName = (v) => `max_height_${v.replace('%', '_percent')}`
 
 // NOTE: TextInput excluded - height properties are not valid props for input elements
 // Test height prop
 testGlobalProp(
   'height',
   validHeightValues,
-  (v) => `height_${v}`,
+  heightClassName,
   null,
   [Body, Button, Card, Title, Flex, Link, Badge]
 )
 
 testGlobalPropAbsence(
   'height',
-  ['height_auto', 'height_xs', 'height_sm', 'height_md', 'height_lg', 'height_xl', 'height_xxl', 'height_xxxl'],
+  ['height_auto', 'height_xs', 'height_sm', 'height_md', 'height_lg', 'height_xl', 'height_xxl', 'height_xxxl', 'height_100_percent', 'height_100vh'],
   undefined,
   { skipNull: true }
 )
@@ -30,14 +33,14 @@ testGlobalPropAbsence(
 testGlobalProp(
   'minHeight',
   validHeightValues,
-  (v) => `min_height_${v}`,
+  minHeightClassName,
   null,
   [Body, Button, Card, Title, Flex, Link, Badge]
 )
 
 testGlobalPropAbsence(
   'minHeight',
-  ['min_height_auto', 'min_height_xs', 'min_height_sm', 'min_height_md', 'min_height_lg', 'min_height_xl', 'min_height_xxl', 'min_height_xxxl'],
+  ['min_height_auto', 'min_height_xs', 'min_height_sm', 'min_height_md', 'min_height_lg', 'min_height_xl', 'min_height_xxl', 'min_height_xxxl', 'min_height_100_percent', 'min_height_100vh'],
   undefined,
   { skipNull: true }
 )
@@ -46,14 +49,14 @@ testGlobalPropAbsence(
 testGlobalProp(
   'maxHeight',
   validHeightValues,
-  (v) => `max_height_${v}`,
+  maxHeightClassName,
   null,
   [Body, Button, Card, Title, Flex, Link, Badge]
 )
 
 testGlobalPropAbsence(
   'maxHeight',
-  ['max_height_auto', 'max_height_xs', 'max_height_sm', 'max_height_md', 'max_height_lg', 'max_height_xl', 'max_height_xxl', 'max_height_xxxl'],
+  ['max_height_auto', 'max_height_xs', 'max_height_sm', 'max_height_md', 'max_height_lg', 'max_height_xl', 'max_height_xxl', 'max_height_xxxl', 'max_height_100_percent', 'max_height_100vh'],
   undefined,
   { skipNull: true }
 )

--- a/playbook/lib/playbook/height.rb
+++ b/playbook/lib/playbook/height.rb
@@ -6,13 +6,13 @@ module Playbook
       base.prop :height
     end
 
-    HEIGHT_VALUES = %w[auto xs sm md lg xl xxl xxxl].freeze
+    HEIGHT_VALUES = %w[auto xs sm md lg xl xxl xxxl 100% 100vh].freeze
 
     def height_props
       value = height
       return nil unless value
 
-      "height_#{value}" if HEIGHT_VALUES.include?(value.to_s)
+      "height_#{filter_classname(value.to_s)}" if HEIGHT_VALUES.include?(value.to_s)
     end
 
     def height_options

--- a/playbook/lib/playbook/max_height.rb
+++ b/playbook/lib/playbook/max_height.rb
@@ -6,13 +6,13 @@ module Playbook
       base.prop :max_height
     end
 
-    MAX_HEIGHT_VALUES = %w[auto xs sm md lg xl xxl xxxl].freeze
+    MAX_HEIGHT_VALUES = %w[auto xs sm md lg xl xxl xxxl 100% 100vh].freeze
 
     def max_height_props
       value = max_height
       return nil unless value
 
-      "max_height_#{value}" if MAX_HEIGHT_VALUES.include?(value.to_s)
+      "max_height_#{filter_classname(value.to_s)}" if MAX_HEIGHT_VALUES.include?(value.to_s)
     end
 
     def max_height_options

--- a/playbook/lib/playbook/min_height.rb
+++ b/playbook/lib/playbook/min_height.rb
@@ -6,13 +6,13 @@ module Playbook
       base.prop :min_height
     end
 
-    MIN_HEIGHT_VALUES = %w[auto xs sm md lg xl xxl xxxl].freeze
+    MIN_HEIGHT_VALUES = %w[auto xs sm md lg xl xxl xxxl 100% 100vh].freeze
 
     def min_height_props
       value = min_height
       return nil unless value
 
-      "min_height_#{value}" if MIN_HEIGHT_VALUES.include?(value.to_s)
+      "min_height_#{filter_classname(value.to_s)}" if MIN_HEIGHT_VALUES.include?(value.to_s)
     end
 
     def min_height_options

--- a/playbook/lib/playbook/pb_forms_global_props_helper.rb
+++ b/playbook/lib/playbook/pb_forms_global_props_helper.rb
@@ -48,11 +48,11 @@ module Playbook
                     when :max_width
                       value.to_s.end_with?("%") ? "max_width_#{value.to_i}_percent" : "max_width_#{value.downcase}"
                     when :height
-                      "height_#{value.downcase}"
+                      value.to_s.end_with?("%") ? "height_#{value.to_i}_percent" : "height_#{value.downcase}"
                     when :min_height
-                      "min_height_#{value.downcase}"
+                      value.to_s.end_with?("%") ? "min_height_#{value.to_i}_percent" : "min_height_#{value.downcase}"
                     when :max_height
-                      "max_height_#{value.downcase}"
+                      value.to_s.end_with?("%") ? "max_height_#{value.to_i}_percent" : "max_height_#{value.downcase}"
                     when :position
                       "position_#{value}"
                     when :vertical_alignment

--- a/playbook/spec/playbook/global_props/height_spec.rb
+++ b/playbook/spec/playbook/global_props/height_spec.rb
@@ -23,32 +23,35 @@ RSpec.describe Playbook::Flex do
     Playbook::PbBadge::Badge,
   ]
 
-  valid_height_values = %w[auto xs sm md lg xl xxl xxxl]
+  valid_height_values = %w[auto xs sm md lg xl xxl xxxl 100% 100vh]
+  height_classname = ->(v) { "height_#{v.gsub('%', '_percent')}" }
+  min_height_classname = ->(v) { "min_height_#{v.gsub('%', '_percent')}" }
+  max_height_classname = ->(v) { "max_height_#{v.gsub('%', '_percent')}" }
 
   test_global_prop(
     :height,
     valid_height_values,
-    ->(v) { "height_#{v}" },
+    height_classname,
     test_subjects: test_subjects
   )
 
   test_global_prop(
     :min_height,
     valid_height_values,
-    ->(v) { "min_height_#{v}" },
+    min_height_classname,
     test_subjects: test_subjects
   )
 
   test_global_prop(
     :max_height,
     valid_height_values,
-    ->(v) { "max_height_#{v}" },
+    max_height_classname,
     test_subjects: test_subjects
   )
 
   test_global_prop_absence(
     :height,
-    %w[height_auto height_xs height_sm height_md height_lg height_xl height_xxl height_xxxl]
+    %w[height_auto height_xs height_sm height_md height_lg height_xl height_xxl height_xxxl height_100_percent height_100vh]
   )
 
   # NOTE: Currently using allow_errors: true because globalProps generates classes for invalid values


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

https://runway.powerhrg.com/backlog_items/PLAY-3110

Add 100% and 100vh as possible values for height props. 

**Screenshots:** Screenshots to visualize your addition/change
<img width="999" height="938" alt="Screenshot 2026-08-14 at 1 16 33 PM" src="https://github.com/user-attachments/assets/b6f10de3-c117-410c-a085-f310cad34dfc" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.