### PR TITLE
DatePicker required indicator docs need kebab-case picker ids

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_required_indicator.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_required_indicator.html.erb
@@ -1,5 +1,5 @@
 <%= pb_rails("date_picker", props: {
-  picker_id: "date_picker_required_indicator",
+  picker_id: "date-picker-required-indicator",
   label: "Required Date Picker",
   required_indicator: true,
 }) %>

--- a/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_required_indicator.jsx
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/docs/_date_picker_required_indicator.jsx
@@ -4,7 +4,7 @@ import DatePicker from "../_date_picker"
 const DatePickerRequiredIndicator = (props) => (
   <DatePicker
       label="Required Date Picker"
-      pickerId="date_picker_required_indicator"
+      pickerId="date-picker-required-indicator"
       requiredIndicator
       {...props}
   />


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Website bug: the Date Picker Required Indicator doc examples were not workign as expected. Show Code opened the DatePicker dropdown menu instead of the code snippet panel and the copy icon for the direct URL did not work, for both React and Rails examples. There was a collision between the pickerId and the doc name - changing the pickerIds from snake_case to kebab-case resolves both issues.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1331" height="891" alt="datepickerrequiredindicator" src="https://github.com/user-attachments/assets/4dcedd75-5560-41f5-89f3-f1540ee06fef" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the DatePicker Required Indicator doc examples - Show Code + Copy URL buttons should now work.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.