### PR TITLE
[PLAY-3197] Advanced Table: Vertical Borders Disappear upon Hover Firefox only

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -1076,6 +1076,30 @@
       }
     }
 
+    // Firefox-specific fix for vertical borders disappearing upon row hover
+    .pb_table.vertical-border .pb_advanced_table_body {
+      td:not(:last-child):not(.last-cell),
+      .pb_table_td:not(:last-child):not(.last-cell) {
+        position: relative;
+        border-right-color: transparent !important;
+
+        &::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          right: -1px;
+          bottom: -1px;
+          width: 1px;
+          background-color: var(--table-border-color);
+        }
+
+        // The base kit gives the first column's divider the column group color
+        &:first-child::before {
+          background-color: var(--column-border-color);
+        }
+      }
+    }
+
     &[class*="column-group-border-"] {
       .pb_advanced_table_header {
         th[colspan]:not([colspan="1"]):not(:last-child),
@@ -1119,6 +1143,14 @@
         .pb_table_td.last-cell:not(:last-child) {
           border-right: none !important;
           box-shadow: 1px 0 0 0 $border_dark !important;
+        }
+      }
+
+      // --table-border-color stays light in dark mode, matches token of base kit's dark vertical border
+      .pb_table.vertical-border .pb_advanced_table_body {
+        td:not(:last-child):not(.last-cell)::before,
+        .pb_table_td:not(:last-child):not(.last-cell)::before {
+          background-color: $border_dark;
         }
       }
 

--- a/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
+++ b/playbook/app/pb_kits/playbook/pb_advanced_table/_advanced_table.scss
@@ -1078,8 +1078,8 @@
 
     // Firefox-specific fix for vertical borders disappearing upon row hover
     .pb_table.vertical-border .pb_advanced_table_body {
-      td:not(:last-child):not(.last-cell),
-      .pb_table_td:not(:last-child):not(.last-cell) {
+      tr:not(.virtualized-table-row) td:not(:last-child):not(.last-cell),
+      .pb_table_tr:not(.virtualized-table-row) .pb_table_td:not(:last-child):not(.last-cell) {
         position: relative;
         border-right-color: transparent !important;
 
@@ -1148,8 +1148,8 @@
 
       // --table-border-color stays light in dark mode, matches token of base kit's dark vertical border
       .pb_table.vertical-border .pb_advanced_table_body {
-        td:not(:last-child):not(.last-cell)::before,
-        .pb_table_td:not(:last-child):not(.last-cell)::before {
+        tr:not(.virtualized-table-row) td:not(:last-child):not(.last-cell)::before,
+        .pb_table_tr:not(.virtualized-table-row) .pb_table_td:not(:last-child):not(.last-cell)::before {
           background-color: $border_dark;
         }
       }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3197](https://runway.powerhrg.com/backlog_items/PLAY-3197) addresses a Firefox-only bug where the vertical borders added to an Advanced Table via `tableProps: vertical_border` would disappear from a row when that specific row was hovered over by the cursor. This issue, while Firefox only, was happening for React & Rails and light & dark modes; it does not happen for the regular Table kit with vertical_border. Adding some Firefox-specific CSS resolves the issue - no doc updates required but locally tested for a basic Advanced Table, a multi-column Advanced Table, and when the columnGroupBorderColor prop was used along with vertical_border (see screenshots from local below).

**Screenshots:** Screenshots to visualize your addition/change
Current Prod (ticket also has link to video from initial bug observation):
<img width="981" height="653" alt="current prod vertical borders disappear firefox" src="https://github.com/user-attachments/assets/5673df78-0ba3-4401-bcd8-806487a345c7" />
Updated:
<img width="964" height="873" alt="for pr react basic table" src="https://github.com/user-attachments/assets/df26b0ce-07d9-433c-83cf-b8f220496736" />
<img width="992" height="836" alt="for pr rails multi column table" src="https://github.com/user-attachments/assets/e9adea56-c633-4416-9dc6-8327fda080b7" />
<img width="975" height="899" alt="for pr with column group border color" src="https://github.com/user-attachments/assets/3bd9f096-8c12-4435-95f2-063f6655cb05" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the Advanced Table Table Props doc example ([rails](https://pr6573.playbook.wc.beta.px.powerapp.cloud/kits/advanced_table/default/rails#advanced_table_table_props), [react](https://pr6573.playbook.wc.beta.px.powerapp.cloud/kits/advanced_table/default/react#advanced_table_table_props)) in Firefox. Hover the mouse over a row and see the vertical borders persist vs. current prod. 


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.