### PR TITLE
[PLAY-3215] Border Radius Global Prop: Fix conflict with background_light

### DIFF
--- a/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/BorderRadiusGlobalProps.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/GlobalPropsAndTokens/ExamplesPage/Examples/BorderRadiusGlobalProps.tsx
@@ -22,7 +22,7 @@ const BorderRadiusGlobalProps = () => {
         {borderRadiusOptions.map((option) => (
           <Flex key={option.value} flexDirection="column" align="center" gap="xs">
             <Card 
-              background="info_subtle"
+              background="light"
               borderRadius={option.value as any}
               className="visual_guide_card_border_radius"
               padding="xs" 

--- a/playbook/app/pb_kits/playbook/pb_card/_card_mixin.scss
+++ b/playbook/app/pb_kits/playbook/pb_card/_card_mixin.scss
@@ -25,6 +25,16 @@ $additional_colors: (
 );
 $background_colors: map-merge($product_colors, $additional_colors);
 $pb_card_header_colors: map-merge(map-merge(map-merge($product_colors, $additional_colors), $category_colors), $status_colors);
+// Prop sizes only — legacy $border_radius keys like "light" collide with background_light.
+$pb_card_border_radius_values: (
+  xs: $border_radius_xs,
+  sm: $border_radius_sm,
+  md: $border_radius_md,
+  lg: $border_radius_lg,
+  xl: $border_radius_xl,
+  none: $border_radius_none,
+  rounded: $border_radius_rounded,
+);
 
 @mixin pb_card_selected($border_color: $primary) {
   border-color: $border_color;
@@ -63,8 +73,8 @@ $pb_card_header_colors: map-merge(map-merge(map-merge($product_colors, $addition
     }
   }
 
-  @each $name, $radius in $border_radius {
-    &[class*=_#{$name}] {
+  @each $name, $radius in $pb_card_border_radius_values {
+    &.pb_card_kit_border_radius_#{$name} {
       border-radius: $radius;
     }
   }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

You can't change a 'light' background card's border radius. This is because of a rule conflict:

```css
.pb_card_kit[class*=background_light] {
  border-radius: 4px
}
```

Fix this bug by removing unused rules (e.g., light, heaviest, normal) and only keep sizes (e.g. xs, sm, md). 

**Screenshots:** Screenshots to visualize your addition/change
<img width="619" height="452" alt="Screenshot 2026-09-11 at 2 45 18 PM" src="https://github.com/user-attachments/assets/ed15b322-f903-48fb-b670-dc2658944f8b" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [x] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.