### PR TITLE
feat: render traefik ingress in production

### DIFF
--- a/playbook-website/config/deploy/templates/ingress.yaml.erb
+++ b/playbook-website/config/deploy/templates/ingress.yaml.erb
@@ -33,7 +33,6 @@ spec:
                 port:
                   number: 80
     <% end %>
-<% if environment != 'production' %>
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -62,4 +61,3 @@ spec:
                 port:
                   number: 80
     <% end %>
-<% end %>


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Adds a parallel Traefik-class Ingress alongside the existing nginx ingress in production as part of the nginx to Traefik ingress migration.

Runway ticket: https://runway.powerhrg.com/backlog_items/WTWR-2365

**Screenshots:**
No UI change. Validation of the flipped host over real DNS.

**How to test?** Steps to confirm the desired behavior:

1. Add the `milano` label to deploy a review env.
2. In the review  PR and confirm its `playbook-traefik` ingress renders and serves 200 with a valid cert.
3. Merge this PR
4. Confirm both ingresses exist in production namespace, for example:
   `kubectl -n playbook-production get ingress` shows `playbook` (nginx) and `playbook-traefik` (traefik).
5. Hit the Traefik VIP directly:
   `curl -sk --resolve playbook.powerapp.cloud:443:10.1.12.28 -o /dev/null -w '%{http_code}' https://playbook.powerapp.cloud/` returns 200.

#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.