### PR TITLE
Playbook Website: Optimize website routing

### DIFF
--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -23,6 +23,7 @@ import {
   syncStoredPlatformFromLocation,
   writeStoredPlatform,
 } from "./src/helpers/platform";
+import { navigateSite } from "./src/utils/siteNavigation";
 
 function WebsiteContent() {
   const {
@@ -135,7 +136,20 @@ function WebsiteContent() {
         `/${nextPlatform}`,
       );
       if (nextPath !== normalizedPath) {
-        navigate(`${nextPath}${location.search}${location.hash}`);
+        // Rails has no Playground tab — drop a stale ?tab=playground so we don't
+        // navigate through it. Route via navigateSite (not raw `navigate`) so a
+        // React→Rails switch made while on staging (Playground tab) goes straight
+        // to prod in one hop instead of rendering the staging route first and
+        // then bouncing to prod from KitShow's staging/prod sync effect.
+        const params = new URLSearchParams(location.search);
+        if (nextPlatform === "rails" && params.get("tab") === "playground") {
+          params.delete("tab");
+        }
+        const search = params.toString();
+        navigateSite(
+          navigate,
+          `${nextPath}${search ? `?${search}` : ""}${location.hash}`,
+        );
       }
       return;
     }

--- a/playbook-website/app/javascript/components/Website/src/app.tsx
+++ b/playbook-website/app/javascript/components/Website/src/app.tsx
@@ -7,21 +7,10 @@ import {
   useLoaderData,
   useParams,
 } from 'react-router-dom'
+import { lazy, Suspense } from 'react'
+import { LoadingInline } from 'playbook-ui'
 
 import App from '../index'
-import Home from './pages/Home'
-import ComponentList from './pages/ComponentList'
-import CategoryShow from './pages/CategoryShow'
-import KitShow from './pages/KitShow'
-import Changelog from './pages/Changelog'
-import GettingStarted from './pages/GettingStarted'
-import DesignGuidelines from './pages/DesignGuidelines'
-import GuidePage from './pages/GuidePage'
-import Playground from './pages/Playground'
-import WorldCup from './pages/WorldCup'
-import Color from './pages/DesignGuidelines/Color'
-import Spacing from './pages/DesignGuidelines/Spacing'
-import Typography from './pages/DesignGuidelines/Typography'
 import Error from './components/Error'
 import {
   CategoryLoader,
@@ -32,20 +21,31 @@ import {
   IconsLoader,
   PlaygroundLoader,
 } from './hooks/loaders'
-import GlobalPropsIndex from './components/GlobalPropsAndTokens/GlobalPropsIndex'
-import GlobalPropsExamples from './components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex'
-import TokensIndex from './components/GlobalPropsAndTokens/TokensIndex'
-import TokensExamples from './components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex'
-import IconsIndex from './components/Icons/IconsIndex'
+
+// Route pages are lazy-loaded (via each Route's `lazy` prop, or React.lazy below
+// for the few pages rendered from an inline wrapper) so every page's code ships
+// as its own chunk fetched on demand, instead of all pages — including the full
+// Playground builder — bundling into one script every page has to download.
+const GlobalPropsExamples = lazy(() => import('./components/GlobalPropsAndTokens/ExamplesPage/GlobalPropsExamplesIndex'))
+const TokensExamples = lazy(() => import('./components/GlobalPropsAndTokens/ExamplesPage/TokensExamplesIndex'))
+const IconsIndex = lazy(() => import('./components/Icons/IconsIndex'))
 
 function GlobalPropsShowPage() {
   const { name } = useParams()
-  return <GlobalPropsExamples routeParamName={name} />
+  return (
+    <Suspense fallback={<LoadingInline />}>
+      <GlobalPropsExamples routeParamName={name} />
+    </Suspense>
+  )
 }
 
 function TokensShowPage() {
   const { name } = useParams()
-  return <TokensExamples routeParamName={name} />
+  return (
+    <Suspense fallback={<LoadingInline />}>
+      <TokensExamples routeParamName={name} />
+    </Suspense>
+  )
 }
 
 function IconsPage() {
@@ -57,12 +57,14 @@ function IconsPage() {
   }: any = useLoaderData()
 
   return (
-    <IconsIndex
-      bannerImageUrl={icon_banner_image_url}
-      iconCategories={icon_categories}
-      iconKitUrl={icon_kit_url}
-      iconsByCategory={icons_by_category}
-    />
+    <Suspense fallback={<LoadingInline />}>
+      <IconsIndex
+        bannerImageUrl={icon_banner_image_url}
+        iconCategories={icon_categories}
+        iconKitUrl={icon_kit_url}
+        iconsByCategory={icons_by_category}
+      />
+    </Suspense>
   )
 }
 
@@ -75,18 +77,24 @@ const router = createBrowserRouter(
       loader={ComponentsLoader}
       path="/"
     >
-      <Route element={<Home />} index />
       <Route
-        element={<KitShow />}
+        index
+        lazy={() => import('./pages/Home').then((mod) => ({ Component: mod.default }))}
+      />
+      <Route
+        lazy={() => import('./pages/KitShow').then((mod) => ({ Component: mod.default }))}
         loader={ComponentShowLoader}
         path="kits/advanced_table/:name/:platform"
       />
       <Route
-        element={<KitShow />}
+        lazy={() => import('./pages/KitShow').then((mod) => ({ Component: mod.default }))}
         loader={ComponentShowLoader}
         path="kits/:name/:platform"
       />
-      <Route path="kits" element={<ComponentList />}>
+      <Route
+        lazy={() => import('./pages/ComponentList').then((mod) => ({ Component: mod.default }))}
+        path="kits"
+      >
         <Route
           element={<Navigate to="react" />}
           loader={ComponentShowLoader}
@@ -94,12 +102,12 @@ const router = createBrowserRouter(
         />
       </Route>
       <Route
-        element={<CategoryShow />}
+        lazy={() => import('./pages/CategoryShow').then((mod) => ({ Component: mod.default }))}
         loader={CategoryLoader}
         path="kit_category/:category"
       />
       <Route
-        element={<GlobalPropsIndex />}
+        lazy={() => import('./components/GlobalPropsAndTokens/GlobalPropsIndex').then((mod) => ({ Component: mod.default }))}
         loader={ComponentsLoader}
         path="global_props"
       />
@@ -109,7 +117,7 @@ const router = createBrowserRouter(
         path="global_props/:name"
       />
       <Route
-        element={<TokensIndex />}
+        lazy={() => import('./components/GlobalPropsAndTokens/TokensIndex').then((mod) => ({ Component: mod.default }))}
         loader={ComponentsLoader}
         path="tokens"
       />
@@ -124,53 +132,56 @@ const router = createBrowserRouter(
         path="icons"
       />
       <Route
-        element={<Playground />}
+        lazy={() => import('./pages/Playground').then((mod) => ({ Component: mod.default }))}
         loader={PlaygroundLoader}
         path="playground"
       />
-      <Route element={<WorldCup />} path="worldcup" />
       <Route
-        element={<Changelog />}
+        lazy={() => import('./pages/WorldCup').then((mod) => ({ Component: mod.default }))}
+        path="worldcup"
+      />
+      <Route
+        lazy={() => import('./pages/Changelog').then((mod) => ({ Component: mod.default }))}
         loader={ComponentsLoader}
         path="changelog"
       />
       <Route
-        element={<Changelog />}
+        lazy={() => import('./pages/Changelog').then((mod) => ({ Component: mod.default }))}
         loader={ComponentsLoader}
         path="changelog/:variant"
       />
       <Route
-        element={<GettingStarted />}
+        lazy={() => import('./pages/GettingStarted').then((mod) => ({ Component: mod.default }))}
         loader={GuidesLoader}
         path="guides/getting_started"
       />
       <Route
-        element={<GuidePage />}
+        lazy={() => import('./pages/GuidePage').then((mod) => ({ Component: mod.default }))}
         loader={GuidePageLoader}
         path="guides/getting_started/:page"
       />
       <Route
-        element={<DesignGuidelines />}
+        lazy={() => import('./pages/DesignGuidelines').then((mod) => ({ Component: mod.default }))}
         loader={GuidesLoader}
         path="guides/design_guidelines"
       />
       <Route
-        element={<Color />}
+        lazy={() => import('./pages/DesignGuidelines/Color').then((mod) => ({ Component: mod.default }))}
         loader={GuidesLoader}
         path="guides/design_guidelines/color"
       />
       <Route
-        element={<Spacing />}
+        lazy={() => import('./pages/DesignGuidelines/Spacing').then((mod) => ({ Component: mod.default }))}
         loader={GuidesLoader}
         path="guides/design_guidelines/spacing"
       />
       <Route
-        element={<Typography />}
+        lazy={() => import('./pages/DesignGuidelines/Typography').then((mod) => ({ Component: mod.default }))}
         loader={GuidesLoader}
         path="guides/design_guidelines/typography"
       />
       <Route
-        element={<GuidePage />}
+        lazy={() => import('./pages/GuidePage').then((mod) => ({ Component: mod.default }))}
         loader={GuidePageLoader}
         path="guides/design_guidelines/:page"
       />

--- a/playbook-website/app/javascript/components/Website/src/utils/siteNavigation.ts
+++ b/playbook-website/app/javascript/components/Website/src/utils/siteNavigation.ts
@@ -49,35 +49,28 @@ export const showPlaygroundVpnRequired = (destinationUrl: string) => {
   )
 }
 
-/**
- * Best-effort check: staging is internal and usually unreachable off VPN.
- * Uses an <img> probe instead of a no-cors fetch — fetch resolves on any HTTP
- * response (even an off-VPN block page), which caused browser-dependent false
- * positives; an <img> only fires onload if the bytes actually decode as an image.
- */
-export const isStagingReachable = (): Promise<boolean> => {
-  if (isStagingHost() || !isProductionHost()) return Promise.resolve(true)
+/** Best-effort check: staging is internal and usually unreachable off VPN. */
+export const isStagingReachable = async (): Promise<boolean> => {
+  if (isStagingHost() || !isProductionHost()) return true
 
-  return new Promise((resolve) => {
-    const probe = new Image()
-    let settled = false
-    let timeoutId = 0
+  const controller = new AbortController()
+  const timeoutId = window.setTimeout(
+    () => controller.abort(),
+    STAGING_CHECK_TIMEOUT_MS
+  )
 
-    const finish = (result: boolean) => {
-      if (settled) return
-      settled = true
-      window.clearTimeout(timeoutId)
-      probe.onload = null
-      probe.onerror = null
-      resolve(result)
-    }
-
-    timeoutId = window.setTimeout(() => finish(false), STAGING_CHECK_TIMEOUT_MS)
-
-    probe.onload = () => finish(true)
-    probe.onerror = () => finish(false)
-    probe.src = `${STAGING_ORIGIN}/favicon.ico?_=${Date.now()}`
-  })
+  try {
+    await fetch(`${STAGING_ORIGIN}/favicon.ico?_=${Date.now()}`, {
+      cache: "no-store",
+      mode: "no-cors",
+      signal: controller.signal,
+    })
+    return true
+  } catch {
+    return false
+  } finally {
+    window.clearTimeout(timeoutId)
+  }
 }
 
 /**

--- a/playbook-website/app/javascript/components/Website/src/utils/siteNavigation.ts
+++ b/playbook-website/app/javascript/components/Website/src/utils/siteNavigation.ts
@@ -49,28 +49,35 @@ export const showPlaygroundVpnRequired = (destinationUrl: string) => {
   )
 }
 
-/** Best-effort check: staging is internal and usually unreachable off VPN. */
-export const isStagingReachable = async (): Promise<boolean> => {
-  if (isStagingHost() || !isProductionHost()) return true
+/**
+ * Best-effort check: staging is internal and usually unreachable off VPN.
+ * Uses an <img> probe instead of a no-cors fetch — fetch resolves on any HTTP
+ * response (even an off-VPN block page), which caused browser-dependent false
+ * positives; an <img> only fires onload if the bytes actually decode as an image.
+ */
+export const isStagingReachable = (): Promise<boolean> => {
+  if (isStagingHost() || !isProductionHost()) return Promise.resolve(true)
 
-  const controller = new AbortController()
-  const timeoutId = window.setTimeout(
-    () => controller.abort(),
-    STAGING_CHECK_TIMEOUT_MS
-  )
+  return new Promise((resolve) => {
+    const probe = new Image()
+    let settled = false
+    let timeoutId = 0
 
-  try {
-    await fetch(`${STAGING_ORIGIN}/favicon.ico?_=${Date.now()}`, {
-      cache: "no-store",
-      mode: "no-cors",
-      signal: controller.signal,
-    })
-    return true
-  } catch {
-    return false
-  } finally {
-    window.clearTimeout(timeoutId)
-  }
+    const finish = (result: boolean) => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timeoutId)
+      probe.onload = null
+      probe.onerror = null
+      resolve(result)
+    }
+
+    timeoutId = window.setTimeout(() => finish(false), STAGING_CHECK_TIMEOUT_MS)
+
+    probe.onload = () => finish(true)
+    probe.onerror = () => finish(false)
+    probe.src = `${STAGING_ORIGIN}/favicon.ico?_=${Date.now()}`
+  })
 }
 
 /**


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

**What does this PR do?**

Two independent fixes for the Website app, split out from the VPN-gating follow-up work — the reachability/dialog piece is intentionally left as-is on prod and not part of this PR.

- **Rails toggle double-hop:** switching platforms from a staging-hosted Playground tab (e.g. `advanced_table`) briefly rendered the Rails route on staging before bouncing to prod — two full page loads instead of one. `handlePlatformChange` in `Website/index.tsx` now routes through the existing `navigateSite()` helper instead of a raw router `navigate()`, so the switch goes straight to prod in one hop. Also drops a stale `?tab=playground` query param when switching to Rails, since Rails has no Playground tab.
- **General site load time:** every route (Home, KitShow, the full Playground builder, WorldCup, GlobalProps/Tokens examples, etc.) was statically imported into one ~770KB gzipped entry bundle, downloaded on every page regardless of whether that page needed it. Converted all routes in `app.tsx` to React Router's `lazy` route loading, so each page ships as its own chunk fetched on demand. No new loading UI needed — `LayoutRight`'s existing `navigation.state === "loading"` spinner already covers the fetch delay.

**How to test?**
1. On VPN, open an AT (or any playground-enabled) kit's Playground tab, then click the Rails toggle — confirm it lands on prod directly with no staging flash/double load.
2. Open the Network tab and navigate between a few pages (Home → kit doc → Playground → WorldCup) — confirm each route fetches its own JS chunk on visit rather than one large bundle already loaded upfront.
3. General regression pass: confirm normal SPA navigation (sidebar links, search, platform toggle on non-Playground pages) still works with no console errors.

#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.