### PR TITLE
[PLAY-3179] Passphrase Kit - Disable Eye Icon when Disabled: React & Rails

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.scss
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.scss
@@ -61,6 +61,10 @@
         display: none;
       }
     }
+
+    &:has(input:disabled) .show-passphrase-icon {
+      pointer-events: none;
+    }
   }
 
   .pb_progress_simple_wrapper, .pb_progress_simple_wrapper_dark {

--- a/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/_passphrase.tsx
@@ -65,6 +65,8 @@ const Passphrase = (props: PassphraseProps): React.ReactElement => {
     [value, uncontrolledValue, uncontrolled]
   )
 
+  const isDisabled = Boolean(inputProps.disabled)
+
   const toggleShowPopover = () => setShowPopover(!showPopover)
   const handleShouldClosePopover = (shouldClosePopover: boolean) => {
     setShowPopover(!shouldClosePopover)
@@ -72,6 +74,7 @@ const Passphrase = (props: PassphraseProps): React.ReactElement => {
 
   const toggleShowPassphrase = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault()
+    if (isDisabled) return
     setShowPassphrase(!showPassphrase)
   }
 
@@ -181,6 +184,7 @@ const Passphrase = (props: PassphraseProps): React.ReactElement => {
               {...inputProps}
           />
           <span
+              aria-disabled={isDisabled || undefined}
               aria-label={
                 showPassphrase
                   ? "Passphrase currently visible. Click icon to hide password"
@@ -196,7 +200,7 @@ const Passphrase = (props: PassphraseProps): React.ReactElement => {
                 }
               }}
               role="button"
-              tabIndex={0}
+              tabIndex={isDisabled ? -1 : 0}
           >
             <Body
                 className={showPassphrase ? "hide-icon" : ""}

--- a/playbook/app/pb_kits/playbook/pb_passphrase/index.ts
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/index.ts
@@ -14,7 +14,7 @@ export default class PbPassphrase extends PbEnhancedElement {
     this.input = this.element.querySelector('.passphrase-text-input input')
     this.visible = false
 
-    if (!this.toggle || !this.input) return
+    if (!this.toggle || !this.input || this.input.disabled) return
 
     this.toggle.addEventListener('click', this.handleToggle)
     this.toggle.addEventListener('keydown', this.handleKeydown)

--- a/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.html.erb
@@ -52,11 +52,12 @@
     <div class="passphrase-text-input-wrapper">
       <%= pb_rails("text_input", props: object.text_input_props) %>
       <span
+        aria-disabled="<%= object.input_disabled? %>"
         aria-label="Passphrase currently hidden. Click icon to reveal password"
         aria-pressed="false"
         class="show-passphrase-icon"
         role="button"
-        tabindex="0"
+        tabindex="<%= object.input_disabled? ? -1 : 0 %>"
       >
         <%= pb_rails("body", props: { classname: "passphrase-toggle-icon", color: "light", dark: object.dark }) do %>
           <%= pb_rails("icon", props: { aria: { label: "eye icon" }, icon: "eye-slash" }) %>

--- a/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.rb
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.rb
@@ -70,6 +70,10 @@ module Playbook
         }.compact
       end
 
+      def input_disabled?
+        !!merged_input_options[:disabled]
+      end
+
       def text_input_data
         input_props.with_indifferent_access.fetch(:data, {}).to_h
       end

--- a/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.test.jsx
+++ b/playbook/app/pb_kits/playbook/pb_passphrase/passphrase.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, within } from '../utilities/test-utils'
+import { fireEvent, render, screen, within } from '../utilities/test-utils'
 import { Passphrase } from 'playbook-ui'
 
 const testId = 'text-input1',
@@ -54,14 +54,41 @@ test('passes input props to input element', () => {
           id: 'test-input-id',
           disabled: true,
         }}
+        uncontrolled
     />
   )
 
   const kit = screen.getByTestId(testId)
   const input = kit.getElementsByTagName('input')[0]
+  const toggle = kit.querySelector('.show-passphrase-icon')
+
   expect(input).toHaveAttribute('name', 'test-name')
   expect(input).toHaveAttribute('id', 'test-input-id')
   expect(input).toBeDisabled()
+  expect(toggle).toHaveAttribute('aria-disabled', 'true')
+  expect(toggle).toHaveAttribute('tabindex', '-1')
+
+  fireEvent.click(toggle)
+  expect(input).toHaveAttribute('type', 'password')
+})
+
+test('toggles passphrase visibility when eye icon is clicked', () => {
+  render(
+    <Passphrase
+        data={{ testid: testId }}
+        uncontrolled
+    />
+  )
+
+  const kit = screen.getByTestId(testId)
+  const input = kit.getElementsByTagName('input')[0]
+  const toggle = kit.querySelector('.show-passphrase-icon')
+
+  fireEvent.click(toggle)
+  expect(input).toHaveAttribute('type', 'text')
+
+  fireEvent.click(toggle)
+  expect(input).toHaveAttribute('type', 'password')
 })
 
 test('popover target shows when tips are given', () => {

--- a/playbook/spec/pb_kits/playbook/kits/passphrase_spec.rb
+++ b/playbook/spec/pb_kits/playbook/kits/passphrase_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe Playbook::PbPassphrase::Passphrase do
     end
   end
 
+  describe "input_disabled?" do
+    it "reflects input_props disabled" do
+      expect(subject.new.input_disabled?).to be false
+      expect(subject.new(input_props: { disabled: true }).input_disabled?).to be true
+    end
+  end
+
   describe "text_input_props" do
     it "merges input props and min_length", :aggregate_failures do
       kit = subject.new(


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3179

Disabled the eye icon when you disable the passphrase.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1954" height="109" alt="Screenshot 2026-09-08 at 2 43 39 PM" src="https://github.com/user-attachments/assets/6f26d5b6-10f5-44b8-aafb-51039cc898ba" />


**How to test?** Steps to confirm the desired behavior:
1. Go to the input options doc for passphrase
2. Check out the disabled input for React and Rails


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [x] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.