### PR TITLE
[PLAY-3181] File Upload kit - add custom_message for parity

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.scss
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.scss
@@ -20,7 +20,7 @@
   }
   .pb_form_group_kit {
     > .pb_button_kit.file_upload_custom_message_spacing {
-      margin-bottom: 0;
+      margin-bottom: $space_xxs;
     }
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.scss
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/_file_upload.scss
@@ -18,6 +18,11 @@
       margin-top: $space_xs;
     }
   }
+  .pb_form_group_kit {
+    > .pb_button_kit.file_upload_custom_message_spacing {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .pb_file_upload_kit_error {

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_custom_message.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_custom_message.html.erb
@@ -1,0 +1,32 @@
+<%= pb_rails("file_upload", props: {
+  accept: ".pdf,.xlsx",
+  custom_message: "Choose a file. The accepted file types are Adobe (.pdf) and Microsoft (.xlsx)",
+  id: "file-upload-custom-message-file-types",
+}) %>
+
+<%= pb_rails("file_upload", props: {
+  custom_message: "Max Size: 10MB.",
+  id: "file-upload-custom-message-max-size",
+  margin_top: "md",
+}) %>
+
+<%= javascript_tag defer: "defer" do %>
+  document.addEventListener("DOMContentLoaded", function () {
+    const fileInput = document.getElementById("upload-file-upload-custom-message-max-size")
+    const maxSize = 10 * 1000 * 1000
+
+    if (!fileInput) return
+
+    fileInput.addEventListener("change", function () {
+      const files = Array.from(fileInput.files || [])
+      const fileTooLarge = files.some((file) => file.size > maxSize)
+
+      if (fileTooLarge) {
+        fileInput.setCustomValidity("File size is too large. Maximum file size is 10MB.")
+        fileInput.reportValidity()
+      } else {
+        fileInput.setCustomValidity("")
+      }
+    })
+  })
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_custom_message_rails.md
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_custom_message_rails.md
@@ -1,0 +1,3 @@
+Use the `custom_message` prop to provide additional information about the files that can be uploaded, such as accepted file types or maximum file size. The `custom_message` is informational only.
+
+The first example demonstrates using it along with the `accept` prop and serves as a description of accepted files. The second example demonstrates using it as a max size warning with a script tag mimicking a client-side alert; however, when actually implemented file size limits should be enforced server-side when processing the uploaded file.

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_input_options.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_input_options.html.erb
@@ -1,0 +1,3 @@
+<%= pb_rails("file_upload", props: { input_options: { name: "my_file_upload"}}) %>
+
+ 

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_input_options.md
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/_file_upload_input_options.md
@@ -1,0 +1,1 @@
+Use `input_options` to access the File Upload input directly. Common implemenation patterns use this to add a `name` prop directly to the input, among other props.

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/_playground.json
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/_playground.json
@@ -3,6 +3,7 @@
   "propTargets": {},
   "defaults": {
     "accept": {},
+    "customMessage": "",
     "dark": false
   },
   "groups": [

--- a/playbook/app/pb_kits/playbook/pb_file_upload/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/docs/example.yml
@@ -3,8 +3,10 @@ examples:
   rails:
   - file_upload_default: File Upload
   - file_upload_custom: Custom
+  - file_upload_custom_message: Add a custom message
   - file_upload_error: Error
   - file_upload_remove_replace: Remove and Replace
+  - file_upload_input_options: Input Options
 
   react:
   - file_upload_default: Default List of files to upload

--- a/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
@@ -10,7 +10,7 @@
           type: "file",
           dark: object.dark,
           error: object.error.presence,
-          margin_bottom: object.custom_message.present? ? "none" : nil,
+          margin_bottom: object.custom_message.present? ? "xxs" : nil,
           input_options: {
             accept: object.accept.presence,
             id: "upload-#{object.id}",

--- a/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.html.erb
@@ -1,8 +1,8 @@
 <%= pb_content_tag(:div) do %>
-      <%= pb_rails("form_group", props: {cursor: "pointer", full_width: object.full_width}) do %>
+      <%= pb_rails("form_group", props: {cursor: "pointer", full_width: object.full_width,  margin_bottom: object.custom_message.present? ? "none" : nil}) do %>
         <label
           for="upload-<%= object.id %>"
-          class="pb_button_kit pb_button_secondary pb_button_inline pb_button_enabled <%= 'dark' if object.dark %>"
+          class="pb_button_kit pb_button_secondary pb_button_inline pb_button_enabled <%= 'dark' if object.dark %> <%= 'file_upload_custom_message_spacing' if object.custom_message.present? %>"
         >
           <%= "#{object.label}" %>
         </label>
@@ -10,11 +10,20 @@
           type: "file",
           dark: object.dark,
           error: object.error.presence,
+          margin_bottom: object.custom_message.present? ? "none" : nil,
           input_options: {
+            accept: object.accept.presence,
             id: "upload-#{object.id}",
-            classname: "cursor_pointer",
-          }.merge(object.input_options)
+            classname: "cursor_pointer ",
+          }.compact.merge(object.input_options)
         }) %>
       <% end %>
-    </label>
+      <% if object.custom_message.present? %>
+        <%= pb_rails("body", props: {
+          text: object.custom_message,
+          dark: object.dark,
+          color: "lighter",
+          classname: "file_upload_custom_message"
+        }) %>
+      <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.rb
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/file_upload.rb
@@ -23,6 +23,9 @@ module Playbook
 
       prop :error, type: Playbook::Props::String
 
+      prop :custom_message, type: Playbook::Props::String,
+                            default: ""
+
       def classname
         file_upload_class = generate_classname("pb_file_upload_kit")
         file_upload_class + error_class + full_width_class

--- a/playbook/app/pb_kits/playbook/pb_file_upload/kit.schema.json
+++ b/playbook/app/pb_kits/playbook/pb_file_upload/kit.schema.json
@@ -18,8 +18,10 @@
     "customMessage": {
       "type": "string",
       "platforms": [
-        "react"
-      ]
+        "react",
+        "rails"
+      ],
+      "default": ""
     },
     "dark": {
       "type": "boolean",

--- a/playbook/spec/pb_kits/playbook/kits/file_upload_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/file_upload_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Playbook::PbFileUpload::FileUpload do
   subject { Playbook::PbFileUpload::FileUpload }
 
   it { is_expected.to define_prop(:accept).of_type(Playbook::Props::String).with_default("") }
+  it { is_expected.to define_prop(:custom_message).of_type(Playbook::Props::String).with_default("") }
   it { is_expected.to define_prop(:files).of_type(Playbook::Props::Array).with_default([]) }
   it { is_expected.to define_prop(:label).of_type(Playbook::Props::String).with_default("Upload File") }
   it { is_expected.to define_prop(:placeholder).of_type(Playbook::Props::String).with_default("No file") }
@@ -40,6 +41,19 @@ RSpec.describe Playbook::PbFileUpload::FileUpload do
 
     it "returns '' if error prop is nil", :aggregate_failures do
       expect(subject.new(error: nil).error_class).to eq ""
+    end
+  end
+
+  describe "#custom_message" do
+    it "returns a file upload with a custom message displayed", :aggregate_failures do
+      kit = subject.new(
+        custom_message: "Choose a file. The accepted file types are Adobe (.pdf) and Microsoft (.xlsx)"
+      )
+
+      expect(kit.custom_message).to eq(
+        "Choose a file. The accepted file types are Adobe (.pdf) and Microsoft (.xlsx)"
+      )
+      expect(subject.new.custom_message).to eq ""
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3181](https://runway.powerhrg.com/backlog_items/PLAY-3181) creates a `custom_message` prop for the Rails File Upload which can serve as Railsy-parity for certain specialized props the React version of the kit already has. Dictating specific accepted files from the `accept prop` or controlling max size would require making this kit into an Enhanced Element kit; redirecting these custom messages into a `custom_message` prop keeps things light weight and does not compromise the native html File Upload at the base of the kit. 

The custom message doc is the first place the `accept` prop is demoed on the page as well (looking through Nitro it appears that devs have been adding accept directly to the input via input options), so that is a nice bonus. The markdown outlines how to use it to mimic React's `acceptedFilesDescription` and `maxSize` props. I also included an additional doc reminding devs about `input_options`, which is the current recommended way to get a `name` prop onto the file upload input itself (and as mentioned what is often passing `accept` as well).

**Screenshots:** Screenshots to visualize your addition/change
<img width="1085" height="506" alt="xxs spacing" src="https://github.com/user-attachments/assets/dba0b64a-d8e8-4614-90b7-bfec50fbc5cb" />
<img width="1117" height="343" alt="input options doc" src="https://github.com/user-attachments/assets/0fef0638-60da-4a81-91ef-477ad2f7bfea" />


**How to test?** Steps to confirm the desired behavior:
1. Go to File Upload Rails page and interact with new [custom message](https://pr6578.playbook.wc.beta.px.powerapp.cloud/kits/file_upload/rails#file_upload_custom_message) and [input options](https://pr6578.playbook.wc.beta.px.powerapp.cloud/kits/file_upload/rails#file_upload_input_options) docs.


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.