### PR TITLE
Declare Playbook's MySQL cluster in the service catalog

### DIFF
--- a/portal.yml
+++ b/portal.yml
@@ -44,6 +44,8 @@ spec:
   owner: ghost-crew
   lifecycle: production
   system: playbook
+  dependsOn:
+    - resource:playbook-mysql
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Component
@@ -62,4 +64,19 @@ spec:
   type: library
   owner: ghost-crew
   lifecycle: production
+  system: playbook
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: playbook-mysql
+  description: Playbook's Percona XtraDB Cluster
+  tags:
+    - relational
+    - mysql
+    - pxc
+    - percona
+spec:
+  type: database
+  owner: ghost-crew
   system: playbook


### PR DESCRIPTION
The service catalog records Playbook's System and two Components, but not the database the website
runs on, so it cannot answer "which applications use MySQL" for this repository.

Adds a Resource for the Percona XtraDB Cluster that
`playbook-website/config/deploy/templates/priority/mysql.yaml.erb` deploys, following the
convention used elsewhere in the organization, and lists it in the website component's
`dependsOn`.

No running system reads this file, so nothing changes at deploy time.
