### PR TITLE
[PLAY-3159] LOCAL POC - Add Nitro ID to /playground and set up for local server test

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,5 @@
+# Local dev: expose MySQL on localhost:3306 when running Rails via yarn start-dev (not inside Docker).
+services:
+  db:
+    ports:
+      - "3306:3306"

--- a/playbook-website/Gemfile
+++ b/playbook-website/Gemfile
@@ -28,6 +28,11 @@ gem "will_paginate"
 gem "sentry-ruby"
 gem "sentry-rails"
 
+# LOCAL POC only — path assumes ~/Projects/nitro-id beside ~/Projects/playbook.
+# Do not merge to main until private-gem packaging is settled with SHIELD.
+gem "omniauth-nitro-id", "1.3.3"
+gem "cittadella", path: "../../nitro-id/cittadella"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/playbook-website/Gemfile.lock
+++ b/playbook-website/Gemfile.lock
@@ -1,4 +1,16 @@
 PATH
+  remote: ../../nitro-id/cittadella
+  specs:
+    cittadella (0.3.5)
+      activerecord-session_store (~> 2.0)
+      json-jwt (~> 1.15.0)
+      jwt (~> 2.7)
+      omniauth (>= 2.1.2)
+      rails (>= 7.0)
+      two_percent (>= 0.5.0)
+      warden (~> 1.2.6)
+
+PATH
   remote: ../playbook
   specs:
     playbook_ui (17.1.0)
@@ -64,6 +76,12 @@ GEM
       activemodel (= 7.2.2.2)
       activesupport (= 7.2.2.2)
       timeout (>= 0.4.0)
+    activerecord-session_store (2.3.0)
+      actionpack (>= 7.1)
+      activerecord (>= 7.1)
+      cgi (>= 0.3.6)
+      rack (>= 2.0.8, < 4)
+      railties (>= 7.1)
     activestorage (7.2.2.2)
       actionpack (= 7.2.2.2)
       activejob (= 7.2.2.2)
@@ -82,7 +100,14 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    aes_key_wrap (1.1.0)
+    aether_observatory (1.2.0)
+      activemodel (>= 7.1)
+      activesupport (>= 7.1)
     ast (2.4.2)
+    attr_required (1.0.2)
     base64 (0.3.0)
     benchmark (0.4.1)
     better_errors (2.10.1)
@@ -90,6 +115,7 @@ GEM
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
     bigdecimal (3.1.8)
+    bindata (3.0.0)
     bindex (0.8.1)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
@@ -97,6 +123,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.3.0)
     byebug (11.1.3)
+    cgi (0.5.2)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -121,8 +148,12 @@ GEM
     front_matter_parser (1.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.1.0)
+      logger
     health_check (3.1.0)
       railties (>= 5.0)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -131,6 +162,13 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.7.2)
+    json-jwt (1.15.3.1)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
+      httpclient
+    jwt (2.10.3)
+      base64
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -151,6 +189,7 @@ GEM
     mini_portile2 (2.8.9)
     minitest (5.25.1)
     msgpack (1.7.2)
+    mutex_m (0.3.0)
     mysql2 (0.5.6)
     net-imap (0.5.12)
       date
@@ -181,6 +220,32 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-musl)
       racc (~> 1.4)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-nitro-id (1.3.3)
+      omniauth-rails_csrf_protection (= 1.0.1)
+      omniauth_openid_connect (~> 0.4.0)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth_openid_connect (0.4.0)
+      addressable (~> 2.5)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 1.1)
+    openid_connect (1.4.2)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.15.0)
+      net-smtp
+      rack-oauth2 (~> 1.21)
+      swd (~> 1.3)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (~> 1.2)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
@@ -189,10 +254,20 @@ GEM
       prettyprint
     prettyprint (0.2.0)
     psych (3.3.4)
+    public_suffix (7.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
+    rack-oauth2 (1.21.3)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.8.3)
       rack
     rack-session (1.0.2)
@@ -290,18 +365,31 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     strscan (3.1.0)
+    swd (1.3.0)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     thor (1.3.2)
     timeout (0.4.4)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
+    two_percent (1.3.1)
+      aether_observatory (>= 1.0)
+      rails (>= 6.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2024.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
     useragent (0.16.11)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     view_component (2.83.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -313,11 +401,16 @@ GEM
       dry-cli (>= 0.7, < 2)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webfinger (1.2.0)
+      activesupport
+      httpclient (>= 2.4)
     webrick (1.9.1)
     websocket-driver (0.8.0)
       base64
@@ -347,12 +440,14 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
+  cittadella!
   diff-lcs (= 1.4.4)
   faker
   front_matter_parser (~> 1.0.1)
   health_check
   listen
   mysql2 (= 0.5.6)
+  omniauth-nitro-id (= 1.3.3)
   playbook_ui!
   psych (< 4)
   puma (~> 6.4.2)

--- a/playbook-website/app/controllers/application_controller.rb
+++ b/playbook-website/app/controllers/application_controller.rb
@@ -10,4 +10,14 @@ class ApplicationController < ActionController::Base
   def set_app_js
     @application_js = %w[application]
   end
+
+  # LOCAL POC: used by layout bootstrap + playground gate
+  def playground_authenticated?
+    return false unless respond_to?(:current_identity, true)
+
+    current_identity(scope: :user).present?
+  rescue
+    false
+  end
+  helper_method :playground_authenticated?
 end

--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -9,6 +9,9 @@ class PagesController < ApplicationController
   include ::ViteRails::TagHelpers
   rescue_from ActionView::MissingTemplate, :with => :page_not_found
 
+  # LOCAL POC: gate full Playground page + /playground.json (not kit Playground tabs)
+  before_action :require_playground_auth, if: :playground_request?
+
   def application
     @kits = MENU["kits"]
     @dark = cookies[:dark_mode] == "true"
@@ -220,6 +223,7 @@ class PagesController < ApplicationController
         render json: {
           kits: @kits,
           dark: @dark,
+          playground_accessible: playground_authenticated?,
           type: @type,
           examples: examples,
           kit: @kit,
@@ -313,6 +317,26 @@ class PagesController < ApplicationController
   helper_method :get_source, :get_description
 
 private
+
+  def playground_request?
+    request.path.include?("playground")
+  end
+
+  def require_playground_auth
+    return if current_identity(scope: :user).present?
+
+    if request.format.json?
+      render json: {
+        error: "unauthorized",
+        login_url: entrypoint_path(:user),
+      }, status: :unauthorized
+      return
+    end
+
+    session[:scope] = "user"
+    session[:return_to] = request.fullpath
+    authenticate_user!(scope: :user)
+  end
 
   # will_paginate expects a numeric page; guide routes use params[:page] for the markdown slug.
   def will_paginate_page

--- a/playbook-website/app/controllers/sessions_controller.rb
+++ b/playbook-website/app/controllers/sessions_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# LOCAL POC: return users to /playground (or stored return_to) after Nitro ID login.
+class SessionsController < ApplicationController
+  include Cittadella::SessionConcern
+
+  set_login_callback_redirect do
+    session.delete(:return_to).presence || "/playground"
+  end
+end

--- a/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
+++ b/playbook-website/app/javascript/components/Website/src/layouts/Sidebar/TopLevelNavItems.tsx
@@ -6,6 +6,25 @@ import { SideBarNavItems } from "./MenuData/SidebarNavItems";
 import { OtherNavItems } from "./NavComponents/OtherNavComponent";
 import { CollapsedHoverNav } from "./CollapsedHoverNav";
 
+declare global {
+  interface Window {
+    __PLAYBOOK_AUTH__?: {
+      playgroundAccessible?: boolean;
+      loginPath?: string;
+      logoutPath?: string;
+    };
+  }
+}
+
+// LOCAL POC: hide Playground nav unless Nitro ID session is present (server still enforces).
+const visibleSideBarNavItems = () => {
+  if (typeof window === "undefined") return SideBarNavItems;
+  if (window.__PLAYBOOK_AUTH__?.playgroundAccessible) return SideBarNavItems;
+  return SideBarNavItems.filter((item) => item.link !== "/playground");
+};
+
+const NAV_ITEMS = visibleSideBarNavItems();
+
 export const TopLevelNavItem = ({
   dark,
   type,
@@ -23,7 +42,7 @@ export const TopLevelNavItem = ({
   const location = useLocation();
   const currentURL = location.pathname + location.search;
   //hook into collapsible logic for top level item
-  const topLevelCollapsibles = SideBarNavItems.map(() => useCollapsible());
+  const topLevelCollapsibles = NAV_ITEMS.map(() => useCollapsible());
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const itemElsRef = useRef<Record<string, HTMLElement | null>>({});
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -75,7 +94,7 @@ export const TopLevelNavItem = ({
 
   //set up toggling for top level item
   const handleComponentsClick = (item, index) => {
-    const linkPath = TopLevelLink(SideBarNavItems[index].link);
+    const linkPath = TopLevelLink(NAV_ITEMS[index].link);
     if (linkPath && navigate) {
       navigate(linkPath);
     }
@@ -265,8 +284,8 @@ export const TopLevelNavItem = ({
     );
   };
 
-  const hoveredItem = SideBarNavItems.find((item) => item.key === hoveredKey);
-  const hoveredIndex = SideBarNavItems.findIndex((item) => item.key === hoveredKey);
+  const hoveredItem = NAV_ITEMS.find((item) => item.key === hoveredKey);
+  const hoveredIndex = NAV_ITEMS.findIndex((item) => item.key === hoveredKey);
 
   const updateTopLevelNavFromHover = (index: number) => {
     topLevelCollapsibles.forEach((collapsible, i) => {
@@ -282,7 +301,7 @@ export const TopLevelNavItem = ({
 
   return (
     <>
-      {SideBarNavItems.map(({ name, key, children, leftIcon, link }, i) => {
+      {NAV_ITEMS.map(({ name, key, children, leftIcon, link }, i) => {
         return renderTopItems(name, key, children, leftIcon, link, i);
       })}
       {sidebarCollapsed && hoveredItem && hoveredKey && (

--- a/playbook-website/app/models/user.rb
+++ b/playbook-website/app/models/user.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  validates :email, presence: true, uniqueness: true
+end

--- a/playbook-website/app/views/layouts/_head.html.erb
+++ b/playbook-website/app/views/layouts/_head.html.erb
@@ -7,6 +7,15 @@
 <%= csrf_meta_tags%>
 <%= csp_meta_tag%>
 
+<%# LOCAL POC: bootstrap auth for SPA nav (Playground link) %>
+<script>
+  window.__PLAYBOOK_AUTH__ = <%= raw({
+    playgroundAccessible: playground_authenticated?,
+    loginPath: entrypoint_path(:user),
+    logoutPath: logout_path,
+  }.to_json) %>;
+</script>
+
 <meta content="user-scalable=0, initial-scale=1.0, minimum-scale=1" name="viewport" />
 
 <style>

--- a/playbook-website/config/database.yml
+++ b/playbook-website/config/database.yml
@@ -5,6 +5,7 @@ base: &base
   username: <%= ENV['DATABASE_USER'] || "root" %>
   password: <%= ENV['DATABASE_PASSWORD'] || "password" %>
   host: <%= ENV['DATABASE_HOST'] || "db" %>
+  port: <%= ENV['DATABASE_PORT'] || 3306 %>
   database: <%= ENV['DATABASE_NAME'] || "playbook_website" %>
   advisory_locks: <%= ENV['DATABASE_ADVISORY_LOCKS'] || false %>
 

--- a/playbook-website/config/initializers/cittadella.rb
+++ b/playbook-website/config/initializers/cittadella.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# LOCAL POC: Nitro ID auth via Cittadella (gates /playground only).
+# Requires NITRO_ID_CLIENT_ID + NITRO_ID_CLIENT_SECRET (same local client as dummy app is fine
+# if redirect URIs point at http://localhost:3000/sessions/nitro_id/callback).
+
+Cittadella.configure do |config|
+  config.omniauth.provider_name = :nitro_id
+  config.omniauth.scope = %i[openid email profile groups offline_access]
+  config.omniauth.client_options = {
+    identifier: ENV.fetch("NITRO_ID_CLIENT_ID", nil),
+    secret: ENV.fetch("NITRO_ID_CLIENT_SECRET", nil),
+  }
+  config.omniauth.post_logout_redirect_uri =
+    ENV.fetch("NITRO_ID_POST_LOGOUT_REDIRECT_URI", "http://localhost:3000/")
+  config.omniauth.issuer = ENV.fetch("NITRO_ID_ISSUER", "https://id.powerhrg.com")
+  config.omniauth.provider_secret =
+    ENV.fetch("NITRO_ID_PROVIDER_SECRET", ENV.fetch("NITRO_ID_API_KEY", nil))
+
+  config.enable_scim_provisioning = false
+
+  config.sessions.controller_name = "sessions"
+
+  # On login, create a local User from the Nitro ID email if one doesn't exist yet.
+  config.sessions.identity_finder = ->(auth_info) {
+    email = auth_info.extra&.raw_info&.email
+    return if email.blank?
+
+    User.find_or_create_by!(email: email)
+  }
+
+  config.sessions.unauthorized_handler = -> {
+    redirect_to entrypoint_path(:user)
+  }
+
+  config.identities.identity(:user)
+end

--- a/playbook-website/config/routes.rb
+++ b/playbook-website/config/routes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # LOCAL POC: Nitro ID / Cittadella (login, callback, logout)
+  mount Cittadella::Engine, at: "/"
+
   root to: "pages#application"
 
   # Legacy /beta/* redirects (301)

--- a/playbook-website/db/migrate/20260827140000_create_users.rb
+++ b/playbook-website/db/migrate/20260827140000_create_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/playbook-website/db/migrate/20260827140001_add_sessions_table.rb
+++ b/playbook-website/db/migrate/20260827140001_add_sessions_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddSessionsTable < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/playbook-website/db/migrate/20260827140002_add_cittadella_attributes.rb
+++ b/playbook-website/db/migrate/20260827140002_add_cittadella_attributes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddCittadellaAttributes < ActiveRecord::Migration[7.2]
+  def change
+    change_table :sessions, bulk: true do |t|
+      t.string :provider_session_id
+      t.string :access_token
+      t.string :refresh_token
+      t.datetime :expires_at
+    end
+    add_reference :sessions, :identity, polymorphic: true, index: true
+  end
+end

--- a/playbook-website/db/migrate/20260827140003_add_scopes.rb
+++ b/playbook-website/db/migrate/20260827140003_add_scopes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddScopes < ActiveRecord::Migration[7.2]
+  def change
+    change_table :sessions, bulk: true do |t|
+      t.remove :access_token, type: :string
+      t.remove :refresh_token, type: :string
+      t.string :scope
+    end
+  end
+end

--- a/playbook-website/db/schema.rb
+++ b/playbook-website/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,5 +12,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_27_140003) do
+  create_table "sessions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "provider_session_id"
+    t.datetime "expires_at"
+    t.string "identity_type"
+    t.bigint "identity_id"
+    t.string "scope"
+    t.index %w[identity_type identity_id], name: "index_sessions_on_identity"
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 end

--- a/playbook-website/db/seeds.rb
+++ b/playbook-website/db/seeds.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Users are created automatically on Nitro ID login (see cittadella.rb identity_finder).
+# Nothing to seed for auth.


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3159

Local spike to gate /playground behind Nitro ID (via Cittadella) so only signed-in Power users can reach it, while the rest of the docs site stays public. Users are created from their login email on first sign-in; this is for investigation only — it depends on a local path gem to Cittadella and MySQL, so CI/packaging still need a real plan before this can ship.

Note: this only works for local servers. CI/CD will likely fail if we tried to build a test env. 

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.