### PR TITLE
fix: bind playbook traefik ingress to public entrypoint in production

### DIFF
--- a/playbook-website/config/deploy/templates/ingress.yaml.erb
+++ b/playbook-website/config/deploy/templates/ingress.yaml.erb
@@ -40,6 +40,10 @@ metadata:
   name: playbook-traefik
   labels:
     app: playbook
+  <% if environment == 'production' %>
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: https,https-public
+  <% end %>
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
**What does this PR do?** 

The playbook-traefik object only bound the internal https entrypoint, so playbook.powerapp.cloud returned 404 page not found through Traefik for any access outside the VPN. This PR adds the annotation traefik.ingress.kubernetes.io/router.entrypoints: https,https-public to allow public access

**Screenshots:**
N/A. Infrastructure change in the deploy template, no UI change.

**How to test?** Steps to confirm the desired behavior:

1. Merge and let milano roll out the production deploy.
2. Confirm playbook-traefik in playbook-production carries the annotation traefik.ingress.kubernetes.io/router.entrypoints: https,https-public.
3. Hit the public Traefik VIP without the VPN:
curl -sS -o /dev/null -w "%{http_code}\n" --resolve playbook.powerapp.cloud:443:74.80.207.40 https://playbook.powerapp.cloud/


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.