### PR TITLE
[PLAY-3131] Form Group React Docs Text Inputs Need State

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_button.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_button.jsx
@@ -1,43 +1,60 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import Button from '../../pb_button/_button'
 import FormGroup from '../../pb_form_group/_form_group'
 import TextInput from '../../pb_text_input/_text_input'
 
-const FormGroupButton = (props) => (
-  <div>
+const FormGroupButton = (props) => {
+  const [searchWithLabel, setSearchWithLabel] = useState('')
+  const [search, setSearch] = useState('')
+
+  const handleUpdateSearchWithLabel = ({ target }) => {
+    setSearchWithLabel(target.value)
+  }
+
+  const handleUpdateSearch = ({ target }) => {
+    setSearch(target.value)
+  }
+
+  return (
     <div>
-      <FormGroup>
-        <TextInput
-            id="search-with-label"
-            label="With Label"
-            placeholder="Search"
-            {...props}
-        />
-        <Button
-            onClick={() => alert('Button Clicked!')}
-            text="Submit"
-            variant="secondary"
-            {...props}
-        />
-      </FormGroup>
+      <div>
+        <FormGroup>
+          <TextInput
+              id="search-with-label"
+              label="With Label"
+              onChange={handleUpdateSearchWithLabel}
+              placeholder="Search"
+              value={searchWithLabel}
+              {...props}
+          />
+          <Button
+              onClick={() => alert('Button Clicked!')}
+              text="Submit"
+              variant="secondary"
+              {...props}
+          />
+        </FormGroup>
+      </div>
+      <br />
+      <div>
+        <FormGroup>
+          <TextInput
+              onChange={handleUpdateSearch}
+              placeholder="Search"
+              value={search}
+              {...props}
+          />
+          <Button
+              onClick={() => alert('Button Clicked!')}
+              text="Submit"
+              variant="secondary"
+              {...props}
+          />
+        </FormGroup>
+      </div>
     </div>
-    <br />
-    <div>
-      <FormGroup>
-        <TextInput
-            placeholder="Search"
-            {...props}
-        />
-        <Button
-            onClick={() => alert('Button Clicked!')}
-            text="Submit"
-            variant="secondary"
-            {...props}
-        />
-      </FormGroup>
-    </div>
-  </div>
-)
+  )
+}
 
 export default FormGroupButton

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_date_picker.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_date_picker.jsx
@@ -1,26 +1,36 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import FormGroup from '../_form_group'
 
 import DatePicker from '../../pb_date_picker/_date_picker'
 import TextInput from '../../pb_text_input/_text_input'
 
-const FormGroupDatePicker = (props) => (
-  <div>
-    <FormGroup>
-      <TextInput
-          id="event-name"
-          label="Event"
-          placeholder="Event Name"
-          {...props}
-      />
-      <DatePicker
-          label="event date"
-          pickerId="date-picker-default"
-          {...props}
-      />
-    </FormGroup>
-  </div>
-)
+const FormGroupDatePicker = (props) => {
+  const [eventName, setEventName] = useState('')
+
+  const handleUpdateEventName = ({ target }) => {
+    setEventName(target.value)
+  }
+
+  return (
+    <div>
+      <FormGroup>
+        <TextInput
+            id="event-name"
+            label="Event"
+            onChange={handleUpdateEventName}
+            placeholder="Event Name"
+            value={eventName}
+            {...props}
+        />
+        <DatePicker
+            label="event date"
+            pickerId="date-picker-default"
+            {...props}
+        />
+      </FormGroup>
+    </div>
+  )
+}
 
 export default FormGroupDatePicker

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_default.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_default.jsx
@@ -1,31 +1,53 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import FormGroup from '../_form_group'
 import TextInput from '../../pb_text_input/_text_input'
 
-const FormGroupDefault = (props) => (
-  <div>
-    <FormGroup>
-      <TextInput
-          id="first-name"
-          label="First Name"
-          placeholder="Enter First Name"
-          {...props}
-      />
-      <TextInput
-          id="middle-initial"
-          label="Middle Initial"
-          placeholder="Enter Middle Initial"
-          {...props}
-      />
-      <TextInput
-          id="last-name"
-          label="Last Name"
-          placeholder="Enter Last Name"
-          {...props}
-      />
-    </FormGroup>
-  </div>
-)
+const FormGroupDefault = (props) => {
+  const [formFields, setFormFields] = useState({
+    firstName: '',
+    middleInitial: '',
+    lastName: '',
+  })
+
+  const handleOnChange = ({ target }) => {
+    const { name, value } = target
+    setFormFields({ ...formFields, [name]: value })
+  }
+
+  return (
+    <div>
+      <FormGroup>
+        <TextInput
+            id="first-name"
+            label="First Name"
+            name="firstName"
+            onChange={handleOnChange}
+            placeholder="Enter First Name"
+            value={formFields.firstName}
+            {...props}
+        />
+        <TextInput
+            id="middle-initial"
+            label="Middle Initial"
+            name="middleInitial"
+            onChange={handleOnChange}
+            placeholder="Enter Middle Initial"
+            value={formFields.middleInitial}
+            {...props}
+        />
+        <TextInput
+            id="last-name"
+            label="Last Name"
+            name="lastName"
+            onChange={handleOnChange}
+            placeholder="Enter Last Name"
+            value={formFields.lastName}
+            {...props}
+        />
+      </FormGroup>
+    </div>
+  )
+}
 
 export default FormGroupDefault

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_full_width.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_full_width.jsx
@@ -1,49 +1,78 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import FormGroup from '../_form_group'
 import TextInput from '../../pb_text_input/_text_input'
 import Button from '../../pb_button/_button'
 
-const FormGroupFullWidth = (props) => (
-  <div>
+const FormGroupFullWidth = (props) => {
+  const [formFields, setFormFields] = useState({
+    firstName: '',
+    middleInitial: '',
+    lastName: '',
+  })
+  const [search, setSearch] = useState('')
+
+  const handleOnChange = ({ target }) => {
+    const { name, value } = target
+    setFormFields({ ...formFields, [name]: value })
+  }
+
+  const handleUpdateSearch = ({ target }) => {
+    setSearch(target.value)
+  }
+
+  return (
     <div>
-      <FormGroup fullWidth>
-        <TextInput
-            id="first-name-full-width"
-            label="First Name"
-            placeholder="Enter First Name"
-            {...props}
-        />
-        <TextInput
-            id="middle-initial-full-width"
-            label="Middle Initial"
-            placeholder="Enter Middle Initial"
-            {...props}
-        />
-        <TextInput
-            id="last-name-full-width"
-            label="Last Name"
-            placeholder="Enter Last Name"
-            {...props}
-        />
-      </FormGroup>
+      <div>
+        <FormGroup fullWidth>
+          <TextInput
+              id="first-name-full-width"
+              label="First Name"
+              name="firstName"
+              onChange={handleOnChange}
+              placeholder="Enter First Name"
+              value={formFields.firstName}
+              {...props}
+          />
+          <TextInput
+              id="middle-initial-full-width"
+              label="Middle Initial"
+              name="middleInitial"
+              onChange={handleOnChange}
+              placeholder="Enter Middle Initial"
+              value={formFields.middleInitial}
+              {...props}
+          />
+          <TextInput
+              id="last-name-full-width"
+              label="Last Name"
+              name="lastName"
+              onChange={handleOnChange}
+              placeholder="Enter Last Name"
+              value={formFields.lastName}
+              {...props}
+          />
+        </FormGroup>
+      </div>
+      <br />
+      <div>
+        <FormGroup fullWidth>
+          <TextInput
+              onChange={handleUpdateSearch}
+              placeholder="Search"
+              value={search}
+              {...props}
+          />
+          <Button
+              onClick={() => alert('Button Clicked!')}
+              text="Submit"
+              variant="secondary"
+              {...props}
+          />
+        </FormGroup>
+      </div>
     </div>
-    <br />
-    <div>
-      <FormGroup fullWidth>
-        <TextInput
-            placeholder="Search"
-            {...props}
-        />
-        <Button
-            onClick={() => alert('Button Clicked!')}
-            text="Submit"
-            variant="secondary"
-            {...props}
-        />
-      </FormGroup>
-    </div>
-  </div>
-)
+  )
+}
 
 export default FormGroupFullWidth

--- a/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.jsx
+++ b/playbook/app/pb_kits/playbook/pb_form_group/docs/_form_group_select.jsx
@@ -8,8 +8,13 @@ import Flex from '../../pb_flex/_flex'
 import Passphrase from '../../pb_passphrase/_passphrase'
 
 const FormGroupSelect = (props) => {
+  const [artistName, setArtistName] = useState('')
   const [input, setInput] = useState("");
   const handleChange = (e) => setInput(e.target.value);
+
+  const handleUpdateArtistName = ({ target }) => {
+    setArtistName(target.value)
+  }
 
   const options = [
     { value: 'Country' },
@@ -36,7 +41,9 @@ const FormGroupSelect = (props) => {
     >
       <FormGroup>
         <TextInput
+            onChange={handleUpdateArtistName}
             placeholder="Enter Artist Name"
+            value={artistName}
             {...props}
         />
         <Select


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3131](https://runway.powerhrg.com/backlog_items/PLAY-3131?from=active_sprint) five of the eight React Form Group docs contain Text Inputs, which require state in order to be interactive. Currently in prod you cannot type in them and it feels like broken/buggy behavior (you can type in Rails Form Group Text Inputs).

**Screenshots:** Screenshots to visualize your addition/change
<img width="893" height="888" alt="formgroup reactdoc typing" src="https://github.com/user-attachments/assets/e7042b26-f103-4166-bf87-35f1ddc5666c" />


**How to test?** Steps to confirm the desired behavior:
1. Go to React Form Group kit page and interact with the Text Inputs in these docs: Default, Button, Full Width, Date Picker, Select.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.