### PR TITLE
[HFH-4935] Add repository metadata to the playbook_ui gemspec

### DIFF
--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -14,6 +14,16 @@ Gem::Specification.new do |s|
   s.description = "Playbook UI is built out in Ruby View Components and React Components. Playbook takes a modern design approach and applies it in a way that makes it easy to support bleeding edge or legacy systems."
   s.license     = "ISC"
 
+  # Published gems do not carry the changelog, so tooling that wants release notes
+  # has to be pointed at the repository. changelog_uri names the file directly
+  # because it lives under playbook/, not at the repository root.
+  s.metadata = {
+    "source_code_uri" => "https://github.com/powerhome/playbook",
+    "changelog_uri" => "https://github.com/powerhome/playbook/blob/master/playbook/CHANGELOG.md",
+    "bug_tracker_uri" => "https://github.com/powerhome/playbook/issues",
+    "documentation_uri" => "https://playbook.powerapp.cloud/",
+  }
+
   s.files = Dir[
     "app/pb_kits/playbook/pb_*/**/*",
     "app/pb_kits/playbook/_*.scss",

--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Playbook Design System"
   s.description = "Playbook UI is built out in Ruby View Components and React Components. Playbook takes a modern design approach and applies it in a way that makes it easy to support bleeding edge or legacy systems."
   s.license     = "ISC"
-  s.metadata = {
+  s.metadata    = {
     "source_code_uri" => "https://github.com/powerhome/playbook",
     "changelog_uri" => "https://github.com/powerhome/playbook/blob/master/playbook/CHANGELOG.md",
     "bug_tracker_uri" => "https://github.com/powerhome/playbook/issues",

--- a/playbook/playbook_ui.gemspec
+++ b/playbook/playbook_ui.gemspec
@@ -13,10 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = "Playbook Design System"
   s.description = "Playbook UI is built out in Ruby View Components and React Components. Playbook takes a modern design approach and applies it in a way that makes it easy to support bleeding edge or legacy systems."
   s.license     = "ISC"
-
-  # Published gems do not carry the changelog, so tooling that wants release notes
-  # has to be pointed at the repository. changelog_uri names the file directly
-  # because it lives under playbook/, not at the repository root.
   s.metadata = {
     "source_code_uri" => "https://github.com/powerhome/playbook",
     "changelog_uri" => "https://github.com/powerhome/playbook/blob/master/playbook/CHANGELOG.md",


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Adds metadata to gemspec, allowing easier automated finding/investigation of the CHANGELOG.

---

The published gem carries no changelog, so anything wanting playbook's release notes has to be pointed back at the repository. RubyGems exposes gemspec metadata through its API, which makes this the place to say where that is.

changelog_uri names the file directly rather than relying on a root CHANGELOG.md, because playbook's lives under playbook/.

source_code_uri, bug_tracker_uri, and documentation_uri also populate the links panel on rubygems.org/gems/playbook_ui, which currently shows only the homepage.
