### PR TITLE
[PLAY-3223] Investigate Cached Playground 404s After VPN Reconnect

### DIFF
--- a/playbook-website/app/controllers/pages_controller.rb
+++ b/playbook-website/app/controllers/pages_controller.rb
@@ -9,6 +9,11 @@ class PagesController < ApplicationController
   include ::ViteRails::TagHelpers
   rescue_from ActionView::MissingTemplate, :with => :page_not_found
 
+  # SPA shells and JSON loaders must not be HTTP-cached. Off-VPN staging can
+  # return a block/404 that browsers otherwise reuse after reconnect (incognito
+  # works because it has an empty cache).
+  before_action :disable_http_caching, only: :application
+
   def application
     @kits = MENU["kits"]
     @dark = cookies[:dark_mode] == "true"
@@ -607,6 +612,12 @@ private
   # Deployed production website host only (not review apps / localhost / staging).
   def playbook_production_host?
     request.host == "playbook.powerapp.cloud"
+  end
+
+  def disable_http_caching
+    response.headers["Cache-Control"] = "private, no-store, no-cache, must-revalidate"
+    response.headers["Expires"] = "0"
+    response.headers["Pragma"] = "no-cache"
   end
 
   # JSON + Rails prerendered examples: ERB under pb_advanced_table/docs expects

--- a/playbook-website/app/javascript/components/Website/index.tsx
+++ b/playbook-website/app/javascript/components/Website/index.tsx
@@ -23,9 +23,12 @@ import {
   syncStoredPlatformFromLocation,
   writeStoredPlatform,
 } from "./src/helpers/platform";
-import { navigateSite } from "./src/utils/siteNavigation";
+import { navigateSite, stripStagingCacheBustFromUrl } from "./src/utils/siteNavigation";
 
 function WebsiteContent() {
+  useEffect(() => {
+    stripStagingCacheBustFromUrl()
+  }, [])
   const {
     kits,
     type,

--- a/playbook-website/app/javascript/components/Website/src/components/Error/index.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/Error/index.tsx
@@ -1,13 +1,36 @@
 import React from 'react';
-import { Caption, Icon, Title } from 'playbook-ui';
+import { Button, Caption, Flex, Icon, Title } from 'playbook-ui';
+import {
+  isStagingHost,
+  withStagingCacheBust,
+} from '../../utils/siteNavigation';
 import styles from './styles.module.scss';
 
 const Error = () => {
+  const onStaging = isStagingHost();
+
+  const reloadWithoutStaleCache = () => {
+    window.location.assign(withStagingCacheBust(window.location.href));
+  };
+
   return (
     <div className={styles.error}>
       <Icon className={styles.icon} icon="warning" size="3x" />
       <Title text="404" size={1} />
-      <Caption>Page not found</Caption>
+      <Caption>
+        {onStaging
+          ? "If you just reconnected to the VPN, reload to bypass a cached offline response."
+          : "Page not found"}
+      </Caption>
+      {onStaging && (
+        <Flex justify="center" marginTop="sm">
+          <Button
+            onClick={reloadWithoutStaleCache}
+            text="Reload Playground"
+            variant="primary"
+          />
+        </Flex>
+      )}
     </div>
   );
 }

--- a/playbook-website/app/javascript/components/Website/src/components/PlaygroundVpnWarningDialog.tsx
+++ b/playbook-website/app/javascript/components/Website/src/components/PlaygroundVpnWarningDialog.tsx
@@ -3,6 +3,7 @@ import { Dialog } from "playbook-ui"
 import {
   PLAYGROUND_VPN_WARNING_EVENT,
   STAGING_ORIGIN,
+  withStagingCacheBust,
 } from "../utils/siteNavigation"
 import type { PlaygroundVpnWarningDetail } from "../utils/siteNavigation"
 
@@ -38,7 +39,9 @@ const PlaygroundVpnWarningDialog = () => {
 
   const tryAgain = () => {
     setOpened(false)
-    window.location.assign(destinationUrl)
+    // Bust at confirm-time so a prior off-VPN 404 for this path is not reused
+    // after the user reconnects and enters Playground again.
+    window.location.assign(withStagingCacheBust(destinationUrl))
   }
 
   return (

--- a/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
+++ b/playbook-website/app/javascript/components/Website/src/hooks/loaders.ts
@@ -13,6 +13,10 @@ interface CategoryTypes {
   components: ComponentTypes[];
 }
 
+// Bypass HTTP cache so a prior off-VPN 404 (or HTML block page) is not reused
+// after the user reconnects and refreshes.
+const FETCH_NO_STORE: RequestInit = { cache: "no-store" };
+
 const sortByName = (a: ComponentTypes, b: ComponentTypes): number => {
   return a.name.localeCompare(b.name);
 }
@@ -26,7 +30,10 @@ let kitsCache: any = null;
 
 async function fetchKits() {
   if (kitsCache) return kitsCache;
-  const response = await fetch("/kits.json");
+  const response = await fetch("/kits.json", FETCH_NO_STORE);
+  if (!response.ok) {
+    throw new Response("Failed to load kits", { status: response.status });
+  }
   const data = await response.json();
   data.kits.forEach(sortComponentsByName);
   kitsCache = data;
@@ -71,7 +78,10 @@ export const ComponentShowLoader = async ({
     url = `${url}${requestUrl.search}`;
   }
 
-  const response = await fetch(url);
+  const response = await fetch(url, FETCH_NO_STORE);
+  if (!response.ok) {
+    throw new Response("Failed to load kit", { status: response.status });
+  }
   const data = await response.json();
   return data;
 };
@@ -100,7 +110,10 @@ export const GuidePageLoader = async ({ params, request }: LoaderFunctionArgs) =
   const guidePath = params.page;
   const { pathname } = new URL(request.url);
   const guideType = pathname.includes('getting_started') ? 'getting_started' : 'design_guidelines';
-  const response = await fetch(`/guides/${guideType}/${guidePath}.json`);
+  const response = await fetch(`/guides/${guideType}/${guidePath}.json`, FETCH_NO_STORE);
+  if (!response.ok) {
+    throw new Response("Failed to load guide", { status: response.status });
+  }
   const data = await response.json();
   return data;
 };
@@ -109,7 +122,10 @@ let iconsCache: any = null;
 
 export const IconsLoader = async () => {
   if (iconsCache) return iconsCache;
-  const response = await fetch("/icons.json");
+  const response = await fetch("/icons.json", FETCH_NO_STORE);
+  if (!response.ok) {
+    throw new Response("Failed to load icons", { status: response.status });
+  }
   const data = await response.json();
   iconsCache = data;
   return data;
@@ -128,7 +144,7 @@ export const PlaygroundLoader = async () => {
   }
 
   if (playgroundCache) return playgroundCache;
-  const response = await fetch("/playground.json");
+  const response = await fetch("/playground.json", FETCH_NO_STORE);
   if (!response.ok) {
     return {
       playground_kits: [],

--- a/playbook-website/app/javascript/components/Website/src/utils/siteNavigation.ts
+++ b/playbook-website/app/javascript/components/Website/src/utils/siteNavigation.ts
@@ -2,6 +2,8 @@ export const PROD_ORIGIN = "https://playbook.powerapp.cloud"
 export const STAGING_ORIGIN = "https://staging.playbook.powerapp.cloud"
 const PROD_HOST = "playbook.powerapp.cloud"
 const STAGING_HOST = "staging.playbook.powerapp.cloud"
+/** Query param used to avoid reusing a browser-cached off-VPN 404 for staging. */
+export const STAGING_CACHE_BUST_PARAM = "_pb"
 
 const normalizePath = (path: string) => (path.startsWith("/") ? path : `/${path}`)
 
@@ -10,8 +12,30 @@ const isPlaygroundPath = (path: string) => {
   return normalized === "/playground" || normalized.startsWith("/playground?")
 }
 
+/**
+ * Append a one-time cache-busting query so navigation to staging does not reuse
+ * a previously cached off-VPN block/404 for the same path.
+ */
+export const withStagingCacheBust = (url: string) => {
+  const parsed = new URL(
+    url,
+    typeof window !== "undefined" ? window.location.origin : PROD_ORIGIN
+  )
+  parsed.searchParams.set(STAGING_CACHE_BUST_PARAM, String(Date.now()))
+  return parsed.toString()
+}
+
 export const isStagingHost = () =>
   typeof window !== "undefined" && window.location.hostname === STAGING_HOST
+
+/** Remove the one-time `_pb` param after a successful staging load. */
+export const stripStagingCacheBustFromUrl = () => {
+  if (!isStagingHost()) return
+  const url = new URL(window.location.href)
+  if (!url.searchParams.has(STAGING_CACHE_BUST_PARAM)) return
+  url.searchParams.delete(STAGING_CACHE_BUST_PARAM)
+  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`)
+}
 
 /** True only on deployed prod — not localhost, review apps, or staging. */
 export const isProductionHost = () =>
@@ -56,7 +80,7 @@ export const showPlaygroundVpnWarning = (destinationUrl: string) => {
  */
 export const goToStaging = (url: string) => {
   if (isStagingHost()) {
-    window.location.assign(url)
+    window.location.assign(withStagingCacheBust(url))
     return
   }
 

--- a/playbook-website/config/deploy/templates/ingress.yaml.erb
+++ b/playbook-website/config/deploy/templates/ingress.yaml.erb
@@ -12,6 +12,12 @@ metadata:
     <% end %>
     <% if environment == 'production' %>
     nginx.ingress.kubernetes.io/whitelist-source-range: '0.0.0.0/0'
+    <% else %>
+    # Staging is VPN-only; deny/not-found responses must not be cached or they
+    # stick after the user reconnects (refresh still 404; incognito works).
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers -s 403,404 "Cache-Control: private, no-store, no-cache, must-revalidate";
+      more_set_headers -s 403,404 "Pragma: no-cache";
     <% end %>
 spec:
   tls:

--- a/playbook-website/spec/controllers/pages_controller_spec.rb
+++ b/playbook-website/spec/controllers/pages_controller_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe PagesController, type: :controller do
       expect(response).to be_successful
     end
 
+    it "disables HTTP caching for SPA shells and JSON loaders" do
+      get :application
+      expect(response.headers["Cache-Control"]).to include("no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+    end
+
+    it "disables HTTP caching for production playground.json 404s" do
+      @request.host = "playbook.powerapp.cloud"
+      @request.env["PATH_INFO"] = "/playground"
+      get :application, format: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.headers["Cache-Control"]).to include("no-store")
+    end
+
     it "assigns variables" do
       get :application
       expect(assigns(:kits)).to be_present


### PR DESCRIPTION
[PLAY-3223](https://runway.powerhrg.com/backlog_items/PLAY-3223)

**Screenshots:** Screenshots to visualize your addition/change


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change


#### Checklist:
- [ ] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new kit`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [ ] **DEPLOY** I have added the `milano` label to show I'm ready for a review.
- [ ] **TESTS** I have added test coverage to my code.
- [ ] **PLAYGROUND** I have added and tested Playground metadata and overrides for all kits and props updated in my code.
- [ ] **SEMVER** I have added a `minor`, `major`, or `patch` label for release.
- [ ] **RC** I have added an `inactive RC` label if not an active RC.