### PR TITLE
[PLAY-3155] POC Form Kit - Auto-bind Model Values and Errors in Fields

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_form/docs/_description.md
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_description.md
@@ -4,3 +4,26 @@ The `form` kit provides consumers with a convenient, consistently styled `<form>
 
 This kit uses rails `form_with` with our custom builder to render forms using other kits such as text_input, select, and typeahead to name a few. Doing so provides UI consistency within forms and makes adding a form to your page easier.
 
+### Model values and errors (edit forms)
+
+When the form is bound to a model (`model:` / `options: { model: ... }`), builder fields read the attribute and its validation errors automatically — similar to Rails `text_field`. You usually do not need to pass `default_date`, `value`, `default_value`, or `error` yourself:
+
+```erb
+<%= form.date_picker :starts_at, props: { label: true } %>
+```
+
+On edit, `starts_at` is pre-populated and any `errors.full_messages_for(:starts_at)` message is shown. Explicit props still win when you pass them.
+
+| Field | Auto value | Auto error |
+| --- | --- | --- |
+| `date_picker` | `default_date` (UTC ISO8601) | yes |
+| `time_picker` | `default_time` (HH:MM) | yes |
+| `dropdown_field` | `default_value` (matched via `options`) | yes |
+| `star_rating_field` | `default_value` | n/a |
+| `multi_level_select` | `selected_ids` | yes |
+| `phone_number_field` / `intl_telephone` | `value` | yes |
+| `typeahead` | `default_options` only if already option-shaped | yes |
+| text / textarea / select / `collection_select` | via Rails | yes |
+
+**Caveats:** dropdown needs `options` to resolve a stored id/value to an option. Typeahead with a bare database id still needs an explicit `default_options`.
+

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_description.md
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_description.md
@@ -25,5 +25,5 @@ On edit, `starts_at` is pre-populated and any `errors.full_messages_for(:starts_
 | `typeahead` | `default_options` only if already option-shaped | yes |
 | text / textarea / select / `collection_select` | via Rails | yes |
 
-**Caveats:** dropdown needs `options` to resolve a stored id/value to an option. Typeahead with a bare database id still needs an explicit `default_options`.
+**Caveats:** dropdown needs `options` to resolve a stored id/value to an option hash; unmatched ids are ignored (not passed through). Typeahead with a bare database id still needs an explicit `default_options`.
 

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.html.erb
@@ -1,33 +1,108 @@
 <%
+  example_collection = [
+    OpenStruct.new(name: "Alabama", value: 1),
+    OpenStruct.new(name: "Alaska", value: 2),
+    OpenStruct.new(name: "Arizona", value: 3),
+  ]
+
   example_dropdown_options = [
     { label: "Open", value: "open", id: "open" },
     { label: "Closed", value: "closed", id: "closed" },
   ]
 
+  example_typeahead_options = [
+    { label: "Gary", value: "1" },
+    { label: "Carlos", value: "2" },
+  ]
+
+  tree_data = [{
+    label: "Power Home Remodeling",
+    value: "Power Home Remodeling",
+    id: "100",
+    expanded: true,
+    children: [
+      {
+        label: "People",
+        value: "People",
+        id: "101",
+        expanded: true,
+        children: [
+          { label: "Talent Acquisition", value: "Talent Acquisition", id: "102" },
+          { label: "Business Affairs", value: "Business Affairs", id: "103" },
+        ],
+      },
+      {
+        label: "Contact Center",
+        value: "Contact Center",
+        id: "107",
+        children: [
+          { label: "Customer Service", value: "Customer Service", id: "109" },
+        ],
+      },
+    ],
+  }]
+
   example_model = Class.new do
     include ActiveModel::Model
-    attr_accessor :name, :starts_at, :opens_at, :status, :phone
+    attr_accessor :name, :email, :spots, :notes, :state_id, :region,
+                  :starts_at, :ends_at, :opens_at, :status, :rating,
+                  :department_ids, :phone, :mobile, :owner
 
     def self.name
       "Example"
     end
   end.new(
     name: "Gary",
+    email: "gary@example.com",
+    spots: 42,
+    notes: "Early arrivals\nVIP seating",
+    state_id: 2,
+    region: 1,
     starts_at: Time.utc(2026, 8, 18, 19, 37, 0),
+    ends_at: Time.utc(2026, 8, 20, 23, 59, 0),
     opens_at: Time.utc(2026, 8, 18, 9, 30, 0),
     status: "open",
-    phone: "+15551234567"
+    rating: 4,
+    department_ids: %w[101 102],
+    phone: "+15551234567",
+    mobile: "+15557654321",
+    owner: { label: "Gary", value: "1" }
   )
   example_model.errors.add(:name, "is invalid")
   example_model.errors.add(:starts_at, "can't be blank")
+  example_model.errors.add(:spots, "must be greater than 0")
 %>
 
 <%= pb_form_with(model: example_model, method: :get, url: "") do |form| %>
   <%= form.text_field :name, props: { label: true } %>
-  <%= form.date_picker :starts_at, props: { label: true } %>
+  <%= form.email_field :email, props: { label: true } %>
+  <%= form.number_field :spots, props: { label: true } %>
+  <%= form.text_area :notes, props: { label: true } %>
+
+  <%= form.date_picker :starts_at, props: { label: true, enable_time: true } %>
+  <%= form.date_picker :ends_at, props: { label: true, enable_time: true } %>
   <%= form.time_picker :opens_at, props: { label: true } %>
+
+  <%= form.select :region, [["Yes", 1], ["No", 2]], props: { label: true } %>
+  <%= form.collection_select :state_id, example_collection, :value, :name, props: { label: true } %>
   <%= form.dropdown_field :status, props: { label: true, options: example_dropdown_options } %>
+
+  <%= form.star_rating_field :rating, props: { variant: "interactive", label: true } %>
+  <%= form.multi_level_select :department_ids, props: {
+        id: "multi-level-select-form-model-defaults",
+        tree_data: tree_data,
+        margin_bottom: "sm",
+        label: true,
+      } %>
+
   <%= form.phone_number_field :phone, props: { label: true } %>
+  <%= form.intl_telephone :mobile, props: { label: true } %>
+  <%= form.typeahead :owner, props: {
+        label: true,
+        options: example_typeahead_options,
+        pills: true,
+        placeholder: "Search for a user",
+      } %>
 
   <%= form.actions do |action| %>
     <%= action.submit %>

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.html.erb
@@ -1,0 +1,36 @@
+<%
+  example_dropdown_options = [
+    { label: "Open", value: "open", id: "open" },
+    { label: "Closed", value: "closed", id: "closed" },
+  ]
+
+  example_model = Class.new do
+    include ActiveModel::Model
+    attr_accessor :name, :starts_at, :opens_at, :status, :phone
+
+    def self.name
+      "Example"
+    end
+  end.new(
+    name: "Gary",
+    starts_at: Time.utc(2026, 8, 18, 19, 37, 0),
+    opens_at: Time.utc(2026, 8, 18, 9, 30, 0),
+    status: "open",
+    phone: "+15551234567"
+  )
+  example_model.errors.add(:name, "is invalid")
+  example_model.errors.add(:starts_at, "can't be blank")
+%>
+
+<%= pb_form_with(model: example_model, method: :get, url: "") do |form| %>
+  <%= form.text_field :name, props: { label: true } %>
+  <%= form.date_picker :starts_at, props: { label: true } %>
+  <%= form.time_picker :opens_at, props: { label: true } %>
+  <%= form.dropdown_field :status, props: { label: true, options: example_dropdown_options } %>
+  <%= form.phone_number_field :phone, props: { label: true } %>
+
+  <%= form.actions do |action| %>
+    <%= action.submit %>
+    <%= action.button props: { type: "reset", text: "Cancel", variant: "secondary" } %>
+  <% end %>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.md
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.md
@@ -1,0 +1,8 @@
+When the form is bound to a model, field values and validation errors are read from the attribute automatically — no `default_date`, `value`, `default_value`, or `error` props required.
+
+This example simulates an edit form after a failed validation: fields are pre-populated from the model, and error messages appear under the invalid attributes.
+
+**Notes**
+- Explicit props still win when you pass them.
+- Dropdown needs `options` so a stored id/value can be matched to an option.
+- Typeahead only auto-binds `default_options` when the attribute is already option-shaped (`{ label, value }` or an array of those). A bare database id still needs an explicit `default_options`.

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.md
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.md
@@ -1,6 +1,8 @@
-When the form is bound to a model, field values and validation errors are read from the attribute automatically — no `default_date`, `value`, `default_value`, or `error` props required.
+When the form is bound to a model, field values and validation errors are read from the attribute automatically — no `default_date`, `value`, `default_value`, `selected_ids`, or `error` props required.
 
-This example simulates an edit form after a failed validation: fields are pre-populated from the model, and error messages appear under the invalid attributes.
+This example simulates an edit form after a failed validation (similar to a real wave/signup edit): fields are pre-populated from the model, and error messages appear under the invalid attributes.
+
+Shown below: `text_field`, `email_field`, `number_field`, `text_area`, `date_picker`, `time_picker`, `select`, `collection_select`, `dropdown_field`, `star_rating_field`, `multi_level_select`, `phone_number_field`, `intl_telephone`, and `typeahead`.
 
 **Notes**
 - Explicit props still win when you pass them.

--- a/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.md
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/_form_form_with_model_defaults.md
@@ -6,5 +6,5 @@ Shown below: `text_field`, `email_field`, `number_field`, `text_area`, `date_pic
 
 **Notes**
 - Explicit props still win when you pass them.
-- Dropdown needs `options` so a stored id/value can be matched to an option.
+- Dropdown needs `options` so a stored id/value can be matched to an option hash; unmatched ids are left unset.
 - Typeahead only auto-binds `default_options` when the attribute is already option-shaped (`{ label, value }` or an array of those). A bare database id still needs an explicit `default_options`.

--- a/playbook/app/pb_kits/playbook/pb_form/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_form/docs/example.yml
@@ -4,5 +4,6 @@ examples:
   - form_form_with: Default
   - form_form_with_validate: Default + Validation
   - form_form_with_validation_msg: Validation + Custom Validation Message
+  - form_form_with_model_defaults: Model Values + Errors
   - form_form_with_loading: Default + Loading
   - form_with_required_indicator: With Optional Required Indicator

--- a/playbook/lib/playbook/forms/builder.rb
+++ b/playbook/lib/playbook/forms/builder.rb
@@ -3,6 +3,7 @@
 module Playbook
   module Forms
     class Builder < ::ActionView::Helpers::FormBuilder
+      require_relative "builder/attribute_defaults"
       require_relative "builder/action_area"
       require_relative "builder/checkbox_field"
       require_relative "builder/collection_select_field"
@@ -17,6 +18,8 @@ module Playbook
       require_relative "builder/time_zone_select_field"
       require_relative "builder/time_picker_field"
       require_relative "builder/typeahead_field"
+
+      include AttributeDefaults
 
       prepend(FormFieldBuilder.new(:email_field, kit_name: "text_input"))
       prepend(FormFieldBuilder.new(:number_field, kit_name: "text_input"))

--- a/playbook/lib/playbook/forms/builder/attribute_defaults.rb
+++ b/playbook/lib/playbook/forms/builder/attribute_defaults.rb
@@ -52,16 +52,35 @@ module Playbook
           end
         end
 
+        # Dropdown only accepts option hashes for default_value. Never return a
+        # bare id/string — that raises in Dropdown#input_default_value.
         def resolve_dropdown_default(value, options)
-          return value if value.is_a?(Hash) || value.is_a?(Array)
-          return value if options.blank?
+          case value
+          when Hash
+            value
+          when Array
+            resolve_dropdown_array_default(value, options)
+          else
+            find_dropdown_option(value, options)
+          end
+        end
+
+        def resolve_dropdown_array_default(values, options)
+          return values if values.all? { |entry| entry.is_a?(Hash) }
+
+          matched = values.filter_map { |entry| find_dropdown_option(entry, options) }
+          matched.presence
+        end
+
+        def find_dropdown_option(value, options)
+          return nil if options.blank?
 
           Array(options).find do |option|
-            next false unless option.respond_to?(:[])
+            next false unless option.respond_to?(:transform_keys)
 
-            option = option.transform_keys(&:to_s)
-            option["id"].to_s == value.to_s || option["value"].to_s == value.to_s
-          end || value
+            normalized = option.transform_keys(&:to_s)
+            normalized["id"].to_s == value.to_s || normalized["value"].to_s == value.to_s
+          end
         end
       end
     end

--- a/playbook/lib/playbook/forms/builder/attribute_defaults.rb
+++ b/playbook/lib/playbook/forms/builder/attribute_defaults.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Playbook
+  module Forms
+    class Builder
+      # Shared helpers so form builder fields can mirror Rails text_field DX:
+      # pull the model attribute and its validation errors unless the caller
+      # explicitly passed those props.
+      module AttributeDefaults
+      private
+
+        def form_attribute_value(name)
+          return nil unless @object
+          return nil unless @object.respond_to?(name)
+
+          @object.public_send(name)
+        end
+
+        def form_attribute_error(name)
+          return nil unless @object.respond_to?(:errors)
+
+          messages = @object.errors.full_messages_for(name)
+          messages.first.presence
+        rescue NoMethodError
+          nil
+        end
+
+        def apply_form_error!(props, name)
+          return if props.key?(:error)
+
+          error = form_attribute_error(name)
+          props[:error] = error if error.present?
+        end
+
+        def serialize_date_picker_default(value)
+          case value
+          when Time, DateTime, ActiveSupport::TimeWithZone
+            value.utc.iso8601
+          when Date
+            value.iso8601
+          else
+            value.presence&.to_s
+          end
+        end
+
+        def serialize_time_picker_default(value)
+          case value
+          when Time, DateTime, ActiveSupport::TimeWithZone
+            value.strftime("%H:%M")
+          else
+            value.presence&.to_s
+          end
+        end
+
+        def resolve_dropdown_default(value, options)
+          return value if value.is_a?(Hash) || value.is_a?(Array)
+          return value if options.blank?
+
+          Array(options).find do |option|
+            next false unless option.respond_to?(:[])
+
+            option = option.transform_keys(&:to_s)
+            option["id"].to_s == value.to_s || option["value"].to_s == value.to_s
+          end || value
+        end
+      end
+    end
+  end
+end

--- a/playbook/lib/playbook/forms/builder/collection_select_field.rb
+++ b/playbook/lib/playbook/forms/builder/collection_select_field.rb
@@ -4,6 +4,9 @@ module Playbook
   module Forms
     class Builder
       def collection_select(name, collection, value_method, text_method, options = {}, html_options = {}, props: {})
+        props = props.dup
+        apply_form_error!(props, name)
+
         props[:input_options] ||= {}
         props[:input_options][:id] ||= "#{@object_name}_#{name}"
 

--- a/playbook/lib/playbook/forms/builder/date_picker_field.rb
+++ b/playbook/lib/playbook/forms/builder/date_picker_field.rb
@@ -4,9 +4,17 @@ module Playbook
   module Forms
     class Builder
       def date_picker(name, props: {})
+        props = props.dup
         prefix = @object_name
         html_attribute_name = "#{prefix}[#{name}]"
         html_id = "#{prefix}_#{name}"
+
+        apply_form_error!(props, name)
+
+        unless props.key?(:default_date)
+          serialized = serialize_date_picker_default(form_attribute_value(name))
+          props[:default_date] = serialized if serialized.present?
+        end
 
         if props[:label] == true
           props[:label] = if @object && @object.class.respond_to?(:human_attribute_name)

--- a/playbook/lib/playbook/forms/builder/dropdown_field.rb
+++ b/playbook/lib/playbook/forms/builder/dropdown_field.rb
@@ -12,7 +12,10 @@ module Playbook
 
         unless props.key?(:default_value)
           value = form_attribute_value(name)
-          props[:default_value] = resolve_dropdown_default(value, props[:options]) unless value.nil?
+          unless value.nil?
+            resolved = resolve_dropdown_default(value, props[:options])
+            props[:default_value] = resolved unless resolved.nil?
+          end
         end
 
         if props[:label] == true

--- a/playbook/lib/playbook/forms/builder/dropdown_field.rb
+++ b/playbook/lib/playbook/forms/builder/dropdown_field.rb
@@ -4,8 +4,17 @@ module Playbook
   module Forms
     class Builder
       def dropdown_field(name, props: {})
+        props = props.dup
         props[:name] = name
         props[:margin_bottom] = "sm"
+
+        apply_form_error!(props, name)
+
+        unless props.key?(:default_value)
+          value = form_attribute_value(name)
+          props[:default_value] = resolve_dropdown_default(value, props[:options]) unless value.nil?
+        end
+
         if props[:label] == true
           props[:label] = if @object && @object.class.respond_to?(:human_attribute_name)
                             @object.class.human_attribute_name(name)

--- a/playbook/lib/playbook/forms/builder/form_field_builder.rb
+++ b/playbook/lib/playbook/forms/builder/form_field_builder.rb
@@ -18,6 +18,8 @@ module Playbook
             props   = props.dup
             options = Hash(options)
 
+            apply_form_error!(props, name)
+
             options[:skip_default_ids] = false unless options.key?(:skip_default_ids)
             # The add-on and error styles are keyed off `.text_input`, so form-built inputs need it too.
             options[:class] = [options[:class], "text_input"].compact.join(" ").strip if kit_name == "text_input"

--- a/playbook/lib/playbook/forms/builder/intl_telephone_field.rb
+++ b/playbook/lib/playbook/forms/builder/intl_telephone_field.rb
@@ -4,8 +4,16 @@ module Playbook
   module Forms
     class Builder
       def intl_telephone(name, props: {})
+        props = props.dup
         props[:name] = name.to_s
         props[:id] ||= "#{@object_name}_#{name}"
+
+        apply_form_error!(props, name)
+
+        unless props.key?(:value)
+          value = form_attribute_value(name)
+          props[:value] = value.to_s if value.present?
+        end
 
         if props[:label] == true
           props[:label] = if @object && @object.class.respond_to?(:human_attribute_name)

--- a/playbook/lib/playbook/forms/builder/multi_level_select_field.rb
+++ b/playbook/lib/playbook/forms/builder/multi_level_select_field.rb
@@ -4,6 +4,15 @@ module Playbook
   module Forms
     class Builder
       def multi_level_select(name, props: {})
+        props = props.dup
+
+        apply_form_error!(props, name)
+
+        unless props.key?(:selected_ids)
+          value = form_attribute_value(name)
+          props[:selected_ids] = Array(value) if value.present?
+        end
+
         if props[:label] == true
           props[:label] = if @object && @object.class.respond_to?(:human_attribute_name)
                             @object.class.human_attribute_name(name)

--- a/playbook/lib/playbook/forms/builder/multi_level_select_field.rb
+++ b/playbook/lib/playbook/forms/builder/multi_level_select_field.rb
@@ -10,7 +10,8 @@ module Playbook
 
         unless props.key?(:selected_ids)
           value = form_attribute_value(name)
-          props[:selected_ids] = Array(value) if value.present?
+          # Kit compares with includes(item.id); tree_data ids are typically strings.
+          props[:selected_ids] = Array(value).map(&:to_s) if value.present?
         end
 
         if props[:label] == true

--- a/playbook/lib/playbook/forms/builder/phone_number_field.rb
+++ b/playbook/lib/playbook/forms/builder/phone_number_field.rb
@@ -4,8 +4,16 @@ module Playbook
   module Forms
     class Builder
       def phone_number_field(name, props: {})
+        props = props.dup
         props[:name] = name.to_s
         props[:id] ||= "#{@object_name}_#{name}"
+
+        apply_form_error!(props, name)
+
+        unless props.key?(:value)
+          value = form_attribute_value(name)
+          props[:value] = value.to_s if value.present?
+        end
 
         if props[:label] == true
           props[:label] = if @object && @object.class.respond_to?(:human_attribute_name)

--- a/playbook/lib/playbook/forms/builder/select_field.rb
+++ b/playbook/lib/playbook/forms/builder/select_field.rb
@@ -4,6 +4,9 @@ module Playbook
   module Forms
     class Builder
       def select(name, choices = nil, options = {}, html_options = {}, props: {}, &block)
+        props = props.dup
+        apply_form_error!(props, name)
+
         props[:input_options] ||= {}
         props[:input_options][:id] ||= "#{@object_name}_#{name}"
 

--- a/playbook/lib/playbook/forms/builder/star_rating_field.rb
+++ b/playbook/lib/playbook/forms/builder/star_rating_field.rb
@@ -4,9 +4,16 @@ module Playbook
   module Forms
     class Builder
       def star_rating_field(name, props: {})
+        props = props.dup
         props[:name] = name
         props[:margin_bottom] = "sm"
         props[:label] = @template.label(@object_name, name) if props[:label] == true
+
+        unless props.key?(:default_value) || props.key?(:rating)
+          value = form_attribute_value(name)
+          props[:default_value] = value unless value.nil?
+        end
+
         @template.pb_rails("star_rating", props: props)
       end
     end

--- a/playbook/lib/playbook/forms/builder/time_picker_field.rb
+++ b/playbook/lib/playbook/forms/builder/time_picker_field.rb
@@ -4,9 +4,17 @@ module Playbook
   module Forms
     class Builder
       def time_picker(name, props: {})
+        props = props.dup
         prefix = @object_name
         html_attribute_name = "#{prefix}[#{name}]"
         html_id = "#{prefix}_#{name}"
+
+        apply_form_error!(props, name)
+
+        unless props.key?(:default_time) || props.key?(:value)
+          serialized = serialize_time_picker_default(form_attribute_value(name))
+          props[:default_time] = serialized if serialized.present?
+        end
 
         if props[:label] == true
           props[:label] = if @object && @object.class.respond_to?(:human_attribute_name)

--- a/playbook/lib/playbook/forms/builder/typeahead_field.rb
+++ b/playbook/lib/playbook/forms/builder/typeahead_field.rb
@@ -4,7 +4,22 @@ module Playbook
   module Forms
     class Builder
       def typeahead(name, _options = {}, _html_options = {}, props: {})
+        props = props.dup
         props[:name] = name
+
+        apply_form_error!(props, name)
+
+        # Only auto-bind when the attribute is already option-shaped ({label,value} or array).
+        # Raw ids/strings still need an explicit default_options from the caller.
+        # Do not use Array(hash) — that flattens to [[:key, val], ...] pairs.
+        unless props.key?(:default_options)
+          value = form_attribute_value(name)
+          if value.is_a?(Hash)
+            props[:default_options] = [value]
+          elsif value.is_a?(Array) && value.first.is_a?(Hash)
+            props[:default_options] = value
+          end
+        end
 
         input_id = "#{name}_input"
         props[:input_options] ||= {}

--- a/playbook/lib/playbook/forms/builder/typeahead_field.rb
+++ b/playbook/lib/playbook/forms/builder/typeahead_field.rb
@@ -16,7 +16,7 @@ module Playbook
           value = form_attribute_value(name)
           if value.is_a?(Hash)
             props[:default_options] = [value]
-          elsif value.is_a?(Array) && value.first.is_a?(Hash)
+          elsif value.is_a?(Array) && value.any? && value.all? { |option| option.is_a?(Hash) }
             props[:default_options] = value
           end
         end

--- a/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
+++ b/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
@@ -262,6 +262,16 @@ RSpec.describe Playbook::Forms::Builder, type: :kit do
       expect(rendered).not_to include("data-default-options")
       expect(CGI.unescapeHTML(rendered)).not_to include('"value":"42"')
     end
+
+    it "does not auto-bind a mixed array that is not all option hashes" do
+      model = build_model(attributes: { owners: [{ label: "Gary", value: "1" }, "2"] })
+
+      rendered = render_form_with(model) do |form|
+        form.typeahead :owners, props: { label: true }
+      end
+
+      expect(rendered).not_to include("data-default-options")
+    end
   end
 
   describe "#star_rating_field" do

--- a/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
+++ b/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
@@ -212,6 +212,19 @@ RSpec.describe Playbook::Forms::Builder, type: :kit do
 
       expect(rendered).to include("101").and include("102")
     end
+
+    it "stringifies integer ids so they match tree_data ids" do
+      model = build_model(attributes: { department_ids: [101, 102] })
+
+      rendered = render_form_with(model) do |form|
+        form.multi_level_select :department_ids, props: {
+          label: true,
+          tree_data: [{ label: "People", value: "People", id: "101" }],
+        }
+      end
+
+      expect(rendered).to include('data-selected-ids="[&quot;101&quot;,&quot;102&quot;]"')
+    end
   end
 
   describe "#typeahead" do

--- a/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
+++ b/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
@@ -141,17 +141,57 @@ RSpec.describe Playbook::Forms::Builder, type: :kit do
   end
 
   describe "#dropdown_field" do
-    it "auto-populates default_value from the model attribute matched to options" do
-      options = [
+    let(:dropdown_options) do
+      [
         { label: "Open", value: "open", id: "open" },
         { label: "Closed", value: "closed", id: "closed" },
       ]
+    end
+
+    it "auto-populates default_value from the model attribute matched to options" do
       model = build_model(attributes: { status: "open" })
 
       rendered = render_form_with(model) do |form|
         form.dropdown_field :status, props: {
           label: true,
-          options: options,
+          options: dropdown_options,
+        }
+      end
+
+      expect(rendered).to include('data-default-value="open"')
+    end
+
+    it "does not pass an unmatched id through as default_value" do
+      model = build_model(attributes: { status: "unknown" })
+
+      expect do
+        render_form_with(model) do |form|
+          form.dropdown_field :status, props: {
+            label: true,
+            options: dropdown_options,
+          }
+        end
+      end.not_to raise_error
+    end
+
+    it "does not pass a bare id when options are blank" do
+      model = build_model(attributes: { status: "open" })
+
+      expect do
+        render_form_with(model) do |form|
+          form.dropdown_field :status, props: { label: true }
+        end
+      end.not_to raise_error
+    end
+
+    it "resolves an array of ids to option hashes for multi_select" do
+      model = build_model(attributes: { status: %w[open missing] })
+
+      rendered = render_form_with(model) do |form|
+        form.dropdown_field :status, props: {
+          label: true,
+          multi_select: true,
+          options: dropdown_options,
         }
       end
 

--- a/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
+++ b/playbook/spec/playbook/forms/builder_attribute_defaults_spec.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "cgi"
+
+RSpec.describe Playbook::Forms::Builder, type: :kit do
+  before do
+    helper.extend Playbook::PbKitHelper
+    helper.define_singleton_method :users_path do |*|
+      "/users"
+    end
+  end
+
+  def render_form_with(model, &block)
+    helper.pb_rails "form", props: { options: { model: model, url: "/users" } }, &block
+  end
+
+  def build_model(attributes:, errors: {})
+    model_name = double(
+      name: "User",
+      singular_route_key: "user",
+      route_key: "users",
+      param_key: "user",
+      i18n_key: :user,
+      human: "User"
+    )
+    errors_proxy = double("errors")
+    allow(errors_proxy).to receive(:full_messages_for) do |attr|
+      Array(errors[attr] || errors[attr.to_sym])
+    end
+    allow(errors_proxy).to receive(:any?) { errors.any? }
+
+    model = double("model", model_name: model_name, persisted?: true, to_key: [1], to_param: "1", id: 1)
+    allow(model).to receive(:to_model).and_return(model)
+    allow(model).to receive(:errors).and_return(errors_proxy)
+
+    model_class = double("UserClass", model_name: model_name)
+    allow(model_class).to receive(:respond_to?).with(:human_attribute_name).and_return(true)
+    allow(model_class).to receive(:human_attribute_name) { |attr| attr.to_s.humanize }
+    allow(model).to receive(:class).and_return(model_class)
+
+    attributes.each do |key, value|
+      allow(model).to receive(key).and_return(value)
+      allow(model).to receive("#{key}_before_type_cast").and_return(value)
+    end
+
+    # FormBuilder may ask for other methods
+    allow(model).to receive(:respond_to?) do |method_name, *|
+      attributes.key?(method_name.to_sym) ||
+        attributes.key?(method_name.to_s) ||
+        %i[errors to_model model_name persisted? to_key to_param id class].include?(method_name.to_sym)
+    end
+
+    model
+  end
+
+  describe "#date_picker" do
+    it "auto-populates default_date from the model attribute as UTC ISO8601" do
+      starts_at = Time.utc(2026, 8, 18, 19, 37, 0)
+      model = build_model(attributes: { starts_at: starts_at })
+
+      rendered = render_form_with(model) do |form|
+        form.date_picker :starts_at, props: { label: true }
+      end
+
+      expect(rendered).to include(starts_at.utc.iso8601)
+      expect(rendered).to include("data-default-value")
+    end
+
+    it "auto-populates error from the model" do
+      model = build_model(
+        attributes: { starts_at: nil },
+        errors: { starts_at: ["Starts at can't be blank"] }
+      )
+
+      rendered = render_form_with(model) do |form|
+        form.date_picker :starts_at, props: { label: true }
+      end
+
+      expect(CGI.unescapeHTML(rendered)).to include("Starts at can't be blank")
+    end
+
+    it "does not override an explicit default_date or error" do
+      model = build_model(
+        attributes: { starts_at: Time.utc(2026, 1, 1) },
+        errors: { starts_at: ["from model"] }
+      )
+
+      rendered = render_form_with(model) do |form|
+        form.date_picker :starts_at, props: {
+          label: true,
+          default_date: "2099-01-01T00:00:00Z",
+          error: "custom error",
+        }
+      end
+
+      expect(rendered).to include("2099-01-01T00:00:00Z")
+      expect(rendered).to include("custom error")
+      expect(rendered).not_to include("from model")
+    end
+  end
+
+  describe "#time_picker" do
+    it "auto-populates default_time from the model attribute" do
+      opens_at = Time.utc(2026, 8, 18, 9, 30, 0)
+      model = build_model(attributes: { opens_at: opens_at })
+
+      rendered = render_form_with(model) do |form|
+        form.time_picker :opens_at, props: { label: true }
+      end
+
+      expect(rendered).to include('data-default-time="09:30"').or include("09:30")
+    end
+  end
+
+  describe "#text_field" do
+    it "auto-populates error from the model" do
+      model = build_model(
+        attributes: { name: "Gary" },
+        errors: { name: ["Name is invalid"] }
+      )
+
+      rendered = render_form_with(model) do |form|
+        form.text_field :name, props: { label: true }
+      end
+
+      expect(rendered).to include("Name is invalid")
+    end
+  end
+
+  describe "#phone_number_field" do
+    it "auto-populates value from the model attribute" do
+      model = build_model(attributes: { phone: "+15551234567" })
+
+      rendered = render_form_with(model) do |form|
+        form.phone_number_field :phone, props: { label: true }
+      end
+
+      expect(rendered).to include("+15551234567")
+    end
+  end
+
+  describe "#dropdown_field" do
+    it "auto-populates default_value from the model attribute matched to options" do
+      options = [
+        { label: "Open", value: "open", id: "open" },
+        { label: "Closed", value: "closed", id: "closed" },
+      ]
+      model = build_model(attributes: { status: "open" })
+
+      rendered = render_form_with(model) do |form|
+        form.dropdown_field :status, props: {
+          label: true,
+          options: options,
+        }
+      end
+
+      expect(rendered).to include('data-default-value="open"')
+    end
+  end
+
+  describe "#multi_level_select" do
+    it "auto-populates selected_ids from the model attribute" do
+      model = build_model(attributes: { department_ids: %w[101 102] })
+
+      rendered = render_form_with(model) do |form|
+        form.multi_level_select :department_ids, props: {
+          label: true,
+          tree_data: [{ label: "People", value: "People", id: "101" }],
+        }
+      end
+
+      expect(rendered).to include("101").and include("102")
+    end
+  end
+
+  describe "#typeahead" do
+    it "auto-populates default_options when the attribute is a single option hash" do
+      option = { label: "Gary", value: "1" }
+      model = build_model(attributes: { owner: option })
+
+      rendered = render_form_with(model) do |form|
+        form.typeahead :owner, props: { label: true, options: [option], pills: true }
+      end
+
+      expect(CGI.unescapeHTML(rendered)).to include("Gary")
+    end
+
+    it "auto-populates default_options when the attribute is an array of option hashes" do
+      options = [{ label: "Gary", value: "1" }, { label: "Carlos", value: "2" }]
+      model = build_model(attributes: { owners: options })
+
+      rendered = render_form_with(model) do |form|
+        form.typeahead :owners, props: { label: true, options: options, pills: true }
+      end
+
+      unescaped = CGI.unescapeHTML(rendered)
+      expect(unescaped).to include("Gary")
+      expect(unescaped).to include("Carlos")
+    end
+
+    it "does not invent default_options from a bare id" do
+      model = build_model(attributes: { owner_id: "42" })
+
+      rendered = render_form_with(model) do |form|
+        form.typeahead :owner_id, props: { label: true }
+      end
+
+      expect(rendered).not_to include("data-default-options")
+      expect(CGI.unescapeHTML(rendered)).not_to include('"value":"42"')
+    end
+  end
+
+  describe "#star_rating_field" do
+    it "auto-populates default_value from the model attribute" do
+      model = build_model(attributes: { rating: 4 })
+
+      rendered = render_form_with(model) do |form|
+        form.star_rating_field :rating, props: { label: true }
+      end
+
+      expect(rendered).to include("4").or include('data-default-value="4"')
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3155

Improve pb_form_with DX so model-bound fields pre-populate and show validation errors without manual default_value or error props.
- Add AttributeDefaults helpers for model attribute + error lookup
- Wire auto-bind for date_picker, time_picker, dropdown_field, star_rating_field, multi_level_select, phone/intl fields, typeahead, and text/select fields
- Add Form kit docs example: Model Values + Errors
- Add builder_attribute_defaults_spec (12 examples)

**Screenshots:** Screenshots to visualize your addition/change
<img width="1949" height="918" alt="Screenshot 2026-08-24 at 2 09 29 PM" src="https://github.com/user-attachments/assets/1dd3b788-0f38-44df-b9fd-a0f07b7296de" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.