### PR TITLE
[PLAY-3175] Remove Lazysizes from PB

### DIFF
--- a/playbook-website/lib/markdown_helper.rb
+++ b/playbook-website/lib/markdown_helper.rb
@@ -145,7 +145,7 @@ module PlaybookWebsite
       def image(link, title, alt_text)
         return nil if link.nil?
 
-        %(<a href="#{link}" target="_blank">#{image_tag(link, title: title, alt: alt_text, class: 'imageloader lazyload')}</a>)
+        %(<a href="#{link}" target="_blank">#{image_tag(link, title: title, alt: alt_text)}</a>)
       end
     end
   end

--- a/playbook/app/entrypoints/playbook-rails.js
+++ b/playbook/app/entrypoints/playbook-rails.js
@@ -89,7 +89,6 @@ import datePickerHelper from 'kits/pb_date_picker/date_picker_helper'
 window.datePickerHelper = datePickerHelper
 
 // Third-party libraries
-import 'lazysizes'
 import 'flatpickr'
 
 // React-Rendered Rails Kits

--- a/playbook/app/entrypoints/playbook.js
+++ b/playbook/app/entrypoints/playbook.js
@@ -1,6 +1,3 @@
-import 'lazysizes/plugins/attrchange/ls.attrchange'
-import 'lazysizes'
-
 export * from '../javascript/kits'
 export * from '../javascript/theme'
 export * from '../javascript/dashboard'

--- a/playbook/app/pb_kits/playbook/pb_avatar/avatar.test.js
+++ b/playbook/app/pb_kits/playbook/pb_avatar/avatar.test.js
@@ -24,7 +24,6 @@ test('loads the given image url and name', () => {
 
   expect(kit).toHaveClass('pb_avatar_kit_size_md')
   expect(kit).toHaveAttribute('data-initials', initials)
-  expect(image).toHaveAttribute('data-src', imageUrl)
   expect(image).toHaveAttribute('src', imageUrl)
   expect(image).toHaveAttribute('alt', imageAlt)
 })

--- a/playbook/app/pb_kits/playbook/pb_background/_background.scss
+++ b/playbook/app/pb_kits/playbook/pb_background/_background.scss
@@ -30,30 +30,15 @@ $background_colors: map-merge($additional_colors, $merge_kits7);
   }
 
   &.fade {
-    opacity: 0;
-    &.lazyloaded {
-      opacity: 1;
-      transition: opacity 400ms ease-in;
-    }
+    animation: pb_background_fade 400ms ease-in forwards;
   }
 
   &.blur {
-    filter: blur(5px);
-    &.lazyloaded {
-      -webkit-filter: blur(0);
-      filter: blur(0);
-      transition: filter 400ms ease-in;
-    }
+    animation: pb_background_blur 400ms ease-in forwards;
   }
 
   &.scale {
-    opacity: 0;
-    transform: scale(0.9);
-    &.lazyloaded {
-      opacity: 1;
-      transform: scale(1);
-      transition: 700ms ease-in;
-    }
+    animation: pb_background_scale 700ms ease-in forwards;
   }
 
   &.imageoverlay {
@@ -80,5 +65,26 @@ $background_colors: map-merge($additional_colors, $merge_kits7);
     &.imageoverlay_#{$key}::before {
       opacity: $value;
     }
+  }
+}
+
+@keyframes pb_background_fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes pb_background_blur {
+  from { filter: blur(5px); }
+  to { filter: blur(0); }
+}
+
+@keyframes pb_background_scale {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_background/_background.tsx
+++ b/playbook/app/pb_kits/playbook/pb_background/_background.tsx
@@ -127,7 +127,6 @@ const Background = (props: BackgroundProps): React.ReactElement => {
   // Build CSS classes and styles using responsive values.
   const classes = classnames(
     buildCss('pb_background_kit'),
-    'lazyload',
     globalProps(props),
     transition,
     {

--- a/playbook/app/pb_kits/playbook/pb_background/background.rb
+++ b/playbook/app/pb_kits/playbook/pb_background/background.rb
@@ -115,7 +115,7 @@ module Playbook
 
       def image_classname
         background_class = custom_color.present? ? "pb_background_custom_color" : "pb_background_color_#{background_color}"
-        background_class_lazy = image_url.present? ? " lazyload #{transition}" : ""
+        background_class_lazy = image_url.present? && transition.present? ? " #{transition}" : ""
         "#{background_class}#{background_class_lazy}"
       end
     end

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_image.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_image.html.erb
@@ -51,8 +51,9 @@
 
         const updateTransition = (transition) => {
           const imageTransition = document.querySelector('.background-image')
-            imageTransition.classList.remove("fade", "blur", "scale", "lazyloaded")
-            imageTransition.classList.add(transition, "lazyload")   
+            imageTransition.classList.remove("fade", "blur", "scale")
+            void imageTransition.offsetWidth
+            imageTransition.classList.add(transition)
         } 
         (transitionDropdown).addEventListener('change', function() {
           updateTransition(option)

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_image.jsx
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_image.jsx
@@ -29,7 +29,7 @@ const BackgroundImage = (props) => {
     <>
       <Background
           alt="colorful background"
-          className="background lazyload"
+          className="background"
           imageUrl="https://images.unsplash.com/photo-1528459801416-a9e53bbf4e17?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
           transition={transition}
           {...props}

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_image.md
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_image.md
@@ -1,1 +1,1 @@
-To add a lazyload on the background image simply use the `transition` prop and one of the three string options `"fade"`, `"blur"`, or `"scale"`.
+To add a transition on the background image, use the `transition` prop with `"fade"`, `"blur"`, or `"scale"`.

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_overlay.jsx
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_overlay.jsx
@@ -9,7 +9,7 @@ const BackgroundOverlay = (props) => {
     <Background
         alt="colorful background"
         backgroundColor="category_21"
-        className="background lazyload"
+        className="background"
         imageOverlay="opacity_2"
         imageUrl="https://unsplash.it/500/400/?image=633"
         {...props}

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_responsive.jsx
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_responsive.jsx
@@ -6,14 +6,14 @@ const BackgroundResponsive = (props) => (
     <Background
         alt="colorful background"
         backgroundColor={{ xs: "primary", sm: "warning", md: "success", lg: "error", xl: "category_1" }}
-        className="background lazyload"
+        className="background"
         padding="xl"
         {...props}
     />
     <br/>
     <Background
         alt="colorful background"
-        className="background lazyload"
+        className="background"
         imageUrl={{
           xs: "https://unsplash.it/500/400/?image=633",
           sm: "https://images.unsplash.com/photo-1528459801416-a9e53bbf4e17?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80",

--- a/playbook/app/pb_kits/playbook/pb_background/docs/_background_size.jsx
+++ b/playbook/app/pb_kits/playbook/pb_background/docs/_background_size.jsx
@@ -6,7 +6,7 @@ const BackgroundSize = (props) => (
     <Background
         alt="colorful background"
         backgroundSize="auto"
-        className="background lazyload"
+        className="background"
         imageUrl="https://images.unsplash.com/photo-1528459801416-a9e53bbf4e17?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
         padding="xl"
         {...props}
@@ -15,7 +15,7 @@ const BackgroundSize = (props) => (
     <Background
         alt="colorful background"
         backgroundSize="cover"
-        className="background lazyload"
+        className="background"
         imageUrl="https://images.unsplash.com/photo-1528459801416-a9e53bbf4e17?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
         padding="xl"
         {...props}
@@ -25,7 +25,7 @@ const BackgroundSize = (props) => (
         alt="colorful background"
         backgroundRepeat="no-repeat"
         backgroundSize="contain"
-        className="background lazyload"
+        className="background"
         imageUrl="https://images.unsplash.com/photo-1528459801416-a9e53bbf4e17?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
         padding="xl"
         {...props}

--- a/playbook/app/pb_kits/playbook/pb_image/_image.scss
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.scss
@@ -23,30 +23,36 @@ $image-sizes: (
   }
 
   &.fade {
-    opacity: 0;
-    &.lazyloaded {
-      opacity: 1;
-      transition: opacity 300ms ease-in;
-    }
+    animation: pb_image_fade 300ms ease-in forwards;
   }
 
   &.blur {
-    filter: blur(5px);
-    &.lazyloaded {
-      -webkit-filter: blur(0);
-      filter: blur(0);
-      transition: filter 300ms ease-in;
-    }
+    animation: pb_image_blur 300ms ease-in forwards;
   }
 
   &.scale {
+    animation: pb_image_scale 700ms ease-in forwards;
+  }
+}
+
+@keyframes pb_image_fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes pb_image_blur {
+  from { filter: blur(5px); }
+  to { filter: blur(0); }
+}
+
+@keyframes pb_image_scale {
+  from {
     opacity: 0;
     transform: scale(0.9);
-    &.lazyloaded {
-      opacity: 1;
-      transform: scale(1);
-      transition: 700ms ease-in;
-    }
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 

--- a/playbook/app/pb_kits/playbook/pb_image/_image.tsx
+++ b/playbook/app/pb_kits/playbook/pb_image/_image.tsx
@@ -35,7 +35,6 @@ const Image = (props: ImageType): React.ReactElement => {
   const ariaProps = buildAriaProps(aria)
   const classes = classnames(
     buildCss('pb_image_kit', size ? `size_${size}` : null),
-    'lazyload',
     transition,
     { rounded },
     globalProps(props),
@@ -53,7 +52,6 @@ const Image = (props: ImageType): React.ReactElement => {
         {...htmlProps}
         alt={alt}
         className={classes}
-        data-src={url}
         id={id}
         onError={onError}
         src={url}

--- a/playbook/app/pb_kits/playbook/pb_image/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_image/docs/_playground.json
@@ -80,7 +80,7 @@
     },
     "blur_transition": {
       "presetName": "Blur Transition",
-      "message": "Use the transition prop to select the lazyload transition class: fade, blur, or scale.",
+      "message": "Use the transition prop to select fade, blur, or scale.",
       "type": "info"
     },
     "custom_error_handler": {

--- a/playbook/app/pb_kits/playbook/pb_image/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_image/docs/_playground.overrides.json
@@ -142,7 +142,7 @@
     },
     "blur_transition": {
       "presetName": "Blur Transition",
-      "message": "Use the transition prop to select the lazyload transition class: fade, blur, or scale.",
+      "message": "Use the transition prop to select fade, blur, or scale.",
       "type": "info"
     },
     "custom_error_handler": {

--- a/playbook/app/pb_kits/playbook/pb_image/docs/_transition_image.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_image/docs/_transition_image.html.erb
@@ -42,9 +42,10 @@
         const updateTransition = (transition) => {
           const imageTransition = document.querySelector('.transition-image')
             imageTransition.removeAttribute("style")
-            imageTransition.classList.remove("fade", "blur", "scale", "lazyloaded")
-            imageTransition.classList.add(transition, "lazyload")
+            imageTransition.classList.remove("fade", "blur", "scale")
             imageTransition.src = "https://unsplash.it/500/400/?image=634"
+            void imageTransition.offsetWidth
+            imageTransition.classList.add(transition)
         }
       
         button.addEventListener('click', function() {

--- a/playbook/app/pb_kits/playbook/pb_image/docs/_transition_image.jsx
+++ b/playbook/app/pb_kits/playbook/pb_image/docs/_transition_image.jsx
@@ -12,15 +12,14 @@ const TransitionImage = (props) => {
     url: '',
     transition: '',
   })
+  const [playKey, setPlayKey] = useState(0)
 
   const loadImage = () => {
-    document.querySelector('.image').classList.remove(transition, 'lazyloaded')
     setApply({
       url: 'https://unsplash.it/500/400/?image=634',
       transition: transition,
-    },
-    document.querySelector('.image').classList.add(transition, 'lazyload')
-    )
+    })
+    setPlayKey((key) => key + 1)
   }
 
   const handleTransition = ({ target }) => {
@@ -65,6 +64,7 @@ const TransitionImage = (props) => {
         <Image
             alt="picture of a misty forest"
             className="image"
+            key={playKey}
             transition={apply.transition}
             url={apply.url}
             {...props}

--- a/playbook/app/pb_kits/playbook/pb_image/image.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_image/image.html.erb
@@ -1,6 +1,6 @@
 <%= tag(:img,
     id: object.id,
-    data: object.data.merge(src: object.url),
+    data: object.data,
     class: object.classname,
     aria: object.aria,
     src: object.url,

--- a/playbook/app/pb_kits/playbook/pb_image/image.rb
+++ b/playbook/app/pb_kits/playbook/pb_image/image.rb
@@ -17,7 +17,7 @@ module Playbook
       prop :url
 
       def classname
-        generate_classname("pb_image_kit#{size_class} #{transition_class} lazyload") + rounded_class
+        generate_classname("pb_image_kit#{size_class} #{transition_class}") + rounded_class
       end
 
     private

--- a/playbook/app/pb_kits/playbook/pb_image/image.test.js
+++ b/playbook/app/pb_kits/playbook/pb_image/image.test.js
@@ -21,20 +21,20 @@ test('alt attribute', () => {
 
 test('default classname', () => {
   const kit = renderKit(Image, props)
-  expect(kit).toHaveClass('pb_image_kit lazyload')
+  expect(kit).toHaveClass('pb_image_kit')
 })
 
 test('size = xs', () => {
   const kit = renderKit(Image, props, { size: 'xs' })
-  expect(kit).toHaveClass('pb_image_kit_size_xs lazyload')
+  expect(kit).toHaveClass('pb_image_kit_size_xs')
 })
 
 test('transition = blur', () => {
   const kit = renderKit(Image, props, { transition: 'blur' })
-  expect(kit).toHaveClass('pb_image_kit lazyload blur')
+  expect(kit).toHaveClass('pb_image_kit blur')
 })
 
 test('rounded = true', () => {
   const kit = renderKit(Image, props, { rounded: true })
-  expect(kit).toHaveClass('pb_image_kit lazyload rounded')
+  expect(kit).toHaveClass('pb_image_kit rounded')
 })

--- a/playbook/package.json
+++ b/playbook/package.json
@@ -105,7 +105,6 @@
     "jest": "26.6.3",
     "jest-axe": "4.1.0",
     "jest-fail-on-console": "3.2.0",
-    "lazysizes": "^5.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-dropzone": "^14.3.5",

--- a/playbook/spec/pb_kits/playbook/kits/background_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/background_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Playbook::PbBackground::Background do
       expect(subject.new(padding: "xl").classname).to eq "pb_background_kit pb_background_color_light p_xl"
       expect(subject.new(background_color: "success").classname).to eq "pb_background_kit pb_background_color_success"
       expect(subject.new(background_color: "category_1").classname).to eq "pb_background_kit pb_background_color_category_1"
-      expect(subject.new(transition: "fade", image_url: "test.jpeg").classname).to eq "pb_background_kit pb_background_color_light lazyload fade"
+      expect(subject.new(transition: "fade", image_url: "test.jpeg").classname).to eq "pb_background_kit pb_background_color_light fade"
       expect(subject.new(custom_color: "#1d99a8").classname).to eq "pb_background_kit pb_background_custom_color"
     end
   end

--- a/playbook/spec/pb_kits/playbook/kits/image_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/image_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Playbook::PbImage::Image do
 
   describe "#classname" do
     it "returns namespaced class name", :aggregate_failures do
-      expect(subject.new({}).classname).to eq "pb_image_kit fade lazyload"
-      expect(subject.new({ size: "xs" }).classname).to eq "pb_image_kit_size_xs fade lazyload"
-      expect(subject.new({ rounded: true }).classname).to eq "pb_image_kit fade lazyload rounded"
+      expect(subject.new({}).classname).to eq "pb_image_kit fade"
+      expect(subject.new({ size: "xs" }).classname).to eq "pb_image_kit_size_xs fade"
+      expect(subject.new({ rounded: true }).classname).to eq "pb_image_kit fade rounded"
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -8561,11 +8561,6 @@ kleur@^3.0.3:
   resolved "https://npm.powerapp.cloud/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lazysizes@^5.3.2:
-  version "5.3.2"
-  resolved "https://npm.powerapp.cloud/lazysizes/-/lazysizes-5.3.2.tgz#27f974c26f5fcc33e7db765c0f4930488c8a2984"
-  integrity sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg==
-
 lazystream@^1.0.0:
   version "1.0.1"
   resolved "https://npm.powerapp.cloud/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

- Removes lazysizes from Playbook. It was only a side-effect import on the React and Rails bundles, not a public export, and Image/Background already set the real image URL so it was not actually lazy-loading. Fade/blur/scale now run from kit CSS animations instead of waiting for the .lazyloaded class.

- Image and Background transition (fade / blur / scale) use @keyframes with the same timings as before
- Removed lazyload, data-src, and .lazyloaded from the kits, docs demos, and markdown images
- Updated Jest, RSpec, and Image playground copy

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
- Open Image kit docs (React and Rails). Confirm default fade still plays and size/rounded examples look correct.
- Use the Image transition demo: pick fade/blur/scale and click Load Image more than once. Animation should replay.
- Open Background image docs. Confirm overlay/size/responsive examples, then use the transition dropdown.
- Check Avatar with an imageUrl — photo should fade in, no missing src.
- Confirm the docs site still loads markdown images.

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.