### PR TITLE
[PLAY-3148] POC React Global Prop - onClick

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/Data/GlobalPropsCards.ts
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/Data/GlobalPropsCards.ts
@@ -105,6 +105,13 @@ export const GlobalPropsCards = [
     link: "/global_props/html_options",
   },
   {
+    title: "onClick",
+    description:
+      "Documents the React-only onClick proof of concept for simple root kits, plus how it differs from existing kit-specific click APIs.",
+    icon: "hand-pointer",
+    link: "/global_props/on_click",
+  },
+  {
     title: "Line Height",
     description:
       "Adjusts the vertical spacing between lines of text, with options like “tight,” “normal,” or “loose.”",

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/OnClick.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/OnClick.tsx
@@ -1,0 +1,294 @@
+import { useState } from "react";
+import { Body, Button, Card, Flex, Title, Table } from "playbook-ui";
+import ShowPage from "../../Templates/ShowPage";
+import PropsExamplesTable from "../../Templates/Subcomponents/PropsExamplesTable";
+import ExampleCodeCard from "../../Templates/Subcomponents/ExampleCodeCard";
+
+const OnClick = () => {
+  const ClickableBody = Body as any;
+  const ClickableCard = Card as any;
+  const ClickableFlex = Flex as any;
+  const ClickableTitle = Title as any;
+
+  const InteractiveExample = ({
+    children,
+    count,
+    label,
+    reset,
+  }: {
+    children: React.ReactNode,
+    count: number,
+    label: string,
+    reset: () => void,
+  }) => {
+    return (
+      <Flex flexDirection="column" gap="xs" width="100%">
+        {children}
+        <Body color="light" text={`${label}: ${count} click${count === 1 ? "" : "s"}`} />
+        <Button
+            onClick={reset}
+            size="sm"
+            text="Reset"
+            variant="secondary"
+        />
+      </Flex>
+    );
+  };
+
+  const VisualGuideCard = () => {
+    const [bodyClicks, setBodyClicks] = useState(0);
+    const [cardClicks, setCardClicks] = useState(0);
+    const [flexClicks, setFlexClicks] = useState(0);
+    const [titleClicks, setTitleClicks] = useState(0);
+    const [buttonClicks, setButtonClicks] = useState(0);
+
+    return (
+      <Flex gap="sm" wrap width="100%">
+        <Card padding="md" width="sm">
+          <Title size={4} text="Body (POC)" />
+          <InteractiveExample
+              count={bodyClicks}
+              label="Body"
+              reset={() => setBodyClicks(0)}
+          >
+            <ClickableBody
+                cursor="pointer"
+                htmlOptions={{ role: "button", tabIndex: 0 }}
+                onClick={() => setBodyClicks((prev: number) => prev + 1)}
+                text="Click this Body example"
+            />
+          </InteractiveExample>
+        </Card>
+        <Card padding="md" width="sm">
+          <Title size={4} text="Card (POC)" />
+          <InteractiveExample
+              count={cardClicks}
+              label="Card"
+              reset={() => setCardClicks(0)}
+          >
+            <ClickableCard
+                cursor="pointer"
+                onClick={() => setCardClicks((prev: number) => prev + 1)}
+                padding="sm"
+            >
+              {"Click this Card example"}
+            </ClickableCard>
+          </InteractiveExample>
+        </Card>
+        <Card padding="md" width="sm">
+          <Title size={4} text="Flex (POC)" />
+          <InteractiveExample
+              count={flexClicks}
+              label="Flex"
+              reset={() => setFlexClicks(0)}
+          >
+            <ClickableFlex
+                alignItems="center"
+                background="light"
+                borderRadius="sm"
+                cursor="pointer"
+                gap="xs"
+                onClick={() => setFlexClicks((prev: number) => prev + 1)}
+                padding="sm"
+            >
+              <Body text="Click this Flex example" />
+            </ClickableFlex>
+          </InteractiveExample>
+        </Card>
+        <Card padding="md" width="sm">
+          <Title size={4} text="Title (POC)" />
+          <InteractiveExample
+              count={titleClicks}
+              label="Title"
+              reset={() => setTitleClicks(0)}
+          >
+            <ClickableTitle
+                cursor="pointer"
+                htmlOptions={{ role: "button", tabIndex: 0 }}
+                onClick={() => setTitleClicks((prev: number) => prev + 1)}
+                size={4}
+                text="Click this Title example"
+            />
+          </InteractiveExample>
+        </Card>
+        <Card padding="md" width="sm">
+          <Title size={4} text="Button (existing API)" />
+          <InteractiveExample
+              count={buttonClicks}
+              label="Button"
+              reset={() => setButtonClicks(0)}
+          >
+            <Button
+                onClick={() => setButtonClicks((prev: number) => prev + 1)}
+                text="Button API stays the same"
+            />
+          </InteractiveExample>
+        </Card>
+      </Flex>
+    );
+  };
+
+  return (
+    <ShowPage
+      title="onClick"
+      description={
+        <>
+          This page documents a React-only proof of concept for exposing{" "}
+          <code>onClick</code> as a first-class global prop on kits that do not
+          already define their own <code>onClick</code> behavior. It is not part
+          of the existing class-based Global Props pipeline, and Rails remains
+          out of scope.
+        </>
+      }
+      descriptionSecondary={
+        <>
+          The goal is consistency for simple presentational kits with a clear
+          root element, while preserving kit-specific click behavior where it
+          already exists. Existing kits with their own <code>onClick</code> may
+          differ in typing, target element, and behavior.
+        </>
+      }
+      VisualGuideCard={VisualGuideCard()}
+    >
+      <PropsExamplesTable
+        headers={["POC Kit", "Type", "React Example", "Notes"]}
+        rows={[
+          [
+            "Body",
+            <ExampleCodeCard copyIcon={false} text="MouseEventHandler" />,
+            <ExampleCodeCard
+              id="onclick-body-react"
+              text={`<Body onClick={() => alert("clicked")} text="Clickable body" />`}
+            />,
+            "Attached to the root Body element in the POC.",
+          ],
+          [
+            "Card",
+            <ExampleCodeCard copyIcon={false} text="MouseEventHandler" />,
+            <ExampleCodeCard
+              id="onclick-card-react"
+              text={`<Card onClick={() => alert("clicked")} cursor="pointer">Content</Card>`}
+            />,
+            "Attached to the root Card tag in the POC.",
+          ],
+          [
+            "Flex",
+            <ExampleCodeCard copyIcon={false} text="MouseEventHandler" />,
+            <ExampleCodeCard
+              id="onclick-flex-react"
+              text={`<Flex onClick={() => alert("clicked")} cursor="pointer">...</Flex>`}
+            />,
+            "Attached to the root Flex div in the POC.",
+          ],
+          [
+            "Title",
+            <ExampleCodeCard copyIcon={false} text="MouseEventHandler" />,
+            <ExampleCodeCard
+              id="onclick-title-react"
+              text={`<Title onClick={() => alert("clicked")} cursor="pointer" text="Clickable title" />`}
+            />,
+            "Attached to the root Title tag in the POC.",
+          ],
+        ]}
+      />
+
+      <Card padding="md">
+        <Title size={3} text="Current POC Scope" />
+        <Body>
+          Only <strong>Body</strong>, <strong>Card</strong>, <strong>Flex</strong>,
+          {" "}and <strong>Title</strong> were updated in this branch. This page
+          intentionally documents the proof of concept rather than implying a
+          full repo-wide rollout.
+        </Body>
+      </Card>
+
+      <Card padding="md">
+        <Title size={3} text="Differences From Existing Kit-Specific onClick" />
+        <Table size="sm">
+          <Table.Head>
+            <Table.Row>
+              <Table.Header>{"Kit"}</Table.Header>
+              <Table.Header>{"Signature / Target"}</Table.Header>
+              <Table.Header>{"Difference"}</Table.Header>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>{"Button"}</Table.Cell>
+              <Table.Cell>{"Mouse event on <button> only"}</Table.Cell>
+              <Table.Cell>{"When Button renders a link, its kit-specific onClick is not attached to the <a> path."}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{"CircleIconButton"}</Table.Cell>
+              <Table.Cell>{"Mouse event on inner Button"}</Table.Cell>
+              <Table.Cell>{"htmlOptions live on the wrapper, but the kit-specific onClick belongs to the inner Button."}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{"FormPill"}</Table.Cell>
+              <Table.Cell>{"Mouse event on close icon only"}</Table.Cell>
+              <Table.Cell>{"The pill body is not the click target."}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{"Nav"}</Table.Cell>
+              <Table.Cell>{"() => void on title link only"}</Table.Cell>
+              <Table.Cell>{"The nav root itself is not the click target."}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{"Nav.Item"}</Table.Cell>
+              <Table.Cell>{"() => void on item / collapsible behavior"}</Table.Cell>
+              <Table.Cell>{"Disabled state and collapsible behavior change how clicks are handled."}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{"StarRating"}</Table.Cell>
+              <Table.Cell>{"(value: number) => void on stars"}</Table.Cell>
+              <Table.Cell>{"This is the key typing conflict that prevents putting onClick into the shared CSS GlobalProps type."}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{"Collapsible"}</Table.Cell>
+              <Table.Cell>{"() => void via context-driven main area"}</Table.Cell>
+              <Table.Cell>{"Its click logic participates in toggle behavior rather than acting like a simple root DOM click."}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{"ButtonToolbar"}</Table.Cell>
+              <Table.Cell>{"Typed publicly, not currently wired"}</Table.Cell>
+              <Table.Cell>{"This prop exists in the API but is not attached to the root today."}</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </Card>
+
+      <PropsExamplesTable
+        headers={["Conflict Case", "Result", "Reason"]}
+        rows={[
+          [
+            "POC kit + htmlOptions.onClick",
+            "First-class onClick wins",
+            "The helper is spread after htmlOptions.",
+          ],
+          [
+            "Kit-specific onClick + htmlOptions.onClick",
+            "Kit-specific behavior stays",
+            "Existing implementations remain unchanged.",
+          ],
+          [
+            "Nested clickable kits",
+            "Both can fire",
+            "Normal React event bubbling still applies unless propagation is stopped.",
+          ],
+        ]}
+      />
+
+      <Card padding="md">
+        <Title size={3} text="Recommendation" />
+        <Body>
+          If Playbook moves forward with a first-class global <code>onClick</code>,
+          it should be a React-only helper applied selectively to kits with a
+          clear root element. Kits that already define their own click behavior
+          should keep their existing APIs and semantics.
+        </Body>
+      </Card>
+    </ShowPage>
+  );
+};
+
+export default OnClick;

--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex.tsx
@@ -3,6 +3,7 @@ import HtmlOptions from "./Examples/HtmlOptions";
 import Margin from "./Examples/Margin";
 import Cursor from "./Examples/Cursor";
 import Hover from "./Examples/Hover";
+import OnClick from "./Examples/OnClick";
 import Dark from "./Examples/Dark";
 import LineHeight from "./Examples/LineHeightGlobalProps";
 import FlexBox from "./Examples/FlexBoxGlobalProps";
@@ -49,6 +50,7 @@ const COMPONENT_MAP = {
   height: Height,
   hover: Hover,
   html_options: HtmlOptions,
+  on_click: OnClick,
   margin: Margin,
   line_height: LineHeight,
   display: Display,

--- a/playbook-website/config/global_props_and_tokens.yml
+++ b/playbook-website/config/global_props_and_tokens.yml
@@ -13,6 +13,7 @@ global_props:
   - height
   - hover
   - html_options
+  - on_click
   - margin
   - line_height
   - display

--- a/playbook/app/pb_kits/playbook/pb_body/_body.tsx
+++ b/playbook/app/pb_kits/playbook/pb_body/_body.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import classnames from 'classnames'
 
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
-import { deprecatedProps, globalProps, GlobalProps } from '../utilities/globalProps'
+import { deprecatedProps, globalEventProps, globalProps, GlobalEventProps, GlobalProps } from '../utilities/globalProps'
 
 import Highlight from '../pb_highlight/_highlight'
 
@@ -21,7 +21,7 @@ type BodyProps = {
   tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'div',
   text?: string,
   variant?: null | 'link',
-} & GlobalProps
+} & GlobalProps & GlobalEventProps
 
 const Body = (props: BodyProps): React.ReactElement => {
   if (props.variant) deprecatedProps() //status prop is deprecated, use color instead please
@@ -56,6 +56,7 @@ const Body = (props: BodyProps): React.ReactElement => {
         {...ariaProps}
         {...dataProps}
         {...htmlProps}
+        {...globalEventProps(props)}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/pb_card/_card.tsx
+++ b/playbook/app/pb_kits/playbook/pb_card/_card.tsx
@@ -6,7 +6,7 @@ import { get } from '../utilities/object'
 import classnames from 'classnames'
 
 import { buildAriaProps, buildDataProps, buildHtmlProps } from '../utilities/props'
-import { GlobalProps, globalProps, globalInlineProps } from '../utilities/globalProps'
+import { GlobalEventProps, GlobalProps, globalEventProps, globalProps, globalInlineProps } from '../utilities/globalProps'
 import type { ProductColors, CategoryColors, BackgroundColors, StatusColors } from '../types/colors'
 
 import Icon from '../pb_icon/_icon'
@@ -34,7 +34,7 @@ type CardPropTypes = {
   padding?: string,
   selected?: boolean,
   tag?: "div" | "section" | "footer" | "header" | "article" | "aside" | "main" | "nav",
-} & GlobalProps
+} & GlobalProps & GlobalEventProps
 
 type CardHeaderProps = {
   headerColor?: BackgroundColors | ProductColors | CategoryColors | StatusColors | "none",
@@ -156,6 +156,7 @@ const Card = (props: CardPropTypes): React.ReactElement => {
             {...dataProps}
             className={classnames(cardCss, globalProps(props), className)}
             {...restHtmlProps}
+            {...globalEventProps(props)}
             style={mergedStyles}
         >
           {subComponentTags('Header')}
@@ -185,6 +186,7 @@ const Card = (props: CardPropTypes): React.ReactElement => {
               {...dataProps}
               className={classnames(cardCss, globalProps(props), className)}
               {...restHtmlProps}
+              {...globalEventProps(props)}
               style={mergedStyles}
             >
               {subComponentTags('Header')}

--- a/playbook/app/pb_kits/playbook/pb_flex/_flex.tsx
+++ b/playbook/app/pb_kits/playbook/pb_flex/_flex.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
-import { GlobalProps, globalProps, globalInlineProps } from '../utilities/globalProps'
+import { GlobalEventProps, GlobalProps, globalEventProps, globalProps, globalInlineProps } from '../utilities/globalProps'
 import { GenericObject, Sizes } from '../types'
 
 type SizeType = Sizes | "none"
@@ -26,7 +26,7 @@ type FlexProps = {
   columnGap?: SizeType | SizeResponsiveType,
   wrap?: boolean,
   alignSelf?: "start" | "end" | "center" | "stretch" | "none"
-} & GlobalProps
+} & GlobalProps & GlobalEventProps
 
 const Flex = (props: FlexProps): React.ReactElement => {
   const {
@@ -97,6 +97,7 @@ const Flex = (props: FlexProps): React.ReactElement => {
         style={dynamicInlineProps}
         {...dataProps}
         {...htmlProps}
+        {...globalEventProps(props)}
     >
       {children}
     </div>

--- a/playbook/app/pb_kits/playbook/pb_title/_title.tsx
+++ b/playbook/app/pb_kits/playbook/pb_title/_title.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { buildAriaProps, buildCss, buildDataProps, buildHtmlProps } from '../utilities/props'
-import { deprecatedProps, GlobalProps, globalProps } from '../utilities/globalProps'
+import { deprecatedProps, GlobalEventProps, GlobalProps, globalEventProps, globalProps } from '../utilities/globalProps'
 
 type SizeType = 1 | 2 | 3 | 4 | "1" | "2" | "3" | "4" | "display"
 type SizeResponsiveType = {[key: string]: SizeType}
@@ -20,7 +20,7 @@ type TitleProps = {
   tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div" | "span",
   text?: string,
   variant?: null | "link",
-} & GlobalProps
+} & GlobalProps & GlobalEventProps
 
 const Title = (props: TitleProps): React.ReactElement => {
   if (props.variant) deprecatedProps() //variant prop is deprecated, use color instead
@@ -87,6 +87,7 @@ const Title = (props: TitleProps): React.ReactElement => {
         {...ariaProps}
         {...dataProps}
         {...htmlProps}
+        {...globalEventProps(props)}
         className={classes}
         id={id}
     >

--- a/playbook/app/pb_kits/playbook/utilities/globalProps.ts
+++ b/playbook/app/pb_kits/playbook/utilities/globalProps.ts
@@ -272,6 +272,18 @@ export type GlobalProps = AlignContent & AlignItems & AlignSelf &
   LineHeight & Margin & Width & MinWidth & MaxWidth & Gap & ColumnGap & RowGap & NumberSpacing & Order & Overflow & Padding &
   Position & Shadow & TextAlign & Truncate & VerticalAlign & ZIndex & { hover?: string } & Top & Right & Bottom & Left & Height & MaxHeight & MinHeight;
 
+// Event handlers are not CSS-class global props. Keep them off GlobalProps so
+// kits with kit-specific onClick signatures (e.g. StarRating) do not conflict.
+export type GlobalEventProps = {
+  onClick?: React.MouseEventHandler<HTMLElement>,
+}
+
+export const globalEventProps = (
+  props: GlobalEventProps
+): Pick<GlobalEventProps, 'onClick'> => {
+  return props.onClick ? { onClick: props.onClick } : {}
+}
+
 const getResponsivePropClasses = (prop: {[key: string]: string}, classPrefix: string) => {
   const keys: string[] = Object.keys(prop)
   const screenSizeValues = ["xs", "sm", "md", "lg", "xl"]

--- a/playbook/app/pb_kits/playbook/utilities/test/globalProps/globalProps.integration.test.js
+++ b/playbook/app/pb_kits/playbook/utilities/test/globalProps/globalProps.integration.test.js
@@ -495,19 +495,20 @@ describe('Global Props Integration Tests', () => {
     })
 
     test('Button with onClick and global props in Card with global props', () => {
-      const handleClick = jest.fn()
+      const cardOnClick = jest.fn()
+      const buttonOnClick = jest.fn()
       
       render(
         <Card
             data={{ testid: 'card-clickable' }}
             margin="lg"
-            onClick={handleClick}
+            onClick={cardOnClick}
             padding="md"
         >
           <Button
               data={{ testid: 'button-clickable' }}
               margin="sm"
-              onClick={handleClick}
+              onClick={buttonOnClick}
               text="Click me"
               variant="primary"
           />
@@ -522,9 +523,10 @@ describe('Global Props Integration Tests', () => {
       expect(card).toHaveClass('p_md')
       expect(button).toHaveClass('m_sm')
       
-      // Both should be clickable
+      // Nested click behavior should preserve both handlers
       button.click()
-      expect(handleClick).toHaveBeenCalledTimes(1)
+      expect(buttonOnClick).toHaveBeenCalledTimes(1)
+      expect(cardOnClick).toHaveBeenCalledTimes(1)
     })
 
     test('Responsive global props in nested layout', () => {

--- a/playbook/app/pb_kits/playbook/utilities/test/globalProps/onClick.test.js
+++ b/playbook/app/pb_kits/playbook/utilities/test/globalProps/onClick.test.js
@@ -1,0 +1,211 @@
+import React from 'react'
+import { fireEvent, render, screen } from '../../test-utils'
+import Body from '../../../pb_body/_body'
+import Button from '../../../pb_button/_button'
+import ButtonToolbar from '../../../pb_button_toolbar/_button_toolbar'
+import Card from '../../../pb_card/_card'
+import Flex from '../../../pb_flex/_flex'
+import FormPill from '../../../pb_form_pill/_form_pill'
+import StarRating from '../../../pb_star_rating/_star_rating'
+import Title from '../../../pb_title/_title'
+import { globalEventProps, globalProps } from '../../globalProps'
+
+const pocKits = [
+  { Kit: Body, name: 'Body', extraProps: { text: 'Test' } },
+  { Kit: Card, name: 'Card', extraProps: { children: 'Test' } },
+  { Kit: Flex, name: 'Flex', extraProps: { children: 'Test' } },
+  { Kit: Title, name: 'Title', extraProps: { text: 'Test' } },
+]
+
+describe('onClick global event prop (POC)', () => {
+  describe('globalEventProps helper', () => {
+    test('returns onClick when provided', () => {
+      const onClick = jest.fn()
+      expect(globalEventProps({ onClick })).toEqual({ onClick })
+    })
+
+    test('returns an empty object when onClick is absent', () => {
+      expect(globalEventProps({})).toEqual({})
+    })
+
+    test('does not generate CSS classes', () => {
+      const onClick = jest.fn()
+      expect(globalProps({ onClick })).toBe('')
+    })
+  })
+
+  describe('attaches to the kit root element', () => {
+    pocKits.forEach(({ Kit, name, extraProps }) => {
+      test(`fires on ${name}`, () => {
+        const onClick = jest.fn()
+        const testId = `onclick-poc-${name.toLowerCase()}`
+        render(
+          <Kit
+              data={{ testid: testId }}
+              onClick={onClick}
+              {...extraProps}
+          />
+        )
+
+        fireEvent.click(screen.getByTestId(testId))
+        expect(onClick).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('conflict with htmlOptions.onClick', () => {
+    test('first-class onClick wins over htmlOptions.onClick', () => {
+      const htmlOnClick = jest.fn()
+      const firstClassOnClick = jest.fn()
+      render(
+        <Card
+            data={{ testid: 'onclick-precedence' }}
+            htmlOptions={{ onClick: htmlOnClick }}
+            onClick={firstClassOnClick}
+        >
+          {'Test'}
+        </Card>
+      )
+
+      fireEvent.click(screen.getByTestId('onclick-precedence'))
+      expect(firstClassOnClick).toHaveBeenCalledTimes(1)
+      expect(htmlOnClick).not.toHaveBeenCalled()
+    })
+
+    test('htmlOptions.onClick still works when first-class onClick is omitted', () => {
+      const htmlOnClick = jest.fn()
+      render(
+        <Body
+            data={{ testid: 'onclick-html-options' }}
+            htmlOptions={{ onClick: htmlOnClick }}
+            text="Test"
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('onclick-html-options'))
+      expect(htmlOnClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('kit-specific onClick remains unchanged', () => {
+    test('Button onClick still fires on the button element', () => {
+      const onClick = jest.fn()
+      render(
+        <Button
+            data={{ testid: 'onclick-button' }}
+            onClick={onClick}
+            text="Click"
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('onclick-button'))
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('Button explicit onClick overrides htmlOptions.onClick', () => {
+      const htmlOnClick = jest.fn()
+      const kitOnClick = jest.fn()
+      render(
+        <Button
+            data={{ testid: 'onclick-button-precedence' }}
+            htmlOptions={{ onClick: htmlOnClick }}
+            onClick={kitOnClick}
+            text="Click"
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('onclick-button-precedence'))
+      expect(kitOnClick).toHaveBeenCalledTimes(1)
+      expect(htmlOnClick).not.toHaveBeenCalled()
+    })
+
+    test('Button with link ignores kit onClick and keeps htmlOptions.onClick', () => {
+      const kitOnClick = jest.fn()
+      const htmlOnClick = jest.fn()
+      render(
+        <Button
+            data={{ testid: 'onclick-button-link' }}
+            htmlOptions={{ onClick: htmlOnClick }}
+            link="#test"
+            onClick={kitOnClick}
+            text="Link"
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('onclick-button-link'))
+      expect(htmlOnClick).toHaveBeenCalledTimes(1)
+      expect(kitOnClick).not.toHaveBeenCalled()
+    })
+
+    test('FormPill onClick still fires only from the close control', () => {
+      const onClick = jest.fn()
+      render(
+        <FormPill
+            data={{ testid: 'onclick-form-pill' }}
+            onClick={onClick}
+            text="Tag"
+        />
+      )
+
+      const pill = screen.getByTestId('onclick-form-pill')
+      fireEvent.click(pill)
+      expect(onClick).not.toHaveBeenCalled()
+
+      fireEvent.click(pill.querySelector('.pb_form_pill_close'))
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('StarRating onClick still receives the star value, not a mouse event', () => {
+      const onClick = jest.fn()
+      render(
+        <StarRating
+            data={{ testid: 'onclick-star-rating' }}
+            onClick={onClick}
+            rating={0}
+            variant="interactive"
+        />
+      )
+
+      fireEvent.click(screen.getByLabelText('Rate 1 out of 5 stars'))
+      expect(onClick).toHaveBeenCalledWith(1)
+      expect(onClick.mock.calls[0][0]).toBe(1)
+    })
+
+    test('ButtonToolbar typed onClick is still not attached to the root', () => {
+      const onClick = jest.fn()
+      render(
+        <ButtonToolbar
+            data={{ testid: 'onclick-button-toolbar' }}
+            onClick={onClick}
+            text="Toolbar"
+        />
+      )
+
+      fireEvent.click(screen.getByTestId('onclick-button-toolbar'))
+      expect(onClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('event bubbling', () => {
+    test('child Button click also fires parent Card onClick', () => {
+      const cardOnClick = jest.fn()
+      const buttonOnClick = jest.fn()
+      render(
+        <Card
+            data={{ testid: 'onclick-bubble-card' }}
+            onClick={cardOnClick}
+        >
+          <Button
+              data={{ testid: 'onclick-bubble-button' }}
+              onClick={buttonOnClick}
+              text="Inner"
+          />
+        </Card>
+      )
+
+      fireEvent.click(screen.getByTestId('onclick-bubble-button'))
+      expect(buttonOnClick).toHaveBeenCalledTimes(1)
+      expect(cardOnClick).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3148

**Screenshots:** Screenshots to visualize your addition/change
<img width="1006" height="1169" alt="Screenshot 2026-08-19 at 8 58 57 AM" src="https://github.com/user-attachments/assets/b66ce33a-70dd-485d-96f1-e463c7c3c555" />

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.