### PR TITLE
[PLAY-3218] Pill - Notification Variant Style Matching to Badge

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
@@ -70,11 +70,11 @@ $pb_pill_notification_colors: (
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    padding: 0 $space-sm/1.8;
-    height: $pb_pill_height;
-    border-radius: $pb_pill_height/2;
+    padding: 0 $space_xs/2 !important;
+    border-radius: $border_rad_light;
     white-space: nowrap;
     background: $color_value;
+    width: 16px;
 
     .pb_pill_text {
       color: $white !important;
@@ -99,8 +99,13 @@ $pb_pill_notification_colors: (
 
     .pb_pill_text {
       font-size: $font_smallest !important;
-      line-height: 1.7;
+      line-height: 1.1;
       color: $white !important;
     }
+  }
+
+  .pb_pill_kit_#{$color_name}_lowercase_notification_sm {
+    text-transform: lowercase;
+    height: 16px !important;
   }
 }

--- a/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
+++ b/playbook/app/pb_kits/playbook/pb_pill/_pill.scss
@@ -74,7 +74,7 @@ $pb_pill_notification_colors: (
     border-radius: $border_rad_light;
     white-space: nowrap;
     background: $color_value;
-    width: 16px;
+    min-width: 16px;
 
     .pb_pill_text {
       color: $white !important;

--- a/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_notification.jsx
+++ b/playbook/app/pb_kits/playbook/pb_pill/docs/_pill_notification.jsx
@@ -11,6 +11,8 @@ const PillNotification = (props) => {
             {...props}
         />
 
+        &nbsp;
+
         <Pill
             notification
             text="4"
@@ -25,6 +27,8 @@ const PillNotification = (props) => {
             variant="error"
             {...props}
         />
+
+        &nbsp;
 
         <Pill
             notification
@@ -41,6 +45,8 @@ const PillNotification = (props) => {
             text="1"
             {...props}
         />
+
+        &nbsp;
 
         <Pill
             notification


### PR DESCRIPTION
[PLAY-3218](https://runway.powerhrg.com/backlog_items/PLAY-3218)

This PR updates the Pill notification styles to match the badge notification styles!

<img width="392" height="365" alt="Screenshot 2026-09-10 at 9 23 02 AM" src="https://github.com/user-attachments/assets/22cd2ce9-6dbc-4832-9755-f848c526ab85" />


**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.