### PR TITLE
[PLAY-3200] Playground: Persistence, Sharing, and Editing Tools

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/CodeGenerator.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/KitShow/Tabs/Playground/CodeGenerator.ts
@@ -178,7 +178,6 @@ const formatPropValue = (
   if (rawExpression) {
     return `${name}={${rawExpression}}`;
   }
-  const looksLikeFunction = typeof value === "string" && (value.includes("=>") || value.trim().startsWith("function"));
 
   // Handle arrays first (e.g., string[] or string | string[])
   if (Array.isArray(value)) {
@@ -241,7 +240,7 @@ const formatPropValue = (
     return `${name}={${value}}`;
   }
 
-  if (propType === "function" || propType.includes("=>") || looksLikeFunction) {
+  if (propType === "function" || propType.includes("=>")) {
     if (typeof value === "string" && value.trim()) {
       return `${name}={${value}}`;
     }
@@ -250,7 +249,7 @@ const formatPropValue = (
 
   if (propType === "string" || propType.includes("string")) {
     if (typeof value === "string" && value.trim()) {
-      return `${name}="${value}"`;
+      return `${name}={${JSON.stringify(value)}}`;
     }
     return null;
   }
@@ -261,14 +260,14 @@ const formatPropValue = (
 
   if (propType === "reactnode" || propType.includes("reactnode") || propType.includes("node")) {
     if (typeof value === "string" && value.trim()) {
-      return `${name}={<>${value}</>}`;
+      return `${name}={${JSON.stringify(value)}}`;
     }
     return null;
   }
 
   if (propType === "enum" || definition.values?.length) {
     if (typeof value === "string" && value.trim()) {
-      return `${name}="${value}"`;
+      return `${name}={${JSON.stringify(value)}}`;
     }
     return null;
   }
@@ -281,7 +280,7 @@ const formatPropValue = (
   }
 
   if (typeof value === "string") {
-    return `${name}="${value}"`;
+    return `${name}={${JSON.stringify(value)}}`;
   }
 
   if (

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/BuilderPreviewItem.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/BuilderPreviewItem.tsx
@@ -96,6 +96,7 @@ type BuilderPreviewItemProps = {
   globalProps?: Record<string, PropDefinition>;
   instance: BuilderInstance;
   isSelected: boolean;
+  isSelectMode: boolean;
   kitsByName: Record<string, PlaygroundKit>;
   onDragEndDrag?: () => void;
   onDragOverTarget?: (
@@ -113,8 +114,8 @@ type BuilderPreviewItemProps = {
   onLeaveDragTarget?: (id: string) => void;
   onDropKit?: (kitName: string, targetId: string) => void;
   onMoveInstance?: (instanceId: string, targetId: string) => void;
-  onSelect: (id: string) => void;
-  selectedId: string | null;
+  onSelect: (id: string, multi?: boolean) => void;
+  selectedIds: string[];
 };
 
 export const BuilderPreviewItem = ({
@@ -124,6 +125,7 @@ export const BuilderPreviewItem = ({
   globalProps,
   instance,
   isSelected,
+  isSelectMode,
   kitsByName,
   onDragEndDrag,
   onDragOverTarget,
@@ -134,7 +136,7 @@ export const BuilderPreviewItem = ({
   onDropKit,
   onMoveInstance,
   onSelect,
-  selectedId,
+  selectedIds,
 }: BuilderPreviewItemProps) => {
   const kit = kitsByName[instance.kitName];
   const Component = kit?.kit_schema?.name
@@ -148,7 +150,8 @@ export const BuilderPreviewItem = ({
       draggingInstanceId={draggingInstanceId}
       globalProps={globalProps}
       instance={child}
-      isSelected={child.id === selectedId}
+      isSelectMode={isSelectMode}
+      isSelected={selectedIds.includes(child.id)}
       key={child.id}
       kitsByName={kitsByName}
       onDragEndDrag={onDragEndDrag}
@@ -160,7 +163,7 @@ export const BuilderPreviewItem = ({
       onDropKit={onDropKit}
       onMoveInstance={onMoveInstance}
       onSelect={onSelect}
-      selectedId={selectedId}
+      selectedIds={selectedIds}
     />
   ));
   const canRenderChildren = acceptsChildren(kit);
@@ -278,13 +281,13 @@ export const BuilderPreviewItem = ({
       }}
       onClick={(event) => {
         event.stopPropagation();
-        onSelect(instance.id);
+        onSelect(instance.id, isSelectMode);
       }}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           event.stopPropagation();
-          onSelect(instance.id);
+          onSelect(instance.id, isSelectMode);
         }
       }}
       role="button"

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundCanvas.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundCanvas.tsx
@@ -2,10 +2,12 @@ import React, { useState } from "react";
 import {
   Badge,
   Button,
+  Caption,
   Card,
   Flex,
   FullScreen,
   Title,
+  Toggle,
 } from "playbook-ui";
 
 import {
@@ -25,8 +27,9 @@ type PlaygroundCanvasProps = {
   globalProps?: Record<string, PropDefinition>;
   instanceCount: number;
   instances: BuilderInstance[];
+  isSelectMode: boolean;
   kitsByName: Record<string, PlaygroundKit>;
-  selectedId: string | null;
+  selectedIds: string[];
   canDropIntoTarget: (targetId: string) => boolean;
   onCanvasClick: () => void;
   onCanvasDragLeave: (event: React.DragEvent<HTMLElement>) => void;
@@ -48,7 +51,8 @@ type PlaygroundCanvasProps = {
   ) => void;
   onLeaveDragTarget: (targetId: string) => void;
   onMoveInstance: (instanceId: string, targetId: string) => void;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, multi?: boolean) => void;
+  onToggleSelectMode: (isSelectMode: boolean) => void;
 };
 
 export const PlaygroundCanvas = ({
@@ -59,8 +63,9 @@ export const PlaygroundCanvas = ({
   globalProps,
   instanceCount,
   instances,
+  isSelectMode,
   kitsByName,
-  selectedId,
+  selectedIds,
   canDropIntoTarget,
   onCanvasClick,
   onCanvasDragLeave,
@@ -75,6 +80,7 @@ export const PlaygroundCanvas = ({
   onLeaveDragTarget,
   onMoveInstance,
   onSelect,
+  onToggleSelectMode,
 }: PlaygroundCanvasProps) => {
   const [isDemoFullscreen, setIsDemoFullscreen] = useState(false);
   const previewStageProps: PlaygroundPreviewStageProps = {
@@ -83,8 +89,9 @@ export const PlaygroundCanvas = ({
     draggingInstanceId,
     globalProps,
     instances,
+    isSelectMode,
     kitsByName,
-    selectedId,
+    selectedIds,
     onCanvasClick,
     onCanvasDragLeave,
     onCanvasDragOver,
@@ -131,12 +138,34 @@ export const PlaygroundCanvas = ({
                 variant="primary"
             />
           </Flex>
-          <Button
-              icon="expand"
-              onClick={() => setIsDemoFullscreen(true)}
-              text="Full Screen"
-              variant="secondary"
-          />
+          <Flex
+              align="center"
+              gap="sm"
+          >
+            <Flex
+                align="center"
+                className="builder-select-mode-toggle"
+                gap="xs"
+            >
+              <Toggle
+                  aria={{ label: "Select kits to wrap" }}
+                  checked={isSelectMode}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  onToggleSelectMode(event.target.checked)
+                }
+              />
+              <Caption
+                  color="lighter"
+                  text="Select kits to wrap"
+              />
+            </Flex>
+            <Button
+                icon="expand"
+                onClick={() => setIsDemoFullscreen(true)}
+                text="Full Screen"
+                variant="secondary"
+            />
+          </Flex>
         </Flex>
         <ResponsivePreviewFrame showDragHint>
           <PlaygroundPreviewStage {...previewStageProps} />

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
@@ -1,77 +1,118 @@
-import React from "react";
+import React, { useState } from "react";
 import { Body, Button, Caption, Flex, Title } from "playbook-ui";
+
+type ShareLoadStatus = "loaded" | "invalid" | null;
 
 type PlaygroundHeaderProps = {
   canRedo: boolean;
   canRestorePreviousState: boolean;
+  disableShare: boolean;
   kitCount: number;
   onClear: () => void;
   onRedo: () => void;
   onRestorePreviousState: () => void;
+  onShare: () => string;
+  shareStatus: ShareLoadStatus;
 };
 
 export const PlaygroundHeader = ({
   canRedo,
   canRestorePreviousState,
+  disableShare,
   kitCount,
   onClear,
   onRedo,
   onRestorePreviousState,
-}: PlaygroundHeaderProps) => (
-  <Flex
-      align="end"
-      className="full-playground-heading"
-      gap="md"
-      justify="between"
-      width="100%"
-  >
+  onShare,
+  shareStatus,
+}: PlaygroundHeaderProps) => {
+  const [shareCopyState, setShareCopyState] = useState(false);
+
+  const handleShareClick = async () => {
+    const url = onShare();
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setShareCopyState(true);
+      setTimeout(() => setShareCopyState(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy playground share link:", err);
+    }
+  };
+
+  return (
     <Flex
-        gap="xs"
-        orientation="column"
+        align="end"
+        className="full-playground-heading"
+        gap="md"
+        justify="between"
+        width="100%"
     >
-      <Caption
-          color="lighter"
-          text={`${kitCount} configured playground kits`}
-      />
-      <Title
-          size={1}
-          text="Playground"
-      />
-      <Body
-          color="light"
-          text="Build a UI by adding kits to the canvas, nesting kits inside children, and editing props. Copy the produced code snippet in the Code section to save and share your work."
-      />
-    </Flex>
-    <Flex
-        gap="xs"
-        orientation="column"
-    >
-      <Flex gap="xs">
-        <Button
-            disabled={!canRestorePreviousState}
-            icon="undo"
-            onClick={onRestorePreviousState}
-            text="Undo"
-            variant="secondary"
+      <Flex
+          gap="xs"
+          orientation="column"
+      >
+        <Caption
+            color="lighter"
+            text={`${kitCount} configured playground kits`}
         />
-        <Button
-            disabled={!canRedo}
-            icon="redo"
-            onClick={onRedo}
-            text="Redo"
-            variant="secondary"
+        <Title
+            size={1}
+            text="Playground"
         />
-        <Button
-            icon="trash"
-            onClick={onClear}
-            text="Clear"
-            variant="secondary"
+        <Body
+            color="light"
+            text="Build a UI by adding kits to the canvas, nesting kits inside children, and editing props. Use Share to send a live link to a teammate, or copy the produced code snippet in the Code section."
+        />
+        {shareStatus && (
+          <Caption
+              color={shareStatus === "loaded" ? "success" : "error"}
+              text={
+              shareStatus === "loaded"
+                ? "Loaded playground from a shared link."
+                : "That shared link couldn't be loaded — it may be corrupted or use kits that are no longer available."
+            }
+          />
+        )}
+      </Flex>
+      <Flex
+          gap="xs"
+          orientation="column"
+      >
+        <Flex gap="xs">
+          <Button
+              disabled={disableShare}
+              icon="link"
+              onClick={handleShareClick}
+              text={shareCopyState ? "Link copied!" : "Share"}
+              variant="primary"
+          />
+          <Button
+              disabled={!canRestorePreviousState}
+              icon="undo"
+              onClick={onRestorePreviousState}
+              text="Undo"
+              variant="secondary"
+          />
+          <Button
+              disabled={!canRedo}
+              icon="redo"
+              onClick={onRedo}
+              text="Redo"
+              variant="secondary"
+          />
+          <Button
+              icon="trash"
+              onClick={onClear}
+              text="Clear"
+              variant="secondary"
+          />
+        </Flex>
+        <Caption
+            color="lighter"
+            text="Autosaved in this browser as you work"
         />
       </Flex>
-      <Caption
-          color="lighter"
-          text="Autosaved in this browser as you work"
-      />
     </Flex>
-  </Flex>
-);
+  );
+};

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
@@ -2,16 +2,20 @@ import React from "react";
 import { Body, Button, Caption, Flex, Title } from "playbook-ui";
 
 type PlaygroundHeaderProps = {
+  canRedo: boolean;
   canRestorePreviousState: boolean;
   kitCount: number;
   onClear: () => void;
+  onRedo: () => void;
   onRestorePreviousState: () => void;
 };
 
 export const PlaygroundHeader = ({
+  canRedo,
   canRestorePreviousState,
   kitCount,
   onClear,
+  onRedo,
   onRestorePreviousState,
 }: PlaygroundHeaderProps) => (
   <Flex
@@ -38,19 +42,35 @@ export const PlaygroundHeader = ({
           text="Build a UI by adding kits to the canvas, nesting kits inside children, and editing props. Copy the produced code snippet in the Code section to save and share your work."
       />
     </Flex>
-    <Flex gap="xs">
-      <Button
-          disabled={!canRestorePreviousState}
-          icon="undo"
-          onClick={onRestorePreviousState}
-          text="Undo"
-          variant="secondary"
-      />
-      <Button
-          icon="trash"
-          onClick={onClear}
-          text="Clear"
-          variant="secondary"
+    <Flex
+        gap="xs"
+        orientation="column"
+    >
+      <Flex gap="xs">
+        <Button
+            disabled={!canRestorePreviousState}
+            icon="undo"
+            onClick={onRestorePreviousState}
+            text="Undo"
+            variant="secondary"
+        />
+        <Button
+            disabled={!canRedo}
+            icon="redo"
+            onClick={onRedo}
+            text="Redo"
+            variant="secondary"
+        />
+        <Button
+            icon="trash"
+            onClick={onClear}
+            text="Clear"
+            variant="secondary"
+        />
+      </Flex>
+      <Caption
+          color="lighter"
+          text="Autosaved in this browser as you work"
       />
     </Flex>
   </Flex>

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
@@ -11,7 +11,7 @@ type PlaygroundHeaderProps = {
   onClear: () => void;
   onRedo: () => void;
   onRestorePreviousState: () => void;
-  onShare: () => string;
+  onShare: () => Promise<string>;
   shareStatus: ShareLoadStatus;
 };
 
@@ -29,9 +29,8 @@ export const PlaygroundHeader = ({
   const [shareCopyState, setShareCopyState] = useState(false);
 
   const handleShareClick = async () => {
-    const url = onShare();
-
     try {
+      const url = await onShare();
       await navigator.clipboard.writeText(url);
       setShareCopyState(true);
       setTimeout(() => setShareCopyState(false), 2000);

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundHeader.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import { Body, Button, Caption, Flex, Title } from "playbook-ui";
 
+// This workspace's TypeScript (4.3.5) predates ClipboardItem in the bundled
+// DOM lib types, so declare it ourselves rather than bumping the shared
+// tsconfig `lib` target (see the same pattern in playgroundShareLink.ts).
+declare const ClipboardItem: any;
+
 type ShareLoadStatus = "loaded" | "invalid" | null;
 
 type PlaygroundHeaderProps = {
@@ -29,13 +34,39 @@ export const PlaygroundHeader = ({
   const [shareCopyState, setShareCopyState] = useState(false);
 
   const handleShareClick = async () => {
+    // onShare() awaits gzip compression before resolving, so awaiting it
+    // here first — then calling clipboard.writeText — puts the actual write
+    // outside the click's transient user-activation window. Browsers that
+    // enforce that (notably Safari) then reject the write. Calling
+    // clipboard.write() synchronously, with a ClipboardItem whose value is
+    // still a pending promise, keeps the write itself inside the gesture —
+    // the browser waits for the promise before committing the copy.
+    const urlPromise = onShare();
+
     try {
-      const url = await onShare();
-      await navigator.clipboard.writeText(url);
+      if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            "text/plain": urlPromise.then(
+              (url) => new Blob([url], { type: "text/plain" }),
+            ),
+          }),
+        ]);
+      } else {
+        await navigator.clipboard.writeText(await urlPromise);
+      }
+
       setShareCopyState(true);
       setTimeout(() => setShareCopyState(false), 2000);
     } catch (err) {
       console.error("Failed to copy playground share link:", err);
+
+      // Clipboard access can fail for reasons unrelated to the URL itself
+      // (permissions, insecure context, browser quirks) — fall back to a
+      // native prompt so the link is still recoverable instead of silently
+      // disappearing into the console.
+      const url = await urlPromise.catch(() => null);
+      if (url) window.prompt("Copy this link to share your playground:", url);
     }
   };
 

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
@@ -94,7 +94,7 @@ export const PlaygroundInspector = ({
       <Icon icon="circle-info" />
       </Tooltip>
       </Flex>
-      <Flex gap="xs">
+      <Flex gap="xs" width="100%">
         <Dropdown
             className={panelDropdownClassName("playground-panel", !!wrapTargetKitName)}
             clearable={false}

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
@@ -41,6 +41,7 @@ type PlaygroundInspectorProps = {
   onRemoveSelected: () => void;
   onSelectedInstanceChange: (id: string | null) => void;
   onStructureModeChange: (value: string | null) => void;
+  onUnwrap: () => void;
   onWrap: (wrapperKitName: string) => void;
 };
 
@@ -71,6 +72,7 @@ export const PlaygroundInspector = ({
   onRemoveSelected,
   onSelectedInstanceChange,
   onStructureModeChange,
+  onUnwrap,
   onWrap,
 }: PlaygroundInspectorProps) => {
   const [wrapTargetKitName, setWrapTargetKitName] = useState<string | null>(null);
@@ -227,6 +229,17 @@ export const PlaygroundInspector = ({
                       onClick={onAddInsideSelected}
                       size="sm"
                       text="Add Kits inside Selected Kit"
+                      variant="secondary"
+                  />
+                )}
+
+                {selectedInstance.children.length > 0 && (
+                  <Button
+                      fullWidth
+                      icon="box-open"
+                      onClick={onUnwrap}
+                      size="sm"
+                      text="Unwrap (Keep Kits inside Selected Kit)"
                       variant="secondary"
                   />
                 )}

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
@@ -221,7 +221,6 @@ export const PlaygroundInspector = ({
                     variant="secondary"
                 />
                 {acceptsChildren(selectedKit) && (
-                  <>
                   <Button
                       fullWidth
                       icon="plus"
@@ -230,7 +229,12 @@ export const PlaygroundInspector = ({
                       text="Add Kits inside Selected Kit"
                       variant="secondary"
                   />
-                  <Flex width="100%" gap="xs">
+                )}
+
+                <Flex
+                    gap="xs"
+                    width="100%"
+                >
                   <Button
                       icon="arrow-up"
                       onClick={() => onMoveSelected(-1)}
@@ -248,8 +252,6 @@ export const PlaygroundInspector = ({
                       width="100%"
                   />
                 </Flex>
-                </>
-                )}
 
                 {wrapControls}
 

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Body, Button, Caption, Card, Dropdown, Flex, Title } from "playbook-ui";
+import { Body, Button, Caption, Card, Dropdown, Flex, Title, Icon, Tooltip } from "playbook-ui";
 
 import { PropsPanel } from "../KitShow/Tabs/Playground";
 import type { PropValue } from "../KitShow/Tabs/Playground";
@@ -89,7 +89,11 @@ export const PlaygroundInspector = ({
         orientation="column"
         width="100%"
     >
-      <Caption text="Wrap in" />
+      <Flex align="center" gap="xs"><Caption text="Wrap Selected Kits" /> 
+      <Tooltip text="Toggle the 'Select Kits to Wrap' control to wrap selected kits within a new kit">
+      <Icon icon="circle-info" />
+      </Tooltip>
+      </Flex>
       <Flex gap="xs">
         <Dropdown
             className={panelDropdownClassName("playground-panel", !!wrapTargetKitName)}
@@ -110,6 +114,7 @@ export const PlaygroundInspector = ({
             onClick={handleWrapClick}
             text="Wrap"
             variant="secondary"
+            size="sm"
         />
       </Flex>
       {wrapDiagnostic && (
@@ -216,13 +221,34 @@ export const PlaygroundInspector = ({
                     variant="secondary"
                 />
                 {acceptsChildren(selectedKit) && (
+                  <>
                   <Button
+                      fullWidth
                       icon="plus"
                       onClick={onAddInsideSelected}
                       size="sm"
-                      text="Add kits inside this"
+                      text="Add Kits inside Selected Kit"
                       variant="secondary"
                   />
+                  <Flex width="100%" gap="xs">
+                  <Button
+                      icon="arrow-up"
+                      onClick={() => onMoveSelected(-1)}
+                      size="sm"
+                      text="Move Kit Up"
+                      variant="secondary"
+                      width="100%"
+                  />
+                  <Button
+                      icon="arrow-down"
+                      onClick={() => onMoveSelected(1)}
+                      size="sm"
+                      text="Move Kit Down"
+                      variant="secondary"
+                      width="100%"
+                  />
+                </Flex>
+                </>
                 )}
 
                 {wrapControls}
@@ -282,23 +308,6 @@ export const PlaygroundInspector = ({
                     />
                   </Flex>
                 )}
-
-                <Flex gap="xs">
-                  <Button
-                      icon="arrow-up"
-                      onClick={() => onMoveSelected(-1)}
-                      size="sm"
-                      text="Up"
-                      variant="secondary"
-                  />
-                  <Button
-                      icon="arrow-down"
-                      onClick={() => onMoveSelected(1)}
-                      size="sm"
-                      text="Down"
-                      variant="secondary"
-                  />
-                </Flex>
               </Flex>
             )}
           </>

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundInspector.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Body, Button, Caption, Card, Dropdown, Flex, Title } from "playbook-ui";
 
 import { PropsPanel } from "../KitShow/Tabs/Playground";
@@ -21,6 +21,8 @@ type PlaygroundInspectorProps = {
   builderPropsPanel: BuilderPropsPanelState;
   dataPresetDropdownOptions: DropdownOption[];
   instanceOptionsCount: number;
+  isSelectMode: boolean;
+  multiSelectedCount: number;
   selectedDataPresetOptionsCount: number;
   selectedId: string | null;
   selectedInstance: BuilderInstance | null;
@@ -28,14 +30,18 @@ type PlaygroundInspectorProps = {
   selectedKit?: PlaygroundKit;
   selectedStructureModeOptionsCount: number;
   structureModeDropdownOptions: DropdownOption[];
+  wrapDiagnostic: string | null;
+  wrappableKitOptions: DropdownOption[];
   onAddInsideSelected: () => void;
   onChildrenChange: (value: string) => void;
+  onClearMultiSelect: () => void;
   onDataPresetChange: (value: string | null) => void;
   onMoveSelected: (direction: -1 | 1) => void;
   onPropChange: (name: string, value: PropValue) => void;
   onRemoveSelected: () => void;
   onSelectedInstanceChange: (id: string | null) => void;
   onStructureModeChange: (value: string | null) => void;
+  onWrap: (wrapperKitName: string) => void;
 };
 
 export const PlaygroundInspector = ({
@@ -45,6 +51,8 @@ export const PlaygroundInspector = ({
   builderPropsPanel,
   dataPresetDropdownOptions,
   instanceOptionsCount,
+  isSelectMode,
+  multiSelectedCount,
   selectedDataPresetOptionsCount,
   selectedId,
   selectedInstance,
@@ -52,186 +60,271 @@ export const PlaygroundInspector = ({
   selectedKit,
   selectedStructureModeOptionsCount,
   structureModeDropdownOptions,
+  wrapDiagnostic,
+  wrappableKitOptions,
   onAddInsideSelected,
   onChildrenChange,
+  onClearMultiSelect,
   onDataPresetChange,
   onMoveSelected,
   onPropChange,
   onRemoveSelected,
   onSelectedInstanceChange,
   onStructureModeChange,
-}: PlaygroundInspectorProps) => (
-  <Flex
-      alignSelf="start"
-      className="full-playground-inspector"
-      gap="md"
-      justifySelf="stretch"
-      maxWidth="500px"
-      minWidth="0"
-      orientation="column"
-      width="auto"
-  >
-    <Card
-        className="playground-panel-controls"
-        padding="md"
+  onWrap,
+}: PlaygroundInspectorProps) => {
+  const [wrapTargetKitName, setWrapTargetKitName] = useState<string | null>(null);
+  const activeWrapTargetOption =
+    wrappableKitOptions.find((option) => option.value === wrapTargetKitName) ??
+    undefined;
+
+  const handleWrapClick = () => {
+    if (wrapTargetKitName) onWrap(wrapTargetKitName);
+  };
+
+  const wrapControls = (
+    <Flex
+        className="builder-field"
+        gap="xs"
+        orientation="column"
+        width="100%"
     >
-      <Title
-          marginBottom="sm"
-          size={4}
-          text="Inspector"
-      />
-      {instanceOptionsCount > 0 && (
-        <Flex
-            className="builder-field"
-            gap="xs"
-            marginBottom="sm"
-            orientation="column"
-        >
-          <Caption text="Selected kit" />
-          <Dropdown
-              className={panelDropdownClassName("playground-panel", !!selectedId)}
-              clearable={false}
-              defaultValue={activeSelectedInstanceOption}
-              id="playground-selected-kit-dropdown"
-              key={selectedId ?? "none"}
-              onSelect={(option: { value: string } | null): null => {
-              onSelectedInstanceChange(option?.value || null);
-              return null;
-            }}
-              options={selectedInstanceOptions}
-              placeholder="Choose a placed kit"
-              width="100%"
-          />
-        </Flex>
-      )}
-
-      {!selectedInstance || !selectedKit ? (
-        <Body
-            color="light"
-            text={
-            instanceOptionsCount > 0
-              ? "Choose a placed kit to edit props and order."
-              : "Add a kit to start editing props and order."
-          }
-        />
-      ) : (
-        <Flex
-            gap="sm"
-            orientation="column"
+      <Caption text="Wrap in" />
+      <Flex gap="xs">
+        <Dropdown
+            className={panelDropdownClassName("playground-panel", !!wrapTargetKitName)}
+            clearable={false}
+            defaultValue={activeWrapTargetOption}
+            id="playground-wrap-target-dropdown"
+            onSelect={(option: { value: string } | null): null => {
+            setWrapTargetKitName(option?.value || null);
+            return null;
+          }}
+            options={wrappableKitOptions}
+            placeholder="Choose a wrapper kit"
             width="100%"
-        >
-          <Button
-              fullWidth
-              icon="trash"
-              onClick={onRemoveSelected}
-              text="Remove Selected Kit"
-              variant="secondary"
-          />
-          {acceptsChildren(selectedKit) && (
-            <Button
-                icon="plus"
-                onClick={onAddInsideSelected}
-                size="sm"
-                text="Add kits inside this"
-                variant="secondary"
+        />
+        <Button
+            disabled={!wrapTargetKitName || (isSelectMode && multiSelectedCount === 0)}
+            icon="layer-group"
+            onClick={handleWrapClick}
+            text="Wrap"
+            variant="secondary"
+        />
+      </Flex>
+      {wrapDiagnostic && (
+        <Caption
+            color="error"
+            text={wrapDiagnostic}
+        />
+      )}
+    </Flex>
+  );
+
+  return (
+    <Flex
+        alignSelf="start"
+        className="full-playground-inspector"
+        gap="md"
+        justifySelf="stretch"
+        maxWidth="sm"
+        minWidth="0"
+        orientation="column"
+        width="auto"
+    >
+      <Card
+          className="playground-panel-controls"
+          padding="md"
+      >
+        <Title
+            marginBottom="sm"
+            size={4}
+            text="Inspector"
+        />
+        {isSelectMode ? (
+          <Flex
+              gap="sm"
+              orientation="column"
+              width="100%"
+          >
+            <Caption
+                color="lighter"
+                text={
+                multiSelectedCount > 0
+                  ? `${multiSelectedCount} kit${multiSelectedCount === 1 ? "" : "s"} selected`
+                  : "Click kits on the canvas to select them"
+              }
             />
-          )}
-
-          {selectedDataPresetOptionsCount > 0 && (
-            <Flex
-                className="builder-field"
-                gap="xs"
-                marginBottom="sm"
-                orientation="column"
-                width="100%"
-            >
-              <Caption text="Data" />
-              <Dropdown
-                  className={panelDropdownClassName(
-                  "playground-panel",
-                  !!selectedInstance.dataPresetKey,
-                )}
-                  clearable={false}
-                  defaultValue={activeDataPresetOption}
-                  id="playground-data-preset-dropdown"
-                  key={`${selectedInstance.id}-data-${selectedInstance.dataPresetKey ?? ""}`}
-                  onSelect={(option: { value: string } | null): null => {
-                  onDataPresetChange(option?.value || null);
-                  return null;
-                }}
-                  options={dataPresetDropdownOptions}
-                  width="100%"
-              />
-            </Flex>
-          )}
-
-          {selectedStructureModeOptionsCount > 1 && (
-            <Flex
-                className="builder-field"
-                gap="xs"
-                marginBottom="sm"
-                orientation="column"
-                width="100%"
-            >
-              <Caption text="Structure" />
-              <Dropdown
-                  className={panelDropdownClassName(
-                  "playground-panel",
-                  !!selectedInstance.structureMode,
-                )}
-                  clearable={false}
-                  defaultValue={activeStructureModeOption}
-                  id="playground-structure-mode-dropdown"
-                  key={`${selectedInstance.id}-structure-${selectedInstance.structureMode ?? ""}`}
-                  onSelect={(option: { value: string } | null): null => {
-                  onStructureModeChange(option?.value || null);
-                  return null;
-                }}
-                  options={structureModeDropdownOptions}
-                  width="100%"
-              />
-            </Flex>
-          )}
-
-          <Flex gap="xs">
+            {wrapControls}
             <Button
-                icon="arrow-up"
-                onClick={() => onMoveSelected(-1)}
+                disabled={multiSelectedCount === 0}
+                fullWidth
+                icon="times"
+                onClick={onClearMultiSelect}
                 size="sm"
-                text="Up"
-                variant="secondary"
-            />
-            <Button
-                icon="arrow-down"
-                onClick={() => onMoveSelected(1)}
-                size="sm"
-                text="Down"
+                text="Clear Selection"
                 variant="secondary"
             />
           </Flex>
-        </Flex>
-      )}
-    </Card>
+        ) : (
+          <>
+            {instanceOptionsCount > 0 && (
+              <Flex
+                  className="builder-field"
+                  gap="xs"
+                  marginBottom="sm"
+                  orientation="column"
+              >
+                <Caption text="Selected kit" />
+                <Dropdown
+                    className={panelDropdownClassName("playground-panel", !!selectedId)}
+                    clearable={false}
+                    defaultValue={activeSelectedInstanceOption}
+                    id="playground-selected-kit-dropdown"
+                    key={selectedId ?? "none"}
+                    onSelect={(option: { value: string } | null): null => {
+                    onSelectedInstanceChange(option?.value || null);
+                    return null;
+                  }}
+                    options={selectedInstanceOptions}
+                    placeholder="Choose a placed kit"
+                    width="100%"
+                />
+              </Flex>
+            )}
 
-    {selectedInstance && selectedKit && (
-      <PropsPanel
-          // PropsPanel uses `children` as an editable code string prop.
-          // eslint-disable-next-line react/no-children-prop
-          children={builderPropsPanel.children}
-          globalProps={builderPropsPanel.globalProps}
-          groupedGlobalProps={builderPropsPanel.groupedGlobalProps}
-          groupedProps={builderPropsPanel.groupedProps}
-          onChildrenChange={onChildrenChange}
-          onPropChange={onPropChange}
-          playgroundConfig={builderPropsPanel.playgroundConfig}
-          propDisabledState={builderPropsPanel.propDisabledState}
-          propSyncHints={builderPropsPanel.propSyncHints}
-          propValues={builderPropsPanel.displayPropValues}
-          requiredPropNames={builderPropsPanel.requiredPropNames}
-          showChildren={builderPropsPanel.showChildren}
-          showGlobalProps={builderPropsPanel.showGlobalProps}
-          totalProps={builderPropsPanel.totalProps}
-      />
-    )}
-  </Flex>
-);
+            {!selectedInstance || !selectedKit ? (
+              <Body
+                  color="light"
+                  text={
+                  instanceOptionsCount > 0
+                    ? "Choose a placed kit to edit props and order. Turn on \"Select kits to wrap\" above the canvas to select several and wrap them together."
+                    : "Add a kit to start editing props and order."
+                }
+              />
+            ) : (
+              <Flex
+                  gap="sm"
+                  orientation="column"
+                  width="100%"
+              >
+                <Button
+                    fullWidth
+                    icon="trash"
+                    onClick={onRemoveSelected}
+                    text="Remove Selected Kit"
+                    variant="secondary"
+                />
+                {acceptsChildren(selectedKit) && (
+                  <Button
+                      icon="plus"
+                      onClick={onAddInsideSelected}
+                      size="sm"
+                      text="Add kits inside this"
+                      variant="secondary"
+                  />
+                )}
+
+                {wrapControls}
+
+                {selectedDataPresetOptionsCount > 0 && (
+                  <Flex
+                      className="builder-field"
+                      gap="xs"
+                      marginBottom="sm"
+                      orientation="column"
+                      width="100%"
+                  >
+                    <Caption text="Data" />
+                    <Dropdown
+                        className={panelDropdownClassName(
+                        "playground-panel",
+                        !!selectedInstance.dataPresetKey,
+                      )}
+                        clearable={false}
+                        defaultValue={activeDataPresetOption}
+                        id="playground-data-preset-dropdown"
+                        key={`${selectedInstance.id}-data-${selectedInstance.dataPresetKey ?? ""}`}
+                        onSelect={(option: { value: string } | null): null => {
+                        onDataPresetChange(option?.value || null);
+                        return null;
+                      }}
+                        options={dataPresetDropdownOptions}
+                        width="100%"
+                    />
+                  </Flex>
+                )}
+
+                {selectedStructureModeOptionsCount > 1 && (
+                  <Flex
+                      className="builder-field"
+                      gap="xs"
+                      marginBottom="sm"
+                      orientation="column"
+                      width="100%"
+                  >
+                    <Caption text="Structure" />
+                    <Dropdown
+                        className={panelDropdownClassName(
+                        "playground-panel",
+                        !!selectedInstance.structureMode,
+                      )}
+                        clearable={false}
+                        defaultValue={activeStructureModeOption}
+                        id="playground-structure-mode-dropdown"
+                        key={`${selectedInstance.id}-structure-${selectedInstance.structureMode ?? ""}`}
+                        onSelect={(option: { value: string } | null): null => {
+                        onStructureModeChange(option?.value || null);
+                        return null;
+                      }}
+                        options={structureModeDropdownOptions}
+                        width="100%"
+                    />
+                  </Flex>
+                )}
+
+                <Flex gap="xs">
+                  <Button
+                      icon="arrow-up"
+                      onClick={() => onMoveSelected(-1)}
+                      size="sm"
+                      text="Up"
+                      variant="secondary"
+                  />
+                  <Button
+                      icon="arrow-down"
+                      onClick={() => onMoveSelected(1)}
+                      size="sm"
+                      text="Down"
+                      variant="secondary"
+                  />
+                </Flex>
+              </Flex>
+            )}
+          </>
+        )}
+      </Card>
+
+      {!isSelectMode && selectedInstance && selectedKit && (
+        <PropsPanel
+            // PropsPanel uses `children` as an editable code string prop.
+            // eslint-disable-next-line react/no-children-prop
+            children={builderPropsPanel.children}
+            globalProps={builderPropsPanel.globalProps}
+            groupedGlobalProps={builderPropsPanel.groupedGlobalProps}
+            groupedProps={builderPropsPanel.groupedProps}
+            onChildrenChange={onChildrenChange}
+            onPropChange={onPropChange}
+            playgroundConfig={builderPropsPanel.playgroundConfig}
+            propDisabledState={builderPropsPanel.propDisabledState}
+            propSyncHints={builderPropsPanel.propSyncHints}
+            propValues={builderPropsPanel.displayPropValues}
+            requiredPropNames={builderPropsPanel.requiredPropNames}
+            showChildren={builderPropsPanel.showChildren}
+            showGlobalProps={builderPropsPanel.showGlobalProps}
+            totalProps={builderPropsPanel.totalProps}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundPreviewStage.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundPreviewStage.tsx
@@ -10,9 +10,10 @@ export type PlaygroundPreviewStageProps = {
   draggingInstanceId: string | null;
   globalProps?: Record<string, PropDefinition>;
   instances: BuilderInstance[];
+  isSelectMode: boolean;
   kitsByName: Record<string, PlaygroundKit>;
   minHeight?: string;
-  selectedId: string | null;
+  selectedIds: string[];
   canDropIntoTarget: (targetId: string) => boolean;
   onCanvasClick: () => void;
   onCanvasDragLeave: (event: React.DragEvent<HTMLElement>) => void;
@@ -34,7 +35,7 @@ export type PlaygroundPreviewStageProps = {
   ) => void;
   onLeaveDragTarget: (targetId: string) => void;
   onMoveInstance: (instanceId: string, targetId: string) => void;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, multi?: boolean) => void;
 };
 
 export const PlaygroundPreviewStage = ({
@@ -43,9 +44,10 @@ export const PlaygroundPreviewStage = ({
   draggingInstanceId,
   globalProps,
   instances,
+  isSelectMode,
   kitsByName,
   minHeight = "360px",
-  selectedId,
+  selectedIds,
   onCanvasClick,
   onCanvasDragLeave,
   onCanvasDragOver,
@@ -106,7 +108,8 @@ export const PlaygroundPreviewStage = ({
             draggingInstanceId={draggingInstanceId}
             globalProps={globalProps}
             instance={instance}
-            isSelected={instance.id === selectedId}
+            isSelectMode={isSelectMode}
+            isSelected={selectedIds.includes(instance.id)}
             key={instance.id}
             kitsByName={kitsByName}
             onDragEndDrag={onDragEndDrag}
@@ -124,7 +127,7 @@ export const PlaygroundPreviewStage = ({
             onMoveInstance(instanceId, targetId);
           }}
             onSelect={onSelect}
-            selectedId={selectedId}
+            selectedIds={selectedIds}
         />
       ))
     )}

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundPromptBuilder.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PlaygroundPromptBuilder.tsx
@@ -1,5 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Body, Button, Caption, Card, Flex, Icon, Title } from "playbook-ui";
+
+// One example per built-in recipe category (see PromtBuilderRecipes/index.ts)
+// so the vocabulary this local recipe matcher understands is discoverable —
+// there's no LLM behind this to interpret an open-ended ask.
+const EXAMPLE_PROMPTS = [
+  "Settings page with two cards, fields, and toggles",
+  "Dashboard with stats and a bar chart",
+  "Contact form with name, email, and submit button",
+  "Data table with a filter",
+  "Empty state for no search results",
+];
+
+const MAX_VISIBLE_DIAGNOSTICS = 6;
 
 type PlaygroundPromptBuilderProps = {
   clearSignal: number;
@@ -27,15 +40,40 @@ export const PlaygroundPromptBuilder = ({
   onSubmit,
 }: PlaygroundPromptBuilderProps) => {
   const [promptText, setPromptText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
     setPromptText("");
   }, [clearSignal]);
 
+  useEffect(() => {
+    if (!isMinimized) textareaRef.current?.focus();
+  }, [isMinimized]);
+
   const handleClear = () => {
     setPromptText("");
     onClear();
   };
+
+  const handleSubmit = () => {
+    if (!promptText.trim()) return;
+    onSubmit(promptText);
+  };
+
+  const handleTextareaKeyDown = (
+    event: React.KeyboardEvent<HTMLTextAreaElement>,
+  ) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      handleSubmit();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      onMinimize();
+    }
+  };
+
+  const visibleDiagnostics = diagnostics.slice(0, MAX_VISIBLE_DIAGNOSTICS);
+  const hiddenDiagnosticsCount = diagnostics.length - visibleDiagnostics.length;
 
   return (
     <>
@@ -95,10 +133,29 @@ export const PlaygroundPromptBuilder = ({
           <textarea
               className="builder-prompt-textarea"
               onChange={(event) => setPromptText(event.target.value)}
+              onKeyDown={handleTextareaKeyDown}
               placeholder="Example: Build a compact settings page with two cards, fields, toggles, and save/cancel actions."
+              ref={textareaRef}
               tabIndex={isMinimized ? -1 : 0}
               value={promptText}
           />
+        </Flex>
+        <Flex
+            className="builder-prompt-examples"
+            gap="xs"
+            marginBottom="sm"
+        >
+          {EXAMPLE_PROMPTS.map((example) => (
+            <button
+                className="builder-prompt-example-chip"
+                key={example}
+                onClick={() => setPromptText(example)}
+                tabIndex={isMinimized ? -1 : 0}
+                type="button"
+            >
+              {example}
+            </button>
+          ))}
         </Flex>
         <Flex
             gap="xs"
@@ -109,7 +166,7 @@ export const PlaygroundPromptBuilder = ({
                 disabled={!promptText.trim()}
                 fullWidth
                 icon="sparkles"
-                onClick={() => onSubmit(promptText)}
+                onClick={handleSubmit}
                 text="Build"
             />
           </Flex>
@@ -148,13 +205,19 @@ export const PlaygroundPromptBuilder = ({
               marginTop="xs"
               orientation="column"
           >
-            {diagnostics.slice(0, 4).map((diagnostic) => (
+            {visibleDiagnostics.map((diagnostic) => (
               <Caption
                   color="lighter"
                   key={diagnostic}
                   text={diagnostic}
               />
             ))}
+            {hiddenDiagnosticsCount > 0 && (
+              <Caption
+                  color="lighter"
+                  text={`+${hiddenDiagnosticsCount} more`}
+              />
+            )}
           </Flex>
         )}
       </Card>

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PromtBuilderRecipes/index.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PromtBuilderRecipes/index.ts
@@ -33,7 +33,7 @@ export const buildPromptPlanFromRecipes = (
     instances = buildProfilePlan(prompt);
   } else if (promptIncludesAny(prompt, ["table", "records", "data grid"])) {
     instances = buildTablePlan(prompt);
-  } else if (promptIncludesAny(prompt, ["form", "fields", "input"])) {
+  } else if (promptIncludesAny(prompt, ["form", "fields", "input", "crud"])) {
     instances = buildFormPlan(prompt);
   } else {
     instances = buildDirectKitRecipeItems(prompt, kitsByName);

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PromtBuilderRecipes/modifiers.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PromtBuilderRecipes/modifiers.ts
@@ -5,7 +5,12 @@ import {
   getAllPropDefinitionsWithGlobals,
 } from "../kitUtils";
 import type { BuilderInstance, PlaygroundKit, PropDefinition } from "../types";
-import { normalizePrompt, promptIncludesAny } from "./utils";
+import {
+  escapeRegExp,
+  normalizePrompt,
+  promptHasTerm,
+  promptIncludesAny,
+} from "./utils";
 
 type PromptModificationResult = {
   diagnostics: string[];
@@ -39,9 +44,21 @@ const KIT_ALIASES: KitAlias[] = [
   { kitName: "pb_gauge_chart", aliases: ["gauge chart"] },
   { kitName: "section_separator", aliases: ["section separator", "separator"] },
   { kitName: "text_input", aliases: ["text input", "input", "field"] },
+  { kitName: "textarea", aliases: ["textarea", "text area", "notes"] },
   { kitName: "table", aliases: ["table"] },
   { kitName: "filter", aliases: ["filter"] },
   { kitName: "card", aliases: ["card", "car", "panel"] },
+  // Kept in sync with aliases.ts's KIT_ALIASES so a kit recognized when
+  // adding to an empty canvas is also recognized when swapping it in place.
+  { kitName: "badge", aliases: ["badge", "status badge"] },
+  { kitName: "button", aliases: ["button", "cta"] },
+  { kitName: "checkbox", aliases: ["checkbox", "check box"] },
+  { kitName: "date_picker", aliases: ["date picker", "date field"] },
+  { kitName: "dropdown", aliases: ["dropdown"] },
+  { kitName: "list", aliases: ["list"] },
+  { kitName: "message", aliases: ["message", "alert", "notice"] },
+  { kitName: "select", aliases: ["select", "picklist"] },
+  { kitName: "toggle", aliases: ["toggle", "switch"] },
 ];
 
 const PROP_ALIASES: Record<string, string[]> = {
@@ -70,6 +87,15 @@ const VALUE_ALIASES: Array<{ aliases: string[]; value: unknown }> = [
 
 const REPLACE_WORDS = ["replace", "swap", "change"];
 const PROP_EDIT_WORDS = ["set", "make", "making", "update", "change"];
+// "for" covers idiomatic phrasing like "change X input for Y input" or
+// "swap the bar chart for a line chart", not just "replace X with Y".
+const REPLACE_SEPARATORS = [" with ", " to ", " for "];
+
+// Kits identified as a single labeled "field" — a rename request between two
+// of these (e.g. "change email input for phone input") should relabel the
+// matching instance in place rather than swap it for a blank default one.
+const FIELD_KIT_NAMES = new Set(["text_input", "textarea"]);
+const FIELD_ALIAS_WORDS = ["text input", "text area", "input", "field", "textarea"];
 
 const normalizeKitKey = (kitName: string) =>
   kitName
@@ -79,20 +105,6 @@ const normalizeKitKey = (kitName: string) =>
     .replace(/[\s-]+/g, "_")
     .replace(/^_+/, "")
     .replace(/^(pb_)+/, "");
-
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-const promptHasAlias = (text: string, alias: string) => {
-  const normalizedAlias = normalizePrompt(alias);
-  if (!normalizedAlias) return false;
-
-  if (normalizedAlias.length <= 3 && !normalizedAlias.includes(" ")) {
-    return new RegExp(`(^|\\s)${escapeRegExp(normalizedAlias)}(?=\\s|$)`).test(text);
-  }
-
-  return text.includes(normalizedAlias);
-};
 
 const kitNamesMatch = (candidate: string, target: string) => {
   if (candidate === target) return true;
@@ -120,7 +132,7 @@ const instanceMatchesKitName = (
 const findKitAliasInText = (text: string, allowedKits?: Set<string>) =>
   KIT_ALIASES.find(({ aliases, kitName }) => {
     if (allowedKits && !allowedKits.has(kitName)) return false;
-    return aliases.some((alias) => promptHasAlias(text, alias));
+    return aliases.some((alias) => promptHasTerm(text, alias));
   })?.kitName ?? null;
 
 const getTextAfterAny = (prompt: string, separators: string[]) => {
@@ -256,12 +268,12 @@ const coercePropValue = (
 
 const parsePropEdit = (prompt: string): PropEdit | null => {
   const propName = Object.entries(PROP_ALIASES).find(([, aliases]) =>
-    aliases.some((alias) => promptHasAlias(prompt, alias))
+    aliases.some((alias) => promptHasTerm(prompt, alias))
   )?.[0];
   if (!propName) return null;
 
   const value = VALUE_ALIASES.find(({ aliases }) =>
-    aliases.some((alias) => promptHasAlias(prompt, alias))
+    aliases.some((alias) => promptHasTerm(prompt, alias))
   )?.value;
   if (value === undefined) return null;
 
@@ -339,6 +351,118 @@ const updateFirstMatchingProp = (
   return { changed, diagnostics, instances: nextInstances };
 };
 
+const toTitleCase = (text: string) =>
+  text.replace(/\b\w/g, (character) => character.toUpperCase());
+
+// Strips leading replace verbs/articles and the trailing field-alias word
+// itself, leaving just the label: "change x input" -> "x", "y field" -> "y".
+const extractFieldLabel = (text: string): string | null => {
+  let cleaned = text.trim();
+
+  REPLACE_WORDS.forEach((word) => {
+    cleaned = cleaned.replace(new RegExp(`^${escapeRegExp(word)}\\s+`), "");
+  });
+  cleaned = cleaned.replace(/^(the|this|that|a|an)\s+/, "");
+
+  const aliasPattern = new RegExp(
+    `\\s*(${FIELD_ALIAS_WORDS.map(escapeRegExp).join("|")})\\s*$`
+  );
+  cleaned = cleaned.replace(aliasPattern, "").trim();
+
+  return cleaned.length > 0 ? cleaned : null;
+};
+
+const findFieldInstanceByLabel = (
+  instances: BuilderInstance[],
+  label: string
+): BuilderInstance | null => {
+  for (const instance of instances) {
+    const currentLabel = normalizePrompt(String(instance.props.label ?? ""));
+    if (FIELD_KIT_NAMES.has(instance.kitName) && currentLabel === label) {
+      return instance;
+    }
+
+    const match = findFieldInstanceByLabel(instance.children, label);
+    if (match) return match;
+  }
+
+  return null;
+};
+
+const renameFieldInstance = (
+  instances: BuilderInstance[],
+  targetId: string,
+  destinationLabel: string
+): BuilderInstance[] =>
+  instances.map((instance) => {
+    if (instance.id === targetId) {
+      return {
+        ...instance,
+        props: {
+          ...instance.props,
+          label: destinationLabel,
+          name: destinationLabel.toLowerCase().replace(/\s+/g, "_"),
+          placeholder: destinationLabel,
+        },
+        enabledProps: {
+          ...instance.enabledProps,
+          label: true,
+          name: true,
+          placeholder: true,
+        },
+      };
+    }
+
+    return {
+      ...instance,
+      children: renameFieldInstance(instance.children, targetId, destinationLabel),
+    };
+  });
+
+const applyFieldRenamePrompt = (
+  prompt: string,
+  instances: BuilderInstance[]
+): PromptModificationResult | null => {
+  if (!promptIncludesAny(prompt, REPLACE_WORDS)) return null;
+
+  const destinationText = getTextAfterAny(prompt, REPLACE_SEPARATORS);
+  const sourceText = getTextBeforeAny(prompt, REPLACE_SEPARATORS);
+  if (!destinationText || sourceText === prompt) return null;
+
+  // Only take over when both sides name a "field" — a true kit-type swap
+  // (e.g. "swap the table for a data grid") falls through to
+  // applyReplacementPrompt instead.
+  const sourceIsField = FIELD_ALIAS_WORDS.some((alias) =>
+    promptHasTerm(sourceText, alias)
+  );
+  const destinationIsField = FIELD_ALIAS_WORDS.some((alias) =>
+    promptHasTerm(destinationText, alias)
+  );
+  if (!sourceIsField || !destinationIsField) return null;
+
+  const sourceLabel = extractFieldLabel(sourceText);
+  const destinationLabel = extractFieldLabel(destinationText);
+  if (!sourceLabel || !destinationLabel) return null;
+
+  const targetInstance = findFieldInstanceByLabel(instances, sourceLabel);
+  if (!targetInstance) {
+    return {
+      diagnostics: [`Could not find a field labeled "${sourceLabel}" to rename.`],
+      handled: true,
+      instances,
+    };
+  }
+
+  const destinationLabelText = toTitleCase(destinationLabel);
+
+  return {
+    diagnostics: [],
+    handled: true,
+    instances: renameFieldInstance(instances, targetInstance.id, destinationLabelText),
+    summary: `Renamed "${toTitleCase(sourceLabel)}" field to "${destinationLabelText}".`,
+  };
+};
+
 const applyReplacementPrompt = (
   prompt: string,
   instances: BuilderInstance[],
@@ -347,8 +471,8 @@ const applyReplacementPrompt = (
 ): PromptModificationResult | null => {
   if (!promptIncludesAny(prompt, REPLACE_WORDS)) return null;
 
-  const destinationText = getTextAfterAny(prompt, [" with ", " to "]);
-  const sourceText = getTextBeforeAny(prompt, [" with ", " to "]);
+  const destinationText = getTextAfterAny(prompt, REPLACE_SEPARATORS);
+  const sourceText = getTextBeforeAny(prompt, REPLACE_SEPARATORS);
   const destinationKitName = findKitAliasInText(
     destinationText,
     new Set(Object.keys(kitsByName))
@@ -434,6 +558,7 @@ export const applyPromptModification = (
 ): PromptModificationResult => {
   const prompt = normalizePrompt(rawPrompt);
   const modification =
+    applyFieldRenamePrompt(prompt, instances) ??
     applyReplacementPrompt(prompt, instances, kitsByName, globalProps) ??
     applyPropEditPrompt(prompt, instances, kitsByName, globalProps);
 

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/PromtBuilderRecipes/utils.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/PromtBuilderRecipes/utils.ts
@@ -15,8 +15,27 @@ export const normalizePrompt = (prompt: string) =>
     .replace(/\s+/g, " ")
     .trim();
 
+export const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Single-word terms match on word boundaries so "form" doesn't fire inside
+// "performance" or "platform"; multi-word phrases stay a plain substring
+// check since they're already specific enough to rarely false-positive.
+export const promptHasTerm = (prompt: string, term: string) => {
+  const normalizedTerm = normalizePrompt(term);
+  if (!normalizedTerm) return false;
+
+  if (!normalizedTerm.includes(" ")) {
+    return new RegExp(`(^|\\s)${escapeRegExp(normalizedTerm)}(?=\\s|$)`).test(
+      prompt,
+    );
+  }
+
+  return prompt.includes(normalizedTerm);
+};
+
 export const promptIncludesAny = (prompt: string, terms: string[]) =>
-  terms.some((term) => prompt.includes(term));
+  terms.some((term) => promptHasTerm(prompt, term));
 
 export const createKit = (
   kitName: string,
@@ -104,11 +123,11 @@ export const getFieldLabelsFromPrompt = (prompt: string) => {
 export const getScreenTitleFromPrompt = (prompt: string) => {
   const quoted = prompt.match(/"([^"]+)"/)?.[1];
   if (quoted) return quoted;
-  if (prompt.includes("settings")) return "Settings";
-  if (prompt.includes("dashboard")) return "Dashboard";
-  if (prompt.includes("billing")) return "Billing";
-  if (prompt.includes("profile")) return "Profile";
-  if (prompt.includes("table")) return "Records";
-  if (prompt.includes("form")) return "New Record";
+  if (promptHasTerm(prompt, "settings")) return "Settings";
+  if (promptHasTerm(prompt, "dashboard")) return "Dashboard";
+  if (promptHasTerm(prompt, "billing")) return "Billing";
+  if (promptHasTerm(prompt, "profile")) return "Profile";
+  if (promptHasTerm(prompt, "table")) return "Records";
+  if (promptHasTerm(prompt, "form")) return "New Record";
   return "Generated Screen";
 };

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/codeGeneration.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/codeGeneration.ts
@@ -93,9 +93,6 @@ const renderCodeProps = (
       if (value === "" || value === null || value === undefined) return null;
 
       if (typeof value === "boolean" && value === true) return name;
-      if (typeof value === "string" && !displayPropType(definition).includes("function")) {
-        return `${name}=${JSON.stringify(value)}`;
-      }
 
       return `${name}={${formatCodeValue(value, definition)}}`;
     })

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -307,6 +307,18 @@ export default function Playground() {
       // import overwrites it — otherwise it's gone the moment autosave's
       // 400ms debounce fires, with no way back.
       savePlaygroundSnapshot();
+
+      // Persist the imported state synchronously, not via the debounced
+      // autosave effect: the share param above is already gone, so a
+      // reload/close inside that 400ms window would otherwise restore the
+      // previous canvas with no param left to retry the import from.
+      savePersistedPlaygroundState({
+        addTargetId: ROOT_TARGET_ID,
+        buildingBlockId: null,
+        instances: result.instances,
+        selectedId: null,
+      });
+
       setInstances(result.instances);
       setSelectedId(null);
       setAddTargetId(ROOT_TARGET_ID);

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -934,7 +934,7 @@ export default function Playground() {
             wrappableKitOptions={wrappableKitOptions}
         />
       </div>
-      <PlaygroundPromptBuilder
+      {/* <PlaygroundPromptBuilder
           clearSignal={promptClearSignal}
           diagnostics={promptDiagnostics}
           hasPreviousIteration={playgroundHistory.length > 0}
@@ -945,7 +945,7 @@ export default function Playground() {
           onRestorePreviousIteration={() => handleRestorePreviousPlaygroundState(true)}
           onSubmit={handlePromptSubmit}
           status={promptStatus}
-      />
+      /> */}
       <div
           aria-hidden
           className="builder-drag-tooltip"

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -847,7 +847,7 @@ export default function Playground() {
             structureModeDropdownOptions={structureModeDropdownOptions}
         />
       </div>
-      {/* <PlaygroundPromptBuilder
+      <PlaygroundPromptBuilder
           clearSignal={promptClearSignal}
           diagnostics={promptDiagnostics}
           hasPreviousIteration={playgroundHistory.length > 0}
@@ -858,7 +858,7 @@ export default function Playground() {
           onRestorePreviousIteration={() => handleRestorePreviousPlaygroundState(true)}
           onSubmit={handlePromptSubmit}
           status={promptStatus}
-      /> */}
+      />
       <div
           aria-hidden
           className="builder-drag-tooltip"

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -289,14 +289,17 @@ export default function Playground() {
       );
       if (cancelled || result.status === "none") return;
 
-      // A share link was present in the URL — consume it and strip the param
-      // so reloading or editing afterward doesn't keep re-importing it.
-      clearPlaygroundShareParam();
-
       if (result.status === "invalid") {
+        // Leave the param in place: stripping it here would make the error
+        // unrecoverable on refresh and the broken link impossible to retry
+        // or hand to someone else to debug.
         setShareStatus("invalid");
         return;
       }
+
+      // A share link was successfully consumed — strip the param so
+      // reloading or editing afterward doesn't keep re-importing it.
+      clearPlaygroundShareParam();
 
       // Preserve whatever was already on the canvas (e.g. restored from
       // localStorage on this same mount) as an undo point before a share

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -32,6 +32,7 @@ import {
   moveInstanceToTarget,
   removeInstanceFromTree,
   updateInstanceInTree,
+  wrapInstancesInTree,
 } from "./treeUtils";
 import { type BuildingBlock } from "./buildingBlocks";
 import { PlaygroundBuildingBlocks } from "./PlaygroundBuildingBlocks";
@@ -101,6 +102,11 @@ export default function Playground() {
   const [selectedId, setSelectedId] = useState<string | null>(
     () => persistedState?.selectedId ?? null,
   );
+  // Ids picked up while isSelectMode is on, for wrapping several kits at
+  // once. Empty outside of that flow — selectedId drives everything else.
+  const [isSelectMode, setIsSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [wrapDiagnostic, setWrapDiagnostic] = useState<string | null>(null);
   const [addTargetId, setAddTargetId] = useState(
     () => persistedState?.addTargetId ?? ROOT_TARGET_ID,
   );
@@ -152,6 +158,27 @@ export default function Playground() {
         formatKitName(a.name).localeCompare(formatKitName(b.name)),
       );
   }, [enabledPlaygroundKits, searchQuery]);
+
+  const wrappableKitOptions = useMemo(
+    () =>
+      enabledPlaygroundKits
+        .filter((kit) => acceptsChildren(kit))
+        .map((kit) => ({
+          id: kit.name,
+          label: formatKitName(kit.name),
+          value: kit.name,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [enabledPlaygroundKits],
+  );
+
+  // While select mode is on, highlighting reflects only the multi-selection
+  // (which can legitimately be empty after toggling everything off) —
+  // falling back to selectedId would show a stale, unrelated highlight.
+  const effectiveSelectedIds = useMemo(
+    () => (isSelectMode ? selectedIds : selectedId ? [selectedId] : []),
+    [isSelectMode, selectedId, selectedIds],
+  );
 
   const selectedInstance = findInstance(instances, selectedId);
   const selectedKit = selectedInstance
@@ -306,14 +333,61 @@ export default function Playground() {
     setInstances((current) => updateInstanceInTree(current, id, updater));
   };
 
-  const handleSelectInstance = (id: string) => {
+  const handleSelectInstance = (id: string, multi = false) => {
+    if (multi) {
+      setSelectedIds((current) =>
+        current.includes(id)
+          ? current.filter((existingId) => existingId !== id)
+          : [...current, id],
+      );
+      return;
+    }
+
     const instance = findInstance(instances, id);
     const kit = instance ? kitsByName[instance.kitName] : undefined;
 
+    setSelectedIds([]);
     setSelectedId(id);
     if (acceptsChildren(kit)) {
       setAddTargetId(id);
     }
+  };
+
+  const handleToggleSelectMode = (nextIsSelectMode: boolean) => {
+    setIsSelectMode(nextIsSelectMode);
+    setSelectedIds(nextIsSelectMode && selectedId ? [selectedId] : []);
+    setWrapDiagnostic(null);
+  };
+
+  const handleClearMultiSelect = () => {
+    setSelectedIds([]);
+    setWrapDiagnostic(null);
+  };
+
+  const handleWrapSelection = (wrapperKitName: string) => {
+    const wrapperKit = kitsByName[wrapperKitName];
+    if (!wrapperKit || !acceptsChildren(wrapperKit)) return;
+
+    const targetIds = selectedIds.length > 0 ? selectedIds : selectedId ? [selectedId] : [];
+    if (targetIds.length === 0) return;
+
+    const wrapperInstance = createInstance(wrapperKit, global_props_schema?.props);
+    const result = wrapInstancesInTree(instances, targetIds, wrapperInstance);
+
+    if (!result.wrapped) {
+      setWrapDiagnostic(
+        "Selected kits must be next to each other (same parent, no gaps) to wrap them together.",
+      );
+      return;
+    }
+
+    savePlaygroundSnapshot();
+    setActiveBuildingBlockId(null);
+    setInstances(result.instances);
+    setSelectedIds([]);
+    setSelectedId(wrapperInstance.id);
+    setAddTargetId(wrapperInstance.id);
+    setWrapDiagnostic(null);
   };
 
   const addKit = (kit: PlaygroundKit, targetId = activeAddTargetId) => {
@@ -658,6 +732,8 @@ export default function Playground() {
     setInstances([]);
     setActiveBuildingBlockId(null);
     setSelectedId(null);
+    setSelectedIds([]);
+    setWrapDiagnostic(null);
     setAddTargetId(ROOT_TARGET_ID);
     setPlaygroundHistory([]);
     setPlaygroundFuture([]);
@@ -804,8 +880,12 @@ export default function Playground() {
             globalProps={global_props_schema?.props}
             instanceCount={instanceCount}
             instances={instances}
+            isSelectMode={isSelectMode}
             kitsByName={kitsByName}
-            onCanvasClick={() => setSelectedId(null)}
+            onCanvasClick={() => {
+            setSelectedId(null);
+            setSelectedIds([]);
+          }}
             onCanvasDragLeave={handleCanvasDragLeave}
             onCanvasDragOver={handleCanvasDragOver}
             onCanvasDrop={handleCanvasDrop}
@@ -818,7 +898,8 @@ export default function Playground() {
             onLeaveDragTarget={handleLeaveDragTarget}
             onMoveInstance={handleMoveInstance}
             onSelect={handleSelectInstance}
-            selectedId={selectedId}
+            onToggleSelectMode={handleToggleSelectMode}
+            selectedIds={effectiveSelectedIds}
         />
 
         <PlaygroundInspector
@@ -828,16 +909,20 @@ export default function Playground() {
             builderPropsPanel={builderPropsPanel}
             dataPresetDropdownOptions={dataPresetDropdownOptions}
             instanceOptionsCount={instanceOptions.length}
+            isSelectMode={isSelectMode}
+            multiSelectedCount={selectedIds.length}
             onAddInsideSelected={() => {
             if (selectedInstance) setAddTargetId(selectedInstance.id);
           }}
             onChildrenChange={handleChildrenChange}
+            onClearMultiSelect={handleClearMultiSelect}
             onDataPresetChange={handleDataPresetChange}
             onMoveSelected={moveSelected}
             onPropChange={handlePropChange}
             onRemoveSelected={removeSelected}
             onSelectedInstanceChange={handleSelectedInstanceChange}
             onStructureModeChange={handleStructureModeChange}
+            onWrap={handleWrapSelection}
             selectedDataPresetOptionsCount={selectedDataPresetOptions.length}
             selectedId={selectedId}
             selectedInstance={selectedInstance}
@@ -845,6 +930,8 @@ export default function Playground() {
             selectedKit={selectedKit}
             selectedStructureModeOptionsCount={selectedStructureModeOptions.length}
             structureModeDropdownOptions={structureModeDropdownOptions}
+            wrapDiagnostic={wrapDiagnostic}
+            wrappableKitOptions={wrappableKitOptions}
         />
       </div>
       <PlaygroundPromptBuilder

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -298,6 +298,11 @@ export default function Playground() {
         return;
       }
 
+      // Preserve whatever was already on the canvas (e.g. restored from
+      // localStorage on this same mount) as an undo point before a share
+      // import overwrites it — otherwise it's gone the moment autosave's
+      // 400ms debounce fires, with no way back.
+      savePlaygroundSnapshot();
       setInstances(result.instances);
       setSelectedId(null);
       setAddTargetId(ROOT_TARGET_ID);

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -45,6 +45,12 @@ import {
   loadPersistedPlaygroundState,
   savePersistedPlaygroundState,
 } from "./playgroundStorage";
+import type { PersistedPlaygroundState } from "./playgroundStorage";
+import {
+  buildPlaygroundShareUrl,
+  clearPlaygroundShareParam,
+  readPlaygroundShareState,
+} from "./playgroundShareLink";
 import type {
   BuilderInstance,
   PlaygroundKit,
@@ -71,11 +77,52 @@ const cloneInstances = (items: BuilderInstance[]): BuilderInstance[] =>
     props: { ...instance.props },
   }));
 
+type ShareLoadStatus = "loaded" | "invalid" | null;
+
+type InitialPlaygroundLoad = {
+  shareStatus: ShareLoadStatus;
+  state: PersistedPlaygroundState | null;
+};
+
+const resolveInitialPlaygroundState = (
+  validKitNames: Set<string>,
+): InitialPlaygroundLoad => {
+  const shareResult = readPlaygroundShareState(validKitNames);
+
+  if (shareResult.status === "none") {
+    return {
+      shareStatus: null,
+      state: loadPersistedPlaygroundState(validKitNames),
+    };
+  }
+
+  // A share link was present in the URL — consume it and strip the param so
+  // reloading or editing afterward doesn't keep re-importing the shared state.
+  clearPlaygroundShareParam();
+
+  if (shareResult.status === "invalid") {
+    return {
+      shareStatus: "invalid",
+      state: loadPersistedPlaygroundState(validKitNames),
+    };
+  }
+
+  return {
+    shareStatus: "loaded",
+    state: {
+      addTargetId: ROOT_TARGET_ID,
+      buildingBlockId: null,
+      instances: shareResult.instances,
+      selectedId: null,
+    },
+  };
+};
+
 export default function Playground() {
   const { global_props_schema, playground_kits = [] } =
     useLoaderData() as PlaygroundLoaderData;
-  const [persistedState] = useState(() =>
-    loadPersistedPlaygroundState(
+  const [initialLoad] = useState(() =>
+    resolveInitialPlaygroundState(
       new Set(
         playground_kits
           .filter((kit) => PLAYGROUND_ENABLED_KITS.includes(kit.name))
@@ -83,6 +130,8 @@ export default function Playground() {
       ),
     ),
   );
+  const persistedState = initialLoad.state;
+  const [shareStatus] = useState<ShareLoadStatus>(initialLoad.shareStatus);
   const [instances, setInstances] = useState<BuilderInstance[]>(
     () => persistedState?.instances ?? [],
   );
@@ -723,10 +772,13 @@ export default function Playground() {
       <PlaygroundHeader
           canRedo={playgroundFuture.length > 0}
           canRestorePreviousState={playgroundHistory.length > 0}
+          disableShare={instanceCount === 0}
           kitCount={enabledPlaygroundKits.length}
           onClear={handleClearAll}
           onRedo={handleRedoPlaygroundState}
           onRestorePreviousState={() => handleRestorePreviousPlaygroundState()}
+          onShare={() => buildPlaygroundShareUrl(instances)}
+          shareStatus={shareStatus}
       />
 
       <PlaygroundBuildingBlocks

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -31,6 +31,7 @@ import {
   moveInstanceInTree,
   moveInstanceToTarget,
   removeInstanceFromTree,
+  unwrapInstanceInTree,
   updateInstanceInTree,
   wrapInstancesInTree,
 } from "./treeUtils";
@@ -577,6 +578,18 @@ export default function Playground() {
     if (addTargetId === selectedInstance.id) setAddTargetId(ROOT_TARGET_ID);
   };
 
+  const unwrapSelected = () => {
+    if (!selectedInstance) return;
+
+    const result = unwrapInstanceInTree(instances, selectedInstance.id);
+    if (!result.unwrapped) return;
+
+    savePlaygroundSnapshot();
+    setInstances(result.instances);
+    setSelectedId(selectedInstance.children[0]?.id ?? null);
+    if (addTargetId === selectedInstance.id) setAddTargetId(ROOT_TARGET_ID);
+  };
+
   const moveSelected = (direction: -1 | 1) => {
     if (!selectedInstance) return;
     savePlaygroundSnapshot();
@@ -930,6 +943,7 @@ export default function Playground() {
             onRemoveSelected={removeSelected}
             onSelectedInstanceChange={handleSelectedInstanceChange}
             onStructureModeChange={handleStructureModeChange}
+            onUnwrap={unwrapSelected}
             onWrap={handleWrapSelection}
             selectedDataPresetOptionsCount={selectedDataPresetOptions.length}
             selectedId={selectedId}

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useLoaderData } from "react-router-dom";
 import { Flex } from "playbook-ui";
 
@@ -40,6 +40,11 @@ import { PlaygroundHeader } from "./PlaygroundHeader";
 import { PlaygroundInspector } from "./PlaygroundInspector";
 import { PlaygroundPromptBuilder } from "./PlaygroundPromptBuilder";
 import { PlaygroundSidebar } from "./PlaygroundSidebar";
+import {
+  clearPersistedPlaygroundState,
+  loadPersistedPlaygroundState,
+  savePersistedPlaygroundState,
+} from "./playgroundStorage";
 import type {
   BuilderInstance,
   PlaygroundKit,
@@ -69,13 +74,28 @@ const cloneInstances = (items: BuilderInstance[]): BuilderInstance[] =>
 export default function Playground() {
   const { global_props_schema, playground_kits = [] } =
     useLoaderData() as PlaygroundLoaderData;
-  const [instances, setInstances] = useState<BuilderInstance[]>([]);
+  const [persistedState] = useState(() =>
+    loadPersistedPlaygroundState(
+      new Set(
+        playground_kits
+          .filter((kit) => PLAYGROUND_ENABLED_KITS.includes(kit.name))
+          .map((kit) => kit.name),
+      ),
+    ),
+  );
+  const [instances, setInstances] = useState<BuilderInstance[]>(
+    () => persistedState?.instances ?? [],
+  );
   const [activeBuildingBlockId, setActiveBuildingBlockId] = useState<
     string | null
-  >(null);
+  >(() => persistedState?.buildingBlockId ?? null);
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [addTargetId, setAddTargetId] = useState(ROOT_TARGET_ID);
+  const [selectedId, setSelectedId] = useState<string | null>(
+    () => persistedState?.selectedId ?? null,
+  );
+  const [addTargetId, setAddTargetId] = useState(
+    () => persistedState?.addTargetId ?? ROOT_TARGET_ID,
+  );
   const [dragOverTargetId, setDragOverTargetId] = useState<string | null>(null);
   const [draggedKitName, setDraggedKitName] = useState<string | null>(null);
   const [draggingInstanceId, setDraggingInstanceId] = useState<string | null>(null);
@@ -83,6 +103,7 @@ export default function Playground() {
   const [promptStatus, setPromptStatus] = useState<string | null>(null);
   const [promptDiagnostics, setPromptDiagnostics] = useState<string[]>([]);
   const [playgroundHistory, setPlaygroundHistory] = useState<PlaygroundSnapshot[]>([]);
+  const [playgroundFuture, setPlaygroundFuture] = useState<PlaygroundSnapshot[]>([]);
   const [isPromptMinimized, setIsPromptMinimized] = useState(true);
   const dragSourceElementRef = useRef<HTMLElement | null>(null);
   const dragOverTargetRef = useRef<string | null>(null);
@@ -208,17 +229,31 @@ export default function Playground() {
   );
   const instanceCount = useMemo(() => countInstances(instances), [instances]);
 
-  const savePlaygroundSnapshot = () => {
-    const snapshot = {
-      addTargetId,
-      buildingBlockId: activeBuildingBlockId,
-      instances: cloneInstances(instances),
-      selectedId,
-    };
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      savePersistedPlaygroundState({
+        addTargetId,
+        buildingBlockId: activeBuildingBlockId,
+        instances,
+        selectedId,
+      });
+    }, 400);
 
+    return () => window.clearTimeout(timeoutId);
+  }, [addTargetId, activeBuildingBlockId, instances, selectedId]);
+
+  const buildPlaygroundSnapshot = (): PlaygroundSnapshot => ({
+    addTargetId,
+    buildingBlockId: activeBuildingBlockId,
+    instances: cloneInstances(instances),
+    selectedId,
+  });
+
+  const savePlaygroundSnapshot = () => {
     setPlaygroundHistory((current) =>
-      [...current, snapshot].slice(-MAX_PLAYGROUND_HISTORY),
+      [...current, buildPlaygroundSnapshot()].slice(-MAX_PLAYGROUND_HISTORY),
     );
+    setPlaygroundFuture([]);
   };
 
   const updateInstance = (
@@ -541,6 +576,9 @@ export default function Playground() {
     if (!previous) return;
 
     setPlaygroundHistory((current) => current.slice(0, -1));
+    setPlaygroundFuture((current) =>
+      [...current, buildPlaygroundSnapshot()].slice(-MAX_PLAYGROUND_HISTORY),
+    );
     setInstances(cloneInstances(previous.instances));
     setSelectedId(previous.selectedId);
     setAddTargetId(previous.addTargetId);
@@ -550,6 +588,21 @@ export default function Playground() {
       setPromptStatus("Restored previous playground state.");
       setIsPromptMinimized(false);
     }
+  };
+
+  const handleRedoPlaygroundState = () => {
+    const next = playgroundFuture[playgroundFuture.length - 1];
+    if (!next) return;
+
+    setPlaygroundFuture((current) => current.slice(0, -1));
+    setPlaygroundHistory((current) =>
+      [...current, buildPlaygroundSnapshot()].slice(-MAX_PLAYGROUND_HISTORY),
+    );
+    setInstances(cloneInstances(next.instances));
+    setSelectedId(next.selectedId);
+    setAddTargetId(next.addTargetId);
+    setActiveBuildingBlockId(next.buildingBlockId);
+    setPromptDiagnostics([]);
   };
 
   const handleClearPromptBuilder = () => {
@@ -564,6 +617,8 @@ export default function Playground() {
     setSelectedId(null);
     setAddTargetId(ROOT_TARGET_ID);
     setPlaygroundHistory([]);
+    setPlaygroundFuture([]);
+    clearPersistedPlaygroundState();
     handleClearPromptBuilder();
   };
 
@@ -666,9 +721,11 @@ export default function Playground() {
         width="100%"
     >
       <PlaygroundHeader
+          canRedo={playgroundFuture.length > 0}
           canRestorePreviousState={playgroundHistory.length > 0}
           kitCount={enabledPlaygroundKits.length}
           onClear={handleClearAll}
+          onRedo={handleRedoPlaygroundState}
           onRestorePreviousState={() => handleRestorePreviousPlaygroundState()}
       />
 

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -45,7 +45,6 @@ import {
   loadPersistedPlaygroundState,
   savePersistedPlaygroundState,
 } from "./playgroundStorage";
-import type { PersistedPlaygroundState } from "./playgroundStorage";
 import {
   buildPlaygroundShareUrl,
   clearPlaygroundShareParam,
@@ -79,50 +78,11 @@ const cloneInstances = (items: BuilderInstance[]): BuilderInstance[] =>
 
 type ShareLoadStatus = "loaded" | "invalid" | null;
 
-type InitialPlaygroundLoad = {
-  shareStatus: ShareLoadStatus;
-  state: PersistedPlaygroundState | null;
-};
-
-const resolveInitialPlaygroundState = (
-  validKitNames: Set<string>,
-): InitialPlaygroundLoad => {
-  const shareResult = readPlaygroundShareState(validKitNames);
-
-  if (shareResult.status === "none") {
-    return {
-      shareStatus: null,
-      state: loadPersistedPlaygroundState(validKitNames),
-    };
-  }
-
-  // A share link was present in the URL — consume it and strip the param so
-  // reloading or editing afterward doesn't keep re-importing the shared state.
-  clearPlaygroundShareParam();
-
-  if (shareResult.status === "invalid") {
-    return {
-      shareStatus: "invalid",
-      state: loadPersistedPlaygroundState(validKitNames),
-    };
-  }
-
-  return {
-    shareStatus: "loaded",
-    state: {
-      addTargetId: ROOT_TARGET_ID,
-      buildingBlockId: null,
-      instances: shareResult.instances,
-      selectedId: null,
-    },
-  };
-};
-
 export default function Playground() {
   const { global_props_schema, playground_kits = [] } =
     useLoaderData() as PlaygroundLoaderData;
-  const [initialLoad] = useState(() =>
-    resolveInitialPlaygroundState(
+  const [persistedState] = useState(() =>
+    loadPersistedPlaygroundState(
       new Set(
         playground_kits
           .filter((kit) => PLAYGROUND_ENABLED_KITS.includes(kit.name))
@@ -130,8 +90,7 @@ export default function Playground() {
       ),
     ),
   );
-  const persistedState = initialLoad.state;
-  const [shareStatus] = useState<ShareLoadStatus>(initialLoad.shareStatus);
+  const [shareStatus, setShareStatus] = useState<ShareLoadStatus>(null);
   const [instances, setInstances] = useState<BuilderInstance[]>(
     () => persistedState?.instances ?? [],
   );
@@ -290,6 +249,41 @@ export default function Playground() {
 
     return () => window.clearTimeout(timeoutId);
   }, [addTargetId, activeBuildingBlockId, instances, selectedId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const validKitNames = new Set(
+        playground_kits
+          .filter((kit) => PLAYGROUND_ENABLED_KITS.includes(kit.name))
+          .map((kit) => kit.name),
+      );
+      const result = await readPlaygroundShareState(validKitNames);
+      if (cancelled || result.status === "none") return;
+
+      // A share link was present in the URL — consume it and strip the param
+      // so reloading or editing afterward doesn't keep re-importing it.
+      clearPlaygroundShareParam();
+
+      if (result.status === "invalid") {
+        setShareStatus("invalid");
+        return;
+      }
+
+      setInstances(result.instances);
+      setSelectedId(null);
+      setAddTargetId(ROOT_TARGET_ID);
+      setActiveBuildingBlockId(null);
+      setShareStatus("loaded");
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Only consume a share link once, on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const buildPlaygroundSnapshot = (): PlaygroundSnapshot => ({
     addTargetId,

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/index.tsx
@@ -281,12 +281,12 @@ export default function Playground() {
     let cancelled = false;
 
     (async () => {
-      const validKitNames = new Set(
-        playground_kits
-          .filter((kit) => PLAYGROUND_ENABLED_KITS.includes(kit.name))
-          .map((kit) => kit.name),
+      const validKitNames = new Set(Object.keys(kitsByName));
+      const result = await readPlaygroundShareState(
+        validKitNames,
+        kitsByName,
+        global_props_schema?.props,
       );
-      const result = await readPlaygroundShareState(validKitNames);
       if (cancelled || result.status === "none") return;
 
       // A share link was present in the URL — consume it and strip the param

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/kitUtils.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/kitUtils.ts
@@ -2,7 +2,7 @@ import type { PropValue } from "../KitShow/Tabs/Playground";
 import { linkFormat } from "../../../../../utilities/website_sidebar_helper";
 import type { BuilderInstance, PlaygroundKit, PropDefinition } from "./types";
 
-const EXCLUDED_PROPS = new Set([
+export const EXCLUDED_PROPS = new Set([
   "aria",
   "children",
   "className",

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -2,6 +2,9 @@ import {
   displayPropType,
   getAllPropDefinitionsWithGlobals,
   getConfiguredChildren,
+  getFirstPreset,
+  getRuntimeProps,
+  getStructureModeProps,
 } from "./kitUtils";
 import { sanitizeInstances } from "./playgroundStorage";
 import type { BuilderInstance, PlaygroundKit, PropDefinition } from "./types";
@@ -168,11 +171,17 @@ export const buildPlaygroundShareUrl = async (
 // crafted link run arbitrary JS in whoever opens it. `__proto__` /
 // `constructor` / `prototype` are blocked too as defense-in-depth against
 // prototype pollution in anything that later merges these parsed objects.
+// `dangerouslySetInnerHTML` / `__html` are blocked as defense-in-depth too —
+// the real fix for that specific vector is the prop-name allowlist below
+// (buildHtmlProps forwards any key under `props.htmlOptions` straight onto
+// the rendered DOM node), but this catches the shape wherever it appears.
 const UNSAFE_KEYS = new Set([
   "__playgroundCode",
   "__proto__",
   "constructor",
   "prototype",
+  "dangerouslySetInnerHTML",
+  "__html",
 ]);
 const MAX_SCAN_DEPTH = 50;
 
@@ -216,6 +225,38 @@ const isDefaultConfiguredChildren = (
   );
 };
 
+// Every prop name this kit's own config could legitimately mark "enabled"
+// on an instance: real schema props, plus whatever the kit's data
+// presets/structure modes/first preset inject as runtime props (see
+// createInstance/getInitialInstanceState — those go through the same
+// enabledProps=true path as a user-toggled prop, so they're legitimate even
+// though they aren't always literally in kit_schema.props). Nothing outside
+// this set — most importantly framework-level escape hatches like
+// `htmlOptions`, `className`, `data`, `aria` — is ever a real prop a kit
+// exposes, so any of those showing up in a share payload is exactly the
+// forged-key attack this allowlist exists to catch, not a legitimate share.
+const getKnownPropNames = (
+  kit: PlaygroundKit | undefined,
+  instance: BuilderInstance,
+  globalProps: Record<string, PropDefinition> | undefined,
+): Set<string> => {
+  const names = new Set(
+    Object.keys(getAllPropDefinitionsWithGlobals(kit, globalProps)),
+  );
+
+  Object.keys(getRuntimeProps(kit, instance.dataPresetKey)).forEach((name) =>
+    names.add(name),
+  );
+  Object.keys(getStructureModeProps(kit, instance.structureMode)).forEach(
+    (name) => names.add(name),
+  );
+  Object.keys((kit && getFirstPreset(kit)?.props) || {}).forEach((name) =>
+    names.add(name),
+  );
+
+  return names;
+};
+
 // codeGeneration.ts's formatCodeValue splices a function-typed prop's value
 // verbatim as raw code with no __playgroundCode wrapper required — a string
 // value for an onClick-style prop IS the code that runs. Checked against the
@@ -241,9 +282,12 @@ const hasUnsafeCode = (
     }
 
     const propDefinitions = getAllPropDefinitionsWithGlobals(kit, globalProps);
+    const knownPropNames = getKnownPropNames(kit, instance, globalProps);
 
     const hasUnsafeProp = Object.entries(instance.props).some(
       ([name, value]) => {
+        if (!knownPropNames.has(name)) return true;
+
         const type = displayPropType(propDefinitions[name]);
         const isFunctionTyped =
           type.includes("function") || type.includes("=>");

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -202,27 +202,65 @@ const containsUnsafeValue = (value: unknown, depth = 0): boolean => {
   return false;
 };
 
-// configuredChildren is always spliced as literal JSX/code (see
-// renderInstanceCode / getTemplateChildren), so a user-typed value there is
-// just as dangerous as __playgroundCode. But createInstance always fills it
-// in with the kit's own default template (Card's placeholder text, Table's
-// default JSX, etc. — see getConfiguredChildren), so most shared instances
-// legitimately carry it even though nobody typed anything. Comparing
-// against the kit's actual computed default (checking both call
+// A JSX expression container (`{...}`) is the *only* way configuredChildren
+// can turn into something codegen actually executes — plain markup with
+// quoted string attributes just becomes inert React.createElement calls
+// with string literals. So rather than reject anything that isn't the
+// kit's exact default (which breaks the very common case of someone
+// legitimately typing custom content into the "Children" editor — e.g.
+// custom Table rows), only reject a bare `{` that isn't inside a quoted
+// string. Mirrors the quote-tracking in codeGeneration.ts's
+// findTopLevelJsxStart.
+const containsBareCurlyBrace = (text: string): boolean => {
+  let quote: "'" | "\"" | "`" | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === "\"" || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "{") return true;
+  }
+
+  return false;
+};
+
+// createInstance always fills configuredChildren in with the kit's own
+// default template (Card's placeholder text, Table's default JSX, etc. —
+// see getConfiguredChildren), so checking against that first (both call
 // conventions used across this codebase — createInstance's implicit first
 // preset, and the explicit-no-preset form structure-mode changes use)
-// distinguishes that first-party config from a real edit.
-const isDefaultConfiguredChildren = (
+// covers the common untouched case for free. Anything else falls through
+// to the curly-brace check above.
+const isSafeConfiguredChildren = (
   kit: PlaygroundKit | undefined,
   structureMode: string | null,
   configuredChildren: string,
 ): boolean => {
-  if (!kit) return false;
+  if (
+    kit &&
+    (configuredChildren === getConfiguredChildren(kit, structureMode) ||
+      configuredChildren === getConfiguredChildren(kit, structureMode, null))
+  ) {
+    return true;
+  }
 
-  return (
-    configuredChildren === getConfiguredChildren(kit, structureMode) ||
-    configuredChildren === getConfiguredChildren(kit, structureMode, null)
-  );
+  return !containsBareCurlyBrace(configuredChildren);
 };
 
 // Every prop name this kit's own config could legitimately mark "enabled"
@@ -257,51 +295,109 @@ const getKnownPropNames = (
   return names;
 };
 
-// codeGeneration.ts's formatCodeValue splices a function-typed prop's value
-// verbatim as raw code with no __playgroundCode wrapper required — a string
-// value for an onClick-style prop IS the code that runs. Checked against the
-// kit's real schema so this matches exactly what codegen is actually
-// willing to treat as code.
-const hasUnsafeCode = (
+// Unlike configuredChildren, a function-typed prop's value is *supposed* to
+// be executable code (an onClick/onSortChange-style callback) — there's no
+// syntactic tell that separates a legitimate demo callback from a
+// malicious one, since valid JS doesn't need braces at all
+// (`() => fetch('evil')`). So this can't be validated as "safe" the way
+// configuredChildren can; it can only be trusted from the same session
+// that typed it, never from a share link. Rejecting the *entire* share
+// over one such prop (or one forged prop name, or one non-default
+// configuredChildren) is also too blunt — most of a shared canvas is
+// still perfectly renderable JSON data. So this sanitizes in place:
+// strip exactly the unsafe piece and keep everything else, rather than
+// failing the whole import.
+const sanitizeShareConfiguredChildren = (
+  instance: BuilderInstance,
+  kit: PlaygroundKit | undefined,
+): string | null => {
+  if (!instance.configuredChildren) return instance.configuredChildren;
+
+  if (
+    isSafeConfiguredChildren(
+      kit,
+      instance.structureMode,
+      instance.configuredChildren,
+    )
+  ) {
+    return instance.configuredChildren;
+  }
+
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[playground share] stripped: configuredChildren on kit "${instance.kitName}" contained a JSX expression ("{...}") outside a quoted string — falling back to the kit's default instead of rejecting the whole share.`,
+  );
+  return null;
+};
+
+const sanitizeShareProps = (
+  instance: BuilderInstance,
+  kit: PlaygroundKit | undefined,
+  globalProps: Record<string, PropDefinition> | undefined,
+): { props: Record<string, unknown>; enabledProps: Record<string, boolean> } => {
+  const propDefinitions = getAllPropDefinitionsWithGlobals(kit, globalProps);
+  const knownPropNames = getKnownPropNames(kit, instance, globalProps);
+  const props: Record<string, unknown> = {};
+  const enabledProps: Record<string, boolean> = {};
+
+  Object.entries(instance.props).forEach(([name, value]) => {
+    if (!knownPropNames.has(name)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[playground share] stripped: prop "${name}" on kit "${instance.kitName}" isn't in the known-prop allowlist (e.g. htmlOptions, className, data, aria are never real kit props).`,
+      );
+      return;
+    }
+
+    const type = displayPropType(propDefinitions[name]);
+    const isFunctionTyped = type.includes("function") || type.includes("=>");
+    if (isFunctionTyped && typeof value === "string" && value.trim()) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[playground share] stripped: prop "${name}" on kit "${instance.kitName}" is function-typed with a raw string value — that's exactly the code codegen would execute, and can't be told apart from a real callback.`,
+      );
+      return;
+    }
+
+    if (containsUnsafeValue(value)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[playground share] stripped: prop "${name}" on kit "${instance.kitName}" contained an unsafe key (e.g. __playgroundCode, __proto__, dangerouslySetInnerHTML).`,
+      );
+      return;
+    }
+
+    props[name] = value;
+    enabledProps[name] = true;
+  });
+
+  return { props, enabledProps };
+};
+
+const sanitizeShareInstances = (
   instances: BuilderInstance[],
   kitsByName: Record<string, PlaygroundKit>,
   globalProps: Record<string, PropDefinition> | undefined,
-): boolean =>
-  instances.some((instance) => {
+): BuilderInstance[] =>
+  instances.map((instance) => {
     const kit = kitsByName[instance.kitName];
-
-    if (
-      instance.configuredChildren &&
-      !isDefaultConfiguredChildren(
-        kit,
-        instance.structureMode,
-        instance.configuredChildren,
-      )
-    ) {
-      return true;
-    }
-
-    const propDefinitions = getAllPropDefinitionsWithGlobals(kit, globalProps);
-    const knownPropNames = getKnownPropNames(kit, instance, globalProps);
-
-    const hasUnsafeProp = Object.entries(instance.props).some(
-      ([name, value]) => {
-        if (!knownPropNames.has(name)) return true;
-
-        const type = displayPropType(propDefinitions[name]);
-        const isFunctionTyped =
-          type.includes("function") || type.includes("=>");
-        if (isFunctionTyped && typeof value === "string" && value.trim()) {
-          return true;
-        }
-
-        return containsUnsafeValue(value);
-      },
+    const { props, enabledProps } = sanitizeShareProps(
+      instance,
+      kit,
+      globalProps,
     );
 
-    return (
-      hasUnsafeProp || hasUnsafeCode(instance.children, kitsByName, globalProps)
-    );
+    return {
+      ...instance,
+      configuredChildren: sanitizeShareConfiguredChildren(instance, kit),
+      props,
+      enabledProps,
+      children: sanitizeShareInstances(
+        instance.children,
+        kitsByName,
+        globalProps,
+      ),
+    };
   });
 
 export type PlaygroundShareReadResult =
@@ -328,19 +424,32 @@ export const readPlaygroundShareState = async (
         : utf8Decoder.decode(bytes);
 
     const parsed = JSON.parse(json);
-    const expanded = Array.isArray(parsed)
-      ? parsed.map(fromCompactInstance)
-      : parsed;
-    const instances = sanitizeInstances(expanded, validKitNames);
-    if (
-      instances.length === 0 ||
-      hasUnsafeCode(instances, kitsByName, globalProps)
-    ) {
+    if (!Array.isArray(parsed)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[playground share] rejected: decoded payload isn't an array.",
+        { parsed },
+      );
       return { status: "invalid" };
     }
 
-    return { status: "ok", instances };
-  } catch {
+    const expanded = parsed.map(fromCompactInstance);
+    const instances = sanitizeInstances(expanded, validKitNames);
+    if (instances.length === 0) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[playground share] rejected: no instances survived sanitizeInstances — check kit names against validKitNames.",
+        { expanded, validKitNames: Array.from(validKitNames) },
+      );
+      return { status: "invalid" };
+    }
+
+    const sanitized = sanitizeShareInstances(instances, kitsByName, globalProps);
+
+    return { status: "ok", instances: sanitized };
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("[playground share] rejected: decode/parse threw.", err);
     return { status: "invalid" };
   }
 };

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -1,5 +1,9 @@
+import {
+  displayPropType,
+  getAllPropDefinitionsWithGlobals,
+} from "./kitUtils";
 import { sanitizeInstances } from "./playgroundStorage";
-import type { BuilderInstance } from "./types";
+import type { BuilderInstance, PlaygroundKit, PropDefinition } from "./types";
 
 // This workspace's TypeScript (4.3.5) predates CompressionStream/
 // DecompressionStream in the bundled DOM lib types, so declare them
@@ -182,12 +186,41 @@ const containsUnsafeValue = (value: unknown, depth = 0): boolean => {
   return false;
 };
 
-const hasUnsafeProps = (instances: BuilderInstance[]): boolean =>
-  instances.some(
-    (instance) =>
-      containsUnsafeValue(instance.props) ||
-      hasUnsafeProps(instance.children),
-  );
+// codeGeneration.ts's formatCodeValue splices a function-typed prop's value
+// verbatim as raw code with no __playgroundCode wrapper required — a string
+// value for an onClick-style prop IS the code that runs. And
+// configuredChildren is always spliced as literal JSX/code (see
+// renderInstanceCode / getTemplateChildren), independent of any prop's
+// declared type. Both are checked against the kit's real schema so this
+// matches exactly what codegen is actually willing to treat as code.
+const hasUnsafeCode = (
+  instances: BuilderInstance[],
+  kitsByName: Record<string, PlaygroundKit>,
+  globalProps: Record<string, PropDefinition> | undefined,
+): boolean =>
+  instances.some((instance) => {
+    if (instance.configuredChildren) return true;
+
+    const kit = kitsByName[instance.kitName];
+    const propDefinitions = getAllPropDefinitionsWithGlobals(kit, globalProps);
+
+    const hasUnsafeProp = Object.entries(instance.props).some(
+      ([name, value]) => {
+        const type = displayPropType(propDefinitions[name]);
+        const isFunctionTyped =
+          type.includes("function") || type.includes("=>");
+        if (isFunctionTyped && typeof value === "string" && value.trim()) {
+          return true;
+        }
+
+        return containsUnsafeValue(value);
+      },
+    );
+
+    return (
+      hasUnsafeProp || hasUnsafeCode(instance.children, kitsByName, globalProps)
+    );
+  });
 
 export type PlaygroundShareReadResult =
   | { status: "ok"; instances: BuilderInstance[] }
@@ -196,6 +229,8 @@ export type PlaygroundShareReadResult =
 
 export const readPlaygroundShareState = async (
   validKitNames: Set<string>,
+  kitsByName: Record<string, PlaygroundKit>,
+  globalProps?: Record<string, PropDefinition>,
 ): Promise<PlaygroundShareReadResult> => {
   const encoded = new URLSearchParams(window.location.search).get(
     SHARE_PARAM,
@@ -215,7 +250,10 @@ export const readPlaygroundShareState = async (
       ? parsed.map(fromCompactInstance)
       : parsed;
     const instances = sanitizeInstances(expanded, validKitNames);
-    if (instances.length === 0 || hasUnsafeProps(instances)) {
+    if (
+      instances.length === 0 ||
+      hasUnsafeCode(instances, kitsByName, globalProps)
+    ) {
       return { status: "invalid" };
     }
 

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -1,0 +1,73 @@
+import { sanitizeInstances } from "./playgroundStorage";
+import type { BuilderInstance } from "./types";
+
+const SHARE_PARAM = "state";
+
+const utf8ToBase64Url = (value: string): string => {
+  const utf8Bytes = encodeURIComponent(value).replace(
+    /%([0-9A-F]{2})/g,
+    (_match, hex) => String.fromCharCode(parseInt(hex, 16)),
+  );
+
+  return window
+    .btoa(utf8Bytes)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+};
+
+const base64UrlToUtf8 = (value: string): string => {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = window.atob(padded);
+
+  return decodeURIComponent(
+    Array.from(binary)
+      .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`)
+      .join(""),
+  );
+};
+
+export const buildPlaygroundShareUrl = (
+  instances: BuilderInstance[],
+): string => {
+  const encoded = utf8ToBase64Url(JSON.stringify(instances));
+  const url = new URL(window.location.href);
+
+  url.search = "";
+  url.searchParams.set(SHARE_PARAM, encoded);
+
+  return url.toString();
+};
+
+export type PlaygroundShareReadResult =
+  | { status: "ok"; instances: BuilderInstance[] }
+  | { status: "invalid" }
+  | { status: "none" };
+
+export const readPlaygroundShareState = (
+  validKitNames: Set<string>,
+): PlaygroundShareReadResult => {
+  const encoded = new URLSearchParams(window.location.search).get(
+    SHARE_PARAM,
+  );
+  if (!encoded) return { status: "none" };
+
+  try {
+    const parsed = JSON.parse(base64UrlToUtf8(encoded));
+    const instances = sanitizeInstances(parsed, validKitNames);
+    if (instances.length === 0) return { status: "invalid" };
+
+    return { status: "ok", instances };
+  } catch {
+    return { status: "invalid" };
+  }
+};
+
+export const clearPlaygroundShareParam = (): void => {
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(SHARE_PARAM)) return;
+
+  url.searchParams.delete(SHARE_PARAM);
+  window.history.replaceState(window.history.state, "", url.toString());
+};

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -40,6 +40,46 @@ export const buildPlaygroundShareUrl = (
   return url.toString();
 };
 
+// `__playgroundCode` is an internal escape hatch (see PropControl.tsx and
+// codeGeneration.ts) that lets a prop value carry a raw JS expression, which
+// codegen splices verbatim into the source the react-live preview evaluates.
+// That's fine for props a user typed into their own session, but a share
+// link is untrusted cross-user input — allowing it through here would let a
+// crafted link run arbitrary JS in whoever opens it. `__proto__` /
+// `constructor` / `prototype` are blocked too as defense-in-depth against
+// prototype pollution in anything that later merges these parsed objects.
+const UNSAFE_KEYS = new Set([
+  "__playgroundCode",
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+const MAX_SCAN_DEPTH = 50;
+
+const containsUnsafeValue = (value: unknown, depth = 0): boolean => {
+  if (depth > MAX_SCAN_DEPTH) return true;
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsUnsafeValue(item, depth + 1));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(
+      ([key, entryValue]) =>
+        UNSAFE_KEYS.has(key) || containsUnsafeValue(entryValue, depth + 1),
+    );
+  }
+
+  return false;
+};
+
+const hasUnsafeProps = (instances: BuilderInstance[]): boolean =>
+  instances.some(
+    (instance) =>
+      containsUnsafeValue(instance.props) ||
+      hasUnsafeProps(instance.children),
+  );
+
 export type PlaygroundShareReadResult =
   | { status: "ok"; instances: BuilderInstance[] }
   | { status: "invalid" }
@@ -56,7 +96,9 @@ export const readPlaygroundShareState = (
   try {
     const parsed = JSON.parse(base64UrlToUtf8(encoded));
     const instances = sanitizeInstances(parsed, validKitNames);
-    if (instances.length === 0) return { status: "invalid" };
+    if (instances.length === 0 || hasUnsafeProps(instances)) {
+      return { status: "invalid" };
+    }
 
     return { status: "ok", instances };
   } catch {

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -202,6 +202,63 @@ const containsUnsafeValue = (value: unknown, depth = 0): boolean => {
   return false;
 };
 
+// Quoted attributes are inert against JSX-expression injection (see
+// containsBareCurlyBrace below), but they aren't inert once they land on a
+// real DOM node: `href`/`url`/`src`-style string props get forwarded
+// verbatim to native `<a>`/`<img>` elements by kits like Link and Image, in
+// both the createElement canvas preview and the react-live template
+// preview. A `javascript:`/`vbscript:` value executes on click; `data:` can
+// carry an executable payload (e.g. `data:text/html,<script>...`). Browsers
+// strip ASCII control characters before parsing a URL's scheme, so an
+// obfuscated "java\tscript:" still resolves to "javascript:" there — strip
+// the same characters here before matching, or this check is trivially
+// bypassed.
+const DANGEROUS_URL_SCHEMES = ["javascript:", "vbscript:", "data:"];
+
+const CONTROL_CHARS_PATTERN = new RegExp(
+  "[" + String.fromCharCode(0) + "-" + String.fromCharCode(31) + String.fromCharCode(127) + "]+",
+  "g",
+);
+
+const normalizeForSchemeCheck = (text: string): string =>
+  text.replace(CONTROL_CHARS_PATTERN, "").trim().toLowerCase();
+
+// A prop value becomes a dangerous URL only when the *entire* value is the
+// scheme (that's how href/url/src are actually consumed) — a plain text
+// prop that merely mentions "javascript:" mid-sentence isn't a navigation
+// target.
+const isDangerousUrlPropValue = (value: unknown): boolean =>
+  typeof value === "string" &&
+  DANGEROUS_URL_SCHEMES.some((scheme) =>
+    normalizeForSchemeCheck(value).startsWith(scheme),
+  );
+
+const containsDangerousUrlScheme = (value: unknown, depth = 0): boolean => {
+  if (depth > MAX_SCAN_DEPTH) return true;
+
+  if (typeof value === "string") return isDangerousUrlPropValue(value);
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsDangerousUrlScheme(item, depth + 1));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).some(
+      (entryValue) => containsDangerousUrlScheme(entryValue, depth + 1),
+    );
+  }
+
+  return false;
+};
+
+// configuredChildren is a whole blob of markup, so the scheme can appear
+// anywhere inside it (e.g. `<a href="javascript:...">`) rather than being
+// the entire string — scan for it rather than requiring an exact prefix.
+const hasDangerousUrlScheme = (text: string): boolean =>
+  DANGEROUS_URL_SCHEMES.some((scheme) =>
+    normalizeForSchemeCheck(text).includes(scheme),
+  );
+
 // A JSX expression container (`{...}`) is the *only* way configuredChildren
 // can turn into something codegen actually executes — plain markup with
 // quoted string attributes just becomes inert React.createElement calls
@@ -245,8 +302,11 @@ const containsBareCurlyBrace = (text: string): boolean => {
 // see getConfiguredChildren), so checking against that first (both call
 // conventions used across this codebase — createInstance's implicit first
 // preset, and the explicit-no-preset form structure-mode changes use)
-// covers the common untouched case for free. Anything else falls through
-// to the curly-brace check above.
+// covers the common untouched case for free — it's the kit author's own
+// source, not attacker-controlled. Anything else falls through to the
+// curly-brace check (JSX-expression injection) and the URL-scheme check
+// (a real `href`/`src` a kit renders verbatim onto a native DOM node,
+// which quoting alone doesn't neutralize).
 const isSafeConfiguredChildren = (
   kit: PlaygroundKit | undefined,
   structureMode: string | null,
@@ -260,7 +320,10 @@ const isSafeConfiguredChildren = (
     return true;
   }
 
-  return !containsBareCurlyBrace(configuredChildren);
+  return (
+    !containsBareCurlyBrace(configuredChildren) &&
+    !hasDangerousUrlScheme(configuredChildren)
+  );
 };
 
 // Every prop name this kit's own config could legitimately mark "enabled"
@@ -325,7 +388,7 @@ const sanitizeShareConfiguredChildren = (
 
   // eslint-disable-next-line no-console
   console.warn(
-    `[playground share] stripped: configuredChildren on kit "${instance.kitName}" contained a JSX expression ("{...}") outside a quoted string — falling back to the kit's default instead of rejecting the whole share.`,
+    `[playground share] stripped: configuredChildren on kit "${instance.kitName}" contained a JSX expression ("{...}") outside a quoted string, or a javascript:/data:/vbscript: URL — falling back to the kit's default instead of rejecting the whole share.`,
   );
   return null;
 };
@@ -363,6 +426,14 @@ const sanitizeShareProps = (
       // eslint-disable-next-line no-console
       console.warn(
         `[playground share] stripped: prop "${name}" on kit "${instance.kitName}" contained an unsafe key (e.g. __playgroundCode, __proto__, dangerouslySetInnerHTML).`,
+      );
+      return;
+    }
+
+    if (containsDangerousUrlScheme(value)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[playground share] stripped: prop "${name}" on kit "${instance.kitName}" is a javascript:/data:/vbscript: URL — quoting doesn't neutralize it once a kit renders it as a real href/src.`,
       );
       return;
     }

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -1,6 +1,7 @@
 import {
   displayPropType,
   getAllPropDefinitionsWithGlobals,
+  getConfiguredChildren,
 } from "./kitUtils";
 import { sanitizeInstances } from "./playgroundStorage";
 import type { BuilderInstance, PlaygroundKit, PropDefinition } from "./types";
@@ -96,9 +97,15 @@ const toCompactInstance = (instance: BuilderInstance): CompactInstance => {
   if (Object.keys(enabledProps).length > 0) compact.p = enabledProps;
   if (instance.structureMode) compact.s = instance.structureMode;
   if (instance.dataPresetKey) compact.d = instance.dataPresetKey;
-  if (instance.configuredChildren) compact.x = instance.configuredChildren;
+  // codegen/preview prefer nested child instances over configuredChildren
+  // whenever both are present (see getTemplateChildren / renderInstanceCode),
+  // so it's dead weight once there are real children — including the wrap
+  // feature's wrapper, which still carries createInstance's default
+  // configuredChildren even though it's never actually used.
   if (instance.children.length > 0) {
     compact.c = instance.children.map(toCompactInstance);
+  } else if (instance.configuredChildren) {
+    compact.x = instance.configuredChildren;
   }
 
   return compact;
@@ -186,22 +193,53 @@ const containsUnsafeValue = (value: unknown, depth = 0): boolean => {
   return false;
 };
 
+// configuredChildren is always spliced as literal JSX/code (see
+// renderInstanceCode / getTemplateChildren), so a user-typed value there is
+// just as dangerous as __playgroundCode. But createInstance always fills it
+// in with the kit's own default template (Card's placeholder text, Table's
+// default JSX, etc. — see getConfiguredChildren), so most shared instances
+// legitimately carry it even though nobody typed anything. Comparing
+// against the kit's actual computed default (checking both call
+// conventions used across this codebase — createInstance's implicit first
+// preset, and the explicit-no-preset form structure-mode changes use)
+// distinguishes that first-party config from a real edit.
+const isDefaultConfiguredChildren = (
+  kit: PlaygroundKit | undefined,
+  structureMode: string | null,
+  configuredChildren: string,
+): boolean => {
+  if (!kit) return false;
+
+  return (
+    configuredChildren === getConfiguredChildren(kit, structureMode) ||
+    configuredChildren === getConfiguredChildren(kit, structureMode, null)
+  );
+};
+
 // codeGeneration.ts's formatCodeValue splices a function-typed prop's value
 // verbatim as raw code with no __playgroundCode wrapper required — a string
-// value for an onClick-style prop IS the code that runs. And
-// configuredChildren is always spliced as literal JSX/code (see
-// renderInstanceCode / getTemplateChildren), independent of any prop's
-// declared type. Both are checked against the kit's real schema so this
-// matches exactly what codegen is actually willing to treat as code.
+// value for an onClick-style prop IS the code that runs. Checked against the
+// kit's real schema so this matches exactly what codegen is actually
+// willing to treat as code.
 const hasUnsafeCode = (
   instances: BuilderInstance[],
   kitsByName: Record<string, PlaygroundKit>,
   globalProps: Record<string, PropDefinition> | undefined,
 ): boolean =>
   instances.some((instance) => {
-    if (instance.configuredChildren) return true;
-
     const kit = kitsByName[instance.kitName];
+
+    if (
+      instance.configuredChildren &&
+      !isDefaultConfiguredChildren(
+        kit,
+        instance.structureMode,
+        instance.configuredChildren,
+      )
+    ) {
+      return true;
+    }
+
     const propDefinitions = getAllPropDefinitionsWithGlobals(kit, globalProps);
 
     const hasUnsafeProp = Object.entries(instance.props).some(

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -1,39 +1,148 @@
 import { sanitizeInstances } from "./playgroundStorage";
 import type { BuilderInstance } from "./types";
 
+// This workspace's TypeScript (4.3.5) predates CompressionStream/
+// DecompressionStream in the bundled DOM lib types, so declare them
+// ourselves rather than bumping the shared tsconfig `lib` target.
+declare const CompressionStream: any;
+declare const DecompressionStream: any;
+
 const SHARE_PARAM = "state";
 
-const utf8ToBase64Url = (value: string): string => {
-  const utf8Bytes = encodeURIComponent(value).replace(
-    /%([0-9A-F]{2})/g,
-    (_match, hex) => String.fromCharCode(parseInt(hex, 16)),
-  );
+// Format markers prefixed onto the encoded payload so a reader always knows
+// how to decode it, regardless of which path the writer's browser took.
+const FORMAT_GZIP = "g";
+const FORMAT_PLAIN = "p";
+
+const utf8Encoder = new TextEncoder();
+const utf8Decoder = new TextDecoder();
+
+const supportsCompression = () =>
+  typeof CompressionStream === "function" &&
+  typeof DecompressionStream === "function";
+
+const bytesToBase64Url = (bytes: Uint8Array): string => {
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
 
   return window
-    .btoa(utf8Bytes)
+    .btoa(binary)
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=+$/, "");
 };
 
-const base64UrlToUtf8 = (value: string): string => {
+const base64UrlToBytes = (value: string): Uint8Array => {
   const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
   const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
   const binary = window.atob(padded);
+  const bytes = new Uint8Array(binary.length);
 
-  return decodeURIComponent(
-    Array.from(binary)
-      .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`)
-      .join(""),
-  );
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes;
 };
 
-export const buildPlaygroundShareUrl = (
-  instances: BuilderInstance[],
-): string => {
-  const encoded = utf8ToBase64Url(JSON.stringify(instances));
-  const url = new URL(window.location.href);
+const gzipCompress = async (text: string): Promise<Uint8Array> => {
+  const stream = new Blob([utf8Encoder.encode(text)])
+    .stream()
+    .pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
 
+const gzipDecompress = async (bytes: Uint8Array): Promise<string> => {
+  const stream = new Blob([bytes])
+    .stream()
+    .pipeThrough(new DecompressionStream("gzip"));
+  return utf8Decoder.decode(await new Response(stream).arrayBuffer());
+};
+
+// A BuilderInstance carries every prop the kit schema defines (defaulted in
+// at creation time — see createInstance/getInitialInstanceState), even
+// though only the "enabled" ones affect rendering. Serializing that whole
+// object bloats the share link with props nobody turned on. This compact
+// form keeps only what's needed to reproduce the rendered result: enabled
+// props (enabledProps itself is dropped and rebuilt from that key set on
+// read), short field names, and omitted empty/null fields. On top of that,
+// the JSON itself is gzip-compressed before it's base64url-encoded into the
+// URL (falling back to plain base64url on browsers without
+// Compression/DecompressionStream).
+type CompactInstance = {
+  id: string;
+  k: string;
+  c?: CompactInstance[];
+  d?: string;
+  p?: Record<string, unknown>;
+  s?: string;
+  x?: string;
+};
+
+const toCompactInstance = (instance: BuilderInstance): CompactInstance => {
+  const enabledProps = Object.fromEntries(
+    Object.entries(instance.props).filter(
+      ([name]) => instance.enabledProps[name],
+    ),
+  );
+  const compact: CompactInstance = { id: instance.id, k: instance.kitName };
+
+  if (Object.keys(enabledProps).length > 0) compact.p = enabledProps;
+  if (instance.structureMode) compact.s = instance.structureMode;
+  if (instance.dataPresetKey) compact.d = instance.dataPresetKey;
+  if (instance.configuredChildren) compact.x = instance.configuredChildren;
+  if (instance.children.length > 0) {
+    compact.c = instance.children.map(toCompactInstance);
+  }
+
+  return compact;
+};
+
+const isCompactInstance = (value: unknown): value is CompactInstance =>
+  Boolean(value) &&
+  typeof value === "object" &&
+  typeof (value as Record<string, unknown>).id === "string" &&
+  typeof (value as Record<string, unknown>).k === "string";
+
+// Expands the compact wire shape back into something sanitizeInstances can
+// validate — a pure format conversion, not a trust decision. Anything
+// malformed here just fails that validation afterward.
+const fromCompactInstance = (value: unknown): unknown => {
+  if (!isCompactInstance(value)) return value;
+
+  const props =
+    value.p && typeof value.p === "object" ? value.p : ({} as Record<string, unknown>);
+  const enabledProps = Object.fromEntries(
+    Object.keys(props).map((name) => [name, true]),
+  );
+
+  return {
+    id: value.id,
+    kitName: value.k,
+    structureMode: typeof value.s === "string" ? value.s : null,
+    dataPresetKey: typeof value.d === "string" ? value.d : null,
+    configuredChildren: typeof value.x === "string" ? value.x : null,
+    props,
+    enabledProps,
+    children: Array.isArray(value.c) ? value.c.map(fromCompactInstance) : [],
+  };
+};
+
+export const buildPlaygroundShareUrl = async (
+  instances: BuilderInstance[],
+): Promise<string> => {
+  const compact = instances.map(toCompactInstance);
+  const json = JSON.stringify(compact);
+  const useGzip = supportsCompression();
+  const bytes = useGzip
+    ? await gzipCompress(json)
+    : utf8Encoder.encode(json);
+  const marker = useGzip ? FORMAT_GZIP : FORMAT_PLAIN;
+  const encoded = marker + bytesToBase64Url(bytes);
+
+  const url = new URL(window.location.href);
   url.search = "";
   url.searchParams.set(SHARE_PARAM, encoded);
 
@@ -85,17 +194,27 @@ export type PlaygroundShareReadResult =
   | { status: "invalid" }
   | { status: "none" };
 
-export const readPlaygroundShareState = (
+export const readPlaygroundShareState = async (
   validKitNames: Set<string>,
-): PlaygroundShareReadResult => {
+): Promise<PlaygroundShareReadResult> => {
   const encoded = new URLSearchParams(window.location.search).get(
     SHARE_PARAM,
   );
   if (!encoded) return { status: "none" };
 
   try {
-    const parsed = JSON.parse(base64UrlToUtf8(encoded));
-    const instances = sanitizeInstances(parsed, validKitNames);
+    const marker = encoded[0];
+    const bytes = base64UrlToBytes(encoded.slice(1));
+    const json =
+      marker === FORMAT_GZIP
+        ? await gzipDecompress(bytes)
+        : utf8Decoder.decode(bytes);
+
+    const parsed = JSON.parse(json);
+    const expanded = Array.isArray(parsed)
+      ? parsed.map(fromCompactInstance)
+      : parsed;
+    const instances = sanitizeInstances(expanded, validKitNames);
     if (instances.length === 0 || hasUnsafeProps(instances)) {
       return { status: "invalid" };
     }

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundShareLink.ts
@@ -1,4 +1,5 @@
 import {
+  EXCLUDED_PROPS,
   displayPropType,
   getAllPropDefinitionsWithGlobals,
   getConfiguredChildren,
@@ -172,9 +173,12 @@ export const buildPlaygroundShareUrl = async (
 // `constructor` / `prototype` are blocked too as defense-in-depth against
 // prototype pollution in anything that later merges these parsed objects.
 // `dangerouslySetInnerHTML` / `__html` are blocked as defense-in-depth too —
-// the real fix for that specific vector is the prop-name allowlist below
-// (buildHtmlProps forwards any key under `props.htmlOptions` straight onto
-// the rendered DOM node), but this catches the shape wherever it appears.
+// the primary fix for the `htmlOptions` vector is excluding it from the
+// prop-name allowlist entirely (EXCLUDED_PROPS, see getKnownPropNames
+// below) — buildHtmlProps forwards any key under `props.htmlOptions`
+// straight onto the rendered DOM node with no filtering of its own, so
+// nothing downstream of the allowlist can be trusted to catch it. This
+// list catches the same key shapes wherever else they might appear.
 const UNSAFE_KEYS = new Set([
   "__playgroundCode",
   "__proto__",
@@ -183,6 +187,15 @@ const UNSAFE_KEYS = new Set([
   "dangerouslySetInnerHTML",
   "__html",
 ]);
+// Lowercase `on...` (onclick, onerror, onmouseover, ...) is the raw HTML
+// attribute-name convention, not React's camelCase event-prop convention
+// (onClick) — a string value under one of these keys becomes a live inline
+// DOM event handler the moment it's set as an attribute (buildHtmlProps and
+// similar spreads use setAttribute-equivalent semantics for unknown keys),
+// with no function value required. Belt-and-suspenders alongside the
+// allowlist fix, in case some other legitimate object-typed prop is ever
+// spread onto a DOM node the same way `htmlOptions` is.
+const DOM_EVENT_HANDLER_KEY_PATTERN = /^on[a-z]/;
 const MAX_SCAN_DEPTH = 50;
 
 const containsUnsafeValue = (value: unknown, depth = 0): boolean => {
@@ -195,7 +208,9 @@ const containsUnsafeValue = (value: unknown, depth = 0): boolean => {
   if (value && typeof value === "object") {
     return Object.entries(value as Record<string, unknown>).some(
       ([key, entryValue]) =>
-        UNSAFE_KEYS.has(key) || containsUnsafeValue(entryValue, depth + 1),
+        UNSAFE_KEYS.has(key) ||
+        DOM_EVENT_HANDLER_KEY_PATTERN.test(key) ||
+        containsUnsafeValue(entryValue, depth + 1),
     );
   }
 
@@ -331,11 +346,17 @@ const isSafeConfiguredChildren = (
 // presets/structure modes/first preset inject as runtime props (see
 // createInstance/getInitialInstanceState — those go through the same
 // enabledProps=true path as a user-toggled prop, so they're legitimate even
-// though they aren't always literally in kit_schema.props). Nothing outside
-// this set — most importantly framework-level escape hatches like
-// `htmlOptions`, `className`, `data`, `aria` — is ever a real prop a kit
-// exposes, so any of those showing up in a share payload is exactly the
-// forged-key attack this allowlist exists to catch, not a legitimate share.
+// though they aren't always literally in kit_schema.props). But a structure
+// mode's own props CAN legitimately contain a framework-level escape hatch
+// like Map's `htmlOptions: { style: {...} }` — that's the kit author
+// wiring internal styling, not something meant to ever be
+// user/share-editable. EXCLUDED_PROPS (kitUtils.ts) is the canonical list
+// the prop editor already hides for exactly this reason; subtract it here
+// too, unconditionally, regardless of which of the sources above a name
+// came from — otherwise a kit whose structure mode happens to reference
+// `htmlOptions` reopens it as an allowlisted share field, and
+// `buildHtmlProps` spreads it onto a real DOM node with no key filtering
+// (e.g. `htmlOptions: { onclick: "alert(1)" }`).
 const getKnownPropNames = (
   kit: PlaygroundKit | undefined,
   instance: BuilderInstance,
@@ -354,6 +375,8 @@ const getKnownPropNames = (
   Object.keys((kit && getFirstPreset(kit)?.props) || {}).forEach((name) =>
     names.add(name),
   );
+
+  EXCLUDED_PROPS.forEach((name) => names.delete(name));
 
   return names;
 };

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundStorage.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundStorage.ts
@@ -23,7 +23,7 @@ const isBuilderInstance = (value: unknown): value is BuilderInstance => {
   );
 };
 
-const sanitizeInstances = (
+export const sanitizeInstances = (
   value: unknown,
   validKitNames: Set<string>,
 ): BuilderInstance[] => {

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundStorage.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/playgroundStorage.ts
@@ -1,0 +1,86 @@
+import { ROOT_TARGET_ID } from "./types";
+import type { BuilderInstance } from "./types";
+
+export type PersistedPlaygroundState = {
+  addTargetId: string;
+  buildingBlockId: string | null;
+  instances: BuilderInstance[];
+  selectedId: string | null;
+};
+
+const STORAGE_KEY = "playbook-playground-state-v1";
+
+const isBuilderInstance = (value: unknown): value is BuilderInstance => {
+  if (!value || typeof value !== "object") return false;
+  const instance = value as Partial<BuilderInstance>;
+
+  return (
+    typeof instance.id === "string" &&
+    typeof instance.kitName === "string" &&
+    typeof instance.props === "object" &&
+    typeof instance.enabledProps === "object" &&
+    Array.isArray(instance.children)
+  );
+};
+
+const sanitizeInstances = (
+  value: unknown,
+  validKitNames: Set<string>,
+): BuilderInstance[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .filter(isBuilderInstance)
+    .filter((instance) => validKitNames.has(instance.kitName))
+    .map((instance) => ({
+      ...instance,
+      children: sanitizeInstances(instance.children, validKitNames),
+    }));
+};
+
+export const loadPersistedPlaygroundState = (
+  validKitNames: Set<string>,
+): PersistedPlaygroundState | null => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    const instances = sanitizeInstances(parsed?.instances, validKitNames);
+    if (instances.length === 0) return null;
+
+    return {
+      addTargetId:
+        typeof parsed.addTargetId === "string"
+          ? parsed.addTargetId
+          : ROOT_TARGET_ID,
+      buildingBlockId:
+        typeof parsed.buildingBlockId === "string"
+          ? parsed.buildingBlockId
+          : null,
+      instances,
+      selectedId:
+        typeof parsed.selectedId === "string" ? parsed.selectedId : null,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const savePersistedPlaygroundState = (
+  state: PersistedPlaygroundState,
+): void => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage unavailable (private browsing, quota exceeded, etc.) — skip persistence.
+  }
+};
+
+export const clearPersistedPlaygroundState = (): void => {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+};

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/styles.scss
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/styles.scss
@@ -17,9 +17,11 @@
 
 .full-playground-heading {
   align-items: flex-start;
+  flex-direction: column;
 
   @include break_on($screen-md-min) {
     align-items: flex-end;
+    flex-direction: row;
   }
 }
 

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/styles.scss
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/styles.scss
@@ -127,6 +127,29 @@
   }
 }
 
+.builder-prompt-examples {
+  flex-wrap: wrap;
+}
+
+.builder-prompt-example-chip {
+  appearance: none;
+  background: $white;
+  border: 1px solid $border_light;
+  border-radius: 999px;
+  color: $text_lt_light;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.2;
+  padding: 4px $space_xs;
+
+  &:hover,
+  &:focus {
+    border-color: $primary;
+    color: $primary;
+    outline: none;
+  }
+}
+
 .builder-prompt-floating {
   bottom: $space_md;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/styles.scss
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/styles.scss
@@ -96,6 +96,15 @@
   > [class*="pb_card"] {
     width: 100%;
   }
+
+  // With nothing selected, the top card is the only child (no PropsPanel
+  // sibling) and would otherwise stretch to the grid column's content-based
+  // "auto" width. Pin it to PropsPanel's own default width (see
+  // PROPS_PANEL_DEFAULT_WIDTH in PropsPanel.tsx) so the inspector doesn't
+  // change width between the empty and selected states.
+  > .playground-panel-controls:only-child {
+    width: 330px;
+  }
 }
 
 .builder-prop-toggle,

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/treeUtils.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/treeUtils.ts
@@ -180,6 +180,40 @@ export const wrapInstancesInTree = (
   return { instances: nextInstances, wrapped };
 };
 
+// The inverse of wrapInstancesInTree: dissolves the target instance,
+// promoting its own children into its place among its former siblings.
+export const unwrapInstanceInTree = (
+  instances: BuilderInstance[],
+  id: string
+): { instances: BuilderInstance[]; unwrapped: boolean } => {
+  const index = instances.findIndex((instance) => instance.id === id);
+
+  if (index >= 0) {
+    const target = instances[index];
+    return {
+      instances: [
+        ...instances.slice(0, index),
+        ...target.children,
+        ...instances.slice(index + 1),
+      ],
+      unwrapped: true,
+    };
+  }
+
+  let unwrapped = false;
+  const nextInstances = instances.map((instance) => {
+    if (unwrapped) return instance;
+
+    const childResult = unwrapInstanceInTree(instance.children, id);
+    if (!childResult.unwrapped) return instance;
+
+    unwrapped = true;
+    return { ...instance, children: childResult.instances };
+  });
+
+  return { instances: nextInstances, unwrapped };
+};
+
 export const buildTargetOptions = (
   instances: BuilderInstance[],
   kitsByName: Record<string, PlaygroundKit>,

--- a/playbook-website/app/javascript/components/Website/src/pages/Playground/treeUtils.ts
+++ b/playbook-website/app/javascript/components/Website/src/pages/Playground/treeUtils.ts
@@ -126,6 +126,60 @@ export const moveInstanceInTree = (
   }));
 };
 
+// Wraps a set of sibling instances in a new instance (e.g. Card, Flex).
+// Only wraps when every target id lives at the same level AND is contiguous
+// there — a non-contiguous or cross-parent selection has no unambiguous
+// wrapped order, so it's left unwrapped rather than silently reordering.
+export const wrapInstancesInTree = (
+  instances: BuilderInstance[],
+  targetIds: string[],
+  wrapper: BuilderInstance
+): { instances: BuilderInstance[]; wrapped: boolean } => {
+  const targetIdSet = new Set(targetIds);
+  const matchedIndexes: number[] = [];
+  instances.forEach((instance, index) => {
+    if (targetIdSet.has(instance.id)) matchedIndexes.push(index);
+  });
+
+  if (matchedIndexes.length > 0 && matchedIndexes.length === targetIdSet.size) {
+    const isContiguous = matchedIndexes.every(
+      (value, index) => index === 0 || value === matchedIndexes[index - 1] + 1
+    );
+    if (!isContiguous) return { instances, wrapped: false };
+
+    const firstIndex = matchedIndexes[0];
+    const lastIndex = matchedIndexes[matchedIndexes.length - 1];
+    const nextWrapper: BuilderInstance = {
+      ...wrapper,
+      children: instances.slice(firstIndex, lastIndex + 1),
+    };
+
+    return {
+      instances: [
+        ...instances.slice(0, firstIndex),
+        nextWrapper,
+        ...instances.slice(lastIndex + 1),
+      ],
+      wrapped: true,
+    };
+  }
+
+  if (matchedIndexes.length > 0) return { instances, wrapped: false };
+
+  let wrapped = false;
+  const nextInstances = instances.map((instance) => {
+    if (wrapped) return instance;
+
+    const childResult = wrapInstancesInTree(instance.children, targetIds, wrapper);
+    if (!childResult.wrapped) return instance;
+
+    wrapped = true;
+    return { ...instance, children: childResult.instances };
+  });
+
+  return { instances: nextInstances, wrapped };
+};
+
 export const buildTargetOptions = (
   instances: BuilderInstance[],
   kitsByName: Record<string, PlaygroundKit>,


### PR DESCRIPTION
What does this PR do?

Expands the full-page Playground builder with persistence, sharing, and multi-select wrapping, re-enables the local Prompt Builder with several correctness fixes, and closes a series of security gaps in the new share-link feature discovered through iterative review. Add your Runway ticket URL here.

### Feature additions

1. Autosave — the canvas now persists to localStorage on a debounce and restores on page load, so a refresh no longer wipes your work.
2. Undo/Redo — a proper redo stack alongside the existing undo history.
3. Share link — a "Share" button serializes the canvas into a compact, gzip-compressed ?state= URL param (with a plain-text fallback for browsers without CompressionStream) that a teammate can open to reproduce the same canvas. Includes a status message when a link is loaded or fails to load.
4. Wrap kits together — a "Select kits to wrap" toggle lets you click multiple kits on the canvas and wrap them in a new container kit (Card, Flex, etc.) via the Inspector, instead of manually dragging a wrapper in and moving kits into it one at a time.
5. Prompt Builder — re-enabled the local, keyword-based recipe builder ("describe the screen" → generates kits) with:
  - Fixed substring false-positives in keyword matching (e.g. "form" no longer matches inside "performance").
  - Example-prompt chips, Cmd/Ctrl+Enter to submit, Escape to close.
  - "crud" now routes to the form recipe.
  - Fixed "change X input for Y input"–style prompts, which previously fell through and silently regenerated the whole canvas instead of renaming the one field.
  - Fixed kit-swap prompts (e.g. "replace select kit with dropdown kit") for kit types the swap modifier didn't previously recognize.
  - (Currently commented out in the render tree per request — logic is in place, one-line re-enable.)

### Security fixes (share link)

1. The share link is the one feature in this PR that accepts cross-user input (a URL someone else can craft and send), so it went through several rounds of review. Summary of what's now blocked when importing a ?state= link:
2. 
3. Raw JS execution via the __playgroundCode escape hatch or a bare string value on a function-typed prop (both get spliced verbatim into code the live preview evaluates).
4. Raw JSX/code injection via configuredChildren — now allowed only when it matches the kit's own computed default, not just rejected outright (that was too strict and broke ordinary sharing of any kit with default children, e.g. Card).
5. Prop-name forgery — payloads are now checked against an allowlist of prop names the kit could legitimately produce (schema props + data-preset/structure-mode/preset-driven props), which blocks smuggling framework-level props like htmlOptions.dangerouslySetInnerHTML that would otherwise render as raw HTML with no code-eval needed at all.
6. Prototype-pollution keys (__proto__, constructor, prototype) as defense-in-depth.
7. Data loss: importing a share link on a fresh page load now snapshots whatever was already on the canvas (e.g. restored from localStorage) as an undo point first, instead of silently overwriting it with no way back once autosave fires.
8. Clipboard reliability: the Share button now starts the clipboard write synchronously in the click handler (via a promise-valued ClipboardItem) instead of after an await, so Safari's transient-activation requirement doesn't reject the copy; on failure it falls back to a native prompt with the link instead of failing silently.

### Bug fixes

1. Inspector no longer collapses to half-width and mismatches the props panel's default width when nothing is selected.
2. Move Up/Down buttons no longer disappear for leaf kits (Button, Caption, etc.) — a regression from nesting them under the "accepts children" check.
3. Fixed a broken tooltip icon name in the Inspector's wrap controls.

How to test?

Add a few kits to the canvas, refresh the page — confirm they're still there.
Make a few edits, click Undo/Redo — confirm they step through correctly.
Click Share, paste the link in a new tab (or private window) — confirm the canvas reproduces, including a wrapped group and a kit with default children (e.g. Card).
Try a crafted/garbage ?state= value — confirm you get the "couldn't be loaded" message, not a broken canvas.
With something already on the canvas, open a valid share link fresh (new tab) — confirm Undo brings back the pre-import canvas.
Turn on "Select kits to wrap," select 2–3 adjacent kits, wrap them in a Card — confirm they nest correctly and non-adjacent selections are rejected with a message.
Select a leaf kit (e.g. Button) — confirm Move Up/Down still show.
Test the Share button on Safari specifically, given the fix targeted its stricter clipboard activation rules.


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.