### PR TITLE
[PLAY-3225] Table Kit Docs: Update docs to use Table with SubComponents

### DIFF
--- a/playbook/app/pb_kits/playbook/pb_table/docs/_sections.yml
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_sections.yml
@@ -15,6 +15,7 @@ sections:
       - table_with_subcomponents_as_divs
       - table_with_background_kit
       - table_colspan
+      - table_as_wrapper
 
   - title: "Sticky & Positional Behaviors"
     examples:

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_action_middle.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_action_middle.html.erb
@@ -1,34 +1,40 @@
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td><%= pb_rails("button", props: { text: "Action", variant: "link", padding_left: "none" }) %></td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td><%= pb_rails("button", props: { text: "Action", variant: "link", padding_left: "none" }) %></td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td><%= pb_rails("button", props: { text: "Action", variant: "link", padding_left: "none" }) %></td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "link", padding_left: "none" }) %>
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "link", padding_left: "none" }) %>
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "link", padding_left: "none" }) %>
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_action_middle.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_action_middle.jsx
@@ -9,20 +9,20 @@ const TableActionMiddle = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -31,14 +31,14 @@ const TableActionMiddle = (props) => {
                 variant="link"
                 {...props}
             />
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -47,14 +47,14 @@ const TableActionMiddle = (props) => {
                 variant="link"
                 {...props}
             />
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -63,11 +63,11 @@ const TableActionMiddle = (props) => {
                 variant="link"
                 {...props}
             />
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_as_wrapper.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_as_wrapper.html.erb
@@ -1,0 +1,34 @@
+<%= pb_rails("table", props: { size: "sm" }) do %>
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+      <th>Column 4</th>
+      <th>Column 5</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+    <tr>
+      <td>Value 1</td>
+      <td>Value 2</td>
+      <td>Value 3</td>
+      <td>Value 4</td>
+      <td>Value 5</td>
+    </tr>
+  </tbody>
+<% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_as_wrapper.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_as_wrapper.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import Table from '../_table'
+
+const TableWrapper = () => {
+  return (
+    <Table
+        size="sm"
+    >
+      <thead>
+        <tr>
+          <th>{'Column 1'}</th>
+          <th>{'Column 2'}</th>
+          <th>{'Column 3'}</th>
+          <th>{'Column 4'}</th>
+          <th>{'Column 5'}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{'Value 1'}</td>
+          <td>{'Value 2'}</td>
+          <td>{'Value 3'}</td>
+          <td>{'Value 4'}</td>
+          <td>{'Value 5'}</td>
+        </tr>
+        <tr>
+          <td>{'Value 1'}</td>
+          <td>{'Value 2'}</td>
+          <td>{'Value 3'}</td>
+          <td>{'Value 4'}</td>
+          <td>{'Value 5'}</td>
+        </tr>
+        <tr>
+          <td>{'Value 1'}</td>
+          <td>{'Value 2'}</td>
+          <td>{'Value 3'}</td>
+          <td>{'Value 4'}</td>
+          <td>{'Value 5'}</td>
+        </tr>
+      </tbody>
+    </Table>
+  )
+}
+
+export default TableWrapper

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_as_wrapper.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_as_wrapper.md
@@ -1,0 +1,2 @@
+Optionally build your table by wrapping native HTML table elements in our Table kit. We recommend using the Table with SubComponents (Table Elements) set up for most situations because because Playbook Global Props and Table props do not work on HTML table elements.
+

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_container.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_container.html.erb
@@ -1,34 +1,34 @@
 <%= pb_rails("table", props: { size: "md", container: false}) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_container.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_container.jsx
@@ -9,38 +9,38 @@ const TableContainer = (props) => {
         size="md"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_contrast_border.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_contrast_border.html.erb
@@ -1,71 +1,71 @@
 <%= pb_rails("table", props: { size: "sm", contrast_border: true }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <br/>
 
 <%= pb_rails("table", props: { size: "sm", contrast_border: true, vertical_border: true }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_contrast_border.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_contrast_border.jsx
@@ -5,44 +5,43 @@ import Table from '../_table'
 const TableContrastBorder = (props) => {
   return (
     <div>
-
       <Table
           contrastBorder
           size="sm"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Column 1'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-        </tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Column 1'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
 
       <br/>
@@ -53,38 +52,38 @@ const TableContrastBorder = (props) => {
           verticalBorder
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Column 1'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-        </tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Column 1'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_data_table.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_data_table.html.erb
@@ -1,34 +1,34 @@
 <%= pb_rails("table", props: { data_table: true }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_data_table.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_data_table.jsx
@@ -8,38 +8,38 @@ const TableDataTable = (props) => {
         dataTable
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_disable_hover.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_disable_hover.html.erb
@@ -1,34 +1,34 @@
 <%= pb_rails("table", props: { size: "md", disable_hover: true }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_disable_hover.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_disable_hover.jsx
@@ -9,38 +9,38 @@ const TableDisableHover = (props) => {
         size="md"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_header.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_header.html.erb
@@ -24,8 +24,8 @@
 <% end %>
 
 <%= pb_rails("table", props: { data_table: true, vertical_border: true, id: "table-header" } ) do %>
-  <thead>
-    <tr>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
       <%= pb_rails("table/table_header", props: {
         text: "Territory",
         id: "territory",
@@ -54,11 +54,11 @@
         ],
       }) %>
       <%= pb_rails("table/table_header", props: { text: "Job Title" }) %>
-    </tr>
-  </thead>
-  <tbody>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
     <% data_rows.each do |row| %>
-      <tr>
+      <%= pb_rails("table/table_row") do %>
         <% row.each do |key, value| %>
           <%= pb_rails("background", props: {
               background_color: (params["sort"] && params["sort"].start_with?(key) ? "info_subtle" : "card_light"),
@@ -68,7 +68,7 @@
             <%= value %>
           <% end %>
         <% end %>
-      </tr>
+      <% end %>
     <% end %>
-  </tbody>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.html.erb
@@ -1,20 +1,20 @@
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
         <%= pb_rails("flex", props: { justify: "end" }) do %>
             <%= pb_rails("body", props: {classname: "flex-item"}) do %>  
                 <%= pb_rails("circle_icon_button", props: { variant: "link", icon: "pencil" }) %>
@@ -23,14 +23,14 @@
                 <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "trash-alt" }) %>
             <% end %>
         <% end %>
-      </td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
         <%= pb_rails("flex", props: { justify: "end" }) do %>
             <%= pb_rails("body", props: {classname: "flex-item"}) do %>  
                 <%= pb_rails("circle_icon_button", props: { variant: "link", icon: "pencil" }) %>
@@ -39,14 +39,14 @@
                 <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "trash-alt" }) %>
             <% end %>
         <% end %>
-      </td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right">
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
         <%= pb_rails("flex", props: { justify: "end" }) do %>
             <%= pb_rails("body", props: {classname: "flex-item"}) do %>  
                 <%= pb_rails("circle_icon_button", props: { variant: "link", icon: "pencil" }) %>
@@ -55,7 +55,7 @@
                 <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "trash-alt" }) %>
             <% end %>
         <% end %>
-      </td>    
-    </tr>
-  </tbody>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_icon_buttons.jsx
@@ -12,22 +12,22 @@ const TableIconButtons = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{''}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{''}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             <Flex
                 justifyContent="end"
                 orientation="row"
@@ -47,15 +47,15 @@ const TableIconButtons = (props) => {
                 />
               </FlexItem>
             </Flex>
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
-            <Flex 
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
+            <Flex
                 justifyContent="end"
                 orientation="row"
             >
@@ -74,15 +74,15 @@ const TableIconButtons = (props) => {
                 />
               </FlexItem>
             </Flex>
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value lk'}</td>
-          <td align="right">
-            <Flex 
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
+            <Flex
                 justifyContent="end"
                 orientation="row"
             >
@@ -101,9 +101,9 @@ const TableIconButtons = (props) => {
                 />
               </FlexItem>
             </Flex>
-          </td>
-        </tr>
-      </tbody>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_lg.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_lg.html.erb
@@ -1,34 +1,34 @@
-<%= pb_rails("table", props: { size: "lg"} ) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+<%= pb_rails("table", props: { size: "lg" }) do %>
+    <%= pb_rails("table/table_head") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_header", props: { text: "Column 1"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 2"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 3"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 4"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 5"}) %>       
+         <% end %>
+    <% end %>
+    <%= pb_rails("table/table_body") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+    <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_lg.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_lg.jsx
@@ -8,38 +8,38 @@ const TableLg = (props) => {
         size="lg"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_md.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_md.html.erb
@@ -1,34 +1,34 @@
 <%= pb_rails("table", props: { size: "md" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+    <%= pb_rails("table/table_head") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_header", props: { text: "Column 1"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 2"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 3"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 4"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 5"}) %>       
+         <% end %>
+    <% end %>
+    <%= pb_rails("table/table_body") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+    <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_md.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_md.jsx
@@ -8,38 +8,38 @@ const TableMd = (props) => {
         size="md"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_multiline.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_multiline.html.erb
@@ -1,34 +1,55 @@
-<%= pb_rails("table", props: { size: "md"}) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+<%= pb_rails("table", props: { size: "md" }) do %>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 1<br />
+        Value 1<br />
+        Value 1
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 3<br />
+        Value 3
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 1<br />
+        Value 1<br />
+        Value 1
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 3<br />
+        Value 3
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 1<br />
+        Value 1<br />
+        Value 1
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 3<br />
+        Value 3
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_multiline.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_multiline.jsx
@@ -8,68 +8,68 @@ const TableMultiline = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>
             {'Value 1'}
             <br />
             {'Value 1'}
             <br />
             {'Value 1'}
-          </td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {'Value 3'}
             <br />
             {'Value 3'}
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>
             {'Value 1'}
             <br />
             {'Value 1'}
             <br />
             {'Value 1'}
-          </td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {'Value 3'}
             <br />
             {'Value 3'}
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>
             {'Value 1'}
             <br />
             {'Value 1'}
             <br />
             {'Value 1'}
-          </td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {'Value 3'}
             <br />
             {'Value 3'}
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.html.erb
@@ -1,34 +1,40 @@
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_one_action.jsx
@@ -9,22 +9,22 @@ const TableOneAction = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{''}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{''}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -33,14 +33,14 @@ const TableOneAction = (props) => {
                 {...props}
             />
             {' '}
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -49,14 +49,14 @@ const TableOneAction = (props) => {
                 {...props}
             />
             {' '}
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             {' '}
             <Button
                 onClick={() => alert('button clicked!')}
@@ -65,9 +65,9 @@ const TableOneAction = (props) => {
                 {...props}
             />
             {' '}
-          </td>
-        </tr>
-      </tbody>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_outer_padding.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_outer_padding.html.erb
@@ -1,34 +1,40 @@
 <%= pb_rails("table", props: { outer_padding: "sm", size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"><%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %></td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_outer_padding.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_outer_padding.jsx
@@ -10,65 +10,59 @@ const TableOuterPadding = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{''}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
-            {' '}
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{''}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 text="Action"
                 variant="secondary"
                 {...props}
             />
-            {' '}
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
-            {' '}
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 text="Action"
                 variant="secondary"
                 {...props}
             />
-            {' '}
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
-            {' '}
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 text="Action"
                 variant="secondary"
                 {...props}
             />
-            {' '}
-          </td>
-        </tr>
-      </tbody>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_responsive_table.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_responsive_table.html.erb
@@ -1,24 +1,24 @@
 <%= pb_rails("title", props: { size: 4, text: "Not Responsive" }) %>
 
 <%= pb_rails("table", props: { responsive: "none" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <br>
@@ -26,24 +26,24 @@
 <%= pb_rails("title", props: { size: 4, text: "Collapse Mobile" }) %>
 
 <%= pb_rails("table", props: { collapse: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <br>
@@ -51,24 +51,24 @@
 <%= pb_rails("title", props: { size: 4, text: "Collapse Tablet" }) %>
 
 <%= pb_rails("table", props: { collapse: "md" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <br>
@@ -76,24 +76,22 @@
 <%= pb_rails("title", props: { size: 4, text: "Collapse Desktop" }) %>
 
 <%= pb_rails("table", props: { collapse: "lg" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>
-
-

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_responsive_table.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_responsive_table.jsx
@@ -15,24 +15,24 @@ const TableResponsiveTable = (props) => {
           responsive="none"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Column 1'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-        </tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Column 1'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
       <br />
       <br />
@@ -45,24 +45,24 @@ const TableResponsiveTable = (props) => {
           collapse="sm"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Column 1'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-        </tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Column 1'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
       <br />
       <br />
@@ -75,24 +75,24 @@ const TableResponsiveTable = (props) => {
           collapse="md"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Column 1'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-        </tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Column 1'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
       <br />
       <br />
@@ -105,24 +105,24 @@ const TableResponsiveTable = (props) => {
           collapse="lg"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Column 1'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{'Value 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
-          </tr>
-        </tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Column 1'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{'Value 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.html.erb
@@ -1,129 +1,129 @@
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Product Colors</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= pb_rails("table/table_row", props: { side_highlight_color: "product_1_highlight" }) do %>
-			<td>Product 1</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Product Colors" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
     <% end %>
-		<%= pb_rails("table/table_row", props: { side_highlight_color: "product_2_highlight" }) do %>
-			<td>Product 2</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "product_1_highlight" }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Product 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "product_2_highlight" }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Product 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "product_3_highlight" }) do %>
-			<td>Product 3</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+      <%= pb_rails("table/table_cell", props: { text: "Product 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "none" }) do %>
-			<td>None</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+      <%= pb_rails("table/table_cell", props: { text: "None" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
-  </tbody>
+  <% end %>
 <% end %>
 
-<br/>
+<br />
 
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Status Colors</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= pb_rails("table/table_row", props: { side_highlight_color: "success" }) do %>
-			<td>Success</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Status Colors" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
     <% end %>
-		<%= pb_rails("table/table_row", props: { side_highlight_color: "warning" }) do %>
-			<td>Warning</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "success" }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Success" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "warning" }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Warning" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "error" }) do %>
-			<td>Error</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+      <%= pb_rails("table/table_cell", props: { text: "Error" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "none" }) do %>
-			<td>None</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+      <%= pb_rails("table/table_cell", props: { text: "None" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
-  </tbody>
+  <% end %>
 <% end %>
 
-<br/>
+<br />
 
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Cateogry Colors</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= pb_rails("table/table_row", props: { side_highlight_color: "category_1" }) do %>
-			<td>Category Color 1</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Category Colors" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
     <% end %>
-		<%= pb_rails("table/table_row", props: { side_highlight_color: "category_2" }) do %>
-			<td>Category Color 2</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "category_1" }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Category Color 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row", props: { side_highlight_color: "category_2" }) do %>
+      <%= pb_rails("table/table_cell", props: { text: "Category Color 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "category_3" }) do %>
-			<td>Category Color 3</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+      <%= pb_rails("table/table_cell", props: { text: "Category Color 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
     <%= pb_rails("table/table_row", props: { side_highlight_color: "none" }) do %>
-			<td>None</td>
-			<td>Value 2</td>
-			<td>Value 3</td>
-			<td>Value 4</td>
-			<td>Value 5</td>
+      <%= pb_rails("table/table_cell", props: { text: "None" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
     <% end %>
-  </tbody>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_side_highlight.jsx
@@ -9,57 +9,57 @@ const TableSideHighlight = (props) => {
           size="sm"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Product colors'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Product colors'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
           <Table.Row
               sideHighlightColor="product_1_highlight"
               {...props}
           >
-            <td>{'Product 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Product 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="product_2_highlight"
               {...props}
           >
-            <td>{'Product 2'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Product 2'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="product_3_highlight"
               {...props}
           >
-            <td>{'Product 3'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Product 3'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="none"
               {...props}
           >
-            <td>{'None'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'None'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
-        </tbody>
+        </Table.Body>
       </Table>
 
       <br />
@@ -68,57 +68,57 @@ const TableSideHighlight = (props) => {
           size="sm"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Status colors'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Status colors'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
           <Table.Row
               sideHighlightColor="success"
               {...props}
           >
-            <td>{'Success'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Success'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="warning"
               {...props}
           >
-            <td>{'Warning'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Warning'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="error"
               {...props}
           >
-            <td>{'Error'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Error'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="none"
               {...props}
           >
-            <td>{'None'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'None'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
-        </tbody>
+        </Table.Body>
       </Table>
 
       <br />
@@ -127,57 +127,57 @@ const TableSideHighlight = (props) => {
           size="sm"
           {...props}
       >
-        <thead>
-          <tr>
-            <th>{'Category Colors'}</th>
-            <th>{'Column 2'}</th>
-            <th>{'Column 3'}</th>
-            <th>{'Column 4'}</th>
-            <th>{'Column 5'}</th>
-          </tr>
-        </thead>
-        <tbody>
+        <Table.Head>
+          <Table.Row>
+            <Table.Header>{'Category Colors'}</Table.Header>
+            <Table.Header>{'Column 2'}</Table.Header>
+            <Table.Header>{'Column 3'}</Table.Header>
+            <Table.Header>{'Column 4'}</Table.Header>
+            <Table.Header>{'Column 5'}</Table.Header>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
           <Table.Row
               sideHighlightColor="category_1"
               {...props}
           >
-            <td>{'Category Color 1'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Category Color 1'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="category_2"
               {...props}
           >
-            <td>{'Category Color 2'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Category Color 2'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="category_3"
               {...props}
           >
-            <td>{'Category Color 3'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'Category Color 3'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
           <Table.Row
               sideHighlightColor="none"
               {...props}
           >
-            <td>{'None'}</td>
-            <td>{'Value 2'}</td>
-            <td>{'Value 3'}</td>
-            <td>{'Value 4'}</td>
-            <td>{'Value 5'}</td>
+            <Table.Cell>{'None'}</Table.Cell>
+            <Table.Cell>{'Value 2'}</Table.Cell>
+            <Table.Cell>{'Value 3'}</Table.Cell>
+            <Table.Cell>{'Value 4'}</Table.Cell>
+            <Table.Cell>{'Value 5'}</Table.Cell>
           </Table.Row>
-        </tbody>
+        </Table.Body>
       </Table>
     </div>
   )

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_single_line.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_single_line.html.erb
@@ -1,48 +1,55 @@
 <%= pb_rails("table", props: { size: "md", single_line: true }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1<br/>Value 1<br/>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3<br/>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 1<br />
+        Value 1<br />
+        Value 1
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 3<br />
+        Value 3
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 1<br />
+        Value 1<br />
+        Value 1
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 3<br />
+        Value 3
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 1<br />
+        Value 1<br />
+        Value 1
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        Value 3<br />
+        Value 3
+      <% end %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_single_line.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_single_line.jsx
@@ -9,68 +9,68 @@ const TableSingleLine = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>
             {'Value 1'}
             <br />
             {'Value 1'}
             <br />
             {'Value 1'}
-          </td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {'Value 3'}
             <br />
             {'Value 3'}
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>
             {'Value 1'}
             <br />
             {'Value 1'}
             <br />
             {'Value 1'}
-          </td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {'Value 3'}
             <br />
             {'Value 3'}
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>
             {'Value 1'}
             <br />
             {'Value 1'}
             <br />
             {'Value 1'}
-          </td>
-          <td>{'Value 2'}</td>
-          <td>
+          </Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>
             {'Value 3'}
             <br />
             {'Value 3'}
-          </td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+          </Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sm.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sm.html.erb
@@ -1,34 +1,34 @@
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+    <%= pb_rails("table/table_head") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_header", props: { text: "Column 1"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 2"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 3"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 4"}) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 5"}) %>       
+         <% end %>
+    <% end %>
+    <%= pb_rails("table/table_body") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4"}) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5"}) %>
+        <% end %>
+    <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sm.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sm.jsx
@@ -8,38 +8,38 @@ const TableSm = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.html.erb
@@ -1,85 +1,92 @@
 <div style="max-height: 320px; overflow-y: auto;">
   <%= pb_rails("table", props: { sticky: true }) do %>
-    <thead>
-      <tr>
-        <th>Column 1</th>
-        <th>Column 2</th>
-        <th>Column 3</th>
-        <th>Column 4</th>
-        <th>Column 5</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-      <tr>
-        <td>Value 1</td>
-        <td>Value 2</td>
-        <td>Value 3</td>
-        <td>Value 4</td>
-        <td>Value 5</td>
-      </tr>
-    </tbody>
+    <%= pb_rails("table/table_head") do %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+        <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+        <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+        <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+        <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_body") do %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+      <%= pb_rails("table/table_row") do %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+        <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.jsx
@@ -8,87 +8,88 @@ const TableSticky = (props) => (
         sticky
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+<Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   </div>
 )

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky.md
@@ -4,9 +4,9 @@ Rails: Pass `sticky: true` to props.
 
 The live example uses a scroll container so sticky behavior is visible in the docs. Scroll inside the preview to see it.
 
-If the table header is not sticking in the right place you will need to pass an inline `top` style to the `thead`. This is often needed when a parent adds padding above the table.
-React Example: `<thead style={{ top: "-16px" }}>`
-Rails Example: `<thead style="top: -16px">`
+If the table header is not sticking in the right place you will need to pass an inline `top` style to the Table Head. This is often needed when a parent adds padding above the table.
+React Examples: `<Table.Head htmlOptions={{ style: { top: "-16px" } }}>` or `<thead style={{ top: "-16px" }}>`
+Rails Examples: `<%= pb_rails("table/table_head", props: { html_options: { style: "top: -16px" } }) do %>` or `<thead style="top: -16px">`
 
 ### Troubleshooting CSS Problems
 Sticky may not work if any parent/ancestor of the sticky element has any of the `overflow` properties set. Additionally, specifying a height on the overflowing container provides measurement for this feature to work properly. In some cases, it may be necessary to set the same parent/ancestor container to `position: static` as well.

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.html.erb
@@ -1,74 +1,75 @@
 <%= pb_rails("table", props: { size: "md", responsive: "scroll", sticky_left_column: ["a"], sticky_right_column: ["b"] }) do %>
-  <thead>
-    <tr>
-      <th data-sticky-id="a">Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-      <th>Column 6</th>
-      <th>Column 7</th>
-      <th>Column 8</th>
-      <th>Column 9</th>
-      <th>Column 10</th>
-      <th>Column 11</th>
-      <th>Column 12</th>
-      <th>Column 13</th>
-      <th>Column 14</th>
-      <th data-sticky-id="b">Column 15</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td data-sticky-id="a">Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td>Value 13</td>
-      <td>Value 14</td>
-      <td data-sticky-id="b">Value 15</td>
-    </tr>
-    <tr>
-      <td data-sticky-id="a">Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td>Value 13</td>
-      <td>Value 14</td>
-      <td data-sticky-id="b">Value 15</td>
-    </tr>
-    <tr>
-      <td data-sticky-id="a">Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td>Value 13</td>
-      <td>Value 14</td>
-      <td data-sticky-id="b">Value 15</td>
-    </tr>
-  </tbody>
+<%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "a" }, text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 6" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 7" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 8" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 9" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 10" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 11" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 12" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 13" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 14" }) %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "b" }, text: "Column 15" }) %>
+    <% end %>
+  <% end %>
+
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "a" }, text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "b" }, text: "Value 15" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "a" }, text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "b" }, text: "Value 15" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "a" }, text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "b" }, text: "Value 15" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_columns.jsx
@@ -9,78 +9,78 @@ const TableStickyColumns = () => {
             stickyLeftColumn={["a"]}
             stickyRightColumn={["b"]}
         >
-            <thead>
-                <tr>
-                    <th data-sticky-id="a">{'Column 1'}</th>
-                    <th>{'Column 2'}</th>
-                    <th>{'Column 3'}</th>
-                    <th>{'Column 4'}</th>
-                    <th>{'Column 5'}</th>
-                    <th>{'Column 6'}</th>
-                    <th>{'Column 7'}</th>
-                    <th>{'Column 8'}</th>
-                    <th>{'Column 9'}</th>
-                    <th>{'Column 10'}</th>
-                    <th>{'Column 11'}</th>
-                    <th>{'Column 12'}</th>
-                    <th>{'Column 13'}</th>
-                    <th>{'Column 14'}</th>
-                    <th data-sticky-id="b">{'Column 15'}</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td data-sticky-id="a">{'Value 1'}</td>
-                    <td>{'Value 2'}</td>
-                    <td>{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td>{'Value 13'}</td>
-                    <td>{'Value 14'}</td>
-                    <td data-sticky-id="b">{'Value 15'}</td>
-                </tr>
-                <tr>
-                    <td data-sticky-id="a">{'Value 1'}</td>
-                    <td>{'Value 2'}</td>
-                    <td>{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td>{'Value 13'}</td>
-                    <td>{'Value 14'}</td>
-                    <td data-sticky-id="b">{'Value 15'}</td>
-                </tr>
-                <tr>
-                    <td data-sticky-id="a">{'Value 1'}</td>
-                    <td>{'Value 2'}</td>
-                    <td>{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td>{'Value 13'}</td>
-                    <td>{'Value 14'}</td>
-                    <td data-sticky-id="b">{'Value 15'}</td>
-                </tr>
-            </tbody>
+            <Table.Head>
+                <Table.Row>
+                    <Table.Header htmlOptions={{ 'data-sticky-id': 'a' }}>{'Column 1'}</Table.Header>
+                    <Table.Header>{'Column 2'}</Table.Header>
+                    <Table.Header>{'Column 3'}</Table.Header>
+                    <Table.Header>{'Column 4'}</Table.Header>
+                    <Table.Header>{'Column 5'}</Table.Header>
+                    <Table.Header>{'Column 6'}</Table.Header>
+                    <Table.Header>{'Column 7'}</Table.Header>
+                    <Table.Header>{'Column 8'}</Table.Header>
+                    <Table.Header>{'Column 9'}</Table.Header>
+                    <Table.Header>{'Column 10'}</Table.Header>
+                    <Table.Header>{'Column 11'}</Table.Header>
+                    <Table.Header>{'Column 12'}</Table.Header>
+                    <Table.Header>{'Column 13'}</Table.Header>
+                    <Table.Header>{'Column 14'}</Table.Header>
+                    <Table.Header htmlOptions={{ 'data-sticky-id': 'b' }}>{'Column 15'}</Table.Header>
+                </Table.Row>
+            </Table.Head>
+            <Table.Body>
+                <Table.Row>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': 'a' }}>{'Value 1'}</Table.Cell>
+                    <Table.Cell>{'Value 2'}</Table.Cell>
+                    <Table.Cell>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell>{'Value 13'}</Table.Cell>
+                    <Table.Cell>{'Value 14'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': 'b' }}>{'Value 15'}</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': 'a' }}>{'Value 1'}</Table.Cell>
+                    <Table.Cell>{'Value 2'}</Table.Cell>
+                    <Table.Cell>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell>{'Value 13'}</Table.Cell>
+                    <Table.Cell>{'Value 14'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': 'b' }}>{'Value 15'}</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': 'a' }}>{'Value 1'}</Table.Cell>
+                    <Table.Cell>{'Value 2'}</Table.Cell>
+                    <Table.Cell>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell>{'Value 13'}</Table.Cell>
+                    <Table.Cell>{'Value 14'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': 'b' }}>{'Value 15'}</Table.Cell>
+                </Table.Row>
+            </Table.Body>
         </Table>
     )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns.html.erb
@@ -1,77 +1,74 @@
 <%= pb_rails("table", props: { size: "md", responsive: "scroll", sticky_left_column: ["1", "2", "3"] }) do %>
-  <thead>
-    <tr>
-      <th data-sticky-id="1">Column 1</th>
-      <th data-sticky-id="2">Column 2</th>
-      <th data-sticky-id="3">Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-      <th>Column 6</th>
-      <th>Column 7</th>
-      <th>Column 8</th>
-      <th>Column 9</th>
-      <th>Column 10</th>
-      <th>Column 11</th>
-      <th>Column 12</th>
-      <th>Column 13</th>
-      <th>Column 14</th>
-      <th>Column 15</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td data-sticky-id="1">Value 1</td>
-      <td data-sticky-id="2">Value 2</td>
-      <td data-sticky-id="3">Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td>Value 13</td>
-      <td>Value 14</td>
-      <td>Value 15</td>
-
-    </tr>
-    <tr>
-      <td data-sticky-id="1">Value 1</td>
-      <td data-sticky-id="2">Value 2</td>
-      <td data-sticky-id="3">Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td>Value 13</td>
-      <td>Value 14</td>
-      <td>Value 15</td>
-
-    </tr>
-    <tr>
-      <td data-sticky-id="1">Value 1</td>
-      <td data-sticky-id="2">Value 2</td>
-      <td data-sticky-id="3">Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td>Value 13</td>
-      <td>Value 14</td>
-      <td>Value 15</td>
-
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "1" }, text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "2" }, text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "3" }, text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 6" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 7" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 8" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 9" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 10" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 11" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 12" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 13" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 14" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 15" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "1" }, text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "2" }, text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "3" }, text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 15" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "1" }, text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "2" }, text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "3" }, text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 15" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "1" }, text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "2" }, text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "3" }, text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 15" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_left_columns.jsx
@@ -8,78 +8,78 @@ const TableStickyLeftColumns = () => {
             size="md"
             stickyLeftColumn={["1", "2", "3"]}
         >
-            <thead>
-                <tr>
-                    <th data-sticky-id="1">{'Column 1'}</th>
-                    <th data-sticky-id="2">{'Column 2'}</th>
-                    <th data-sticky-id="3">{'Column 3'}</th>
-                    <th>{'Column 4'}</th>
-                    <th>{'Column 5'}</th>
-                    <th>{'Column 6'}</th>
-                    <th>{'Column 7'}</th>
-                    <th>{'Column 8'}</th>
-                    <th>{'Column 9'}</th>
-                    <th>{'Column 10'}</th>
-                    <th>{'Column 11'}</th>
-                    <th>{'Column 12'}</th>
-                    <th>{'Column 13'}</th>
-                    <th>{'Column 14'}</th>
-                    <th>{'Column 15'}</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td data-sticky-id="1">{'Value 1'}</td>
-                    <td data-sticky-id="2">{'Value 2'}</td>
-                    <td data-sticky-id="3">{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td>{'Value 13'}</td>
-                    <td>{'Value 14'}</td>
-                    <td>{'Value 15'}</td>
-                </tr>
-                <tr>
-                    <td data-sticky-id="1">{'Value 1'}</td>
-                    <td data-sticky-id="2">{'Value 2'}</td>
-                    <td data-sticky-id="3">{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td>{'Value 13'}</td>
-                    <td>{'Value 14'}</td>
-                    <td>{'Value 15'}</td>
-                </tr>
-                <tr>
-                    <td data-sticky-id="1">{'Value 1'}</td>
-                    <td data-sticky-id="2">{'Value 2'}</td>
-                    <td data-sticky-id="3">{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td>{'Value 13'}</td>
-                    <td>{'Value 14'}</td>
-                    <td>{'Value 15'}</td>
-                </tr>
-            </tbody>
+            <Table.Head>
+                <Table.Row>
+                <Table.Header htmlOptions={{ 'data-sticky-id': '1' }}>{'Column 1'}</Table.Header>
+                <Table.Header htmlOptions={{ 'data-sticky-id': '2' }}>{'Column 2'}</Table.Header>
+                <Table.Header htmlOptions={{ 'data-sticky-id': '3' }}>{'Column 3'}</Table.Header>
+                <Table.Header>{'Column 4'}</Table.Header>
+                <Table.Header>{'Column 5'}</Table.Header>
+                <Table.Header>{'Column 6'}</Table.Header>
+                <Table.Header>{'Column 7'}</Table.Header>
+                <Table.Header>{'Column 8'}</Table.Header>
+                <Table.Header>{'Column 9'}</Table.Header>
+                <Table.Header>{'Column 10'}</Table.Header>
+                <Table.Header>{'Column 11'}</Table.Header>
+                <Table.Header>{'Column 12'}</Table.Header>
+                <Table.Header>{'Column 13'}</Table.Header>
+                <Table.Header>{'Column 14'}</Table.Header>
+                <Table.Header>{'Column 15'}</Table.Header>
+                </Table.Row>
+            </Table.Head>
+            <Table.Body>
+                <Table.Row>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '1' }}>{'Value 1'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '2' }}>{'Value 2'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '3' }}>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell>{'Value 13'}</Table.Cell>
+                    <Table.Cell>{'Value 14'}</Table.Cell>
+                    <Table.Cell>{'Value 15'}</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '1' }}>{'Value 1'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '2' }}>{'Value 2'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '3' }}>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell>{'Value 13'}</Table.Cell>
+                    <Table.Cell>{'Value 14'}</Table.Cell>
+                    <Table.Cell>{'Value 15'}</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '1' }}>{'Value 1'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '2' }}>{'Value 2'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '3' }}>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell>{'Value 13'}</Table.Cell>
+                    <Table.Cell>{'Value 14'}</Table.Cell>
+                    <Table.Cell>{'Value 15'}</Table.Cell>
+                </Table.Row>
+            </Table.Body>
         </Table>
     )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.html.erb
@@ -1,74 +1,74 @@
 <%= pb_rails("table", props: { size: "md", responsive: "scroll", sticky_right_column: ["13", "14", "15"] }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-      <th>Column 6</th>
-      <th>Column 7</th>
-      <th>Column 8</th>
-      <th>Column 9</th>
-      <th>Column 10</th>
-      <th>Column 11</th>
-      <th>Column 12</th>
-      <th data-sticky-id="13">Column 13</th>
-      <th data-sticky-id="14">Column 14</th>
-      <th data-sticky-id="15">Column 15</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td data-sticky-id="13">Value 13</td>
-      <td data-sticky-id="14">Value 14</td>
-      <td data-sticky-id="15">Value 15</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td data-sticky-id="13">Value 13</td>
-      <td data-sticky-id="14">Value 14</td>
-      <td data-sticky-id="15">Value 15</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-      <td>Value 6</td>
-      <td>Value 7</td>
-      <td>Value 8</td>
-      <td>Value 9</td>
-      <td>Value 10</td>
-      <td>Value 11</td>
-      <td>Value 12</td>
-      <td data-sticky-id="13">Value 13</td>
-      <td data-sticky-id="14">Value 14</td>
-      <td data-sticky-id="15">Value 15</td>
-    </tr>
-  </tbody>
+<%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 6" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 7" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 8" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 9" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 10" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 11" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 12" }) %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "13" }, text: "Column 13" }) %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "14" }, text: "Column 14" }) %>
+      <%= pb_rails("table/table_header", props: { html_options: { "data-sticky-id": "15" }, text: "Column 15" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "13" }, text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "14" }, text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "15" }, text: "Value 15" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "13" }, text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "14" }, text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "15" }, text: "Value 15" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 6" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 7" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 8" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 9" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 10" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 11" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 12" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "13" }, text: "Value 13" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "14" }, text: "Value 14" }) %>
+      <%= pb_rails("table/table_cell", props: { html_options: { "data-sticky-id": "15" }, text: "Value 15" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_sticky_right_columns.jsx
@@ -8,78 +8,78 @@ const TableStickyRightColumns = () => {
             size="md"
             stickyRightColumn={["13", "14", "15"]}
         >
-            <thead>
-                <tr>
-                    <th>{'Column 1'}</th>
-                    <th>{'Column 2'}</th>
-                    <th>{'Column 3'}</th>
-                    <th>{'Column 4'}</th>
-                    <th>{'Column 5'}</th>
-                    <th>{'Column 6'}</th>
-                    <th>{'Column 7'}</th>
-                    <th>{'Column 8'}</th>
-                    <th>{'Column 9'}</th>
-                    <th>{'Column 10'}</th>
-                    <th>{'Column 11'}</th>
-                    <th>{'Column 12'}</th>
-                    <th data-sticky-id="13">{'Column 13'}</th>
-                    <th data-sticky-id="14">{'Column 14'}</th>
-                    <th data-sticky-id="15">{'Column 15'}</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>{'Value 1'}</td>
-                    <td>{'Value 2'}</td>
-                    <td>{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td data-sticky-id="13">{'Value 13'}</td>
-                    <td data-sticky-id="14">{'Value 14'}</td>
-                    <td data-sticky-id="15">{'Value 15'}</td>
-                </tr>
-                <tr>
-                    <td>{'Value 1'}</td>
-                    <td>{'Value 2'}</td>
-                    <td>{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td data-sticky-id="13">{'Value 13'}</td>
-                    <td data-sticky-id="14">{'Value 14'}</td>
-                    <td data-sticky-id="15">{'Value 15'}</td>
-                </tr>
-                <tr>
-                    <td>{'Value 1'}</td>
-                    <td>{'Value 2'}</td>
-                    <td>{'Value 3'}</td>
-                    <td>{'Value 4'}</td>
-                    <td>{'Value 5'}</td>
-                    <td>{'Value 6'}</td>
-                    <td>{'Value 7'}</td>
-                    <td>{'Value 8'}</td>
-                    <td>{'Value 9'}</td>
-                    <td>{'Value 10'}</td>
-                    <td>{'Value 11'}</td>
-                    <td>{'Value 12'}</td>
-                    <td data-sticky-id="13">{'Value 13'}</td>
-                    <td data-sticky-id="14">{'Value 14'}</td>
-                    <td data-sticky-id="15">{'Value 15'}</td>
-                </tr>
-            </tbody>
+            <Table.Head>
+                <Table.Row>
+                <Table.Header>{'Column 1'}</Table.Header>
+                <Table.Header>{'Column 2'}</Table.Header>
+                <Table.Header>{'Column 3'}</Table.Header>
+                <Table.Header>{'Column 4'}</Table.Header>
+                <Table.Header>{'Column 5'}</Table.Header>
+                <Table.Header>{'Column 6'}</Table.Header>
+                <Table.Header>{'Column 7'}</Table.Header>
+                <Table.Header>{'Column 8'}</Table.Header>
+                <Table.Header>{'Column 9'}</Table.Header>
+                <Table.Header>{'Column 10'}</Table.Header>
+                <Table.Header>{'Column 11'}</Table.Header>
+                <Table.Header>{'Column 12'}</Table.Header>
+                <Table.Header htmlOptions={{ 'data-sticky-id': '13' }}>{'Column 13'}</Table.Header>
+                <Table.Header htmlOptions={{ 'data-sticky-id': '14' }}>{'Column 14'}</Table.Header>
+                <Table.Header htmlOptions={{ 'data-sticky-id': '15' }}>{'Column 15'}</Table.Header>
+                </Table.Row>
+            </Table.Head>
+            <Table.Body>
+                <Table.Row>
+                    <Table.Cell>{'Value 1'}</Table.Cell>
+                    <Table.Cell>{'Value 2'}</Table.Cell>
+                    <Table.Cell>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '13' }}>{'Value 13'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '14' }}>{'Value 14'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '15' }}>{'Value 15'}</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                    <Table.Cell>{'Value 1'}</Table.Cell>
+                    <Table.Cell>{'Value 2'}</Table.Cell>
+                    <Table.Cell>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '13' }}>{'Value 13'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '14' }}>{'Value 14'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '15' }}>{'Value 15'}</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                    <Table.Cell>{'Value 1'}</Table.Cell>
+                    <Table.Cell>{'Value 2'}</Table.Cell>
+                    <Table.Cell>{'Value 3'}</Table.Cell>
+                    <Table.Cell>{'Value 4'}</Table.Cell>
+                    <Table.Cell>{'Value 5'}</Table.Cell>
+                    <Table.Cell>{'Value 6'}</Table.Cell>
+                    <Table.Cell>{'Value 7'}</Table.Cell>
+                    <Table.Cell>{'Value 8'}</Table.Cell>
+                    <Table.Cell>{'Value 9'}</Table.Cell>
+                    <Table.Cell>{'Value 10'}</Table.Cell>
+                    <Table.Cell>{'Value 11'}</Table.Cell>
+                    <Table.Cell>{'Value 12'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '13' }}>{'Value 13'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '14' }}>{'Value 14'}</Table.Cell>
+                    <Table.Cell htmlOptions={{ 'data-sticky-id': '15' }}>{'Value 15'}</Table.Cell>
+                </Table.Row>
+            </Table.Body>
         </Table>
     )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.html.erb
@@ -1,43 +1,43 @@
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right">
-      <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
-      <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
-      </td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right">
-      <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
-      <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
-      </td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right">
-      <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
-      <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
-      </td>    
-      </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
+        <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
+        <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text_align: "right" }) do %>
+        <%= pb_rails("button", props: { text: "Tertiary Action", variant: "link", padding_left: "none" }) %>
+        <%= pb_rails("button", props: { text: "Secondary Action", variant: "secondary" }) %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_actions.jsx
@@ -3,28 +3,28 @@ import React from 'react'
 import Table from '../_table'
 import Button from '../../pb_button/_button'
 
-const TableOneAction = (props) => {
+const TableTwoActions = (props) => {
   return (
     <Table
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{''}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{''}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 paddingLeft="none"
@@ -38,14 +38,14 @@ const TableOneAction = (props) => {
                 variant="secondary"
                 {...props}
             />
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 paddingLeft="none"
@@ -59,14 +59,14 @@ const TableOneAction = (props) => {
                 variant="secondary"
                 {...props}
             />
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell textAlign="right">
             <Button
                 onClick={() => alert('button clicked!')}
                 paddingLeft="none"
@@ -80,11 +80,11 @@ const TableOneAction = (props) => {
                 variant="secondary"
                 {...props}
             />
-          </td>
-        </tr>
-      </tbody>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }
 
-export default TableOneAction
+export default TableTwoActions

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.html.erb
@@ -1,34 +1,46 @@
 <%= pb_rails("table", props: { size: "sm" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td align="right"> <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %> </td>
-      </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        <%= pb_rails("flex", props: { justify: "end" }) do %>
+          <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %>
+        <% end %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        <%= pb_rails("flex", props: { justify: "end" }) do %>
+          <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %>
+        <% end %>
+      <% end %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell") do %>
+        <%= pb_rails("flex", props: { justify: "end" }) do %>
+          <%= pb_rails("circle_icon_button", props: { variant: "secondary", icon: "ellipsis-h" }) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_two_plus_actions.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import Table from '../_table'
 import CircleIconButton from '../../pb_circle_icon_button/_circle_icon_button'
+import Flex from '../../pb_flex/_flex'
 
 const TableTwoPlusActions = (props) => {
   return (
@@ -9,60 +10,62 @@ const TableTwoPlusActions = (props) => {
         size="sm"
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{''}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
-            {' '}
-            <CircleIconButton
-                icon="ellipsis-h"
-                variant="secondary"
-                {...props}
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
-            {' '}
-            <CircleIconButton
-                icon="ellipsis-h"
-                variant="secondary"
-                {...props}
-            />
-          </td>
-
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td align="right">
-            {' '}
-            <CircleIconButton
-                icon="ellipsis-h"
-                variant="secondary"
-                {...props}
-            />
-          </td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{''}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>
+            <Flex justify="end">
+              <CircleIconButton
+                  icon="ellipsis-h"
+                  variant="secondary"
+                  {...props}
+              />
+            </Flex>
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>
+            <Flex justify="end">
+              <CircleIconButton
+                  icon="ellipsis-h"
+                  variant="secondary"
+                  {...props}
+              />
+            </Flex>
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>
+            <Flex justify="end">
+              <CircleIconButton
+                  icon="ellipsis-h"
+                  variant="secondary"
+                  {...props}
+              />
+            </Flex>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_vertical_border.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_vertical_border.html.erb
@@ -1,34 +1,34 @@
 <%= pb_rails("table", props: { size: "sm", vertical_border: true }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-      <th>Column 4</th>
-      <th>Column 5</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-      <td>Value 4</td>
-      <td>Value 5</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_vertical_border.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_vertical_border.jsx
@@ -9,38 +9,38 @@ const TableVerticalBorder = (props) => {
         verticalBorder
         {...props}
     >
-      <thead>
-        <tr>
-          <th>{'Column 1'}</th>
-          <th>{'Column 2'}</th>
-          <th>{'Column 3'}</th>
-          <th>{'Column 4'}</th>
-          <th>{'Column 5'}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-        <tr>
-          <td>{'Value 1'}</td>
-          <td>{'Value 2'}</td>
-          <td>{'Value 3'}</td>
-          <td>{'Value 4'}</td>
-          <td>{'Value 5'}</td>
-        </tr>
-      </tbody>
+      <Table.Head>
+        <Table.Row>
+          <Table.Header>{'Column 1'}</Table.Header>
+          <Table.Header>{'Column 2'}</Table.Header>
+          <Table.Header>{'Column 3'}</Table.Header>
+          <Table.Header>{'Column 4'}</Table.Header>
+          <Table.Header>{'Column 5'}</Table.Header>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>{'Value 1'}</Table.Cell>
+          <Table.Cell>{'Value 2'}</Table.Cell>
+          <Table.Cell>{'Value 3'}</Table.Cell>
+          <Table.Cell>{'Value 4'}</Table.Cell>
+          <Table.Cell>{'Value 5'}</Table.Cell>
+        </Table.Row>
+      </Table.Body>
     </Table>
   )
 }

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_background_kit.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_background_kit.html.erb
@@ -1,43 +1,43 @@
 <%= pb_rails("table", props: { size: "sm", margin_bottom: "lg" }) do %>
-  <thead>
-    <tr>
-      <th>Column 1</th>
-      <th>Column 2</th>
-      <th>Column 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
     <%= pb_rails("background", props: { background_color: "error_subtle", tag: "tr" }) do %>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
     <% end %>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
     <%= pb_rails("background", props: { background_color: "warning_subtle", tag: "tr" }) do %>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
     <% end %>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
-  </tbody>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
+  <% end %>
 <% end %>
 <%= pb_rails("table", props: { size: "sm", margin_bottom: "lg" }) do %>
   <colgroup>
@@ -45,31 +45,33 @@
     <%= pb_rails("background", props: { background_color: "info_subtle", tag: "col" }) %>
     <%= pb_rails("background", props: { background_color: "warning_subtle", tag: "col" }) %>
   </colgroup>
-  <thead>
-    <th>Column 1</th>
-    <th>Column 2</th>
-    <th>Column 3</th>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
-    <tr>
-      <td>Value 1</td>
-      <td>Value 2</td>
-      <td>Value 3</td>
-    </tr>
-  </tbody>
+  <%= pb_rails("table/table_head") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+      <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+    <% end %>
+  <% end %>
+  <%= pb_rails("table/table_body") do %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
+    <%= pb_rails("table/table_row") do %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+      <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_background_kit.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_background_kit.jsx
@@ -10,51 +10,51 @@ const TableWithBackgroundKit = (props) => {
         <Table
             {...props}
         >
-          <thead>
-            <tr>
-                <th>{'Column 1'}</th>
-                <th>{'Column 2'}</th>
-                <th>{'Column 3'}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
+          <Table.Head>
+            <Table.Row>
+              <Table.Header>{'Column 1'}</Table.Header>
+              <Table.Header>{'Column 2'}</Table.Header>
+              <Table.Header>{'Column 3'}</Table.Header>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
             <Background
                 backgroundColor="error_subtle"
-                tag='tr'
+                tag="tr"
             >
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
             </Background>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
             <Background
                 backgroundColor="warning_subtle"
-                tag='tr'
+                tag="tr"
             >
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
             </Background>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-          </tbody>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
       </div>
       <div>
@@ -65,56 +65,46 @@ const TableWithBackgroundKit = (props) => {
           <colgroup>
             <Background
                 backgroundColor="error_subtle"
-                tag='col'
+                tag="col"
             />
             <Background
                 backgroundColor="info_subtle"
-                tag='col'
+                tag="col"
             />
             <Background
                 backgroundColor="warning_subtle"
-                tag='col'
+                tag="col"
             />
           </colgroup>
-          <thead>
-            <tr>
-              <th>{'Column 1'}</th>
-              <th>{'Column 2'}</th>
-              <th>{'Column 3'}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-            </tr>
-          </tbody>
+          <Table.Head>
+            <Table.Row>
+              <Table.Header>{'Column 1'}</Table.Header>
+              <Table.Header>{'Column 2'}</Table.Header>
+              <Table.Header>{'Column 3'}</Table.Header>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
         </div>
     </div>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_header_style_borderless.html.erb
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_header_style_borderless.html.erb
@@ -1,34 +1,34 @@
 <%= pb_rails("table", props: { size: "sm", header_style: "borderless" }) do %>
-    <thead>
-        <tr>
-            <th>Column 1</th>
-            <th>Column 2</th>
-            <th>Column 3</th>
-            <th>Column 4</th>
-            <th>Column 5</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>Value 1</td>
-            <td>Value 2</td>
-            <td>Value 3</td>
-            <td>Value 4</td>
-            <td>Value 5</td>
-        </tr>
-        <tr>
-            <td>Value 1</td>
-            <td>Value 2</td>
-            <td>Value 3</td>
-            <td>Value 4</td>
-            <td>Value 5</td>
-        </tr>
-        <tr>
-            <td>Value 1</td>
-            <td>Value 2</td>
-            <td>Value 3</td>
-            <td>Value 4</td>
-            <td>Value 5</td>
-        </tr>
-    </tbody>
+    <%= pb_rails("table/table_head") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_header", props: { text: "Column 1" }) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 2" }) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 3" }) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 4" }) %>
+            <%= pb_rails("table/table_header", props: { text: "Column 5" }) %>
+        <% end %>
+    <% end %>
+    <%= pb_rails("table/table_body") do %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+        <% end %>
+        <%= pb_rails("table/table_row") do %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 1" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 2" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 3" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 4" }) %>
+            <%= pb_rails("table/table_cell", props: { text: "Value 5" }) %>
+        <% end %>
+    <% end %>
 <% end %>

--- a/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_header_style_borderless.jsx
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/_table_with_header_style_borderless.jsx
@@ -10,38 +10,38 @@ const TableWithHeaderStyleBorderless = (props) => {
             size="sm"
             {...props}
         >
-          <thead>
-              <tr>
-                  <th>{'Column 1'}</th>
-                  <th>{'Column 2'}</th>
-                  <th>{'Column 3'}</th>
-                  <th>{'Column 4'}</th>
-                  <th>{'Column 5'}</th>
-              </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-              <td>{'Value 4'}</td>
-              <td>{'Value 5'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-              <td>{'Value 4'}</td>
-              <td>{'Value 5'}</td>
-            </tr>
-            <tr>
-              <td>{'Value 1'}</td>
-              <td>{'Value 2'}</td>
-              <td>{'Value 3'}</td>
-              <td>{'Value 4'}</td>
-              <td>{'Value 5'}</td>
-            </tr>
-          </tbody>
+          <Table.Head>
+            <Table.Row>
+              <Table.Header>{'Column 1'}</Table.Header>
+              <Table.Header>{'Column 2'}</Table.Header>
+              <Table.Header>{'Column 3'}</Table.Header>
+              <Table.Header>{'Column 4'}</Table.Header>
+              <Table.Header>{'Column 5'}</Table.Header>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+              <Table.Cell>{'Value 4'}</Table.Cell>
+              <Table.Cell>{'Value 5'}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+              <Table.Cell>{'Value 4'}</Table.Cell>
+              <Table.Cell>{'Value 5'}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{'Value 1'}</Table.Cell>
+              <Table.Cell>{'Value 2'}</Table.Cell>
+              <Table.Cell>{'Value 3'}</Table.Cell>
+              <Table.Cell>{'Value 4'}</Table.Cell>
+              <Table.Cell>{'Value 5'}</Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
     </>
   )

--- a/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
@@ -46,6 +46,7 @@ examples:
     - table_with_filter_variant_with_pagination: Variant with Filter and Pagination
     - table_with_filter_with_card_title_props: Variant with Filter (with Card and Title Props)
     - table_colspan: Table with Colspan
+    - table_as_wrapper: Table as Wrapper
     
   react:
     - table_sm: Small
@@ -92,3 +93,4 @@ examples:
     - table_with_filter_variant_with_pagination: Variant with Filter and Pagination
     - table_with_filter_with_card_title_props: Variant with Filter (with Card and Title Props)
     - table_colspan: Table with Colspan
+    - table_as_wrapper: Table as Wrapper

--- a/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/example.yml
@@ -46,7 +46,7 @@ examples:
     - table_with_filter_variant_with_pagination: Variant with Filter and Pagination
     - table_with_filter_with_card_title_props: Variant with Filter (with Card and Title Props)
     - table_colspan: Table with Colspan
-    - table_as_wrapper: Table as Wrapper
+    - table_as_wrapper: Table as Wrapper (Legacy)
     
   react:
     - table_sm: Small
@@ -93,4 +93,4 @@ examples:
     - table_with_filter_variant_with_pagination: Variant with Filter and Pagination
     - table_with_filter_with_card_title_props: Variant with Filter (with Card and Title Props)
     - table_colspan: Table with Colspan
-    - table_as_wrapper: Table as Wrapper
+    - table_as_wrapper: Table as Wrapper (Legacy)

--- a/playbook/app/pb_kits/playbook/pb_table/docs/index.js
+++ b/playbook/app/pb_kits/playbook/pb_table/docs/index.js
@@ -43,3 +43,4 @@ export { default as TableWithFilterVariant } from './_table_with_filter_variant.
 export { default as TableWithFilterVariantWithPagination } from './_table_with_filter_variant_with_pagination.jsx'
 export { default as TableWithFilterWithCardTitleProps } from './_table_with_filter_with_card_title_props.jsx'
 export { default as TableColspan } from './_table_colspan.jsx'
+export { default as TableAsWrapper } from './_table_as_wrapper.jsx'


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
[PLAY-3225](https://runway.powerhrg.com/backlog_items/PLAY-3225) updates 24 react and 25 rails doc examples to use the Table with Subcomponents version of the Table kit instead of wrapping HTML elements. It adds an additional "Table as Wrapper" doc example demonstrating but advising against using the Table kit as a wrapper for HTML elements.

**Screenshots:** Screenshots to visualize your addition/change
<img width="1149" height="881" alt="tableaswrapperlegacy" src="https://github.com/user-attachments/assets/6e6df999-2065-4498-8ae2-4bb673ceb6c3" />


**How to test?** Steps to confirm the desired behavior:
1. Compare the updated doc examples in the review env to production - they should look and function identically when set up as Table SubComponents.
2. React docs updated (by section): Size & Density: all 6; Layout & Structure: Responsive Tables and Table with Background Kit; Sticky & Positional Behaviors: Sticky Header, Sticky Left Column, Sticky Right Column, Sticky Left and Right Columns, Side Highlight, Table Container Off; Data Presentation: all 3; Header Variants: Header Style Borderless; Interactive Tables: Disable Hover; Table Actions: all 5.
3. Rails docs updated (by section):  Size & Density: all 6; Layout & Structure: Responsive Tables and Table with Background Kit; Sticky & Positional Behaviors: Sticky Header, Sticky Left Column, Sticky Right Column, Sticky Left and Right Columns, Side Highlight, Table Container Off; Data Presentation: all 3; Header Variants: Table Header, Header Style Borderless; Interactive Tables: Disable Hover; Table Actions: all 5.
4. See added "Table as Wrapper (Legacy)" doc example ([rails](https://pr6653.playbook.wc.beta.gm.powerapp.cloud/kits/table/rails#table_as_wrapper), [react](https://pr6653.playbook.wc.beta.gm.powerapp.cloud/kits/table/react#table_as_wrapper)).


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
~~- [ ] **TESTS** I have added test coverage to my code.~~
~~- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.~~
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [x] **RC** I have added an `inactive RC` label if not an active RC.