### PR TITLE
[PLAY-3150] Dropdown: Add react hook form support

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
@@ -113,7 +113,6 @@ type DropdownProps = {
     label?: string;
     multiSelect?: boolean;
     name?: string;
-    onBlur?: (event: React.FocusEvent) => void;
     onChange?: (event: { target: { name?: string; value: any } }) => void;
     onSelect?: (arg: GenericObject) => null;
     options?: GenericObject;
@@ -160,7 +159,6 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
         multiSelect = false,
         formPillProps,
         name,
-        onBlur,
         onChange,
         onSelect,
         options,
@@ -653,8 +651,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
                   </label>
                 )}
                 <div className={`dropdown_wrapper ${error ? 'error' : ''}`}
-                    onBlur={(e) => {
-                        onBlur && onBlur(e);
+                    onBlur={() => {
                         // Debounce to delay the execution to prevent jumpiness in Focus state
                         setTimeout(() => {
                             const active = document.activeElement;

--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
@@ -114,7 +114,7 @@ type DropdownProps = {
     multiSelect?: boolean;
     name?: string;
     onBlur?: (event: React.FocusEvent) => void;
-    onChange?: any;
+    onChange?: (event: { target: { name?: string; value: any } }) => void;
     onSelect?: (arg: GenericObject) => null;
     options?: GenericObject;
     placeholder?: string;
@@ -422,14 +422,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
 
     const handleSelectionChange = (value: any) => {
         onSelect && onSelect(value);
-        if (onChange) {
-            const isReactHookForm = onChange.toString().includes("target");
-            if (isReactHookForm) {
-                onChange({ target: { name, value } });
-            } else {
-                onChange(value);
-            }
-        }
+        onChange && onChange({ target: { name, value } });
     };
 
       const handleOptionClick = (clickedItem: GenericObject) => {

--- a/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/_dropdown.tsx
@@ -112,6 +112,9 @@ type DropdownProps = {
     isClosed?: boolean;
     label?: string;
     multiSelect?: boolean;
+    name?: string;
+    onBlur?: (event: React.FocusEvent) => void;
+    onChange?: any;
     onSelect?: (arg: GenericObject) => null;
     options?: GenericObject;
     placeholder?: string;
@@ -156,6 +159,9 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
         label,
         multiSelect = false,
         formPillProps,
+        name,
+        onBlur,
+        onChange,
         onSelect,
         options,
         placeholder,
@@ -414,6 +420,17 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
         setIsDropDownClosed(false);
     };
 
+    const handleSelectionChange = (value: any) => {
+        onSelect && onSelect(value);
+        if (onChange) {
+            const isReactHookForm = onChange.toString().includes("target");
+            if (isReactHookForm) {
+                onChange({ target: { name, value } });
+            } else {
+                onChange(value);
+            }
+        }
+    };
 
       const handleOptionClick = (clickedItem: GenericObject) => {
                 if (disabled) return;
@@ -426,7 +443,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
                        const next = exists
                        ? list.filter((option) => option.value !== clickedItem.value)
                            : [...list, clickedItem];
-                   onSelect && onSelect(next);
+                   handleSelectionChange(next);
                        return next;
                    });
                    setFilterItem("");
@@ -439,7 +456,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
                    if (shouldCloseOnClick) {
                        setIsDropDownClosed(true);
                    }
-                   onSelect && onSelect(clickedItem);
+                   handleSelectionChange(clickedItem);
                    
                    // Sync with DatePickers if this is a quickpick variant
                    if (variant === "quickpick" && Array.isArray(clickedItem.value)) {
@@ -468,10 +485,10 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
       if (disabled) return;
       if (multiSelect) {
         setSelected([]);
-        onSelect && onSelect([]);
+        handleSelectionChange([]);
       } else {
         setSelected({});
-        onSelect && onSelect(null);
+        handleSelectionChange(null);
         setFocusedOptionIndex(-1);
         setFilterItem("");
         
@@ -505,10 +522,10 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
       clearSelected: () => {
         if (multiSelect) {
           setSelected([]);
-          onSelect && onSelect([]);
+          handleSelectionChange([]);
         } else {
           setSelected({});
-          onSelect && onSelect(null);
+          handleSelectionChange(null);
         }
         setFilterItem("");
         setIsDropDownClosed(true);
@@ -522,16 +539,16 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
         clearSelected: () => {
           if (multiSelect) {
             setSelected([]);
-            onSelect && onSelect([]);
+            handleSelectionChange([]);
           } else {
             setSelected({});
-            onSelect && onSelect(null);
+            handleSelectionChange(null);
           }
           setFilterItem("");
           setIsDropDownClosed(true);
         },
       };
-    }, [multiSelect, onSelect, setSelected, setFilterItem, setIsDropDownClosed]);
+    }, [multiSelect, handleSelectionChange, setSelected, setFilterItem, setIsDropDownClosed]);
 
     useImperativeHandle(ref, () => imperativeRef.current);
 
@@ -594,6 +611,7 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
                     handleBackspace,
                     handleChange,
                     handleOptionClick,
+                    handleSelectionChange,
                     handleWrapperClick,
                     inputRef,
                     inputWrapperRef,
@@ -642,7 +660,8 @@ let Dropdown = (props: DropdownProps, ref: any): React.ReactElement | null => {
                   </label>
                 )}
                 <div className={`dropdown_wrapper ${error ? 'error' : ''}`}
-                    onBlur={() => {
+                    onBlur={(e) => {
+                        onBlur && onBlur(e);
                         // Debounce to delay the execution to prevent jumpiness in Focus state
                         setTimeout(() => {
                             const active = document.activeElement;

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_multi_select_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_multi_select_react_hook.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import Dropdown from '../_dropdown'
+import Title from '../../pb_title/_title'
+import { useForm } from 'react-hook-form'
+
+const options = [
+  { label: 'United States', value: 'unitedStates', id: 'us' },
+  { label: 'United Kingdom', value: 'unitedKingdom', id: 'gb' },
+  { label: 'Canada', value: 'canada', id: 'ca' },
+  { label: 'Pakistan', value: 'pakistan', id: 'pk' },
+  { label: 'India', value: 'india', id: 'in' },
+  { label: 'Australia', value: 'australia', id: 'au' },
+  { label: 'New Zealand', value: 'new Zealand', id: 'nz' },
+  { label: 'Italy', value: 'italy', id: 'it' },
+  { label: 'Spain', value: 'spain', id: 'es' },
+]
+
+const DropdownMultiSelectReactHook = (props) => {
+  const { register, watch } = useForm()
+
+  const selectedCountries = watch('countries')
+
+  return (
+    <>
+      <Dropdown
+          label="Countries"
+          multiSelect
+          options={options}
+          {...props}
+          {...register('countries')}
+      />
+      <Title
+          marginTop="sm"
+          size={4}
+          text="Selected Countries"
+      />
+      {selectedCountries && selectedCountries.map(country => (
+        <p key={country.id}>{`${country.label} - ${country.value}`}</p>
+      ))}
+    </>
+  )
+}
+
+export default DropdownMultiSelectReactHook

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_multi_select_react_hook.md
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_multi_select_react_hook.md
@@ -1,0 +1,1 @@
+You can pass `react-hook-form` props to a multi-select Dropdown. Spread `register` onto Dropdown with `multiSelect` to keep the selected options array in form state.

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_react_hook.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_react_hook.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import Dropdown from '../_dropdown'
+import Title from '../../pb_title/_title'
+import { useForm } from 'react-hook-form'
+
+const options = [
+  { label: 'United States', value: 'unitedStates', id: 'us' },
+  { label: 'Canada', value: 'canada', id: 'ca' },
+  { label: 'Pakistan', value: 'pakistan', id: 'pk' },
+]
+
+const DropdownReactHook = (props) => {
+  const { register, watch } = useForm()
+
+  const selectedCountry = watch('country')
+
+  return (
+    <>
+      <Dropdown
+          label="Countries"
+          options={options}
+          {...props}
+          {...register('country')}
+      />
+      <Title
+          marginTop="sm"
+          size={4}
+          text="Selected Country"
+      />
+      <p>{selectedCountry && `${selectedCountry.label} - ${selectedCountry.value}`}</p>
+    </>
+  )
+}
+
+export default DropdownReactHook

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_react_hook.md
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_dropdown_react_hook.md
@@ -1,0 +1,1 @@
+You can pass `react-hook-form` props to the Dropdown kit. Spread `register` onto a single-select Dropdown to keep the selected option in form state.

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_playground.json
@@ -88,6 +88,7 @@
       "name": "Content",
       "props": [
         "label",
+        "name",
         "placeholder",
         "options",
         "defaultValue",
@@ -130,6 +131,7 @@
     {
       "name": "Events",
       "props": [
+        "onChange",
         "onSelect"
       ]
     }

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/_playground.overrides.json
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/_playground.overrides.json
@@ -70,6 +70,7 @@
       "name": "Content",
       "props": [
         "label",
+        "name",
         "placeholder",
         "options",
         "defaultValue",
@@ -111,7 +112,7 @@
     },
     {
       "name": "Events",
-      "props": ["onSelect"]
+      "props": ["onChange", "onSelect"]
     }
   ],
   "presets": [

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/example.yml
@@ -81,3 +81,6 @@ examples:
   - dropdown_required_indicator: Required Indicator
   - dropdown_disabled: Disabled Input
   - dropdown_grouped_options: Grouped Options
+  - dropdown_react_hook: React Hook
+  - dropdown_multi_select_react_hook: React Hook Multi Select
+

--- a/playbook/app/pb_kits/playbook/pb_dropdown/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/docs/index.js
@@ -1,4 +1,6 @@
 export { default as DropdownDefault } from './_dropdown_default.jsx'
+export { default as DropdownReactHook } from './_dropdown_react_hook.jsx'
+export { default as DropdownMultiSelectReactHook } from './_dropdown_multi_select_react_hook.jsx'
 export { default as DropdownWithCustomDisplay } from './_dropdown_with_custom_display.jsx'
 export { default as DropdownWithCustomOptions } from './_dropdown_with_custom_options.jsx'
 export { default as DropdownWithCustomTrigger } from './_dropdown_with_custom_trigger.jsx'

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -1199,32 +1199,3 @@ test('autocomplete selection still fires onSelect', () => {
 
   expect(onSelect).toHaveBeenCalledWith(options[1])
 })
-
-test('onBlur is optional and does not throw', () => {
-  render(
-    <Dropdown
-        data={{ testid: testId }}
-        options={options}
-    />
-  )
-
-  const kit = screen.getByTestId(testId)
-  fireEvent.blur(kit.querySelector('.dropdown_wrapper'))
-})
-
-test('onBlur fires when provided', () => {
-  const onBlur = jest.fn()
-
-  render(
-    <Dropdown
-        data={{ testid: testId }}
-        onBlur={onBlur}
-        options={options}
-    />
-  )
-
-  const kit = screen.getByTestId(testId)
-  fireEvent.blur(kit.querySelector('.dropdown_wrapper'))
-
-  expect(onBlur).toHaveBeenCalledTimes(1)
-})

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -997,28 +997,8 @@ test('disabled prop disables autocomplete input', () => {
   expect(input).toBeDisabled()
 })
 
-test('onChange receives selected option for non react-hook-form handlers', () => {
+test('onChange uses react-hook-form event shape', () => {
   const onChange = jest.fn()
-
-  render(
-    <Dropdown
-        data={{ testid: testId }}
-        onChange={onChange}
-        options={options}
-    />
-  )
-
-  const kit = screen.getByTestId(testId)
-  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
-
-  expect(onChange).toHaveBeenCalledWith(options[0])
-})
-
-test('onChange uses react-hook-form event shape when handler reads target', () => {
-  const calls = []
-  function onChange(event) {
-    calls.push(event.target)
-  }
 
   render(
     <Dropdown
@@ -1032,14 +1012,13 @@ test('onChange uses react-hook-form event shape when handler reads target', () =
   const kit = screen.getByTestId(testId)
   fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
 
-  expect(calls[0]).toEqual({ name: 'color', value: options[0] })
+  expect(onChange).toHaveBeenCalledWith({
+    target: { name: 'color', value: options[0] },
+  })
 })
 
 test('react-hook-form onChange receives selected options for multiSelect', () => {
-  const calls = []
-  function onChange(event) {
-    calls.push(event.target)
-  }
+  const onChange = jest.fn()
 
   render(
     <Dropdown
@@ -1055,8 +1034,12 @@ test('react-hook-form onChange receives selected options for multiSelect', () =>
   fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
   fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
 
-  expect(calls[0]).toEqual({ name: 'languages', value: [options[0]] })
-  expect(calls[1]).toEqual({ name: 'languages', value: [options[0], options[1]] })
+  expect(onChange.mock.calls[0][0]).toEqual({
+    target: { name: 'languages', value: [options[0]] },
+  })
+  expect(onChange.mock.calls[1][0]).toEqual({
+    target: { name: 'languages', value: [options[0], options[1]] },
+  })
 })
 
 test('onSelect still fires when onChange is provided', () => {
@@ -1066,6 +1049,7 @@ test('onSelect still fires when onChange is provided', () => {
   render(
     <Dropdown
         data={{ testid: testId }}
+        name="country"
         onChange={onChange}
         onSelect={onSelect}
         options={options}
@@ -1076,7 +1060,9 @@ test('onSelect still fires when onChange is provided', () => {
   fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
 
   expect(onSelect).toHaveBeenCalledWith(options[0])
-  expect(onChange).toHaveBeenCalledWith(options[0])
+  expect(onChange).toHaveBeenCalledWith({
+    target: { name: 'country', value: options[0] },
+  })
 })
 
 test('onSelect-only single select still receives the option object', () => {

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -996,3 +996,85 @@ test('disabled prop disables autocomplete input', () => {
 
   expect(input).toBeDisabled()
 })
+
+test('onChange receives selected option for non react-hook-form handlers', () => {
+  const onChange = jest.fn()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        onChange={onChange}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+
+  expect(onChange).toHaveBeenCalledWith(options[0])
+})
+
+test('onChange uses react-hook-form event shape when handler reads target', () => {
+  const calls = []
+  function onChange(event) {
+    calls.push(event.target)
+  }
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        name="color"
+        onChange={onChange}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+
+  expect(calls[0]).toEqual({ name: 'color', value: options[0] })
+})
+
+test('react-hook-form onChange receives selected options for multiSelect', () => {
+  const calls = []
+  function onChange(event) {
+    calls.push(event.target)
+  }
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        multiSelect
+        name="languages"
+        onChange={onChange}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+
+  expect(calls[0]).toEqual({ name: 'languages', value: [options[0]] })
+  expect(calls[1]).toEqual({ name: 'languages', value: [options[0], options[1]] })
+})
+
+test('onSelect still fires when onChange is provided', () => {
+  const onSelect = jest.fn()
+  const onChange = jest.fn()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        onChange={onChange}
+        onSelect={onSelect}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+
+  expect(onSelect).toHaveBeenCalledWith(options[0])
+  expect(onChange).toHaveBeenCalledWith(options[0])
+})

--- a/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/dropdown.test.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { render, screen, fireEvent, waitFor } from "../utilities/test-utils"
+import { render, screen, fireEvent, waitFor, act } from "../utilities/test-utils"
 
 import { Dropdown, Icon, IconCircle } from 'playbook-ui'
 import DateTime from "../pb_kit/dateTime.ts"
@@ -1077,4 +1077,168 @@ test('onSelect still fires when onChange is provided', () => {
 
   expect(onSelect).toHaveBeenCalledWith(options[0])
   expect(onChange).toHaveBeenCalledWith(options[0])
+})
+
+test('onSelect-only single select still receives the option object', () => {
+  const onSelect = jest.fn()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        onSelect={onSelect}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+
+  expect(onSelect).toHaveBeenCalledTimes(1)
+  expect(onSelect).toHaveBeenCalledWith(options[0])
+})
+
+test('onSelect-only multiSelect still receives the selected options array', () => {
+  const onSelect = jest.fn()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        multiSelect
+        onSelect={onSelect}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[0])
+
+  expect(onSelect.mock.calls[0][0]).toEqual([options[0]])
+  expect(onSelect.mock.calls[1][0]).toEqual([options[0], options[1]])
+})
+
+test('onSelect-only clearSelected still receives null', () => {
+  const onSelect = jest.fn()
+  const dropdownRef = React.createRef()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        defaultValue={options[0]}
+        onSelect={onSelect}
+        options={options}
+        ref={dropdownRef}
+    />
+  )
+
+  act(() => {
+    dropdownRef.current.clearSelected()
+  })
+
+  expect(onSelect).toHaveBeenCalledWith(null)
+})
+
+test('onSelect-only clear icon still receives null', () => {
+  const onSelect = jest.fn()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        defaultValue={options[0]}
+        onSelect={onSelect}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelector('[aria-label="times icon"]').closest('div'))
+
+  expect(onSelect).toHaveBeenCalledWith(null)
+})
+
+test('onSelect-only removing a multiSelect pill still receives remaining options', () => {
+  const onSelect = jest.fn()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        defaultValue={[options[0], options[1]]}
+        multiSelect
+        onSelect={onSelect}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelector('.pb_form_pill_close'))
+
+  expect(onSelect).toHaveBeenCalledWith([options[1]])
+})
+
+test('autocomplete typing does not fire onSelect or onChange', () => {
+  const onSelect = jest.fn()
+  const onChange = jest.fn()
+
+  render(
+    <Dropdown
+        autocomplete
+        data={{ testid: testId }}
+        onChange={onChange}
+        onSelect={onSelect}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.change(kit.querySelector('.dropdown_input'), { target: { value: 'Can' } })
+
+  expect(onSelect).not.toHaveBeenCalled()
+  expect(onChange).not.toHaveBeenCalled()
+})
+
+test('autocomplete selection still fires onSelect', () => {
+  const onSelect = jest.fn()
+
+  render(
+    <Dropdown
+        autocomplete
+        data={{ testid: testId }}
+        onSelect={onSelect}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.click(kit.querySelectorAll('.pb_dropdown_option_list')[1])
+
+  expect(onSelect).toHaveBeenCalledWith(options[1])
+})
+
+test('onBlur is optional and does not throw', () => {
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.blur(kit.querySelector('.dropdown_wrapper'))
+})
+
+test('onBlur fires when provided', () => {
+  const onBlur = jest.fn()
+
+  render(
+    <Dropdown
+        data={{ testid: testId }}
+        onBlur={onBlur}
+        options={options}
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  fireEvent.blur(kit.querySelector('.dropdown_wrapper'))
+
+  expect(onBlur).toHaveBeenCalledTimes(1)
 })

--- a/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
@@ -129,7 +129,7 @@
       ]
     },
     "onChange": {
-      "type": "any",
+      "type": "function",
       "platforms": [
         "react"
       ]

--- a/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
@@ -122,12 +122,6 @@
         "rails"
       ]
     },
-    "onBlur": {
-      "type": "function",
-      "platforms": [
-        "react"
-      ]
-    },
     "onChange": {
       "type": "function",
       "platforms": [

--- a/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/kit.schema.json
@@ -115,6 +115,25 @@
       ],
       "default": false
     },
+    "name": {
+      "type": "string",
+      "platforms": [
+        "react",
+        "rails"
+      ]
+    },
+    "onBlur": {
+      "type": "function",
+      "platforms": [
+        "react"
+      ]
+    },
+    "onChange": {
+      "type": "any",
+      "platforms": [
+        "react"
+      ]
+    },
     "onSelect": {
       "type": "function",
       "platforms": [
@@ -193,12 +212,6 @@
         "rails"
       ],
       "default": false
-    },
-    "name": {
-      "platforms": [
-        "rails"
-      ],
-      "type": "string"
     },
     "required": {
       "platforms": [

--- a/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/MultiSelectTriggerDisplay.tsx
+++ b/playbook/app/pb_kits/playbook/pb_dropdown/subcomponents/MultiSelectTriggerDisplay.tsx
@@ -19,7 +19,7 @@ const MultiSelectTriggerDisplay = ({
   dark = false,
 }: MultiSelectTriggerDisplayProps) => {
 
-  const { setSelected, onSelect, formPillProps } = useContext(DropdownContext);
+  const { setSelected, handleSelectionChange, formPillProps } = useContext(DropdownContext);
 
   if (selected.length === 0) {
     if (autocomplete) return null;
@@ -35,7 +35,7 @@ const MultiSelectTriggerDisplay = ({
  const handleRemoveIconClick = (option: GenericObject) => {
   setSelected((prev: GenericObject[]) => {
       const next = prev.filter((item) => item.label !== option.label);
-      onSelect && onSelect(next);
+      handleSelectionChange && handleSelectionChange(next);
       return next;
     });
  } 


### PR DESCRIPTION
[PLAY-3150](https://runway.powerhrg.com/backlog_items/PLAY-3150)

Adds react-Hook-form control to Dropdown kit.

**Screenshots:** Screenshots to visualize your addition/change

<img width="829" height="384" alt="Screenshot 2026-08-24 at 11 52 45 AM" src="https://github.com/user-attachments/assets/c177639d-eb59-4047-a002-97e9cc7c498d" />

<img width="835" height="409" alt="Screenshot 2026-08-24 at 11 52 42 AM" src="https://github.com/user-attachments/assets/b61cc1b3-86c3-4dcc-9f5f-897d959a2d1e" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.