### PR TITLE
[PLAY-3213] Vite upgrade to 6.4.3

### DIFF
--- a/playbook-website/package.json
+++ b/playbook-website/package.json
@@ -51,7 +51,7 @@
     "react-router-dom": "^6.16.0",
     "react-simple-code-editor": "^0.13.1",
     "sass": "^1.77.6",
-    "vite": "6.3.5",
+    "vite": "6.4.3",
     "vite-plugin-ruby": "^5.0.0",
     "zxcvbn": "^4.4.2"
   },

--- a/playbook/package.json
+++ b/playbook/package.json
@@ -118,7 +118,7 @@
     "terser": "^5.39.0",
     "ts-jest": "26.5.6",
     "typescript": "4.3.5",
-    "vite": "6.3.5",
+    "vite": "6.4.3",
     "vite-bundle-visualizer": "^1.2.1",
     "vite-plugin-ruby": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12453,10 +12453,10 @@ vite-plugin-ruby@^5.0.0:
     debug "^4.3.4"
     fast-glob "^3.3.2"
 
-vite@6.3.5:
-  version "6.3.5"
-  resolved "https://npm.powerapp.cloud/vite/-/vite-6.3.5.tgz#fec73879013c9c0128c8d284504c6d19410d12a3"
-  integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
+vite@6.4.3:
+  version "6.4.3"
+  resolved "https://npm.powerapp.cloud/vite/-/vite-6.4.3.tgz#85a164db7ce706f2a776812efa2b340f1721858e"
+  integrity sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==
   dependencies:
     esbuild "^0.25.0"
     fdir "^6.4.4"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[Runway Story](https://runway.powerhrg.com/backlog_items/PLAY-3213?from=backlog)

Updates Vite to 6.4.3 to address several dependabot alerts

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.