### PR TITLE
[PLAY-3152] Select Playground Interactivity

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_select/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_playground.json
@@ -1,5 +1,5 @@
 {
-  "template": "<Select{{props}} />",
+  "template": "<Select{{props}} onChange={handleSelectChange} value={selectValue} />",
   "propTargets": {},
   "defaults": {
     "compact": false,
@@ -120,6 +120,7 @@
         "label": "Teams",
         "name": "teams",
         "multiple": true,
+        "value": [],
         "options": [
           {
             "value": "eng",
@@ -167,6 +168,10 @@
     }
   },
   "hints": {
+    "controlled_state": {
+      "message": "Select is controlled when value is set, so the snippet uses useState and onChange to keep the selection changeable.",
+      "type": "info"
+    },
     "default": {
       "presetName": "Default",
       "message": "Default shows a labeled select with a selected value and a simple options array.",
@@ -188,6 +193,13 @@
       "type": "info"
     }
   },
+  "wrapper": "const SelectPlayground = () => {\n  const [selectValue, setSelectValue] = useState(value)\n\n  const handleSelectChange = (event) => {\n    const { multiple, selectedOptions } = event.target\n\n    setSelectValue(multiple ? Array.from(selectedOptions, (option) => option.value) : event.target.value)\n  }\n\n  return {{component}}\n}\n\n<SelectPlayground />",
+  "statefulProps": [
+    "value"
+  ],
+  "externalImports": [
+    "import React, { useState } from 'react'"
+  ],
   "hiddenProps": [
     "inputOptions",
     "includeBlank"

--- a/playbook/app/pb_kits/playbook/pb_select/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_select/docs/_playground.overrides.json
@@ -1,4 +1,8 @@
 {
+  "template": "<Select{{props}} onChange={handleSelectChange} value={selectValue} />",
+  "wrapper": "const SelectPlayground = () => {\n  const [selectValue, setSelectValue] = useState(value)\n\n  const handleSelectChange = (event) => {\n    const { multiple, selectedOptions } = event.target\n\n    setSelectValue(multiple ? Array.from(selectedOptions, (option) => option.value) : event.target.value)\n  }\n\n  return {{component}}\n}\n\n<SelectPlayground />",
+  "statefulProps": ["value"],
+  "externalImports": ["import React, { useState } from 'react'"],
   "defaults": {
     "blankSelection": "Select an option",
     "compact": false,
@@ -69,6 +73,7 @@
         "label": "Teams",
         "name": "teams",
         "multiple": true,
+        "value": [],
         "options": [
           { "value": "eng", "text": "Engineering" },
           { "value": "design", "text": "Design" },
@@ -96,6 +101,10 @@
     "requiredIndicator": { "requires": "label" }
   },
   "hints": {
+    "controlled_state": {
+      "message": "Select is controlled when value is set, so the snippet uses useState and onChange to keep the selection changeable.",
+      "type": "info"
+    },
     "default": {
       "presetName": "Default",
       "message": "Default shows a labeled select with a selected value and a simple options array.",


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3152](https://runway.powerhrg.com/backlog_items/PLAY-3152) adds a state wrapper to the Select Playground files so that a user can fully interact with the input. Text Input and Textarea have the same set up in place to add an internal playground state - includes additional code in the code snippet and a notice about it. Applies to both the Select Playground page and the Select within the All Kits Playground.

**Screenshots:** Screenshots to visualize your addition/change
Current Prod: Select dropdown opens but unable to actually select a different option
<img width="1040" height="750" alt="select not allowing selection" src="https://github.com/user-attachments/assets/f56066de-5553-482f-b0ce-a4856bb66d1e" />

Updated: Select allows for selection of other options, includes same disclaimer re: state wrapper code as other kits have
<img width="1241" height="1036" alt="select playground updated" src="https://github.com/user-attachments/assets/10a181a6-c526-46ef-a2f8-9a5b70b42da2" />
<img width="1387" height="267" alt="select all kits playground" src="https://github.com/user-attachments/assets/55a41637-5e7a-4fc7-a094-9eba46c5ffbe" />


**How to test?** Steps to confirm the desired behavior:
1. Go to Select React Playground - you can now select an option from the Select and see it display in the input. Same for All Kits Playground (Select unselectable in prod but works in review env).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.