### PR TITLE
[PLAY-3184] Pagination - Align React and Rails Styling

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
+++ b/playbook/app/pb_kits/playbook/pb_pagination/_pagination.scss
@@ -110,25 +110,6 @@ $top_bottom_radius: 0px;
 
 
 .pb_pagination:has(> .pagination-desktop) {
-
-  @media (min-width: 768px) {
-    padding: $space_xxs 0px !important;
-    overflow: hidden;
-
-    .pagination-left > a,
-    .pagination-left > span,
-    .pagination-right > a,
-    .pagination-right > span {
-      padding: 6px 11px 5px;
-    }
-
-    .pagination-number > a,
-    .pagination-number > span,
-    .active > span {
-      padding: 6px 13px 5px 13px !important;
-    }
-  }
-
   .pagination-left,
   .pagination-right {
     padding: 0;
@@ -177,6 +158,28 @@ $top_bottom_radius: 0px;
       @media (max-width: 435px) {
         padding: 6px 10px !important;
       }
+    }
+  }
+
+  // Match React desktop: inline (not inline-flex) + space_xs; vertical-align clears baseline gap.
+  @media (min-width: 768px) {
+    padding: $space_xs 0px !important;
+    overflow: hidden;
+    vertical-align: top;
+
+    .pagination-left > a,
+    .pagination-left > span,
+    .pagination-right > a,
+    .pagination-right > span {
+      display: inline;
+      padding: 7px 11px 6px;
+    }
+
+    .pagination-number > a,
+    .pagination-number > span,
+    .active > span {
+      display: inline;
+      padding: $pagination_padding !important;
     }
   }
 }

--- a/playbook/lib/playbook/pagination_renderer.rb
+++ b/playbook/lib/playbook/pagination_renderer.rb
@@ -25,7 +25,7 @@ module Playbook
 
         desktop = template.content_tag(
           :div,
-          template.safe_join(desktop_items, @options[:link_separator].to_s),
+          template.safe_join(desktop_items),
           class: "pagination-desktop"
         )
         mobile = mobile_pagination


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
https://runway.powerhrg.com/backlog_items/PLAY-3184

Make Rails pagination styling consistent with React- height/spacing
Match 41px React height and remove extra baseline gap and will_paginate item separators that made Rails taller/looser

**Screenshots:** Screenshots to visualize your addition/change

**Before:**
<img width="1158" height="508" alt="Screenshot 2026-09-09 at 10 11 17 AM" src="https://github.com/user-attachments/assets/df997186-2e35-4619-af3c-9ca691035581" />

**After:**
<img width="1166" height="504" alt="Screenshot 2026-09-09 at 10 11 41 AM" src="https://github.com/user-attachments/assets/6d8e04a8-48e5-4371-bd4a-b077888194d3" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [x] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.