### PR TITLE
[PLAY-3199] Optimize Playbook Production Bundle

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/Components/VirtualizedTableView.tsx
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/Components/VirtualizedTableView.tsx
@@ -4,6 +4,7 @@ import { flexRender, Cell, Row } from "@tanstack/react-table"
 import { VirtualItem } from "@tanstack/react-virtual"
 
 import { GenericObject } from "../../types"
+import { debounce } from "../../utilities/object"
 
 import { isChrome } from "../Utilities/BrowserCheck"
 import { getVirtualizedRowStyle } from "../Utilities/TableContainerStyles"
@@ -75,19 +76,6 @@ export const VirtualizedTableView = ({
     });
 
     return widths;
-  };
-
-  // Debounce function to prevent too many updates during resize
-  const debounce = <T extends (...args: any[]) => any>(func: T, wait: number): ((...args: Parameters<T>) => void) => {
-    let timeout: ReturnType<typeof setTimeout>;
-    return function executedFunction(...args: Parameters<T>) {
-      const later = () => {
-        clearTimeout(timeout);
-        func(...args);
-      };
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
-    };
   };
 
   // Update column widths when component mounts and when sorting changes

--- a/playbook/package.json
+++ b/playbook/package.json
@@ -38,6 +38,7 @@
     "test-coverage-summary": "jest --collectCoverage --coverageReporters=\"json-summary\"",
     "release": "rm -rf dist; npx vite build && yarn build:ai:full",
     "watch": "npx vite build --watch",
+    "analyze:bundle": "vite-bundle-visualizer",
     "generate:tokens": "node scripts/generate-tokens.js",
     "generate:playground-configs": "node scripts/generate-playground-configs.js",
     "generate:ai-metadata": "node scripts/generate-ai-metadata.mjs",
@@ -60,6 +61,9 @@
   "files": [
     "dist/*",
     "fonts/*"
+  ],
+  "sideEffects": [
+    "**/*.css"
   ],
   "bugs": {
     "url": "https://github.com/powerhome/playbook/issues"

--- a/playbook/vite.config.ts
+++ b/playbook/vite.config.ts
@@ -15,10 +15,6 @@ export default defineConfig({
   },
   build: {
     minify: isProduction ? 'terser' : false,
-    terserOptions: {
-      mangle: false,
-      compress: false,
-    },
     rollupOptions: {
       preserveEntrySignatures: 'strict',
       input: {


### PR DESCRIPTION
What does this PR do?

This PR introduces Playbook bundle optimizations aimed at reducing shipped JavaScript and removing unnecessary duplicate code.

Changes include:

- Enables Terser compress and mangle during production builds for better minification.
- Adds sideEffects configuration for CSS so bundlers can more effectively tree shake unused JavaScript without removing required styles.
- Updates Advanced Table's VirtualizedTableView to use Playbook's existing shared debounce utility instead of defining its own implementation.

How to test?

- Build Playbook and confirm the production build completes successfully.
- Test Playbook in a consuming application to confirm kits and styles continue to load correctly.
- Regression test Advanced Table virtualization, including column resizing and sorting.
- Compare bundle output/size before and after the changes to confirm the expected optimization.

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.