### PR TITLE
[PLAY-3230] Playbook Website: Expand and Prioritize Playbook Website Search

### DIFF
--- a/playbook-website/app/helpers/application_helper.rb
+++ b/playbook-website/app/helpers/application_helper.rb
@@ -82,6 +82,7 @@ module ApplicationHelper
             end
     {
       label: label,
+      props: kit_search_props(kit),
       value: if @type == "react"
                "/#{kit == 'advanced_table' ? 'kit_category' : 'kits'}/#{kit}#{kit == 'advanced_table' ? '?type=react' : '/react'}"
              else
@@ -95,6 +96,24 @@ module ApplicationHelper
   end
 
 private
+
+  def kit_search_props(kit)
+    schema_path = ::Playbook.kit_path(kit, "", "kit.schema.json")
+    return [] unless schema_path.exist?
+
+    Rails.cache.fetch(["kit_search_props", kit, schema_path.mtime.to_i]) do
+      schema = JSON.parse(schema_path.read)
+      schema.fetch("props", {}).map do |name, definition|
+        {
+          name: name,
+          platforms: Array(definition["platforms"]),
+        }
+      end
+    end
+  rescue JSON::ParserError => e
+    Rails.logger.error("Error reading kit search props for #{kit}: #{e.message}")
+    []
+  end
 
   def dark_mode_props(props)
     if props[:dark].nil?

--- a/playbook-website/app/javascript/components/Website/src/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/KitSearch.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Typeahead, Badge, Flex } from 'playbook-ui'
 import { matchSorter } from 'match-sorter'
 import { useDarkMode } from '../contexts/DarkModeContext'
+import { formatPropNameForPlatform } from '../helpers/platform'
 
 type Kit = {
   label: string,
+  props?: KitProp[],
   value: string,
   type?: string,
+}
+
+type KitProp = {
+  name: string,
+  platforms: string[],
 }
 
 type KitSearchProps = {
@@ -20,10 +27,26 @@ type KitSearchProps = {
   searchResetKey?: string,
 }
 
+const putPropsLast = (items: Kit[]): Kit[] => [
+  ...items.filter(({ type }) => type !== 'prop'),
+  ...items.filter(({ type }) => type === 'prop'),
+]
+
 const combineKitsandVisualGuidelines = (
   kits: Kit[],
+  platform: string,
   global_props_and_tokens?: Record<string, any>,
 ): Kit[] => {
+  const propItems = kits.flatMap((kit) =>
+    kit.props
+      ?.filter(({ platforms }) => platforms.length === 0 || platforms.includes(platform))
+      .map(({ name }) => ({
+        label: `${formatPropNameForPlatform(name, platform)} (${kit.label})`,
+        type: 'prop',
+        value: kit.value,
+      })) || [],
+  )
+
   const globalPropsItems = global_props_and_tokens?.global_props?.map((item: string) => ({
     label: item.replace(/_/g, ' ').replace(/\b\w/g, (char: string) => char.toUpperCase()),
     value: `/global_props/${item}`,
@@ -36,7 +59,10 @@ const combineKitsandVisualGuidelines = (
     type: 'token'
   })) || []
   
-  return [...kits, ...globalPropsItems, ...tokensItems].sort((a, b) => a.label.localeCompare(b.label))
+  const items = [...kits, ...globalPropsItems, ...tokensItems, ...propItems]
+    .sort((a, b) => a.label.localeCompare(b.label))
+
+  return putPropsLast(items)
 }
 
 const normalizePathForPlatform = (path: string, platform: string) => {
@@ -65,9 +91,17 @@ const normalizePathForPlatform = (path: string, platform: string) => {
 }
 
 const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_tokens, marginBottom, onNavigate, searchResetKey }: KitSearchProps) => {
-  const kitsAndGuidelines = combineKitsandVisualGuidelines(kits, global_props_and_tokens)
+  const kitsAndGuidelines = useMemo(
+    () => combineKitsandVisualGuidelines(kits, platform, global_props_and_tokens),
+    [kits, platform, global_props_and_tokens],
+  )
   const { darkMode } = useDarkMode()
-  const [filteredKits, setFilteredKits] = useState(kitsAndGuidelines)
+  const [query, setQuery] = useState('')
+  const filteredKits = useMemo(() => {
+    if (!query) return kitsAndGuidelines
+
+    return putPropsLast(matchSorter(kitsAndGuidelines, query, { keys: ['label'] }))
+  }, [kitsAndGuidelines, query])
 
   useEffect(() => {
     if (id === 'desktop-kit-search') {
@@ -93,12 +127,7 @@ const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_t
   }
 
   const handleFilteredKits = (query: string) => {
-    if (query) {
-      const results = matchSorter(kitsAndGuidelines, query, { keys: ['label'] })
-      setFilteredKits(results)
-    } else {
-      setFilteredKits(kitsAndGuidelines)
-    }
+    setQuery(query)
   }
 
   const Item = ({ labelLeft, type }: { labelLeft: string, type: string }) => (
@@ -107,7 +136,7 @@ const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_t
         <Badge
           dark={darkMode}
           margin="xs"
-          text={type === 'global_prop' ? 'Global Prop' : 'Token'}
+          text={type === 'global_prop' ? 'Global Prop' : type === 'prop' ? 'Kit Prop' : 'Token'}
           variant="primary"
         />
     </Flex>
@@ -118,6 +147,7 @@ const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_t
         key={`${id}__${searchResetKey ?? ''}`}
         className={classname}
         dark={darkMode}
+        filterOption={() => true}
         id={id}
         marginBottom={marginBottom || 'sm'}
         onChange={handleChange}
@@ -125,7 +155,7 @@ const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_t
         options={filteredKits}
         placeholder="Search..."
         valueComponent={(option: Kit) => {
-          if (option.type === 'global_prop' || option.type === 'token') {
+          if (option.type === 'global_prop' || option.type === 'prop' || option.type === 'token') {
             return <Item labelLeft={option.label} type={option.type} />
           }
           return <>{option.label}</>

--- a/playbook-website/app/javascript/components/Website/src/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/KitSearch.tsx
@@ -145,9 +145,12 @@ const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_t
     }
   }, [ id ])
 
-  const handleChange = (selection: any) => {
+  const handleChange = (selection: Kit | null) => {
     if (selection) {
-      const nextPath = normalizePathForPlatform(selection.value, platform)
+      const selectedPlatform = selection.type === 'prop' && selection.platforms?.length === 1
+        ? selection.platforms[0]
+        : platform
+      const nextPath = normalizePathForPlatform(selection.value, selectedPlatform)
 
       if (onNavigate) {
         onNavigate(nextPath)

--- a/playbook-website/app/javascript/components/Website/src/components/KitSearch.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/KitSearch.tsx
@@ -2,11 +2,12 @@ import { useEffect, useMemo, useState } from 'react'
 import { Typeahead, Badge, Flex } from 'playbook-ui'
 import { matchSorter } from 'match-sorter'
 import { useDarkMode } from '../contexts/DarkModeContext'
-import { formatPropNameForPlatform } from '../helpers/platform'
 
 type Kit = {
   label: string,
+  platforms?: string[],
   props?: KitProp[],
+  searchTerms?: string[],
   value: string,
   type?: string,
 }
@@ -32,20 +33,50 @@ const putPropsLast = (items: Kit[]): Kit[] => [
   ...items.filter(({ type }) => type === 'prop'),
 ]
 
+const normalizePropName = (name: string): string =>
+  name.replace(/[_-]/g, '').toLowerCase()
+
+const kitPropBadge = (platforms: string[]): string => {
+  const supportsReact = platforms.includes('react')
+  const supportsRails = platforms.includes('rails')
+
+  if (supportsReact && supportsRails) return 'Kit Prop (React & Rails)'
+  if (supportsReact) return 'Kit Prop (React)'
+  if (supportsRails) return 'Kit Prop (Rails)'
+  return 'Kit Prop'
+}
+
+const kitPropItems = (kit: Kit): Kit[] => {
+  const propsByName = new Map<string, { name: string, platforms: Set<string>, searchTerms: Set<string> }>()
+
+  kit.props?.forEach(({ name, platforms }) => {
+    const normalizedName = normalizePropName(name)
+    const prop = propsByName.get(normalizedName) || {
+      name,
+      platforms: new Set<string>(),
+      searchTerms: new Set<string>(),
+    }
+    const supportedPlatforms = platforms.length > 0 ? platforms : ['react', 'rails']
+
+    supportedPlatforms.forEach((supportedPlatform) => prop.platforms.add(supportedPlatform))
+    prop.searchTerms.add(name)
+    propsByName.set(normalizedName, prop)
+  })
+
+  return Array.from(propsByName.values()).map(({ name, platforms, searchTerms }) => ({
+    label: `${name} (${kit.label})`,
+    platforms: Array.from(platforms),
+    searchTerms: Array.from(searchTerms),
+    type: 'prop',
+    value: kit.value,
+  }))
+}
+
 const combineKitsandVisualGuidelines = (
   kits: Kit[],
-  platform: string,
   global_props_and_tokens?: Record<string, any>,
 ): Kit[] => {
-  const propItems = kits.flatMap((kit) =>
-    kit.props
-      ?.filter(({ platforms }) => platforms.length === 0 || platforms.includes(platform))
-      .map(({ name }) => ({
-        label: `${formatPropNameForPlatform(name, platform)} (${kit.label})`,
-        type: 'prop',
-        value: kit.value,
-      })) || [],
-  )
+  const propItems = kits.flatMap(kitPropItems)
 
   const globalPropsItems = global_props_and_tokens?.global_props?.map((item: string) => ({
     label: item.replace(/_/g, ' ').replace(/\b\w/g, (char: string) => char.toUpperCase()),
@@ -92,15 +123,15 @@ const normalizePathForPlatform = (path: string, platform: string) => {
 
 const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_tokens, marginBottom, onNavigate, searchResetKey }: KitSearchProps) => {
   const kitsAndGuidelines = useMemo(
-    () => combineKitsandVisualGuidelines(kits, platform, global_props_and_tokens),
-    [kits, platform, global_props_and_tokens],
+    () => combineKitsandVisualGuidelines(kits, global_props_and_tokens),
+    [kits, global_props_and_tokens],
   )
   const { darkMode } = useDarkMode()
   const [query, setQuery] = useState('')
   const filteredKits = useMemo(() => {
     if (!query) return kitsAndGuidelines
 
-    return putPropsLast(matchSorter(kitsAndGuidelines, query, { keys: ['label'] }))
+    return putPropsLast(matchSorter(kitsAndGuidelines, query, { keys: ['label', 'searchTerms'] }))
   }, [kitsAndGuidelines, query])
 
   useEffect(() => {
@@ -130,13 +161,17 @@ const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_t
     setQuery(query)
   }
 
-  const Item = ({ labelLeft, type }: { labelLeft: string, type: string }) => (
+  const Item = ({ labelLeft, platforms = [], type }: { labelLeft: string, platforms?: string[], type: string }) => (
     <Flex alignItems="center" justify="between">
         {labelLeft}
         <Badge
           dark={darkMode}
           margin="xs"
-          text={type === 'global_prop' ? 'Global Prop' : type === 'prop' ? 'Kit Prop' : 'Token'}
+          text={type === 'global_prop'
+            ? 'Global Prop'
+            : type === 'prop'
+              ? kitPropBadge(platforms)
+              : 'Token'}
           variant="primary"
         />
     </Flex>
@@ -156,7 +191,7 @@ const KitSearch = ({ classname, id, kits, platform = 'react', global_props_and_t
         placeholder="Search..."
         valueComponent={(option: Kit) => {
           if (option.type === 'global_prop' || option.type === 'prop' || option.type === 'token') {
-            return <Item labelLeft={option.label} type={option.type} />
+            return <Item labelLeft={option.label} platforms={option.platforms} type={option.type} />
           }
           return <>{option.label}</>
         }}


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

[PLAY-3230](https://runway.powerhrg.com/backlog_items/PLAY-3230?from=active_sprint)

- Expands the website’s kit search to include kit prop names alongside kits, global props, and tokens.
- Reads prop names and supported platforms from each kit’s generated schema.
- Displays prop results as propName (Kit Name).
- Labels results as Kit Prop (React), Kit Prop (Rails), or Kit Prop (React & Rails).
- Merges equivalent camelCase and snake_case prop names.
- Shows all props regardless of the active platform.
- Keeps prop results at the end of the dropdown to reduce noise.
- Navigates prop selections to their associated kit.
- Caches schema-derived search data using the schema modification time.
- Disables Typeahead’s built-in label filter so custom prop matches remain visible.

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.