### PR TITLE
[PLAY-3141] Date Picker Allow Input Formatting Issue

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -100,6 +100,56 @@ describe('DatePicker Kit', () => {
     expect(kit).not.toHaveAttribute('data-default-value')
   })
 
+  test.each([
+    ['08152026', '08/15/2026'],
+    ['08/15/2026', '08/15/2026'],
+    ['12312026', '12/31/2026'],
+  ])('allowInput saves the typed date %s as %s', async (typedValue, expectedValue) => {
+    const testId = `datepicker-allow-input-${typedValue.replace(/\//g, '')}`
+    render(
+      <DatePicker
+          allowInput
+          data={{ testid: testId }}
+          format="m/d/Y"
+          pickerId={`date-picker-allow-input-${typedValue.replace(/\//g, '')}`}
+          placeholder="mm/dd/yyyy"
+      />
+    )
+
+    const kit = screen.getByTestId(testId)
+    const input = within(kit).getByPlaceholderText('mm/dd/yyyy')
+
+    fireEvent.change(input, { target: { value: typedValue } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(input).toHaveValue(expectedValue)
+    })
+  })
+
+  test('allowInput leaves ambiguous digit-only input to flatpickr', async () => {
+    const testId = 'datepicker-allow-input-unpadded'
+    render(
+      <DatePicker
+          allowInput
+          data={{ testid: testId }}
+          format="m/d/Y"
+          pickerId="date-picker-allow-input-unpadded"
+          placeholder="mm/dd/yyyy"
+      />
+    )
+
+    const kit = screen.getByTestId(testId)
+    const input = within(kit).getByPlaceholderText('mm/dd/yyyy')
+
+    fireEvent.change(input, { target: { value: '0815' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(input).not.toHaveValue('08/15')
+    })
+  })
+
   test('inLine alone adds inline-date-picker class and inline control icons, not the calendar icon', () => {
     const testId = 'datepicker-inline-only'
     render(

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker.test.js
@@ -101,17 +101,46 @@ describe('DatePicker Kit', () => {
   })
 
   test.each([
-    ['08152026', '08/15/2026'],
-    ['08/15/2026', '08/15/2026'],
-    ['12312026', '12/31/2026'],
-  ])('allowInput saves the typed date %s as %s', async (typedValue, expectedValue) => {
-    const testId = `datepicker-allow-input-${typedValue.replace(/\//g, '')}`
+    ['no-separators', '08152026', '08/15/2026'],
+    ['all-separators', '08/15/2026', '08/15/2026'],
+    ['year-end', '12312026', '12/31/2026'],
+    ['separator-before-year-only', '0326/2026', '03/26/2026'],
+    ['separator-after-month-only', '03/262026', '03/26/2026'],
+  ])('allowInput saves the typed date %s as %s', async (caseName, typedValue, expectedValue) => {
+    const testId = `datepicker-allow-input-${caseName}`
     render(
       <DatePicker
           allowInput
           data={{ testid: testId }}
           format="m/d/Y"
-          pickerId={`date-picker-allow-input-${typedValue.replace(/\//g, '')}`}
+          pickerId={`date-picker-allow-input-${caseName}`}
+          placeholder="mm/dd/yyyy"
+      />
+    )
+
+    const kit = screen.getByTestId(testId)
+    const input = within(kit).getByPlaceholderText('mm/dd/yyyy')
+
+    fireEvent.change(input, { target: { value: typedValue } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(input).toHaveValue(expectedValue)
+    })
+  })
+
+  test.each([
+    ['no-slashes', '08122026 at 12:00 AM', '08/12/2026 at 12:00 AM'],
+    ['with-slashes', '08/12/2026 at 12:00 AM', '08/12/2026 at 12:00 AM'],
+  ])('allowInput with enableTime saves %s as %s', async (caseName, typedValue, expectedValue) => {
+    const testId = `datepicker-allow-input-time-${caseName}`
+    render(
+      <DatePicker
+          allowInput
+          data={{ testid: testId }}
+          enableTime
+          format="m/d/Y"
+          pickerId={`date-picker-allow-input-time-${caseName}`}
           placeholder="mm/dd/yyyy"
       />
     )

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -31,24 +31,39 @@ const getPositionElement = (element: string | Element) => {
 // For allowInput: digits a zero-padded value occupies for each flatpickr date token
 const dateTokenWidths: { [key: string]: number } = { Y: 4, d: 2, j: 2, m: 2, n: 2, y: 2 }
 
-// Flatpickr parses format separators as "any character", so allowInput values typed without them 
-// ("08152026" for "m/d/Y") get mis-grouped into day "52", which overflows to 09/21/2026. Put the separators back before it parses.
-const withDateSeparators = (dateStr: string, format: string) => {
-  if (typeof dateStr !== 'string' || !/^\d+$/.test(dateStr.trim())) return dateStr
+const escapeForCharacterClass = (char: string) => char.replace(/[\\\]^-]/g, '\\$&')
 
-  const digits = dateStr.trim()
+// Flatpickr parses format separators as "any character" and re-matches a growing regex per token,
+// so allowInput values with missing separators get mis-grouped: "08152026" (m/d/Y) reads day "52"
+// and "0326/2026" reads day "6". Rebuild the leading date run with the format's own separators
+// whenever it holds exactly the digits the format expects, leaving any suffix (enableTime's
+// "at 12:00 AM") untouched. Partial ("0326/2026") and unseparated ("03262026") input both normalize;
+const withDateSeparators = (dateStr: string, format: string) => {
+  if (typeof dateStr !== 'string') return dateStr
+
   const tokens = [...(format || '').split(' ')[0]]
   const expectedLength = tokens.reduce((total, token) => total + (dateTokenWidths[token] || 0), 0)
   const hasUnsupportedToken = tokens.some((token) => /[a-z]/i.test(token) && !dateTokenWidths[token])
-  if (hasUnsupportedToken || digits.length !== expectedLength) return dateStr
+  if (hasUnsupportedToken || expectedLength === 0) return dateStr
+
+  const separators = [...new Set(tokens.filter((token) => !dateTokenWidths[token]))]
+  const separatorClass = separators.map(escapeForCharacterClass).join('')
+  const match = dateStr.match(new RegExp(`^(\\s*)([\\d${separatorClass}]*\\d)([\\s\\S]*)$`))
+  if (!match) return dateStr
+
+  const [, leadingSpace, dateRun, rest] = match
+  const digits = separatorClass ? dateRun.replace(new RegExp(`[${separatorClass}]`, 'g'), '') : dateRun
+  if (digits.length !== expectedLength) return dateStr
 
   let position = 0
-  return tokens.map((token) => {
+  const dated = tokens.map((token) => {
     const width = dateTokenWidths[token]
     if (!width) return token
     position += width
     return digits.slice(position - width, position)
   }).join('')
+
+  return `${leadingSpace}${dated}${rest}`
 }
 
 type DatePickerConfig = {

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -599,7 +599,9 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
     minDate: effectiveMinDate,
     mode,
     nextArrow: `<div style="height: 14px;">${angleRightString}</div>`,
-    parseDate: (datestr, format) => flatpickr.parseDate(withDateSeparators(datestr, format), format),
+    ...(allowInput && {
+      parseDate: (datestr, format) => flatpickr.parseDate(withDateSeparators(datestr, format), format),
+    }),
     onOpen: [(_selectedDates, _dateStr, fp) => {
       activePortalZIndex = portalHost
         ? resolvePortaledFloatingZIndex(

--- a/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
+++ b/playbook/app/pb_kits/playbook/pb_date_picker/date_picker_helper.ts
@@ -28,6 +28,29 @@ const getPositionElement = (element: string | Element) => {
   return (typeof element === 'string') ? document.querySelectorAll(element)[0] : element
 }
 
+// For allowInput: digits a zero-padded value occupies for each flatpickr date token
+const dateTokenWidths: { [key: string]: number } = { Y: 4, d: 2, j: 2, m: 2, n: 2, y: 2 }
+
+// Flatpickr parses format separators as "any character", so allowInput values typed without them 
+// ("08152026" for "m/d/Y") get mis-grouped into day "52", which overflows to 09/21/2026. Put the separators back before it parses.
+const withDateSeparators = (dateStr: string, format: string) => {
+  if (typeof dateStr !== 'string' || !/^\d+$/.test(dateStr.trim())) return dateStr
+
+  const digits = dateStr.trim()
+  const tokens = [...(format || '').split(' ')[0]]
+  const expectedLength = tokens.reduce((total, token) => total + (dateTokenWidths[token] || 0), 0)
+  const hasUnsupportedToken = tokens.some((token) => /[a-z]/i.test(token) && !dateTokenWidths[token])
+  if (hasUnsupportedToken || digits.length !== expectedLength) return dateStr
+
+  let position = 0
+  return tokens.map((token) => {
+    const width = dateTokenWidths[token]
+    if (!width) return token
+    position += width
+    return digits.slice(position - width, position)
+  }).join('')
+}
+
 type DatePickerConfig = {
   closeOnSelect?: boolean,
   customQuickPickDates: { override: boolean, dates: any[] },
@@ -576,6 +599,7 @@ const datePickerHelper = (config: DatePickerConfig, scrollContainer: string | HT
     minDate: effectiveMinDate,
     mode,
     nextArrow: `<div style="height: 14px;">${angleRightString}</div>`,
+    parseDate: (datestr, format) => flatpickr.parseDate(withDateSeparators(datestr, format), format),
     onOpen: [(_selectedDates, _dateStr, fp) => {
       activePortalZIndex = portalHost
         ? resolvePortaledFloatingZIndex(


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3141](https://runway.powerhrg.com/backlog_items/PLAY-3141?from=active_sprint) adjusts allowInput logic so that dates are correctly input into the DatePicker even when typed into the input without separators between m/d/y. This update in date_picker_helper.ts works all versions of the prop (React allowInput, Rails allow_input, and form.date_picker allow_input).

[CSB with alpha](https://codesandbox.io/p/devbox/play-2970-message-kit-mention-height-forked-6xl63z?workspaceId=ws_SCBCWoPHNib7imF8jEmoG5) demos allowInput and allowInput + enableTime prop combo.

**Screenshots:** Screenshots to visualize your addition/chang
Current Prod: 08152026 is submitted but appears in Date Picker as 09/21/2026
<img width="512" height="570" alt="prod same date" src="https://github.com/user-attachments/assets/bbdd67ae-5f0c-4ffa-9d15-bc0f90437fb1" />

Review Env: entered date is date that appears in the Date Picker
<img width="1146" height="493" alt="review env 1" src="https://github.com/user-attachments/assets/970d8ad4-12ad-45a9-b98a-297b5dd0a8a7" />
<img width="1152" height="562" alt="review env 2" src="https://github.com/user-attachments/assets/55b61de3-44df-479a-b3ea-bc3028d162d2" />

**How to test?** Steps to confirm the desired behavior:
1. Go to "Allow Input" Date Picker doc examples ([rails](https://pr6525.playbook.wc.beta.px.powerapp.cloud/kits/date_picker/rails#date_picker_allow_input), [react](https://pr6525.playbook.wc.beta.px.powerapp.cloud/kits/date_picker/react#date_picker_allow_input)) - type in a date without including forward slash separators and see it correctly appear in the Date Picker dropdown.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.